### PR TITLE
Declare crc-32 as a dependency of the published @wp-playground/storage package

### DIFF
--- a/packages/nx-extensions/src/executors/package-json/executor.ts
+++ b/packages/nx-extensions/src/executors/package-json/executor.ts
@@ -127,7 +127,9 @@ async function buildPackageJson(
 	sourceFileMap?: ProjectFileMap,
 	sourceDeps?: Set<string>
 ) {
-	const packageJson = createPackageJson(
+	const packageJson: ReturnType<typeof createPackageJson> & {
+		publishedDependencies?: Record<string, string>;
+	} = createPackageJson(
 		context.projectName,
 		context.projectGraph,
 		{

--- a/packages/nx-extensions/src/executors/package-json/executor.ts
+++ b/packages/nx-extensions/src/executors/package-json/executor.ts
@@ -164,6 +164,19 @@ async function buildPackageJson(
 		}
 	}
 
+	// Add dependencies that only exist in the published build output. Bundled
+	// vendored code may retain bare imports that are invisible to the
+	// source-file analysis above, e.g. @wp-playground/storage bundles the
+	// vendored isomorphic-git sources, which import crc-32. Packages declare
+	// such dependencies in a `publishedDependencies` field in their
+	// package.json, which npm ignores during workspace installs.
+	for (const [name, version] of Object.entries(
+		getPublishedDependencies(context)
+	)) {
+		packageJson.dependencies[name] = version;
+	}
+	delete packageJson.publishedDependencies;
+
 	for (const dep of monorepoDependencies) {
 		packageJson.dependencies[dep.name] = dep.version;
 	}
@@ -206,6 +219,25 @@ async function buildPackageJson(
 		options.outputPath + '/package.json',
 		serializeJson(packageJson)
 	);
+}
+
+function getPublishedDependencies(
+	context: ExecutorContext
+): Record<string, string> {
+	if (!context.projectName) {
+		return {};
+	}
+	const projectRoot =
+		context.projectGraph.nodes[context.projectName]?.data?.root;
+	if (!projectRoot) {
+		return {};
+	}
+	const packageJsonPath = `${context.root}/${projectRoot}/package.json`;
+	if (!fs.existsSync(packageJsonPath)) {
+		return {};
+	}
+	const packageJson = JSON.parse(fs.readFileSync(packageJsonPath).toString());
+	return packageJson.publishedDependencies ?? {};
 }
 
 interface MonorepoDependency {

--- a/packages/playground/storage/package.json
+++ b/packages/playground/storage/package.json
@@ -37,5 +37,8 @@
 	"types": "index.d.ts",
 	"dependencies": {
 		"pako": "^1.0.10"
+	},
+	"publishedDependencies": {
+		"crc-32": "1.2.2"
 	}
 }

--- a/packages/playground/test-built-npm-packages/commonjs-and-jest/tests/deps.spec.ts
+++ b/packages/playground/test-built-npm-packages/commonjs-and-jest/tests/deps.spec.ts
@@ -59,6 +59,19 @@ function getSourceImports(projectDir: string): Set<string> {
 	return imports;
 }
 
+/**
+ * Returns the names declared in a project's `publishedDependencies` field.
+ * These are bare imports that survive only in bundled vendored build output
+ * (e.g. @wp-playground/storage bundles isomorphic-git, which imports crc-32),
+ * so they are intentionally absent from the package's own source files.
+ */
+function getPublishedDependencies(projectDir: string): Set<string> {
+	const pkgJsonPath = path.join(projectDir, 'package.json');
+	if (!fs.existsSync(pkgJsonPath)) return new Set();
+	const pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf-8'));
+	return new Set<string>(Object.keys(pkgJson.publishedDependencies || {}));
+}
+
 function getInstalledPackages(): Array<{ name: string; dir: string }> {
 	const results: Array<{ name: string; dir: string }> = [];
 	for (const scope of ['@php-wasm', '@wp-playground']) {
@@ -83,6 +96,7 @@ describe('Built package dependencies', () => {
 			if (!directory || !fs.existsSync(directory)) return;
 
 			const sourceImports = getSourceImports(directory);
+			const publishedDependencies = getPublishedDependencies(directory);
 
 			const packageJsonFile = JSON.parse(
 				fs.readFileSync(path.join(pkg.dir, 'package.json'), 'utf-8')
@@ -93,7 +107,10 @@ describe('Built package dependencies', () => {
 			);
 
 			for (const dependency of dependencies) {
-				expect(sourceImports).toContain(dependency);
+				expect(
+					sourceImports.has(dependency) ||
+						publishedDependencies.has(dependency)
+				).toBe(true);
 			}
 		});
 	});

--- a/packages/playground/test-built-npm-packages/es-modules-and-vitest/tests/deps.spec.ts
+++ b/packages/playground/test-built-npm-packages/es-modules-and-vitest/tests/deps.spec.ts
@@ -63,6 +63,19 @@ function getSourceImports(projectDir: string): Set<string> {
 	return imports;
 }
 
+/**
+ * Returns the names declared in a project's `publishedDependencies` field.
+ * These are bare imports that survive only in bundled vendored build output
+ * (e.g. @wp-playground/storage bundles isomorphic-git, which imports crc-32),
+ * so they are intentionally absent from the package's own source files.
+ */
+function getPublishedDependencies(projectDir: string): Set<string> {
+	const pkgJsonPath = path.join(projectDir, 'package.json');
+	if (!fs.existsSync(pkgJsonPath)) return new Set();
+	const pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf-8'));
+	return new Set<string>(Object.keys(pkgJson.publishedDependencies || {}));
+}
+
 function getInstalledPackages(): Array<{ name: string; dir: string }> {
 	const results: Array<{ name: string; dir: string }> = [];
 	for (const scope of ['@php-wasm', '@wp-playground']) {
@@ -87,6 +100,7 @@ describe('Built package dependencies', () => {
 			if (!directory || !fs.existsSync(directory)) return;
 
 			const sourceImports = getSourceImports(directory);
+			const publishedDependencies = getPublishedDependencies(directory);
 
 			const packageJsonFile = JSON.parse(
 				fs.readFileSync(path.join(pkg.dir, 'package.json'), 'utf-8')
@@ -98,8 +112,9 @@ describe('Built package dependencies', () => {
 
 			for (const dependency of dependencies) {
 				assert.ok(
-					sourceImports.has(dependency),
-					`${pkg.name} declares dependency "${dependency}" but it is not imported from any source file`
+					sourceImports.has(dependency) ||
+						publishedDependencies.has(dependency),
+					`${pkg.name} declares dependency "${dependency}" but it is not imported from any source file or declared in publishedDependencies`
 				);
 			}
 		});


### PR DESCRIPTION
## Motivation for the change, related issues

Fixes #3711.

`pnpm add @wp-playground/storage && node -e 'import("@wp-playground/storage")'` fails with `ERR_MODULE_NOT_FOUND: Cannot find package 'crc-32'`. The built `storage/index.js` bundles the vendored isomorphic-git sources (`GitPackIndex` and friends), which import `crc-32`. That import stays external in the build output, but the published `package.json` never declares it — the `package-json` executor intentionally filters the generated dependency list down to packages imported directly by the package's own source files, and this import lives in the bundled vendored code where the source-file analysis can't see it. npm only resolves it through hoisting; pnpm's strict `node_modules` does not.

## Implementation details

- `packages/playground/storage/package.json` declares `"publishedDependencies": { "crc-32": "1.2.2" }` (same version as the root workspace dependency).
- The `package-json` executor merges `publishedDependencies` into the generated `dependencies` after its direct-import filter runs, and strips the field itself from the published output.

Why not simply add `crc-32` to the regular `dependencies`? Two reasons:

1. The executor's direct-import filter would delete it again — the whole point of the filter is that source files don't import it.
2. Keeping it out of `dependencies` means `npm install` doesn't touch `package-lock.json` or install a duplicate copy into the workspace (the root workspace already pins `crc-32@1.2.2` for the vendored isomorphic-git checkout).

The new field gives any package that bundles vendored code an explicit way to declare the bare imports that remain in its build output — per the issue's suggestion to check other packages, this mechanism is reusable if more cases turn up.

## Testing Instructions (or ideally a Blueprint)

1. `npx nx build playground-storage`
2. `cat dist/packages/playground/storage/package.json` — `dependencies` now contains `"crc-32": "1.2.2"`, and no `publishedDependencies` field is present.
3. `grep -o 'from "crc-32"' dist/packages/playground/storage/index.js` — confirms the build output still imports it.
4. `git diff package-lock.json` after `npm install` — empty; the workspace lockfile is unaffected.
5. To reproduce the original failure on the published 3.1.35 release: `pnpm add @wp-playground/storage@3.1.35`, then `node --input-type=module -e 'await import("@wp-playground/storage")'`.