### PR TITLE
[Website] Show a specific error when an invalid plugin or theme slug is used in a Blueprint

### DIFF
--- a/packages/playground/blueprints/src/index.ts
+++ b/packages/playground/blueprints/src/index.ts
@@ -53,6 +53,7 @@ export type {
 } from './lib/v1/resources';
 export {
 	BlueprintFilesystemRequiredError,
+	InvalidAssetSlugError,
 	ResourceDownloadError,
 } from './lib/v1/resources';
 export * from './lib/steps';

--- a/packages/playground/blueprints/src/lib/v1/resources.spec.ts
+++ b/packages/playground/blueprints/src/lib/v1/resources.spec.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+	ResourceDownloadError,
+	InvalidAssetSlugError,
+	CorePluginResource,
+	CoreThemeResource,
+} from './resources';
+
+vi.mock('@php-wasm/web-service-worker', () => ({
+	fetchWithCorsProxy: vi.fn(),
+}));
+
+import { fetchWithCorsProxy } from '@php-wasm/web-service-worker';
+
+const mockFetch = fetchWithCorsProxy as ReturnType<typeof vi.fn>;
+
+function makeOkResponse() {
+	return {
+		ok: true,
+		status: 200,
+		headers: { get: () => null },
+		arrayBuffer: async () => new ArrayBuffer(4),
+		clone: function () {
+			return this;
+		},
+	} as unknown as Response;
+}
+
+function makeErrorResponse(status: number) {
+	return {
+		ok: false,
+		status,
+		statusText: String(status),
+	} as unknown as Response;
+}
+
+describe('ResourceDownloadError', () => {
+	it('carries statusCode when provided', () => {
+		const err = new ResourceDownloadError('msg', 'https://example.com', {
+			statusCode: 404,
+		});
+		expect(err.statusCode).toBe(404);
+		expect(err.url).toBe('https://example.com');
+		expect(err.name).toBe('ResourceDownloadError');
+	});
+
+	it('statusCode is undefined when not provided', () => {
+		const err = new ResourceDownloadError('msg', 'https://example.com');
+		expect(err.statusCode).toBeUndefined();
+	});
+});
+
+describe('InvalidAssetSlugError', () => {
+	it('is a subclass of ResourceDownloadError', () => {
+		const err = new InvalidAssetSlugError(
+			'bad-slug',
+			'plugin',
+			'https://downloads.wordpress.org/plugin/bad-slug.latest-stable.zip'
+		);
+		expect(err).toBeInstanceOf(ResourceDownloadError);
+		expect(err.name).toBe('InvalidAssetSlugError');
+		expect(err.slug).toBe('bad-slug');
+		expect(err.assetType).toBe('plugin');
+		expect(err.statusCode).toBe(404);
+		expect(err.message).toContain('bad-slug');
+		expect(err.message).toContain('plugin');
+	});
+});
+
+describe('CorePluginResource', () => {
+	beforeEach(() => {
+		mockFetch.mockReset();
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it('throws InvalidAssetSlugError on a 404 response', async () => {
+		mockFetch.mockResolvedValue(makeErrorResponse(404));
+		const resource = new CorePluginResource({
+			resource: 'wordpress.org/plugins',
+			slug: 'nonexistent-plugin-xyz',
+		});
+		await expect(resource.resolve()).rejects.toThrow(InvalidAssetSlugError);
+		await expect(resource.resolve()).rejects.toMatchObject({
+			slug: 'nonexistent-plugin-xyz',
+			assetType: 'plugin',
+		});
+	});
+
+	it('throws ResourceDownloadError (not InvalidAssetSlugError) on a 403 response', async () => {
+		mockFetch.mockResolvedValue(makeErrorResponse(403));
+		const resource = new CorePluginResource({
+			resource: 'wordpress.org/plugins',
+			slug: 'some-plugin',
+		});
+		await expect(resource.resolve()).rejects.toThrow(ResourceDownloadError);
+		await expect(resource.resolve()).rejects.not.toThrow(
+			InvalidAssetSlugError
+		);
+	});
+
+	it('resolves successfully on a 200 response', async () => {
+		mockFetch.mockResolvedValue(makeOkResponse());
+		const resource = new CorePluginResource({
+			resource: 'wordpress.org/plugins',
+			slug: 'my-plugin',
+		});
+		const file = await resource.resolve();
+		expect(file).toBeInstanceOf(File);
+	});
+});
+
+describe('CoreThemeResource', () => {
+	beforeEach(() => {
+		mockFetch.mockReset();
+	});
+
+	it('throws InvalidAssetSlugError on a 404 response', async () => {
+		mockFetch.mockResolvedValue(makeErrorResponse(404));
+		const resource = new CoreThemeResource({
+			resource: 'wordpress.org/themes',
+			slug: 'nonexistent-theme-xyz',
+		});
+		await expect(resource.resolve()).rejects.toThrow(InvalidAssetSlugError);
+		await expect(resource.resolve()).rejects.toMatchObject({
+			slug: 'nonexistent-theme-xyz',
+			assetType: 'theme',
+		});
+	});
+
+	it('resolves successfully on a 200 response', async () => {
+		mockFetch.mockResolvedValue(makeOkResponse());
+		const resource = new CoreThemeResource({
+			resource: 'wordpress.org/themes',
+			slug: 'twentytwenty',
+		});
+		const file = await resource.resolve();
+		expect(file).toBeInstanceOf(File);
+	});
+});

--- a/packages/playground/blueprints/src/lib/v1/resources.ts
+++ b/packages/playground/blueprints/src/lib/v1/resources.ts
@@ -47,11 +47,41 @@ export class BlueprintFilesystemRequiredError extends Error {
  */
 export class ResourceDownloadError extends Error {
 	public readonly url: string;
+	public readonly statusCode?: number;
 
-	constructor(message: string, url: string, options?: ErrorOptions) {
-		super(message, options);
+	constructor(
+		message: string,
+		url: string,
+		options?: ErrorOptions & { statusCode?: number }
+	) {
+		const { statusCode, ...errorOptions } = options ?? {};
+		super(message, errorOptions);
 		this.name = 'ResourceDownloadError';
 		this.url = url;
+		this.statusCode = statusCode;
+	}
+}
+
+/**
+ * Error thrown when a plugin or theme slug does not exist on WordPress.org.
+ *
+ * Callers should present a user-friendly message pointing to the slug as the
+ * likely cause rather than treating this as a generic network failure.
+ */
+export class InvalidAssetSlugError extends ResourceDownloadError {
+	public readonly slug: string;
+	public readonly assetType: 'plugin' | 'theme';
+
+	constructor(slug: string, assetType: 'plugin' | 'theme', url: string) {
+		super(
+			`The ${assetType} "${slug}" could not be found on WordPress.org. ` +
+				`Please verify that "${slug}" is a valid ${assetType} slug.`,
+			url,
+			{ statusCode: 404 }
+		);
+		this.name = 'InvalidAssetSlugError';
+		this.slug = slug;
+		this.assetType = assetType;
 	}
 }
 
@@ -543,7 +573,8 @@ export abstract class FetchResource extends Resource<File> {
 			if (!response.ok) {
 				throw new ResourceDownloadError(
 					`Could not download "${url}"`,
-					url
+					url,
+					{ statusCode: response.status }
 				);
 			}
 			response = await cloneResponseMonitorProgress(
@@ -553,7 +584,8 @@ export abstract class FetchResource extends Resource<File> {
 			if (response.status !== 200) {
 				throw new ResourceDownloadError(
 					`Could not download "${url}"`,
-					url
+					url,
+					{ statusCode: response.status }
 				);
 			}
 			const filename =
@@ -564,6 +596,9 @@ export abstract class FetchResource extends Resource<File> {
 				encodeURIComponent(url);
 			return new File([await response.arrayBuffer()], filename);
 		} catch (e) {
+			if (e instanceof ResourceDownloadError) {
+				throw e;
+			}
 			throw new ResourceDownloadError(
 				`Could not download "${url}".\n\n` +
 					`Confirm that the URL is correct, the server is reachable, and the file is ` +
@@ -906,6 +941,23 @@ export class CoreThemeResource extends FetchResource {
 		const zipName = toDirectoryZipName(this.resource.slug);
 		return `https://downloads.wordpress.org/theme/${zipName}`;
 	}
+	override async resolve() {
+		try {
+			return await super.resolve();
+		} catch (error) {
+			if (
+				error instanceof ResourceDownloadError &&
+				error.statusCode === 404
+			) {
+				throw new InvalidAssetSlugError(
+					this.resource.slug,
+					'theme',
+					this.getURL()
+				);
+			}
+			throw error;
+		}
+	}
 }
 
 /**
@@ -928,6 +980,24 @@ export class CorePluginResource extends FetchResource {
 	getURL() {
 		const zipName = toDirectoryZipName(this.resource.slug);
 		return `https://downloads.wordpress.org/plugin/${zipName}`;
+	}
+
+	override async resolve() {
+		try {
+			return await super.resolve();
+		} catch (error) {
+			if (
+				error instanceof ResourceDownloadError &&
+				error.statusCode === 404
+			) {
+				throw new InvalidAssetSlugError(
+					this.resource.slug,
+					'plugin',
+					this.getURL()
+				);
+			}
+			throw error;
+		}
 	}
 }
 

--- a/packages/playground/website/src/components/site-error-modal/get-site-error-view.tsx
+++ b/packages/playground/website/src/components/site-error-modal/get-site-error-view.tsx
@@ -37,7 +37,8 @@ export function getSiteErrorView(
 	if (
 		blueprintStepError &&
 		error !== 'network-firewall-interference' &&
-		error !== 'resource-download-failed'
+		error !== 'resource-download-failed' &&
+		error !== 'invalid-asset-slug'
 	) {
 		return blueprintStepExecutionView(context);
 	}
@@ -60,6 +61,8 @@ export function getSiteErrorView(
 			return directoryHandleUnknownErrorView();
 		case 'network-firewall-interference':
 			return networkFirewallInterferenceView(context);
+		case 'invalid-asset-slug':
+			return invalidAssetSlugView(context);
 		case 'resource-download-failed':
 			return resourceDownloadFailedView(context);
 		case 'site-boot-failed':
@@ -467,6 +470,80 @@ function networkFirewallInterferenceView({
 			>
 				Retry
 			</Button>,
+			<Button
+				variant="primary"
+				key="start-without-blueprint"
+				onClick={helpers.reloadWithoutBlueprint}
+			>
+				Start without a Blueprint
+			</Button>,
+		],
+	};
+}
+
+function invalidAssetSlugView({
+	errorDetails,
+	helpers,
+}: SiteErrorViewContext): SiteErrorViewConfig {
+	const details = errorDetails as Record<string, unknown> | undefined;
+	const message =
+		typeof details?.message === 'string' ? details.message : undefined;
+	const targetUrl = extractTargetUrl(errorDetails);
+
+	return {
+		title: 'Plugin or theme not found on WordPress.org',
+		isDeveloperError: true,
+		hideReportButton: true,
+		hideTroubleshootWithAiButton: true,
+		detailSummaryOverride: 'Technical details',
+		body: (
+			<>
+				<p className={css.errorLead}>
+					{message ||
+						'A plugin or theme slug in the Blueprint could not be found on WordPress.org.'}
+				</p>
+				{targetUrl ? (
+					<p>
+						Attempted URL:{' '}
+						<a
+							className={css.errorLink}
+							href={targetUrl}
+							target="_blank"
+							rel="noopener noreferrer"
+						>
+							{targetUrl}
+						</a>
+					</p>
+				) : null}
+				<ul className={css.errorList}>
+					<li>
+						Double-check the slug spelling in your Blueprint's{' '}
+						<code>installPlugin</code> or <code>installTheme</code>{' '}
+						step.
+					</li>
+					<li>
+						Confirm the asset is publicly available on{' '}
+						<a
+							href="https://wordpress.org/plugins/"
+							target="_blank"
+							rel="noopener noreferrer"
+						>
+							wordpress.org/plugins
+						</a>{' '}
+						or{' '}
+						<a
+							href="https://wordpress.org/themes/"
+							target="_blank"
+							rel="noopener noreferrer"
+						>
+							wordpress.org/themes
+						</a>
+						.
+					</li>
+				</ul>
+			</>
+		),
+		actions: [
 			<Button
 				variant="primary"
 				key="start-without-blueprint"

--- a/packages/playground/website/src/lib/state/redux/boot-site-client.ts
+++ b/packages/playground/website/src/lib/state/redux/boot-site-client.ts
@@ -42,6 +42,7 @@ import {
 import {
 	findFirewallErrorInCauseChain,
 	findDownloadErrorInCauseChain,
+	findInvalidSlugErrorInCauseChain,
 } from './error-utils';
 import { PHPMYADMIN_INSTALL_PATH } from '@wp-playground/tools';
 import { phpExtensionQueryArgsToExtensionsArray } from '../url/php-extension-query';
@@ -263,6 +264,13 @@ export function bootSiteClient(
 					setActiveSiteError({
 						error: 'network-firewall-interference',
 						details: firewallError,
+					})
+				);
+			} else if (findInvalidSlugErrorInCauseChain(e)) {
+				dispatch(
+					setActiveSiteError({
+						error: 'invalid-asset-slug',
+						details: e,
 					})
 				);
 			} else if (findDownloadErrorInCauseChain(e)) {

--- a/packages/playground/website/src/lib/state/redux/error-utils.ts
+++ b/packages/playground/website/src/lib/state/redux/error-utils.ts
@@ -62,12 +62,50 @@ const DOWNLOAD_ERROR_PATTERNS = [
  * WebAssembly.CompileError and LinkError occur when the browser tries
  * to compile a non-WASM response (e.g. an HTML error page) as WASM.
  * ResourceDownloadError is thrown for Blueprint resource fetch failures.
+ * InvalidAssetSlugError extends ResourceDownloadError but is checked
+ * separately so callers can show a targeted error message.
  */
 const DOWNLOAD_ERROR_CLASS_NAMES = [
 	'CompileError',
 	'LinkError',
 	'ResourceDownloadError',
+	'InvalidAssetSlugError',
 ];
+
+/**
+ * Search through an error's cause chain for an InvalidAssetSlugError.
+ * Returns the slug and assetType if found, otherwise undefined.
+ *
+ * Checks both instanceof and the error's name property to handle
+ * Comlink-serialized errors (which lose their prototype chain).
+ */
+export function findInvalidSlugErrorInCauseChain(
+	error: unknown
+): { slug: string; assetType: string } | undefined {
+	let current: unknown = error;
+	const seen = new Set<Error>();
+	let depth = 0;
+	while (current && depth < MAX_CAUSE_CHAIN_DEPTH) {
+		if (current instanceof Error) {
+			if (seen.has(current)) {
+				break;
+			}
+			seen.add(current);
+			const className =
+				(current as any).originalErrorClassName || current.name;
+			if (className === 'InvalidAssetSlugError') {
+				return {
+					slug: String((current as any).slug ?? 'unknown'),
+					assetType: String((current as any).assetType ?? 'asset'),
+				};
+			}
+		}
+		current =
+			current instanceof Error ? (current as Error).cause : undefined;
+		depth++;
+	}
+	return undefined;
+}
 
 /**
  * Search through an error's cause chain to find a network/download error.

--- a/packages/playground/website/src/lib/state/redux/slice-ui.ts
+++ b/packages/playground/website/src/lib/state/redux/slice-ui.ts
@@ -15,6 +15,7 @@ export type SiteError =
 	| 'blueprint-filesystem-required'
 	| 'blueprint-validation-failed'
 	| 'network-firewall-interference'
+	| 'invalid-asset-slug'
 	| 'resource-download-failed';
 
 export type SiteManagerSection = 'sidebar' | 'site-details' | 'blueprints';


### PR DESCRIPTION
## What

When a Blueprint's `installPlugin` or `installTheme` step references a slug that doesn't exist on WordPress.org, the download returns HTTP 404. Previously this surfaced as the generic "Could not download required files" error with no indication that the slug itself was the problem.

This PR makes that failure actionable:

- `ResourceDownloadError` now carries an optional `statusCode` so subclasses can inspect the HTTP status.
- `FetchResource.resolve()` no longer double-wraps its own `ResourceDownloadError` in the outer catch block; unexpected network errors still get wrapped.
- New `InvalidAssetSlugError` (extends `ResourceDownloadError`) is thrown by `CorePluginResource` and `CoreThemeResource` when a 404 is received, with the slug and asset type embedded.
- New `SiteError` variant `'invalid-asset-slug'` wired through Redux (`slice-ui.ts`, `boot-site-client.ts`) and the error modal (`get-site-error-view.tsx`), showing a targeted message, the failed download URL, and links to search wordpress.org.
- New `findInvalidSlugErrorInCauseChain()` helper in `error-utils.ts` detects the error across Comlink serialisation boundaries (by `.name`, not `instanceof`).

## Why

Closes #2042. Follows the approach suggested by @bgrgicak in the issue comments: add a structured error type in the resource resolver and surface it as a dedicated modal view in the website.

## Testing

- Added `packages/playground/blueprints/src/lib/v1/resources.spec.ts` with 8 unit tests:
  - `ResourceDownloadError` carries `statusCode`
  - `InvalidAssetSlugError` is a subclass of `ResourceDownloadError` with correct fields
  - `CorePluginResource` throws `InvalidAssetSlugError` on 404, `ResourceDownloadError` (not `InvalidAssetSlugError`) on 403, and resolves on 200
  - `CoreThemeResource` same for 404 and 200
- `npx nx test playground-blueprints` — 187/187 pass
- `npx nx typecheck playground-blueprints playground-website` — clean
- `npx nx lint playground-blueprints playground-website` — clean