### PR TITLE
Warn before unloading when site has unsaved changes

### DIFF
--- a/packages/playground/website/src/components/browser-chrome/save-status-indicator.tsx
+++ b/packages/playground/website/src/components/browser-chrome/save-status-indicator.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import css from './save-status-indicator.module.css';
 import classNames from 'classnames';
 import {
@@ -36,6 +36,20 @@ export function SaveStatusIndicator() {
 	const opfsSync = clientInfo?.opfsSync;
 	const status = getSaveStatus(activeSite, clientInfo);
 	const isAutosaved = activeSite ? isAutosavedSite(activeSite) : false;
+
+	useEffect(() => {
+		if (status !== 'unsaved') {
+			return;
+		}
+		const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+			event.preventDefault();
+			return (event.returnValue = '');
+		};
+		window.addEventListener('beforeunload', handleBeforeUnload);
+		return () => {
+			window.removeEventListener('beforeunload', handleBeforeUnload);
+		};
+	}, [status]);
 	const localFsAvailability = useLocalFsAvailability(clientInfo?.client);
 	const canStorePermanently =
 		isOpfsAvailable || localFsAvailability === 'available';


### PR DESCRIPTION
## Motivation for the change, related issues

Closes #81.

Users were losing unsaved work when closing a tab with a temporary Playground site. The save-status indicator already tracked the `'unsaved'` state (sites with `storage: none`) — it just never wired up the browser's unload guard.

## Implementation details

`packages/playground/website/src/components/browser-chrome/save-status-indicator.tsx`:

- Added a `useEffect` that registers a `beforeunload` listener when `status === 'unsaved'` (temporary sites with no storage) and cleans it up when the status changes.
- Handler calls `event.preventDefault()` and sets `event.returnValue = ''` — the cross-browser pattern for triggering the native "Leave site?" dialog.
- Sites with storage (showing "Autosaved" or "Saved") are not affected.

## Screenshots

| "Unsaved" state arms the guard | Native "Leave site?" dialog on close |
| --- | --- |
| <img width="480" alt="Unsaved indicator in the toolbar" src="https://github.com/user-attachments/assets/92fc4481-20fb-4748-93b9-a41ae8c32659" /> | <img width="480" alt="Leave site? dialog on close" src="https://github.com/user-attachments/assets/6b262cfa-3ec3-4d81-a813-26f8d2d61741" /> |

## Testing Instructions (or ideally a Blueprint)

1. Open http://localhost:5400 in Chrome.
2. A temporary site loads by default — confirm the toolbar shows the yellow **"Unsaved"** indicator (not blue "Autosaved").
3. Click anywhere on the outer Playground toolbar (gear icon, layout switcher, etc.) to give Chrome a user gesture on the outer page.
4. Press **Cmd+W** (Mac) / **Ctrl+W** (Windows) — the browser shows **"Leave site? Changes that you made may not be saved."**
5. Click **Cancel** to stay on the page.
6. **Contrast**: open a site that shows "Autosaved" → Cmd+W → no dialog appears.