### PR TITLE
Show full cause chain when CLI blueprint step produces a blank error

### DIFF
--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -801,7 +801,10 @@ export async function parseOptionsAndRunCLI(argsToParse: string[]) {
 						break;
 					}
 					seenErrors.add(currentError);
-					messageChain.push(describeError(currentError));
+					const msg = describeError(currentError);
+					if (msg) {
+						messageChain.push(msg);
+					}
 					currentError =
 						currentError.cause instanceof Error
 							? currentError.cause
@@ -822,9 +825,45 @@ export async function parseOptionsAndRunCLI(argsToParse: string[]) {
 }
 
 /**
+ * Walk the cause chain and build a "X caused by: Y" message string.
+ *
+ * This is used in the startup-error catch path so that blueprint errors
+ * surface their full cause chain, matching the output produced by the
+ * outer try/catch in the CLI entry point.
+ */
+function buildErrorMessage(error: unknown): string {
+	if (!(error instanceof Error)) {
+		return describeError(error);
+	}
+	const messageChain: string[] = [];
+	const seenErrors = new Set<Error>();
+	let currentError: Error | undefined = error;
+	for (let depth = 0; currentError && depth < 20; depth++) {
+		if (seenErrors.has(currentError)) {
+			messageChain.push('[Circular error cause]');
+			break;
+		}
+		seenErrors.add(currentError);
+		const msg = describeError(currentError);
+		if (msg) {
+			messageChain.push(msg);
+		}
+		currentError =
+			currentError.cause instanceof Error
+				? currentError.cause
+				: undefined;
+	}
+	return messageChain.join(' caused by: ') || describeError(error);
+}
+
+/**
  * Describe an error for display. Handles Error instances, Comlink-serialized
  * plain objects (which lose their Error prototype during worker thread
  * transfer), and arbitrary values.
+ *
+ * When the top-level error has no message of its own, the cause chain is
+ * walked to surface the first useful description — this prevents "Error:"
+ * with a blank body when a wrapper error is created without a message.
  */
 function describeError(error: unknown): string {
 	if (error instanceof Error) {
@@ -844,6 +883,14 @@ function describeError(error: unknown): string {
 		}
 		if (parts.length > 0) {
 			return parts.join(' — ');
+		}
+		// No message on this error — try the cause chain before falling back
+		// to the stack trace, so that useful context from wrapped errors is shown.
+		if (error.cause !== undefined) {
+			const causeDescription = describeError(error.cause);
+			if (causeDescription) {
+				return causeDescription;
+			}
 		}
 		return error.stack || String(error);
 	}
@@ -1766,7 +1813,13 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer | void> {
 					phpLogs = await playgroundPool.readFileAsText(errorLogPath);
 				}
 				await disposeCLI();
-				throw new Error(phpLogs, { cause: error });
+				// Use the PHP log as the primary message only when it is
+				// non-empty; an empty phpLogs would produce a blank "Error:"
+				// and hide the original error's cause chain.
+				if (phpLogs) {
+					throw new Error(phpLogs, { cause: error });
+				}
+				throw error;
 			}
 		},
 		async handleRequest(request: PHPRequest): Promise<StreamedPHPResponse> {
@@ -1831,7 +1884,7 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer | void> {
 			return response;
 		},
 	}).catch((error) => {
-		cliOutput.printError(describeError(error));
+		cliOutput.printError(buildErrorMessage(error));
 		process.exit(1);
 	});
 


### PR DESCRIPTION
When a Blueprint runPHP step fails and the CLI is in debug mode, the catch block wraps the original error in `new Error(phpLogs, { cause })`. If the PHP error log is empty, this creates a top-level error with an empty message, and the old single-call `describeError(error)` at the startup-error catch site would print "Error:" with nothing after it.

Three-part fix:
- `describeError`: fall through to the `cause` chain when the top-level error has no message, so the first useful description bubbles up.
- Debug-mode catch: skip the wrapper when `phpLogs` is empty and re-throw the original error, preserving its message and cause chain.
- Startup-error catch: use a new `buildErrorMessage` helper that walks the full cause chain (matching the outer CLI try/catch) instead of only inspecting the top-level error.

Fixes #3614

## Motivation for the change, related issues

## Implementation details

## Testing Instructions (or ideally a Blueprint)
