### PR TITLE
Guard SQLITE_MAIN_FILE with defined() in playground_save_wp_env_info

### DIFF
--- a/packages/playground/wordpress/src/platform-mu-plugins.ts
+++ b/packages/playground/wordpress/src/platform-mu-plugins.ts
@@ -25,7 +25,9 @@ export async function writeCommonPlatformMuPlugins(
 					'path' => FQDB,
 					'driver_path' => defined('WP_MYSQL_ON_SQLITE_LOADER_PATH')
 						? WP_MYSQL_ON_SQLITE_LOADER_PATH
-						: dirname(SQLITE_MAIN_FILE) . '/wp-pdo-mysql-on-sqlite.php',
+						: (defined('SQLITE_MAIN_FILE')
+							? dirname(SQLITE_MAIN_FILE) . '/wp-pdo-mysql-on-sqlite.php'
+							: null),
 				);
 			} else {
 				$db_info = array(

--- a/packages/playground/wordpress/src/platform-mu-plugins.ts
+++ b/packages/playground/wordpress/src/platform-mu-plugins.ts
@@ -20,15 +20,12 @@ export async function writeCommonPlatformMuPlugins(
 		// Named function (not a closure) so this file parses on PHP 5.2.
 		function playground_save_wp_env_info() {
 			if (defined('DB_ENGINE') && DB_ENGINE === 'sqlite') {
-				$db_info = array(
-					'type' => 'sqlite',
-					'path' => FQDB,
-					'driver_path' => defined('WP_MYSQL_ON_SQLITE_LOADER_PATH')
-						? WP_MYSQL_ON_SQLITE_LOADER_PATH
-						: (defined('SQLITE_MAIN_FILE')
-							? dirname(SQLITE_MAIN_FILE) . '/wp-pdo-mysql-on-sqlite.php'
-							: null),
-				);
+				$db_info = array('type' => 'sqlite', 'path' => FQDB);
+				if (defined('WP_MYSQL_ON_SQLITE_LOADER_PATH')) {
+					$db_info['driver_path'] = WP_MYSQL_ON_SQLITE_LOADER_PATH;
+				} elseif (defined('SQLITE_MAIN_FILE')) {
+					$db_info['driver_path'] = dirname(SQLITE_MAIN_FILE) . '/wp-pdo-mysql-on-sqlite.php';
+				}
 			} else {
 				$db_info = array(
 					'type' => 'mysql',


### PR DESCRIPTION
## Motivation for the change, related issues

Fixes #3489.

When a Blueprint combines `login: true`, a `defineWpConfigConsts` step, and a WordPress-loading step, a secondary PHP runtime may be created to handle the wp-config rewrite. That runtime has WordPress fully booted (so `FQDB` is set by `db.php`), but `SQLITE_MAIN_FILE` is only defined via `php.defineConstant()` on the first runtime — leaving it undefined on subsequent ones.

The `playground_save_wp_env_info` hook fires on `wp_loaded` on every PHP runtime that fully boots WordPress. Without the guard, any runtime that lacks `SQLITE_MAIN_FILE` fatals with "Undefined constant".

## Implementation details

Changed `$db_info` construction to build the array without `driver_path` first, then conditionally add it only when one of the two path constants is actually defined:

- If `WP_MYSQL_ON_SQLITE_LOADER_PATH` is defined → use it (existing behaviour, unchanged).
- Else if `SQLITE_MAIN_FILE` is defined → derive the path from it (existing behaviour, unchanged).
- Otherwise → `driver_path` is omitted from the array entirely.

This avoids setting `driver_path` to `null`, which would break the consumers (`DbiMysqli.php`, `adminer-mysql-on-sqlite-driver.php`) that do `require_once $wp_env['db']['driver_path']` without a null check.

## Testing Instructions (or ideally a Blueprint)

Use a Blueprint that triggers the secondary-runtime path — for example:

```json
{
  "login": true,
  "steps": [
    {
      "step": "defineWpConfigConsts",
      "consts": { "MY_CUSTOM_CONST": "value" }
    }
  ]
}
```

Before this fix, running such a Blueprint would fatal with "Undefined constant 'SQLITE_MAIN_FILE'". After the fix it completes without error.

To verify `driver_path` still works on the main runtime: open the database panel (phpMyAdmin or Adminer) and confirm it loads normally.