### PR TITLE
[Website] Say Autosaved for known autosaved Playgrounds

### DIFF
--- a/packages/playground/website/playwright/e2e/website-ui.spec.ts
+++ b/packages/playground/website/playwright/e2e/website-ui.spec.ts
@@ -759,8 +759,9 @@ test.describe('Default Playground storage', () => {
 		expect(new URL(website.page.url()).searchParams.get('site-slug')).toBe(
 			null
 		);
+		await expect(website.page.getByText('Autosaving')).toHaveCount(0);
 		await expect(
-			website.page.getByText(/Autosaving|Finalizing autosave/)
+			website.page.getByText('Finalizing autosave')
 		).toHaveCount(0);
 		await expect(
 			website.page.getByRole('button', { name: 'Unsaved' })
@@ -790,17 +791,15 @@ test.describe('Default Playground storage', () => {
 				}
 			)
 		);
-		const autosavingIndex = saveStatusSamples.findIndex(
-			({ text }) => text === 'Autosaving'
-		);
-		const autosavedIndex = saveStatusSamples.findIndex(
-			({ text }) => text === 'Autosaved'
-		);
-		expect(autosavingIndex).toBeGreaterThan(-1);
-		expect(autosavedIndex).toBeGreaterThan(autosavingIndex);
+		expect(
+			saveStatusSamples.some(({ text }) => text === 'Autosaved')
+		).toBe(true);
+		expect(
+			saveStatusSamples.some(({ text }) => text === 'Autosaving')
+		).toBe(false);
 		expect(
 			saveStatusSamples.some(({ ariaLabel }) =>
-				/^Autosaving [1-9]\d*%$/.test(ariaLabel ?? '')
+				/^Autosaved [1-9]\d*%$/.test(ariaLabel ?? '')
 			)
 		).toBe(true);
 	});
@@ -1285,7 +1284,7 @@ test.describe('Default Playground storage', () => {
 			)
 			.toBe('explicit');
 		await expect(
-			website.page.getByText(/Autosaved|Autosaving|Finalizing autosave/)
+			website.page.getByText(/Autosaved|Finalizing autosave/)
 		).toHaveCount(0);
 		await expect(
 			website.page.getByText(/Saved Playground|Saving|Finalizing save/)

--- a/packages/playground/website/src/components/browser-chrome/save-status-indicator.tsx
+++ b/packages/playground/website/src/components/browser-chrome/save-status-indicator.tsx
@@ -261,7 +261,9 @@ function getSaveStatus(
  * Uses the sync operation when it is known, then falls back to site lifecycle.
  *
  * `initialOpfsSyncPending` alone is not enough to mean "autosaving": explicit
- * browser saves also do their first MEMFS-to-OPFS sync after boot.
+ * browser saves also do their first MEMFS-to-OPFS sync after boot. Known
+ * autosaved Playgrounds keep the completed-state label while the pending OPFS
+ * sync finishes because they are already represented as autosaves in Site Manager.
  */
 function getSyncLabel({
 	site,
@@ -270,9 +272,13 @@ function getSyncLabel({
 	site: SiteInfo | undefined;
 	opfsSync: OpfsSync | undefined;
 }) {
-	return opfsSync?.operation === 'autosave' || (site && isAutosavedSite(site))
-		? 'Autosaving'
-		: 'Saving';
+	if (opfsSync?.operation === 'save') {
+		return 'Saving';
+	}
+	if (site && isAutosavedSite(site)) {
+		return 'Autosaved';
+	}
+	return opfsSync?.operation === 'autosave' ? 'Autosaving' : 'Saving';
 }
 
 /**


### PR DESCRIPTION
## What changed

- Keep the browser chrome status label as "Autosaved" for known autosaved Playgrounds while their pending OPFS sync finishes.
- Preserve "Saving" for explicit saves and the existing "Autosaving" fallback for autosave operations without a known autosaved site.
- Update the website Playwright expectations for the autosaved-site status label.

## Why

The previous "Autosaving" label was misleading once the Playground was already known and represented as an autosave in Site Manager. The status should describe that lifecycle state as "Autosaved".

## Validation

- `git diff --check`
- `npm exec nx run playground-website:typecheck` could not run because Nx modules are not installed in this workspace.
