### PR TITLE
[Website] Make My Playgrounds overlay responsive and full-screen

### DIFF
--- a/packages/playground/website/src/components/saved-playgrounds-overlay/index.tsx
+++ b/packages/playground/website/src/components/saved-playgrounds-overlay/index.tsx
@@ -44,10 +44,8 @@ import {
 	OverlaySection,
 } from '../overlay';
 
-/**
- * Maximum stored Playgrounds to show before collapsing the list.
- */
-const MAX_VISIBLE_STORED_SITES = 8;
+const COMPACT_LAYOUT_QUERY = '(max-width: 875px)';
+const MAX_VISIBLE_COMPACT_STORED_SITES = 2;
 
 type BlueprintsIndexEntry = {
 	title: string;
@@ -64,6 +62,30 @@ export type OverlayViewMode = 'main' | 'blueprints';
 interface SavedPlaygroundsOverlayProps {
 	onClose: () => void;
 	initialViewMode?: OverlayViewMode;
+}
+
+function useIsCompactLayout() {
+	const [isCompactLayout, setIsCompactLayout] = useState(() => {
+		return (
+			typeof window !== 'undefined' &&
+			window.matchMedia(COMPACT_LAYOUT_QUERY).matches
+		);
+	});
+
+	useEffect(() => {
+		const mediaQuery = window.matchMedia(COMPACT_LAYOUT_QUERY);
+		const updateIsCompactLayout = () => {
+			setIsCompactLayout(mediaQuery.matches);
+		};
+
+		updateIsCompactLayout();
+		mediaQuery.addEventListener('change', updateIsCompactLayout);
+		return () => {
+			mediaQuery.removeEventListener('change', updateIsCompactLayout);
+		};
+	}, []);
+
+	return isCompactLayout;
 }
 
 function PullRequestIcon() {
@@ -100,6 +122,7 @@ export function SavedPlaygroundsOverlay({
 	const [pendingZipTargetSlug, setPendingZipTargetSlug] = useState<
 		string | null
 	>(null);
+	const isCompactLayout = useIsCompactLayout();
 
 	useEffect(() => {
 		if (
@@ -363,12 +386,6 @@ export function SavedPlaygroundsOverlay({
 		},
 	];
 
-	const visibleStoredSites = showAllStoredSites
-		? storedSites
-		: storedSites.slice(0, MAX_VISIBLE_STORED_SITES);
-	const hiddenStoredSitesCount =
-		storedSites.length - visibleStoredSites.length;
-
 	function formatSiteCreatedDate(site: SiteInfo) {
 		return site.metadata.whenCreated
 			? new Date(site.metadata.whenCreated).toLocaleDateString(
@@ -424,9 +441,15 @@ export function SavedPlaygroundsOverlay({
 								type="button"
 								className={css.keepButton}
 								onClick={() => openSaveModalForSite(site)}
+								aria-label="Store this Playground permanently"
 								title="Store this Playground permanently so it is not pruned from recent autosaves."
 							>
-								Store permanently
+								<span className={css.keepButtonFullText}>
+									Store permanently
+								</span>
+								<span className={css.keepButtonCompactText}>
+									Keep
+								</span>
 							</button>
 						)}
 						<DropdownMenu
@@ -486,6 +509,12 @@ export function SavedPlaygroundsOverlay({
 	}
 
 	function renderYourPlaygroundsSection() {
+		const visibleStoredSites =
+			isCompactLayout && !showAllStoredSites
+				? storedSites.slice(0, MAX_VISIBLE_COMPACT_STORED_SITES)
+				: storedSites;
+		const hiddenStoredSitesCount =
+			storedSites.length - visibleStoredSites.length;
 		const visibleSites = [
 			...(temporarySite ? [temporarySite] : []),
 			...visibleStoredSites,
@@ -494,7 +523,10 @@ export function SavedPlaygroundsOverlay({
 		return (
 			<OverlaySection
 				title="Your Playgrounds"
-				className={css.playgroundsSection}
+				className={classNames(
+					css.playgroundsSection,
+					css.yourPlaygroundsSection
+				)}
 			>
 				{visibleSites.length === 0 ? (
 					<p className={css.emptyMessage}>
@@ -510,19 +542,26 @@ export function SavedPlaygroundsOverlay({
 						{visibleSites.map(renderSiteRow)}
 					</div>
 				)}
-				{hiddenStoredSitesCount > 0 && (
+				{isCompactLayout && hiddenStoredSitesCount > 0 && (
 					<button
 						type="button"
-						className={css.showMoreButton}
-						onClick={() =>
-							setShowAllStoredSites(!showAllStoredSites)
-						}
+						className={css.viewAllPlaygroundsButton}
+						onClick={() => setShowAllStoredSites(true)}
 					>
-						{showAllStoredSites
-							? 'Show fewer Playgrounds'
-							: `Show ${hiddenStoredSitesCount} more Playgrounds`}
+						View all
 					</button>
 				)}
+				{isCompactLayout &&
+					showAllStoredSites &&
+					storedSites.length > MAX_VISIBLE_COMPACT_STORED_SITES && (
+						<button
+							type="button"
+							className={css.viewAllPlaygroundsButton}
+							onClick={() => setShowAllStoredSites(false)}
+						>
+							Show fewer
+						</button>
+					)}
 			</OverlaySection>
 		);
 	}
@@ -726,7 +765,6 @@ export function SavedPlaygroundsOverlay({
 			</button>
 			<OverlayBody className={css.playgroundsBody}>
 				<div className={css.playgroundsColumns}>
-					{renderYourPlaygroundsSection()}
 					<OverlaySection
 						title="Start a new Playground"
 						className={css.playgroundsSection}
@@ -771,62 +809,70 @@ export function SavedPlaygroundsOverlay({
 							})}
 						</div>
 					</OverlaySection>
-				</div>
+					{renderYourPlaygroundsSection()}
 
-				<OverlaySection
-					title="Start from a Blueprint"
-					className={classNames(
-						css.playgroundsSection,
-						css.blueprintsSection
-					)}
-				>
-					{blueprintsLoading ? (
-						<div className={css.loadingContainer}>
-							<Spinner />
-						</div>
-					) : blueprintsError ? (
-						<p className={css.emptyMessage}>
-							Unable to load blueprints. Check your connection.
-						</p>
-					) : (
-						<div className={css.blueprintsRow}>
-							{allBlueprints.map((blueprint) => (
-								<button
-									key={blueprint.path}
-									className={css.blueprintPreviewCard}
-									onClick={() =>
-										previewBlueprint(blueprint.path)
-									}
-								>
-									<div
-										className={
-											css.blueprintPreviewThumbnail
+					<OverlaySection
+						title="Start from a Blueprint"
+						className={classNames(
+							css.playgroundsSection,
+							css.blueprintsSection
+						)}
+					>
+						{blueprintsLoading ? (
+							<div className={css.loadingContainer}>
+								<Spinner />
+							</div>
+						) : blueprintsError ? (
+							<p className={css.emptyMessage}>
+								Unable to load blueprints. Check your
+								connection.
+							</p>
+						) : (
+							<div className={css.blueprintsRow}>
+								{allBlueprints.map((blueprint) => (
+									<button
+										key={blueprint.path}
+										className={css.blueprintPreviewCard}
+										onClick={() =>
+											previewBlueprint(blueprint.path)
 										}
 									>
-										{blueprint.screenshot_url ? (
-											<img
-												src={blueprint.screenshot_url}
-												alt=""
-												loading="lazy"
-											/>
-										) : (
-											<div
-												className={
-													css.blueprintPlaceholder
-												}
-											>
-												<WordPressIcon />
-											</div>
-										)}
-									</div>
-									<span className={css.blueprintPreviewTitle}>
-										{blueprint.title}
-									</span>
-								</button>
-							))}
-						</div>
-					)}
-				</OverlaySection>
+										<div
+											className={
+												css.blueprintPreviewThumbnail
+											}
+										>
+											{blueprint.screenshot_url ? (
+												<img
+													src={
+														blueprint.screenshot_url
+													}
+													alt=""
+													loading="lazy"
+												/>
+											) : (
+												<div
+													className={
+														css.blueprintPlaceholder
+													}
+												>
+													<WordPressIcon />
+												</div>
+											)}
+										</div>
+										<span
+											className={
+												css.blueprintPreviewTitle
+											}
+										>
+											{blueprint.title}
+										</span>
+									</button>
+								))}
+							</div>
+						)}
+					</OverlaySection>
+				</div>
 			</OverlayBody>
 		</Overlay>
 	);

--- a/packages/playground/website/src/components/saved-playgrounds-overlay/style.module.css
+++ b/packages/playground/website/src/components/saved-playgrounds-overlay/style.module.css
@@ -353,7 +353,11 @@
 	border-color: #8fa1ff;
 }
 
-.showMoreButton {
+.keepButtonCompactText {
+	display: none;
+}
+
+.viewAllPlaygroundsButton {
 	align-items: center;
 	background: transparent;
 	border: 1px solid #3c4349;
@@ -367,7 +371,7 @@
 	padding: 8px 12px;
 }
 
-.showMoreButton:hover {
+.viewAllPlaygroundsButton:hover {
 	background: #2c3338;
 	color: #fff;
 }
@@ -585,16 +589,19 @@
 }
 
 .playgroundsOverlay.playgroundsOverlay {
-	--playgrounds-overlay-top: 50px;
+	--playgrounds-overlay-top: 36px;
+	--playgrounds-close-button-top: 24px;
 	--playgrounds-close-button-offset: 20px;
 	--playgrounds-body-top-padding: calc(
 		var(--playgrounds-close-button-offset) + 52px
 	);
-	top: var(--playgrounds-overlay-top);
+	overscroll-behavior: none;
 }
 
 .playgroundsContent.playgroundsContent {
+	box-sizing: border-box;
 	max-width: none;
+	padding-top: var(--playgrounds-overlay-top);
 }
 
 .playgroundsBody.playgroundsBody {
@@ -603,9 +610,10 @@
 
 .playgroundsCloseButton {
 	align-items: center;
-	background: transparent;
+	background: #1e2327;
 	border: none;
 	border-radius: 4px;
+	box-shadow: 0 0 0 12px #1e2327;
 	color: #949494;
 	cursor: pointer;
 	display: flex;
@@ -613,14 +621,12 @@
 	padding: 4px;
 	position: fixed;
 	right: 24px;
-	top: calc(
-		var(--playgrounds-overlay-top) + var(--playgrounds-close-button-offset)
-	);
+	top: var(--playgrounds-close-button-top);
 	z-index: 101;
 }
 
 .playgroundsCloseButton:hover {
-	background: rgba(255, 255, 255, 0.1);
+	background: #2c3338;
 	color: #fff;
 }
 
@@ -632,9 +638,14 @@
 	align-items: start;
 	column-gap: clamp(48px, 9.5vw, 137px);
 	display: grid;
-	grid-template-columns: minmax(420px, 710px) minmax(420px, 492px);
-	margin-bottom: 96px;
+	row-gap: 28px;
+	grid-template-columns: minmax(420px, 492px) minmax(420px, 710px);
+	margin: 0 auto;
 	max-width: 1339px;
+}
+
+.playgroundsColumns > * {
+	min-width: 0;
 }
 
 .playgroundsSection {
@@ -645,6 +656,10 @@
 	font-size: clamp(24px, 2.2vw, 28px) !important;
 	line-height: 1.2 !important;
 	margin-bottom: 18px !important;
+}
+
+.playgroundsColumns .playgroundsSection h2 {
+	text-align: center;
 }
 
 .playgroundsList .siteRowContent {
@@ -677,6 +692,12 @@
 
 .playgroundsList .siteRowMenu {
 	margin-right: 16px;
+}
+
+.playgroundsList {
+	max-height: 273px;
+	overflow-y: auto;
+	scrollbar-gutter: stable;
 }
 
 .playgroundsSection .creationRow {
@@ -715,8 +736,12 @@
 .blueprintsSection .blueprintsRow {
 	display: grid;
 	gap: 24px 20px;
-	grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+	grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
 	padding: 0 8px 16px 0;
+}
+
+.blueprintsSection {
+	grid-column: 1 / -1;
 }
 
 .blueprintsSection .blueprintPreviewCard {
@@ -735,7 +760,7 @@
 @media (max-width: 1050px) {
 	.playgroundsColumns {
 		column-gap: 48px;
-		grid-template-columns: minmax(380px, 1fr) minmax(360px, 440px);
+		grid-template-columns: minmax(360px, 440px) minmax(380px, 1fr);
 	}
 
 	.playgroundsSection .creationTitle {
@@ -745,9 +770,22 @@
 
 @media (max-width: 875px) {
 	.playgroundsColumns {
-		gap: 48px;
+		gap: 40px;
 		grid-template-columns: 1fr;
-		margin-bottom: 64px;
+	}
+
+	.blueprintsSection {
+		order: 3;
+	}
+
+	.yourPlaygroundsSection {
+		order: 2;
+	}
+
+	.playgroundsList {
+		max-height: none;
+		overflow-y: visible;
+		scrollbar-gutter: auto;
 	}
 
 	.playgroundsSection .creationRow {
@@ -758,11 +796,52 @@
 		gap: 8px;
 		grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
 	}
+
+	.blueprintsSection .blueprintPreviewCard {
+		align-items: center;
+		background: none;
+		border: none;
+		flex-direction: column;
+		gap: 8px;
+		overflow: visible;
+		padding: 0;
+	}
+
+	.blueprintsSection .blueprintPreviewThumbnail {
+		aspect-ratio: 4 / 3;
+		border: 2px solid #3c4349;
+		border-radius: 8px;
+		height: auto;
+		width: 100% !important;
+	}
+
+	.blueprintsSection .blueprintPreviewTitle {
+		font-size: 16px;
+		text-align: center;
+		white-space: normal;
+	}
 }
 
 @media (max-width: 640px) {
+	.playgroundsOverlay.playgroundsOverlay {
+		--playgrounds-overlay-top: 24px;
+		--playgrounds-close-button-top: calc(
+			var(--playgrounds-overlay-top) +
+				var(--playgrounds-close-button-offset)
+		);
+		--playgrounds-close-button-offset: 16px;
+	}
+
 	.playgroundsBody.playgroundsBody {
 		padding: var(--playgrounds-body-top-padding) 20px 48px;
+	}
+
+	.playgroundsCloseButton {
+		right: 8px;
+	}
+
+	.playgroundsColumns {
+		gap: 32px;
 	}
 
 	.playgroundsList .siteRowContent {
@@ -787,14 +866,46 @@
 		font-size: 13px;
 	}
 
+	.keepButtonFullText {
+		display: none;
+	}
+
+	.keepButtonCompactText {
+		display: inline;
+	}
+
 	.playgroundsSection .creationRow {
+		gap: 8px;
 		grid-template-columns: repeat(2, minmax(0, 1fr));
+	}
+
+	.playgroundsSection .creationButton {
+		min-height: 86px;
+		padding: 10px 6px;
+	}
+
+	.playgroundsSection .creationIcon {
+		height: 30px;
+		width: 30px;
+	}
+
+	.playgroundsSection .creationIcon :global(svg) {
+		height: 24px;
+		width: 24px;
+	}
+
+	.playgroundsSection .newPlaygroundIcon :global(svg) {
+		height: 28px;
+		width: 28px;
+	}
+
+	.playgroundsSection .creationTitle {
+		font-size: 14px;
 	}
 }
 
 @media (max-width: 500px) {
 	.playgroundsOverlay.playgroundsOverlay {
-		--playgrounds-overlay-top: 96px;
 		--playgrounds-close-button-offset: 16px;
 	}
 }


### PR DESCRIPTION
## What it does

Makes the `Your Playgrounds` overlay use the full viewport while preserving the modal's content structure.

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/WordPress/wordpress-playground/decb95d057de83cd5b11679394385d45d32ba20d/.github/pr-screenshots/3795-before-desktop.png" alt="Before: the overlay starts below the toolbar, Your Playgrounds appears first, and Blueprint tiles are smaller" width="420" /> | <img src="https://raw.githubusercontent.com/WordPress/wordpress-playground/decb95d057de83cd5b11679394385d45d32ba20d/.github/pr-screenshots/3795-after-desktop.png" alt="After: full-screen overlay with Start a new Playground on the left, Your Playgrounds on the right, and larger Blueprint previews" width="420" /> |

## Rationale

The overlay was visually split between the browser chrome area and its own modal content. On smaller screens, the close button could collide with the scrolled content; on desktop, the layout also regressed from the intended ordering and Blueprint tile sizing.

## Implementation

- Removes the overlay top offset so the modal covers the whole viewport.
- Keeps `Start a new Playground` on the left and `Your Playgrounds` on the right on desktop.
- Places `Start from a Blueprint` below both sections with larger desktop previews.
- Uses compact behavior below `875px`, including shorter stored-site labels and a limited default list.
- Keeps the close button fixed, with separate desktop and mobile offsets so it stays visible without crowding content.

## Testing instructions

1. Open `http://127.0.0.1:5400/website-server/`.
2. Open `Your Playgrounds`.
3. On desktop, verify the overlay is full-screen, the close button is inset from the edge, and Blueprint previews are large.
4. Resize below `875px` and verify the sections stack as: start options, your playgrounds, blueprints.
5. Scroll on mobile and verify the close button remains visible without overlapping content.

Validated with:

```bash
git diff --check
npx nx lint playground-website --lintFilePatterns=packages/playground/website/src/components/saved-playgrounds-overlay/index.tsx
```

GitHub Actions passed on this PR.
