### PR TITLE
[Personal-WP] Fix relay routing

### DIFF
--- a/packages/playground/personal-wp/src/components/site-manager/site-info-panel/index.tsx
+++ b/packages/playground/personal-wp/src/components/site-manager/site-info-panel/index.tsx
@@ -46,6 +46,7 @@ import {
 	subscribeToRemoteAccessStatus,
 } from '../../../lib/remote-access-service';
 import { normalizeVerificationCode } from '@wp-playground/remote-access';
+import { logPersonalWpEvent } from '../../../lib/personalwp/usage-stats';
 import css from './style.module.css';
 
 const SiteFileBrowser = lazy(() =>
@@ -149,6 +150,7 @@ function RemoteAccessSection() {
 		setMessage(null);
 		try {
 			const shareUrl = await startRemoteAccess(playground);
+			logPersonalWpEvent('remote_access_started');
 			setMessage(
 				(await copyUrl(shareUrl))
 					? 'Remote access link copied.'

--- a/packages/playground/personal-wp/src/lib/personalwp/usage-stats.ts
+++ b/packages/playground/personal-wp/src/lib/personalwp/usage-stats.ts
@@ -17,7 +17,8 @@ type JsonValue =
 export type PersonalWpUsageStatsEvent =
 	| 'wordpress_installed'
 	| 'returning_visit'
-	| 'blueprint_installed';
+	| 'blueprint_installed'
+	| 'remote_access_started';
 
 export type PersonalWpUsageStatsProperties = Record<string, JsonValue>;
 export type BlueprintInstallUsageStatsTrigger =

--- a/packages/playground/website-deployment/custom-redirects-lib.php
+++ b/packages/playground/website-deployment/custom-redirects-lib.php
@@ -389,7 +389,7 @@ function playground_maybe_set_environment( $requested_path ) {
 		return true;
 	}
 
-	if ( str_ends_with( $requested_path, 'relay.php' ) ) {
+	if ( basename( $requested_path ) === 'relay.php' ) {
 		// Define DB_PASSWORD early so Atomic_Persistent_Data can work.
 		__atomic_env_define( 'DB_PASSWORD' );
 		return true;

--- a/packages/playground/website-deployment/custom-redirects-lib.php
+++ b/packages/playground/website-deployment/custom-redirects-lib.php
@@ -186,6 +186,16 @@ function playground_maybe_rewrite( $original_requested_path ) {
 		$requested_path = '/plugin-proxy.php';
 	}
 
+	if (
+		playground_is_my_wordpress_net_request() &&
+		(
+			'/relay' === $requested_path ||
+			str_starts_with( $requested_path, '/relay/' )
+		)
+	) {
+		$requested_path = '/relay.php';
+	}
+
 	if ( $requested_path !== $original_requested_path ) {
 		return $requested_path;
 	}
@@ -379,6 +389,12 @@ function playground_maybe_set_environment( $requested_path ) {
 		return true;
 	}
 
+	if ( str_ends_with( $requested_path, 'relay.php' ) ) {
+		// Define DB_PASSWORD early so Atomic_Persistent_Data can work.
+		__atomic_env_define( 'DB_PASSWORD' );
+		return true;
+	}
+
 	return false;
 }
 
@@ -387,7 +403,7 @@ function playground_get_custom_response_headers( $requested_path ) {
 
 	if ( 'iframe-worker.html' === $filename ) {
 		return array( 'Origin-Agent-Cluster: ?1' );
-	} elseif ( in_array( $filename, array( 'mywp-event.php', 'mywp-event-dashboard.php' ), true ) ) {
+	} elseif ( in_array( $filename, array( 'mywp-event.php', 'mywp-event-dashboard.php', 'relay.php' ), true ) ) {
 		return array( 'Cache-Control: no-store' );
 	} elseif ( str_ends_with( $filename, 'store.zip' ) ) {
 		// Disable compression so zip file can be read piece by piece

--- a/packages/playground/website-deployment/my-wordpress-net/mywp-event-dashboard.php
+++ b/packages/playground/website-deployment/my-wordpress-net/mywp-event-dashboard.php
@@ -996,6 +996,7 @@ function mywp_event_dashboard_get_current_area( $groups ) {
 				'new-installs',
 				'returning-visitors',
 				'blueprint-installs',
+				'remote-access',
 			),
 			true
 		)
@@ -1012,6 +1013,7 @@ function mywp_event_dashboard_area( $type, $plugin_slug = null ) {
 		'new-installs' => 'New installs',
 		'returning-visitors' => 'Returning visitors',
 		'blueprint-installs' => 'Blueprint installs',
+		'remote-access' => 'Remote Access',
 		'plugin' => 'Plugin',
 	);
 
@@ -1040,6 +1042,7 @@ function mywp_event_dashboard_render_area_controls(
 		mywp_event_dashboard_area( 'new-installs' ),
 		mywp_event_dashboard_area( 'returning-visitors' ),
 		mywp_event_dashboard_area( 'blueprint-installs' ),
+		mywp_event_dashboard_area( 'remote-access' ),
 	);
 	$plugin_slug_rows = mywp_event_dashboard_plugin_slug_rows( $groups );
 	?>
@@ -1167,6 +1170,18 @@ function mywp_event_dashboard_render_area(
 					'blueprint_installed:request_source',
 					'blueprint_installed:blueprint_source',
 				),
+				$stats,
+				$groups,
+				$metric_definitions
+			);
+			return;
+
+		case 'remote-access':
+			mywp_event_dashboard_render_event_area(
+				'Remote Access',
+				'Remote Access sessions started from Site Tools.',
+				'remote_access_started',
+				array(),
 				$stats,
 				$groups,
 				$metric_definitions
@@ -1332,6 +1347,10 @@ function mywp_event_dashboard_render_overview_cards( $groups ) {
 		$groups,
 		'blueprint_installed'
 	);
+	$remote_access_started = mywp_event_dashboard_event_count(
+		$groups,
+		'remote_access_started'
+	);
 	$total_views = mywp_event_dashboard_sum_views( $groups['event'] ?? array() );
 	?>
 	<section class="grid" aria-label="Event totals">
@@ -1354,6 +1373,13 @@ function mywp_event_dashboard_render_overview_cards( $groups ) {
 			<div class="stat-number"><?php echo mywp_event_dashboard_number( $blueprint_installs ); ?></div>
 			<div class="kpi-detail">
 				<?php echo mywp_event_dashboard_ratio( $blueprint_installs, $new_installs ); ?> per new install
+			</div>
+		</div>
+		<div class="panel">
+			<div class="muted">Remote Access starts</div>
+			<div class="stat-number"><?php echo mywp_event_dashboard_number( $remote_access_started ); ?></div>
+			<div class="kpi-detail">
+				<?php echo mywp_event_dashboard_ratio( $remote_access_started, $new_installs ); ?> per new install
 			</div>
 		</div>
 		<div class="panel">
@@ -1436,6 +1462,7 @@ function mywp_event_dashboard_order_event_values( $event_values ) {
 		'wordpress_installed',
 		'returning_visit',
 		'blueprint_installed',
+		'remote_access_started',
 	);
 	$ordered_values = array();
 	foreach ( $preferred_order as $event_value ) {
@@ -1583,6 +1610,7 @@ function mywp_event_dashboard_event_color( $event ) {
 		'wordpress_installed' => '#0a7a69',
 		'returning_visit' => '#3858e9',
 		'blueprint_installed' => '#b26200',
+		'remote_access_started' => '#8a2424',
 	);
 
 	if ( isset( $colors[ $event ] ) ) {
@@ -1607,6 +1635,7 @@ function mywp_event_dashboard_event_label( $event ) {
 		'wordpress_installed' => 'New installs',
 		'returning_visit' => 'Returning visits',
 		'blueprint_installed' => 'Blueprint installs',
+		'remote_access_started' => 'Remote Access starts',
 	);
 
 	return $labels[ $event ] ?? $event;

--- a/packages/playground/website-deployment/my-wordpress-net/mywp-event.php
+++ b/packages/playground/website-deployment/my-wordpress-net/mywp-event.php
@@ -10,6 +10,7 @@ const MYWP_EVENT_ALLOWED_EVENTS = array(
 	'wordpress_installed',
 	'returning_visit',
 	'blueprint_installed',
+	'remote_access_started',
 );
 
 if ( 'cli' !== php_sapi_name() ) {

--- a/packages/playground/website-deployment/my-wordpress-net/mywp-event.php
+++ b/packages/playground/website-deployment/my-wordpress-net/mywp-event.php
@@ -230,6 +230,10 @@ function mywp_event_collect_stat_bumps( $payload ) {
 	$bumps = array();
 	mywp_event_add_bump( $bumps, 'event', $event );
 
+	if ( 'remote_access_started' === $event ) {
+		return $bumps;
+	}
+
 	mywp_event_add_allowed_property(
 		$bumps,
 		$event,

--- a/packages/playground/website-deployment/tests.php
+++ b/packages/playground/website-deployment/tests.php
@@ -85,7 +85,33 @@ assert_equal(
     'My WordPress event dashboard should not be edge cached'
 );
 
+$mywp_relay_headers = playground_get_custom_response_headers( '/relay.php' );
+assert_equal(
+    true,
+    in_array( 'Cache-Control: no-store', $mywp_relay_headers, true ),
+    'My WordPress relay endpoint should not be edge cached'
+);
+
 $mywp_event_server_snapshot = $_SERVER;
+
+$_SERVER['HTTP_HOST'] = 'my.wordpress.net';
+assert_equal(
+    '/relay.php',
+    playground_maybe_rewrite( '/relay/session' ),
+    'My WordPress relay session endpoint should be routed to relay.php'
+);
+assert_equal(
+    '/relay.php',
+    playground_maybe_rewrite( '/relay/session/abc/signal' ),
+    'My WordPress relay subpaths should be routed to relay.php'
+);
+
+$_SERVER['HTTP_HOST'] = 'playground.wordpress.net';
+assert_equal(
+    false,
+    playground_maybe_rewrite( '/relay/session' ),
+    'Playground host should not route relay paths to my.wordpress.net relay.php'
+);
 
 $_SERVER['HTTP_HOST'] = 'my.wordpress.net';
 assert_equal(
@@ -376,6 +402,16 @@ assert_equal(
 );
 
 assert_equal(
+    '/mywp-event-dashboard.php?range=30&granularity=day&area=remote-access',
+    mywp_event_dashboard_filter_url(
+        30,
+        'day',
+        mywp_event_dashboard_area( 'remote-access' )
+    ),
+    'Dashboard filter URLs should support the Remote Access area'
+);
+
+assert_equal(
     7,
     mywp_event_dashboard_metric_value_count(
         array(
@@ -554,6 +590,24 @@ assert_equal(
         true
     ),
     'Allowed request source was not counted'
+);
+
+$remote_access_bumps = mywp_event_collect_stat_bumps( array(
+    'schema' => 'personal-wp-event/v1',
+    'app' => 'personal-wp',
+    'event' => 'remote_access_started',
+) );
+
+assert_equal(
+    array(
+        array(
+            'name' => 'event',
+            'value' => 'remote_access_started',
+            'views' => 1,
+        ),
+    ),
+    $remote_access_bumps,
+    'Remote Access starts should be counted as aggregate events only'
 );
 
 assert_equal(

--- a/packages/playground/website-deployment/tests.php
+++ b/packages/playground/website-deployment/tests.php
@@ -596,6 +596,10 @@ $remote_access_bumps = mywp_event_collect_stat_bumps( array(
     'schema' => 'personal-wp-event/v1',
     'app' => 'personal-wp',
     'event' => 'remote_access_started',
+    'properties' => array(
+        'site_age_bucket' => '1-7-days',
+        'previous_visit_age_bucket' => 'same-day',
+    ),
 ) );
 
 assert_equal(


### PR DESCRIPTION
## What

Fixes My WordPress deployment routing so `/relay/*` requests, including `POST /relay/session`, execute `relay.php` instead of falling through to the My WordPress index fallback.

The relay PHP endpoint is also marked `Cache-Control: no-store` and gets the DB environment setup path used by the other My WordPress PHP endpoints.

This also tracks aggregate Remote Access starts through the existing `mywp-event.php` pipeline and exposes the count in the stats dashboard. The event records only the aggregate event name `remote_access_started`; it does not include access codes, session IDs, URLs, or device details.

## Validation

- `php packages/playground/website-deployment/tests.php`
- `php -l packages/playground/website-deployment/custom-redirects-lib.php`
- `php -l packages/playground/website-deployment/my-wordpress-net/mywp-event.php`
- `php -l packages/playground/website-deployment/my-wordpress-net/mywp-event-dashboard.php`
- `npm exec nx lint playground-personal-wp`
- `npm exec nx typecheck playground-personal-wp`
- `npm exec nx test playground-personal-wp --testFile=usage-stats.spec.ts`
- `git diff --check`
