### PR TITLE
Use direct relay.php endpoints for Remote Access

### DIFF
--- a/packages/playground/personal-wp/src/components/remote-access-viewer/index.tsx
+++ b/packages/playground/personal-wp/src/components/remote-access-viewer/index.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import css from './style.module.css';
 import {
 	buildConnectUrlFromScopedIframeUrl,
+	buildRemoteAccessRelayEndpointUrl,
 	buildRemoteAccessScopedIframeUrl,
 	clearRemoteAccessRelayMapping,
 	DirectTunnelGuest,
@@ -105,9 +106,14 @@ export function RemoteAccessViewer({ sessionId }: RemoteAccessViewerProps) {
 
 	const statusUrl = useMemo(
 		() =>
-			`${window.location.origin}/relay/${sessionId}/status?gid=${encodeURIComponent(
-				guestId
-			)}`,
+			buildRemoteAccessRelayEndpointUrl(
+				window.location.origin,
+				'status',
+				{
+					sessionId,
+					gid: guestId,
+				}
+			),
 		[guestId, sessionId]
 	);
 

--- a/packages/playground/remote-access/README.md
+++ b/packages/playground/remote-access/README.md
@@ -31,7 +31,7 @@ reuse the same pieces without copying them.
 A consuming package needs to provide four app-specific pieces around this
 package:
 
-1. A deployed copy of `relay.php` at `/relay/*`, backed by the Remote Access
+1. A deployed copy of `relay.php` at `/relay.php`, backed by the Remote Access
    MySQL tables.
 2. A host UI that can access a running Playground client and call
    `RemoteAccessHostController.start(playgroundClient)`.
@@ -48,7 +48,18 @@ API.
 
 ## Server Relay
 
-Deploy `relay.php` so these paths reach it:
+Deploy `relay.php` so it can be called directly. The client uses these direct
+endpoints:
+
+- `POST /relay.php?action=session`
+- `GET /relay.php?action=code&accessCode=:accessCode`
+- `GET /relay.php?action=status&sessionId=:sessionId`
+- `GET /relay.php?action=signal&sessionId=:sessionId`
+- `POST /relay.php?action=signal&sessionId=:sessionId`
+- `POST /relay.php?action=close&sessionId=:sessionId`
+
+The relay also accepts these pretty paths for deployments that route them to
+`relay.php`:
 
 - `POST /relay/session`
 - `GET /relay/code/:accessCode`

--- a/packages/playground/remote-access/relay.php
+++ b/packages/playground/remote-access/relay.php
@@ -39,9 +39,14 @@ if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
 
 $path = parse_url($_SERVER['REQUEST_URI'] ?? '/', PHP_URL_PATH) ?: '/';
 $path = preg_replace('#^/website-server#', '', $path);
+$relayAction = getQueryStringValue('action');
 
 try {
-    if ($path === '/relay/session' && $_SERVER['REQUEST_METHOD'] === 'POST') {
+    if ($relayAction !== null) {
+        if (!handleDirectRelayRequest($relayAction)) {
+            jsonResponse(['error' => 'Not found'], 404);
+        }
+    } elseif ($path === '/relay/session' && $_SERVER['REQUEST_METHOD'] === 'POST') {
         handleCreateSession();
     } elseif (preg_match('#^/relay/code/([0-9-]+)$#', $path, $matches) && $_SERVER['REQUEST_METHOD'] === 'GET') {
         handleResolveAccessCode($matches[1]);
@@ -63,6 +68,64 @@ try {
 } catch (Throwable $e) {
     error_log('Remote access relay error: ' . $e->getMessage());
     jsonResponse(['error' => 'Remote access relay error'], 500);
+}
+
+function handleDirectRelayRequest(string $action): bool {
+    if ($action === 'session' && $_SERVER['REQUEST_METHOD'] === 'POST') {
+        handleCreateSession();
+        return true;
+    }
+
+    if ($action === 'code' && $_SERVER['REQUEST_METHOD'] === 'GET') {
+        $accessCode = getQueryStringValue('accessCode');
+        if ($accessCode === null) {
+            return false;
+        }
+        handleResolveAccessCode($accessCode);
+        return true;
+    }
+
+    if ($action === 'status' && $_SERVER['REQUEST_METHOD'] === 'GET') {
+        $sessionId = getQueryStringValue('sessionId');
+        if ($sessionId === null) {
+            return false;
+        }
+        handleStatus($sessionId);
+        return true;
+    }
+
+    if ($action === 'signal') {
+        $sessionId = getQueryStringValue('sessionId');
+        if ($sessionId === null) {
+            return false;
+        }
+        if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+            handlePostSignal($sessionId);
+            return true;
+        }
+        if ($_SERVER['REQUEST_METHOD'] === 'GET') {
+            handlePollSignal($sessionId);
+            return true;
+        }
+    }
+
+    if ($action === 'close' && $_SERVER['REQUEST_METHOD'] === 'POST') {
+        $sessionId = getQueryStringValue('sessionId');
+        if ($sessionId === null) {
+            return false;
+        }
+        handleClose($sessionId);
+        return true;
+    }
+
+    return false;
+}
+
+function getQueryStringValue(string $name): ?string {
+    if (!isset($_GET[$name]) || !is_string($_GET[$name])) {
+        return null;
+    }
+    return $_GET[$name];
 }
 
 function handleCreateSession(): void {

--- a/packages/playground/remote-access/relay.php
+++ b/packages/playground/remote-access/relay.php
@@ -79,7 +79,8 @@ function handleDirectRelayRequest(string $action): bool {
     if ($action === 'code' && $_SERVER['REQUEST_METHOD'] === 'GET') {
         $accessCode = getQueryStringValue('accessCode');
         if ($accessCode === null) {
-            return false;
+            jsonResponse(['error' => 'Missing accessCode'], 400);
+            return true;
         }
         handleResolveAccessCode($accessCode);
         return true;
@@ -88,7 +89,8 @@ function handleDirectRelayRequest(string $action): bool {
     if ($action === 'status' && $_SERVER['REQUEST_METHOD'] === 'GET') {
         $sessionId = getQueryStringValue('sessionId');
         if ($sessionId === null) {
-            return false;
+            jsonResponse(['error' => 'Missing sessionId'], 400);
+            return true;
         }
         handleStatus($sessionId);
         return true;
@@ -97,7 +99,8 @@ function handleDirectRelayRequest(string $action): bool {
     if ($action === 'signal') {
         $sessionId = getQueryStringValue('sessionId');
         if ($sessionId === null) {
-            return false;
+            jsonResponse(['error' => 'Missing sessionId'], 400);
+            return true;
         }
         if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             handlePostSignal($sessionId);
@@ -112,7 +115,8 @@ function handleDirectRelayRequest(string $action): bool {
     if ($action === 'close' && $_SERVER['REQUEST_METHOD'] === 'POST') {
         $sessionId = getQueryStringValue('sessionId');
         if ($sessionId === null) {
-            return false;
+            jsonResponse(['error' => 'Missing sessionId'], 400);
+            return true;
         }
         handleClose($sessionId);
         return true;

--- a/packages/playground/remote-access/src/connect-code.spec.ts
+++ b/packages/playground/remote-access/src/connect-code.spec.ts
@@ -53,5 +53,17 @@ describe('remote access connect code helpers', () => {
 		).toBe(
 			'https://example.com/relay.php?action=signal&sessionId=session-1&to=guest&since=12&gid=guest+1'
 		);
+		expect(
+			buildRemoteAccessRelayEndpointUrl(
+				'https://example.com/base',
+				'session'
+			)
+		).toBe('https://example.com/base/relay.php?action=session');
+		expect(
+			buildRemoteAccessRelayEndpointUrl(
+				'https://example.com/base/',
+				'session'
+			)
+		).toBe('https://example.com/base/relay.php?action=session');
 	});
 });

--- a/packages/playground/remote-access/src/connect-code.spec.ts
+++ b/packages/playground/remote-access/src/connect-code.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+	buildRemoteAccessRelayEndpointUrl,
 	buildRemoteAccessUrl,
 	formatAccessCode,
 	normalizeAccessCode,
@@ -36,5 +37,21 @@ describe('remote access connect code helpers', () => {
 				'session-3'
 			)
 		).toBe('/connect/?tab=all&share=session-3');
+	});
+
+	it('builds direct relay.php endpoint URLs', () => {
+		expect(
+			buildRemoteAccessRelayEndpointUrl('https://example.com', 'session')
+		).toBe('https://example.com/relay.php?action=session');
+		expect(
+			buildRemoteAccessRelayEndpointUrl('https://example.com', 'signal', {
+				sessionId: 'session-1',
+				to: 'guest',
+				since: 12,
+				gid: 'guest 1',
+			})
+		).toBe(
+			'https://example.com/relay.php?action=signal&sessionId=session-1&to=guest&since=12&gid=guest+1'
+		);
 	});
 });

--- a/packages/playground/remote-access/src/connect-code.ts
+++ b/packages/playground/remote-access/src/connect-code.ts
@@ -2,6 +2,8 @@ export interface ResolveAccessCodeResponse {
 	sessionId: string;
 }
 
+type RelayEndpointAction = 'session' | 'code' | 'status' | 'signal' | 'close';
+
 export function normalizeAccessCode(value: string): string | null {
 	const digits = value.replace(/\D+/g, '');
 	if (digits.length !== 6) {
@@ -22,11 +24,28 @@ export async function resolveAccessCode(
 	relayUrl: string,
 	accessCode: string
 ): Promise<ResolveAccessCodeResponse> {
-	const response = await fetch(`${relayUrl}/relay/code/${accessCode}`);
+	const response = await fetch(
+		buildRemoteAccessRelayEndpointUrl(relayUrl, 'code', { accessCode })
+	);
 	if (!response.ok) {
 		throw new ResolveAccessCodeError(response);
 	}
 	return (await response.json()) as ResolveAccessCodeResponse;
+}
+
+export function buildRemoteAccessRelayEndpointUrl(
+	relayUrl: string,
+	action: RelayEndpointAction,
+	params: Record<string, string | number | null | undefined> = {}
+): string {
+	const url = new URL('/relay.php', relayUrl);
+	url.searchParams.set('action', action);
+	for (const [name, value] of Object.entries(params)) {
+		if (value !== null && value !== undefined) {
+			url.searchParams.set(name, String(value));
+		}
+	}
+	return url.toString();
 }
 
 export function buildRemoteAccessUrl(

--- a/packages/playground/remote-access/src/connect-code.ts
+++ b/packages/playground/remote-access/src/connect-code.ts
@@ -38,7 +38,11 @@ export function buildRemoteAccessRelayEndpointUrl(
 	action: RelayEndpointAction,
 	params: Record<string, string | number | null | undefined> = {}
 ): string {
-	const url = new URL('/relay.php', relayUrl);
+	const baseUrl = new URL(relayUrl);
+	if (!baseUrl.pathname.endsWith('/')) {
+		baseUrl.pathname = `${baseUrl.pathname}/`;
+	}
+	const url = new URL('relay.php', baseUrl);
 	url.searchParams.set('action', action);
 	for (const [name, value] of Object.entries(params)) {
 		if (value !== null && value !== undefined) {

--- a/packages/playground/remote-access/src/remote-access-direct-tunnel.spec.ts
+++ b/packages/playground/remote-access/src/remote-access-direct-tunnel.spec.ts
@@ -299,7 +299,7 @@ describe('remote access direct tunnel', () => {
 		).requestFreshOffer();
 
 		expect(fetchMock).toHaveBeenCalledWith(
-			'https://example.test/relay/session-1/signal',
+			'https://example.test/relay.php?action=signal&sessionId=session-1',
 			expect.objectContaining({
 				method: 'POST',
 				body: JSON.stringify({

--- a/packages/playground/remote-access/src/remote-access-direct-tunnel.ts
+++ b/packages/playground/remote-access/src/remote-access-direct-tunnel.ts
@@ -11,6 +11,7 @@ import {
 	normalizeVerificationCode,
 	readAttemptSignal,
 } from './remote-access-tunnel-utils';
+import { buildRemoteAccessRelayEndpointUrl } from './connect-code';
 import type { RemoteAccessHostClient } from './types';
 
 export type TunnelHostStatus =
@@ -489,9 +490,12 @@ export class DirectTunnelHost {
 		}
 
 		this.setStatus('connecting');
-		const response = await fetch(`${this.relayUrl}/relay/session`, {
-			method: 'POST',
-		});
+		const response = await fetch(
+			buildRemoteAccessRelayEndpointUrl(this.relayUrl, 'session'),
+			{
+				method: 'POST',
+			}
+		);
 		if (!response.ok) {
 			this.setStatus('error');
 			throw new Error(
@@ -539,7 +543,9 @@ export class DirectTunnelHost {
 		if (sessionIdToClose) {
 			try {
 				await fetch(
-					`${this.relayUrl}/relay/${sessionIdToClose}/close`,
+					buildRemoteAccessRelayEndpointUrl(this.relayUrl, 'close', {
+						sessionId: sessionIdToClose,
+					}),
 					{ method: 'POST', keepalive: true }
 				);
 			} catch (e) {
@@ -1239,7 +1245,11 @@ export class DirectTunnelHost {
 		while (this.isActive && this.sessionId) {
 			try {
 				const response = await fetch(
-					`${this.relayUrl}/relay/${this.sessionId}/signal?to=host&since=${this.signalCursor}`
+					buildRemoteAccessRelayEndpointUrl(this.relayUrl, 'signal', {
+						sessionId: this.sessionId,
+						to: 'host',
+						since: this.signalCursor,
+					})
 				);
 				if (!response.ok) {
 					throw new Error(
@@ -1373,16 +1383,21 @@ export class DirectTunnelHost {
 		if (!this.sessionId) {
 			return;
 		}
-		await fetch(`${this.relayUrl}/relay/${this.sessionId}/signal`, {
-			method: 'POST',
-			headers: { 'Content-Type': 'application/json' },
-			body: JSON.stringify({
-				from: 'host',
-				to,
-				type,
-				data,
+		await fetch(
+			buildRemoteAccessRelayEndpointUrl(this.relayUrl, 'signal', {
+				sessionId: this.sessionId,
 			}),
-		});
+			{
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({
+					from: 'host',
+					to,
+					type,
+					data,
+				}),
+			}
+		);
 	}
 
 	private emit<K extends keyof TunnelHostEvents>(
@@ -1690,9 +1705,12 @@ export class DirectTunnelGuest {
 		while (this.isActive) {
 			try {
 				const response = await fetch(
-					`${this.relayUrl}/relay/${this.sessionId}/signal?to=guest&since=${this.signalCursor}&gid=${encodeURIComponent(
-						this.guestId
-					)}`
+					buildRemoteAccessRelayEndpointUrl(this.relayUrl, 'signal', {
+						sessionId: this.sessionId,
+						to: 'guest',
+						since: this.signalCursor,
+						gid: this.guestId,
+					})
 				);
 				if (!response.ok) {
 					throw new Error(
@@ -2099,15 +2117,20 @@ export class DirectTunnelGuest {
 		type: SignalType,
 		data: unknown
 	): Promise<void> {
-		await fetch(`${this.relayUrl}/relay/${this.sessionId}/signal`, {
-			method: 'POST',
-			headers: { 'Content-Type': 'application/json' },
-			body: JSON.stringify({
-				from: 'guest',
-				to,
-				type,
-				data,
+		await fetch(
+			buildRemoteAccessRelayEndpointUrl(this.relayUrl, 'signal', {
+				sessionId: this.sessionId,
 			}),
-		});
+			{
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({
+					from: 'guest',
+					to,
+					type,
+					data,
+				}),
+			}
+		);
 	}
 }


### PR DESCRIPTION
## What

Switches Remote Access relay traffic to call `relay.php` directly instead of relying on pretty `/relay/*` routes.

The client now uses URLs like:

- `POST /relay.php?action=session`
- `GET /relay.php?action=code&accessCode=...`
- `GET /relay.php?action=status&sessionId=...`
- `GET|POST /relay.php?action=signal&sessionId=...`
- `POST /relay.php?action=close&sessionId=...`

The PHP relay still accepts the existing `/relay/*` paths for compatibility, but direct `relay.php` URLs are now the primary code path. This avoids deployment environments where `/relay/session` falls through to the app/index fallback before PHP routing can handle it.

## Validation

- `npm exec nx test playground-remote-access`
- `npm exec nx lint playground-remote-access`
- `npm exec nx build playground-remote-access`
- `npm exec nx lint playground-personal-wp`
- `npm exec nx typecheck playground-personal-wp`
- `php -l packages/playground/remote-access/relay.php`
- `git diff --check`
