### PR TITLE
[GitHub Actions] Close stale draft pull requests

### DIFF
--- a/.github/workflows/stale-draft-pull-requests.yml
+++ b/.github/workflows/stale-draft-pull-requests.yml
@@ -31,6 +31,8 @@ jobs:
                       const WARN_MARKER = '<!-- stale-draft-bot:warned -->';
                       const BOT_LOGIN = 'github-actions[bot]';
                       const now = Date.now();
+                      const OWN_WARNING_UPDATE_GRACE_MS = 60 * 1000;
+                      const SLACK_SECTION_LIMIT = 20;
 
                       const WARN_BODY = [
                           WARN_MARKER,
@@ -48,12 +50,24 @@ jobs:
                       const isOwnWarning = (c) =>
                           c.user?.login === BOT_LOGIN && c.body?.includes(WARN_MARKER);
 
-                      const escapeHtml = (value) =>
+                      const daysSince = (time) => Math.floor((now - time) / DAY_MS);
+
+                      const newestByCreatedAt = (items) =>
+                          items.reduce((newest, item) => {
+                              if (!newest) {
+                                  return item;
+                              }
+                              return new Date(item.created_at) > new Date(newest.created_at)
+                                  ? item
+                                  : newest;
+                          }, undefined);
+
+                      const escapeMarkdown = (value) =>
                           value
-                              .replaceAll('&', '&amp;')
-                              .replaceAll('<', '&lt;')
-                              .replaceAll('>', '&gt;')
-                              .replaceAll('"', '&quot;');
+                              .replaceAll('\\', '\\\\')
+                              .replaceAll('|', '\\|')
+                              .replaceAll('[', '\\[')
+                              .replaceAll(']', '\\]');
 
                       const escapeSlack = (value) =>
                           value
@@ -62,39 +76,50 @@ jobs:
                               .replaceAll('>', '&gt;');
 
                       const prSummaryLink = (pr) =>
-                          `<a href="${pr.html_url}">#${pr.number}</a> ${escapeHtml(pr.title)}`;
+                          `[#${pr.number}](${pr.html_url}) ${escapeMarkdown(pr.title)}`;
 
                       const prSlackLink = (pr) =>
                           `<${pr.html_url}|#${pr.number}> ${escapeSlack(pr.title)}`;
 
                       const summaryRow = (pr, reason) => [prSummaryLink(pr), reason];
-                      const slackRow = (pr, reason) => `• ${prSlackLink(pr)} — ${reason}`;
+                      const slackRow = (pr, reason) => `- ${prSlackLink(pr)} - ${reason}`;
 
                       const warnedPrs = [];
                       const gracePrs = [];
                       const closedPrs = [];
 
                       const addSummaryTable = (title, rows) => {
-                          core.summary.addHeading(title, 3);
+                          core.summary.addRaw(`### ${title}\n\n`);
 
                           if (rows.length === 0) {
                               core.summary.addRaw('None\n\n');
                               return;
                           }
 
-                          core.summary.addTable([
-                              [
-                                  { data: 'Pull request', header: true },
-                                  { data: 'Reason', header: true },
-                              ],
-                              ...rows,
-                          ]);
+                          core.summary.addRaw('| Pull request | Reason |\n');
+                          core.summary.addRaw('| --- | --- |\n');
+                          for (const [pullRequest, reason] of rows) {
+                              core.summary.addRaw(
+                                  `| ${pullRequest} | ${escapeMarkdown(reason)} |\n`
+                              );
+                          }
+                          core.summary.addRaw('\n');
                       };
 
-                      const slackSection = (title, rows) => [
-                          `*${title}:*`,
-                          rows.length === 0 ? 'None' : rows.join('\n'),
-                      ].join('\n');
+                      const slackSection = (title, rows, runUrl) => {
+                          if (rows.length === 0) {
+                              return [`*${title}:*`, 'None'].join('\n');
+                          }
+
+                          const visibleRows = rows.slice(0, SLACK_SECTION_LIMIT);
+                          const hiddenRows = rows.length - visibleRows.length;
+                          const suffix =
+                              hiddenRows > 0
+                                  ? `\n...and ${hiddenRows} more. See the Actions summary: ${runUrl}`
+                                  : '';
+
+                          return [`*${title}:*`, `${visibleRows.join('\n')}${suffix}`].join('\n');
+                      };
 
                       const { owner, repo } = context.repo;
 
@@ -102,66 +127,78 @@ jobs:
                           owner, repo, state: 'open', per_page: 100,
                       });
                       const drafts = prs.filter((pr) => pr.draft === true);
+                      const runUrl =
+                          `https://github.com/${owner}/${repo}/actions/runs/${context.runId}`;
 
                       for (const pr of drafts) {
                           const num = pr.number;
+                          const prUpdatedTime = new Date(pr.updated_at).getTime();
+                          const daysSincePrUpdate = daysSince(prUpdatedTime);
 
-                          const [commits, issueComments, reviewComments, reviews] = await Promise.all([
-                              github.paginate(github.rest.pulls.listCommits,
-                                  { owner, repo, pull_number: num, per_page: 100 }),
-                              github.paginate(github.rest.issues.listComments,
-                                  { owner, repo, issue_number: num, per_page: 100 }),
-                              github.paginate(github.rest.pulls.listReviewComments,
-                                  { owner, repo, pull_number: num, per_page: 100 }),
-                              github.paginate(github.rest.pulls.listReviews,
-                                  { owner, repo, pull_number: num, per_page: 100 }),
-                          ]);
+                          if (daysSincePrUpdate < GRACE_DAYS) {
+                              continue;
+                          }
 
-                          const timestamps = [
-                              new Date(pr.created_at).getTime(),
-                              ...commits.map((c) => new Date(c.commit.committer.date).getTime()),
-                              ...issueComments
-                                  .filter((c) => !isOwnWarning(c))
-                                  .map((c) => new Date(c.created_at).getTime()),
-                              ...reviewComments.map((c) => new Date(c.created_at).getTime()),
-                              ...reviews
-                                  .filter((r) => r.submitted_at)
-                                  .map((r) => new Date(r.submitted_at).getTime()),
-                          ];
+                          const issueComments = await github.paginate(
+                              github.rest.issues.listComments,
+                              {
+                                  owner,
+                                  repo,
+                                  issue_number: num,
+                                  per_page: 100,
+                                  direction: 'asc',
+                              }
+                          );
 
-                          const lastActivity = Math.max(...timestamps);
-                          const daysIdle = Math.floor((now - lastActivity) / DAY_MS);
-                          const lastWarning = issueComments.filter(isOwnWarning).at(-1);
+                          const lastWarning = newestByCreatedAt(
+                              issueComments.filter(isOwnWarning)
+                          );
 
                           if (lastWarning) {
                               const lastWarningTime = new Date(lastWarning.created_at).getTime();
-                              if (lastWarningTime > lastActivity) {
-                                  const warningAgeDays = Math.floor((now - lastWarningTime) / DAY_MS);
-                                  if (warningAgeDays >= GRACE_DAYS) {
-                                      const reason = `${warningAgeDays} days since warning`;
-                                      closedPrs.push({
+                              const warningAgeDays = daysSince(lastWarningTime);
+                              const prUpdatedAfterWarning =
+                                  prUpdatedTime > lastWarningTime + OWN_WARNING_UPDATE_GRACE_MS;
+
+                              if (prUpdatedAfterWarning) {
+                                  if (daysSincePrUpdate >= WARN_DAYS) {
+                                      const reason = `${daysSincePrUpdate} days since PR update`;
+                                      warnedPrs.push({
                                           summary: summaryRow(pr, reason),
                                           slack: slackRow(pr, reason),
                                       });
                                       await github.rest.issues.createComment({
-                                          owner, repo, issue_number: num, body: CLOSE_BODY,
-                                      });
-                                      await github.rest.pulls.update({
-                                          owner, repo, pull_number: num, state: 'closed',
-                                      });
-                                  } else {
-                                      const reason = `${warningAgeDays} days since warning`;
-                                      gracePrs.push({
-                                          summary: summaryRow(pr, reason),
-                                          slack: slackRow(pr, reason),
+                                          owner, repo, issue_number: num, body: WARN_BODY,
                                       });
                                   }
                                   continue;
                               }
+
+                              if (warningAgeDays >= GRACE_DAYS) {
+                                  const reason = `${warningAgeDays} days since warning`;
+                                  closedPrs.push({
+                                      summary: summaryRow(pr, reason),
+                                      slack: slackRow(pr, reason),
+                                  });
+                                  await github.rest.issues.createComment({
+                                      owner, repo, issue_number: num, body: CLOSE_BODY,
+                                  });
+                                  await github.rest.pulls.update({
+                                      owner, repo, pull_number: num, state: 'closed',
+                                  });
+                              } else {
+                                  const reason = `${warningAgeDays} days since warning`;
+                                  gracePrs.push({
+                                      summary: summaryRow(pr, reason),
+                                      slack: slackRow(pr, reason),
+                                  });
+                              }
+
+                              continue;
                           }
 
-                          if (daysIdle >= WARN_DAYS) {
-                              const reason = `${daysIdle} days idle`;
+                          if (daysSincePrUpdate >= WARN_DAYS) {
+                              const reason = `${daysSincePrUpdate} days since PR update`;
                               warnedPrs.push({
                                   summary: summaryRow(pr, reason),
                                   slack: slackRow(pr, reason),
@@ -188,15 +225,21 @@ jobs:
                       const slackText = [
                           '*Stale draft pull requests report*',
                           `Checked ${drafts.length} open draft pull requests.`,
+                          `Full report: ${runUrl}`,
                           '',
-                          slackSection('Warnings posted', warnedPrs.map((pr) => pr.slack)),
+                          slackSection(
+                              'Warnings posted',
+                              warnedPrs.map((pr) => pr.slack),
+                              runUrl
+                          ),
                           '',
                           slackSection(
                               'Already warned, still in grace period',
-                              gracePrs.map((pr) => pr.slack)
+                              gracePrs.map((pr) => pr.slack),
+                              runUrl
                           ),
                           '',
-                          slackSection('Closed', closedPrs.map((pr) => pr.slack)),
+                          slackSection('Closed', closedPrs.map((pr) => pr.slack), runUrl),
                       ].join('\n');
 
                       core.setOutput('slack-message', JSON.stringify({ text: slackText }));
@@ -209,4 +252,5 @@ jobs:
                   curl --fail --show-error --silent \
                       -H 'Content-type: application/json' \
                       --data "$SLACK_MESSAGE" \
-                      "$SLACK_WEBHOOK_URL"
+                      "$SLACK_WEBHOOK_URL" ||
+                      echo "Slack notification failed; stale draft processing already completed."

--- a/.github/workflows/stale-draft-pull-requests.yml
+++ b/.github/workflows/stale-draft-pull-requests.yml
@@ -1,0 +1,106 @@
+name: Close stale draft pull requests
+
+on:
+    schedule:
+        - cron: '0 7 * * *'
+    workflow_dispatch:
+
+concurrency:
+    group: stale-draft-prs
+
+permissions: {}
+
+jobs:
+    process:
+        if: github.repository == 'WordPress/wordpress-playground'
+        runs-on: ubuntu-latest
+        timeout-minutes: 30
+        permissions:
+            pull-requests: write
+            issues: write
+        steps:
+            - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
+              with:
+                  script: |
+                      const WARN_DAYS = 30;
+                      const GRACE_DAYS = 7;
+                      const DAY_MS = 24 * 60 * 60 * 1000;
+                      const WARN_MARKER = '<!-- stale-draft-bot:warned -->';
+                      const BOT_LOGIN = 'github-actions[bot]';
+                      const now = Date.now();
+
+                      const WARN_BODY = [
+                          WARN_MARKER,
+                          'This draft pull request has had no commits or comments in the last 30 days.',
+                          '',
+                          'If it is still active, please push a commit, leave a comment, or mark it ready for review. Otherwise it will be automatically closed after 7 more days of inactivity.',
+                      ].join('\n');
+
+                      const CLOSE_BODY = [
+                          'Closing this draft pull request because it has received no activity in the 7 days since the warning above.',
+                          '',
+                          'No worries — feel free to reopen it any time if you would like to continue the work.',
+                      ].join('\n');
+
+                      const isOwnWarning = (c) =>
+                          c.user?.login === BOT_LOGIN && c.body?.includes(WARN_MARKER);
+
+                      const { owner, repo } = context.repo;
+
+                      const prs = await github.paginate(github.rest.pulls.list, {
+                          owner, repo, state: 'open', per_page: 100,
+                      });
+                      const drafts = prs.filter((pr) => pr.draft === true);
+
+                      for (const pr of drafts) {
+                          const num = pr.number;
+
+                          const [commits, issueComments, reviewComments, reviews] = await Promise.all([
+                              github.paginate(github.rest.pulls.listCommits,
+                                  { owner, repo, pull_number: num, per_page: 100 }),
+                              github.paginate(github.rest.issues.listComments,
+                                  { owner, repo, issue_number: num, per_page: 100 }),
+                              github.paginate(github.rest.pulls.listReviewComments,
+                                  { owner, repo, pull_number: num, per_page: 100 }),
+                              github.paginate(github.rest.pulls.listReviews,
+                                  { owner, repo, pull_number: num, per_page: 100 }),
+                          ]);
+
+                          const timestamps = [
+                              new Date(pr.created_at).getTime(),
+                              ...commits.map((c) => new Date(c.commit.committer.date).getTime()),
+                              ...issueComments
+                                  .filter((c) => !isOwnWarning(c))
+                                  .map((c) => new Date(c.created_at).getTime()),
+                              ...reviewComments.map((c) => new Date(c.created_at).getTime()),
+                              ...reviews
+                                  .filter((r) => r.submitted_at)
+                                  .map((r) => new Date(r.submitted_at).getTime()),
+                          ];
+
+                          const lastActivity = Math.max(...timestamps);
+                          const daysIdle = Math.floor((now - lastActivity) / DAY_MS);
+                          const lastWarning = issueComments.filter(isOwnWarning).at(-1);
+
+                          if (lastWarning) {
+                              const lastWarningTime = new Date(lastWarning.created_at).getTime();
+                              if (lastWarningTime > lastActivity) {
+                                  const warningAgeDays = Math.floor((now - lastWarningTime) / DAY_MS);
+                                  if (warningAgeDays >= GRACE_DAYS) {
+                                      await github.rest.issues.createComment({
+                                          owner, repo, issue_number: num, body: CLOSE_BODY,
+                                      });
+                                      await github.rest.pulls.update({
+                                          owner, repo, pull_number: num, state: 'closed',
+                                      });
+                                  }
+                                  continue;
+                              }
+                          }
+
+                          if (daysIdle >= WARN_DAYS) {
+                              await github.rest.issues.createComment({
+                                  owner, repo, issue_number: num, body: WARN_BODY,
+                              });
+                          }
+                      }

--- a/.github/workflows/stale-draft-pull-requests.yml
+++ b/.github/workflows/stale-draft-pull-requests.yml
@@ -15,11 +15,14 @@ jobs:
         if: github.repository == 'WordPress/wordpress-playground'
         runs-on: ubuntu-latest
         timeout-minutes: 30
+        env:
+            SLACK_WEBHOOK_URL: ${{ secrets.STALE_DRAFT_PRS_SLACK_WEBHOOK }}
         permissions:
             pull-requests: write
             issues: write
         steps:
             - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
+              id: stale-drafts
               with:
                   script: |
                       const WARN_DAYS = 30;
@@ -44,6 +47,54 @@ jobs:
 
                       const isOwnWarning = (c) =>
                           c.user?.login === BOT_LOGIN && c.body?.includes(WARN_MARKER);
+
+                      const escapeHtml = (value) =>
+                          value
+                              .replaceAll('&', '&amp;')
+                              .replaceAll('<', '&lt;')
+                              .replaceAll('>', '&gt;')
+                              .replaceAll('"', '&quot;');
+
+                      const escapeSlack = (value) =>
+                          value
+                              .replaceAll('&', '&amp;')
+                              .replaceAll('<', '&lt;')
+                              .replaceAll('>', '&gt;');
+
+                      const prSummaryLink = (pr) =>
+                          `<a href="${pr.html_url}">#${pr.number}</a> ${escapeHtml(pr.title)}`;
+
+                      const prSlackLink = (pr) =>
+                          `<${pr.html_url}|#${pr.number}> ${escapeSlack(pr.title)}`;
+
+                      const summaryRow = (pr, reason) => [prSummaryLink(pr), reason];
+                      const slackRow = (pr, reason) => `• ${prSlackLink(pr)} — ${reason}`;
+
+                      const warnedPrs = [];
+                      const gracePrs = [];
+                      const closedPrs = [];
+
+                      const addSummaryTable = (title, rows) => {
+                          core.summary.addHeading(title, 3);
+
+                          if (rows.length === 0) {
+                              core.summary.addRaw('None\n\n');
+                              return;
+                          }
+
+                          core.summary.addTable([
+                              [
+                                  { data: 'Pull request', header: true },
+                                  { data: 'Reason', header: true },
+                              ],
+                              ...rows,
+                          ]);
+                      };
+
+                      const slackSection = (title, rows) => [
+                          `*${title}:*`,
+                          rows.length === 0 ? 'None' : rows.join('\n'),
+                      ].join('\n');
 
                       const { owner, repo } = context.repo;
 
@@ -87,11 +138,22 @@ jobs:
                               if (lastWarningTime > lastActivity) {
                                   const warningAgeDays = Math.floor((now - lastWarningTime) / DAY_MS);
                                   if (warningAgeDays >= GRACE_DAYS) {
+                                      const reason = `${warningAgeDays} days since warning`;
+                                      closedPrs.push({
+                                          summary: summaryRow(pr, reason),
+                                          slack: slackRow(pr, reason),
+                                      });
                                       await github.rest.issues.createComment({
                                           owner, repo, issue_number: num, body: CLOSE_BODY,
                                       });
                                       await github.rest.pulls.update({
                                           owner, repo, pull_number: num, state: 'closed',
+                                      });
+                                  } else {
+                                      const reason = `${warningAgeDays} days since warning`;
+                                      gracePrs.push({
+                                          summary: summaryRow(pr, reason),
+                                          slack: slackRow(pr, reason),
                                       });
                                   }
                                   continue;
@@ -99,8 +161,52 @@ jobs:
                           }
 
                           if (daysIdle >= WARN_DAYS) {
+                              const reason = `${daysIdle} days idle`;
+                              warnedPrs.push({
+                                  summary: summaryRow(pr, reason),
+                                  slack: slackRow(pr, reason),
+                              });
                               await github.rest.issues.createComment({
                                   owner, repo, issue_number: num, body: WARN_BODY,
                               });
                           }
                       }
+
+                      core.summary
+                          .addHeading('Stale draft pull requests')
+                          .addRaw(`Checked ${drafts.length} open draft pull requests.\n\n`);
+
+                      addSummaryTable('Warnings posted', warnedPrs.map((pr) => pr.summary));
+                      addSummaryTable(
+                          'Already warned, still in grace period',
+                          gracePrs.map((pr) => pr.summary)
+                      );
+                      addSummaryTable('Closed', closedPrs.map((pr) => pr.summary));
+
+                      await core.summary.write();
+
+                      const slackText = [
+                          '*Stale draft pull requests report*',
+                          `Checked ${drafts.length} open draft pull requests.`,
+                          '',
+                          slackSection('Warnings posted', warnedPrs.map((pr) => pr.slack)),
+                          '',
+                          slackSection(
+                              'Already warned, still in grace period',
+                              gracePrs.map((pr) => pr.slack)
+                          ),
+                          '',
+                          slackSection('Closed', closedPrs.map((pr) => pr.slack)),
+                      ].join('\n');
+
+                      core.setOutput('slack-message', JSON.stringify({ text: slackText }));
+
+            - name: Send Slack report
+              if: env.SLACK_WEBHOOK_URL != ''
+              env:
+                  SLACK_MESSAGE: ${{ steps.stale-drafts.outputs.slack-message }}
+              run: |
+                  curl --fail --show-error --silent \
+                      -H 'Content-type: application/json' \
+                      --data "$SLACK_MESSAGE" \
+                      "$SLACK_WEBHOOK_URL"


### PR DESCRIPTION
## Motivation for the change, related issues

Open draft pull requests in this repository accumulate indefinitely. There are 56 open drafts today, and 33 of them have had no commits, comments, or reviews for more than 30 days — several have been silent for over six months. There is no automation that surfaces or retires abandoned drafts, so they bury PRs that are still active.

## Implementation details

Adds `.github/workflows/stale-draft-pull-requests.yml`, a scheduled workflow that runs daily at 07:00 UTC and can also be triggered manually from the Actions tab. For each open draft pull request, the workflow computes the last real activity timestamp from:

- the PR creation date,
- every commit's committer date,
- every non-bot issue comment, every review comment, and every submitted review.

The bot's own warning comments are excluded from this activity calculation so they don't reset the idle clock.

For each draft the workflow does one of:

1. **Warn** — if the PR has been idle for at least 30 days and no warning has been posted since the last real activity, post a warning comment carrying a hidden HTML marker.
2. **Close** — if a warning has already been posted, that warning is at least 7 days old, and no real activity happened since the warning, post a closing comment and close the PR.
3. **Skip** — otherwise.

Pushing a commit, leaving a comment, or submitting a review after a warning invalidates the active warning and restarts the cycle, so a draft is never closed without a 7-day grace window after a warning is posted.

Other workflow hygiene:

- `concurrency.group: stale-draft-prs` prevents overlapping runs from posting duplicate warnings.
- `if: github.repository == 'WordPress/wordpress-playground'` keeps forks from running the workflow against their own drafts.
- Workflow-level `permissions: {}` denies all scopes; the job opts in only to `pull-requests: write` and `issues: write`.
- `actions/github-script` is pinned to the commit SHA for `v7.0.1` since the job has write permissions.

## Testing Instructions (or ideally a Blueprint)

GitHub Actions workflows are difficult to unit-test in isolation. After merging:

1. Manually trigger the workflow from the Actions tab (`workflow_dispatch`) and confirm it iterates every open draft pull request without errors.
2. The first run will warn the ~33 existing idle drafts. No PR will be closed on day 0, because no prior warnings exist.
3. Wait 7 days. Confirm that drafts that received the warning and got no further activity are closed with the closing comment.
4. Confirm that any commit, issue comment, review comment, or submitted review posted after a warning prevents closure on the next run.