### PR TITLE
Docs: replace rewrite-flushing writeFile examples

### DIFF
--- a/packages/docs/site/docs/blueprints/08-examples.md
+++ b/packages/docs/site/docs/blueprints/08-examples.md
@@ -205,21 +205,18 @@ For a detailed explanation of why this is needed, refer to the [Troubleshoot and
 
 ## Load PHP code on every request (mu-plugin)
 
-Use the `writeFile` step to add code to a mu-plugin that runs on every request.
+Use the `writeFile` step to add code to `mu-plugins`, where it runs on every request.
 
 <BlueprintExample blueprint={{
-	"landingPage": "/category/uncategorized/",
-	"features": {
-		"networking": true
-	},
+	"landingPage": "/wp-admin/",
 	"steps": [
 		{
 			"step": "login"
 		},
 		{
 			"step": "writeFile",
-			"path": "/wordpress/wp-content/mu-plugins/rewrite.php",
-			"data": "<?php add_action( 'after_setup_theme', function() { global $wp_rewrite; $wp_rewrite->set_permalink_structure('/%postname%/'); $wp_rewrite->flush_rules(); } );"
+			"path": "/wordpress/wp-content/mu-plugins/demo-footer.php",
+			"data": "<?php add_filter( 'admin_footer_text', function () { return 'Added by mu-plugin code.'; } );"
 		}
 	]
 }} />

--- a/packages/docs/site/docs/main/guides/for-theme-developers.md
+++ b/packages/docs/site/docs/main/guides/for-theme-developers.md
@@ -125,22 +125,22 @@ With the [`resetData`](/blueprints/steps#resetData) step, you can remove the def
 
 ### `writeFile`
 
-With the [`writeFile`](/blueprints/steps#resetData) step, you can write data to a file at a specified path. You may want to use this step to write custom PHP code in a PHP file inside the `mu-plugins` folder of the Playground WordPress instance, so the code is executed automatically when the WordPress instance is loaded.
-One of the things you can do through this step is to enable pretty permalinks for your Playground instance:
+With the [`writeFile`](/blueprints/steps#WriteFileStep) step, you can write data to a file at a specified path. You may want to use this step to write custom PHP code in a PHP file inside the `mu-plugins` folder of the Playground WordPress instance, so the code is executed automatically when the WordPress instance is loaded.
+For example, you can add a demo-specific body class that your theme can use for Playground-only styling:
 
 ```json
 "steps": [
 	...,
 	{
 		"step": "writeFile",
-		"path": "/wordpress/wp-content/mu-plugins/rewrite.php",
-		"data": "<?php /* Use pretty permalinks */ add_action( 'after_setup_theme', function() { global $wp_rewrite; $wp_rewrite->set_permalink_structure('/%postname%/'); $wp_rewrite->flush_rules(); } );"
+		"path": "/wordpress/wp-content/mu-plugins/demo-body-class.php",
+		"data": "<?php add_filter( 'body_class', function ( $classes ) { $classes[] = 'playground-demo'; return $classes; } );"
 	},
 	...
 ]
 ```
 
-[<kbd> &nbsp; Run Blueprint &nbsp; </kbd>](https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/wordpress/blueprints/trunk/blueprints/install-activate-setup-theme-from-gh-repo/blueprint.json) &nbsp; [<kbd> &nbsp; See <code>blueprint.json</code> &nbsp; </kbd>](https://github.com/WordPress/blueprints/blob/eb6da7dfa295a095eea2e424c0ae83a219803a8d/blueprints/install-activate-setup-theme-from-gh-repo/blueprint.json#L19)
+[<kbd> &nbsp; Run Blueprint &nbsp; </kbd>](https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/wordpress/blueprints/trunk/blueprints/install-activate-setup-theme-from-gh-repo/blueprint.json) &nbsp; [<kbd> &nbsp; See <code>blueprint.json</code> &nbsp; </kbd>](https://github.com/WordPress/blueprints/blob/trunk/blueprints/install-activate-setup-theme-from-gh-repo/blueprint.json#L16)
 
 ### `updateUserMeta`
 


### PR DESCRIPTION
## Summary

- Replace `writeFile` examples that flushed rewrite rules on every request with harmless mu-plugin examples
- Fix the `writeFile` documentation link to use the generated `WriteFileStep` anchor
- Update the theme guide to reference the body-class example merged in WordPress/blueprints#220
- Simplify the standalone example by removing unnecessary networking and opening it in wp-admin

Fixes #2195

## Testing

- `git diff --check`
- `npx prettier --check packages/docs/site/docs/blueprints/08-examples.md packages/docs/site/docs/main/guides/for-theme-developers.md`
- `npx nx build docs-site`
- GitHub Actions passed on the latest commit

The docs build still reports existing TypeDoc/Docusaurus warnings unrelated to this change.
