### PR TITLE
Update Playwright installation command to avoid unnecessary installat…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -416,7 +416,7 @@ jobs:
             - name: Validate publish package overrides
               run: node tools/scripts/check-publish-package-overrides.mjs
             - name: Install Playwright Browsers
-              run: npx --yes playwright@1.61.0 install --with-deps chromium
+              run: npx --no-install playwright install --with-deps chromium
             - name: Build packages, start local registry, and run integration tests
               run: packages/playground/test-built-npm-packages/run-tests.sh
 


### PR DESCRIPTION
Playwright 1.55.1 bundles Firefox 141, which does not support import.meta
in module service workers. Registering the Playground service worker
therefore threw "an exception during script evaluation", boot never got a
controlling service worker, and every website e2e test timed out (the
three Firefox shards ran the full 30 min and were cancelled).

Firefox shipped module service worker support (and import.meta in that
scope) in Firefox 147. Playwright 1.61.0 bundles Firefox 151, on which the
unmodified production sw.js registers and activates normally.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>## Motivation for the change, related issues

## Implementation details

## Testing Instructions (or ideally a Blueprint)
