### PR TITLE
[PHP] Preserve missing NODEFS mount points during runtime rotation

### DIFF
--- a/packages/php-wasm/node/src/lib/node-fs-mount.ts
+++ b/packages/php-wasm/node/src/lib/node-fs-mount.ts
@@ -23,11 +23,21 @@ export function createNodeFsMountHandler(localPath: string): MountHandler {
 		 * PHP-WASM source: https://github.com/WordPress/wordpress-playground/blob/5821cee231f452d050fd337b99ad0b26ebda487e/packages/php-wasm/compile/php/Dockerfile#L2148
 		 */
 		let removeVfsNode = false;
-		const mountRoot = realpathSync(localPath);
+		let mountRoot: string;
+		try {
+			mountRoot = realpathSync(localPath);
+		} catch (e) {
+			throw markMissingMountSource(e, localPath);
+		}
 		if (!FSHelpers.fileExists(FS, vfsMountPoint)) {
 			// Resolve symlinks so both the VFS placeholder and NODEFS root
 			// match the target's file-or-directory shape.
-			const stat = statSync(mountRoot);
+			let stat: ReturnType<typeof statSync>;
+			try {
+				stat = statSync(mountRoot);
+			} catch (e) {
+				throw markMissingMountSource(e, localPath);
+			}
 			if (stat.isFile()) {
 				FS.mkdirTree(dirname(vfsMountPoint));
 				FS.writeFile(vfsMountPoint, '');
@@ -70,4 +80,25 @@ export function createNodeFsMountHandler(localPath: string): MountHandler {
 			}
 		};
 	};
+}
+
+/**
+ * Marks ENOENT from NODEFS source lookup so rotation can handle only that race.
+ */
+function markMissingMountSource(error: unknown, localPath: string) {
+	const errnoError = error as NodeJS.ErrnoException;
+	if (errnoError.code === 'ENOENT') {
+		const missingSourceError = new Error(
+			`Unable to mount ${localPath}: source path does not exist.`,
+			{ cause: error }
+		) as NodeJS.ErrnoException & {
+			phpWasmMountSourceMissing: true;
+		};
+		missingSourceError.code = 'ENOENT';
+		missingSourceError.path = localPath;
+		missingSourceError.phpWasmMountSourceMissing = true;
+		return missingSourceError;
+	}
+
+	return error;
 }

--- a/packages/php-wasm/node/src/test/mount.spec.ts
+++ b/packages/php-wasm/node/src/test/mount.spec.ts
@@ -46,6 +46,22 @@ describe('Mounting', () => {
 		php.exit();
 	});
 
+	it('Should reject a missing local source path', async () => {
+		const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'temp-'));
+		const missingSourcePath = path.join(tempDir, 'missing-source.txt');
+
+		try {
+			await expect(
+				php.mount(
+					'/missing-source.txt',
+					createNodeFsMountHandler(missingSourcePath)
+				)
+			).rejects.toMatchObject({ code: 'ENOENT' });
+		} finally {
+			fs.rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
 	[
 		{
 			filePath: testFilePath,

--- a/packages/php-wasm/node/src/test/rotate-php-runtime.spec.ts
+++ b/packages/php-wasm/node/src/test/rotate-php-runtime.spec.ts
@@ -112,6 +112,116 @@ describe.each([true, false])(
 			expect(php.readFileAsText('/test-root/file')).toBe('playground');
 		});
 
+		it('Preserves a single-file NODEFS mount through PHP runtime recreation', async () => {
+			const recreateRuntimeSpy = vitest.fn(recreateRuntime);
+
+			const php = new PHP(await recreateRuntime());
+			php.enableRuntimeRotation({
+				recreateRuntime: recreateRuntimeSpy,
+				maxRequests: 1,
+			});
+
+			const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'temp-'));
+			const tempFile = path.join(tempDir, 'file');
+			fs.writeFileSync(tempFile, 'playground');
+
+			try {
+				await php.mount(
+					'/test-file',
+					createNodeFsMountHandler(tempFile)
+				);
+				expect(php.isFile('/test-file')).toBe(true);
+				expect(php.readFileAsText('/test-file')).toBe('playground');
+
+				await php.run({ code: `` });
+				await php.run({ code: `` });
+
+				expect(recreateRuntimeSpy).toHaveBeenCalledTimes(1);
+				expect(php.isFile('/test-file')).toBe(true);
+				expect(php.readFileAsText('/test-file')).toBe('playground');
+			} finally {
+				fs.rmSync(tempDir, { recursive: true, force: true });
+				php.exit();
+			}
+		});
+
+		it('Preserves VFS mount points when NODEFS sources disappear before runtime recreation', async () => {
+			const recreateRuntimeSpy = vitest.fn(recreateRuntime);
+
+			const php = new PHP(await recreateRuntime());
+			php.enableRuntimeRotation({
+				recreateRuntime: recreateRuntimeSpy,
+				maxRequests: 1,
+			});
+
+			const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'temp-'));
+			const tempFile = path.join(tempDir, 'uploads-tail.txt');
+			const tempMountedDir = path.join(tempDir, 'static-pages');
+			fs.writeFileSync(tempFile, 'tail');
+			fs.mkdirSync(tempMountedDir);
+			fs.writeFileSync(path.join(tempMountedDir, 'index.html'), 'static');
+
+			try {
+				await php.mount(
+					'/wordpress/wp-content/uploads/uploads-tail.txt',
+					createNodeFsMountHandler(tempFile)
+				);
+				await php.mount(
+					'/wordpress/wp-content/uploads/static-pages',
+					createNodeFsMountHandler(tempMountedDir)
+				);
+				php.writeFile(
+					'/wordpress/wp-content/uploads/memfs-sibling.txt',
+					'preserved'
+				);
+
+				expect(
+					php.isFile('/wordpress/wp-content/uploads/uploads-tail.txt')
+				).toBe(true);
+				expect(
+					php.isDir('/wordpress/wp-content/uploads/static-pages')
+				).toBe(true);
+
+				await php.run({ code: `` });
+				fs.unlinkSync(tempFile);
+				fs.rmSync(tempMountedDir, { recursive: true });
+
+				expect(
+					php.isFile('/wordpress/wp-content/uploads/uploads-tail.txt')
+				).toBe(true);
+				expect(
+					php.isDir('/wordpress/wp-content/uploads/static-pages')
+				).toBe(true);
+
+				await expect(php.run({ code: `` })).resolves.toBeDefined();
+				expect(recreateRuntimeSpy).toHaveBeenCalledTimes(1);
+
+				expect(
+					php.isFile('/wordpress/wp-content/uploads/uploads-tail.txt')
+				).toBe(true);
+				expect(
+					php.isDir('/wordpress/wp-content/uploads/static-pages')
+				).toBe(true);
+				expect(
+					php.readFileAsText(
+						'/wordpress/wp-content/uploads/memfs-sibling.txt'
+					)
+				).toBe('preserved');
+
+				await expect(php.run({ code: `` })).resolves.toBeDefined();
+				expect(recreateRuntimeSpy).toHaveBeenCalledTimes(2);
+				expect(
+					php.isFile('/wordpress/wp-content/uploads/uploads-tail.txt')
+				).toBe(true);
+				expect(
+					php.isDir('/wordpress/wp-content/uploads/static-pages')
+				).toBe(true);
+			} finally {
+				fs.rmSync(tempDir, { recursive: true, force: true });
+				php.exit();
+			}
+		});
+
 		it('Preserves 4 WordPress plugin mounts through PHP runtime recreation', async () => {
 			// Rotate the PHP runtime
 			const recreateRuntimeSpy = vitest.fn(recreateRuntime);

--- a/packages/php-wasm/universal/src/lib/php.ts
+++ b/packages/php-wasm/universal/src/lib/php.ts
@@ -3,6 +3,7 @@ import {
 	Semaphore,
 	basename,
 	createSpawnHandler,
+	dirname,
 	joinPaths,
 } from '@php-wasm/util';
 import type { Emscripten } from './emscripten-types';
@@ -63,6 +64,21 @@ type MountObject = {
 	mountHandler: MountHandler;
 	unmount: () => Promise<any>;
 };
+
+/**
+ * Describes the VFS node shape visible at a mount point before rotation.
+ */
+type MountPointSnapshot =
+	| {
+			kind: 'directory';
+	  }
+	| {
+			kind: 'file';
+	  }
+	| {
+			kind: 'symlink';
+			target: string;
+	  };
 
 /**
  * An environment-agnostic wrapper around the Emscripten PHP runtime
@@ -1426,6 +1442,7 @@ export class PHP implements Disposable {
 		const mountHandlersToReapplyInOrder = Object.entries(this.#mounts).map(
 			([vfsPath, mount]) => ({
 				mountHandler: mount.mountHandler,
+				mountPointSnapshot: snapshotMountPoint(oldFS, vfsPath),
 				vfsPath,
 			})
 		);
@@ -1475,9 +1492,31 @@ export class PHP implements Disposable {
 		}
 
 		// Re-mount all the mount handlers in order
-		for (const { mountHandler, vfsPath } of mountHandlersToReapplyInOrder) {
-			this.mkdir(vfsPath);
-			await this.mount(vfsPath, mountHandler);
+		for (const {
+			mountHandler,
+			mountPointSnapshot,
+			vfsPath,
+		} of mountHandlersToReapplyInOrder) {
+			try {
+				await this.mount(vfsPath, mountHandler);
+			} catch (e) {
+				if (isMissingMountSourceError(e)) {
+					// Initial mounts still reject missing sources. During rotation,
+					// keep the pre-rotation VFS shape and drop the stale mount.
+					restoreMountPointSnapshot(
+						newFs,
+						vfsPath,
+						mountPointSnapshot
+					);
+					continue;
+				}
+				if (!isMissingMountTargetPathError(e)) {
+					throw e;
+				}
+
+				this.mkdir(vfsPath);
+				await this.mount(vfsPath, mountHandler);
+			}
 		}
 		try {
 			newFs.chdir(oldCWD);
@@ -1756,6 +1795,75 @@ function copyMEMFSNodes(
 	for (const filename of filenames) {
 		copyMEMFSNodes(source, target, joinPaths(path, filename));
 	}
+}
+
+/**
+ * Captures the VFS node shape hidden by a mount before rotation removes it.
+ */
+function snapshotMountPoint(
+	source: Emscripten.FileSystemInstance,
+	path: string
+): MountPointSnapshot | undefined {
+	try {
+		const oldNode = source.lookupPath(path, { follow: false });
+		if (source.isLink(oldNode.node.mode)) {
+			return { kind: 'symlink', target: source.readlink(path) };
+		}
+		if (source.isDir(oldNode.node.mode)) {
+			return { kind: 'directory' };
+		}
+
+		return { kind: 'file' };
+	} catch {
+		return undefined;
+	}
+}
+
+/**
+ * Recreates the pre-rotation mount point when its backing source disappeared.
+ */
+function restoreMountPointSnapshot(
+	target: Emscripten.FileSystemInstance,
+	path: string,
+	snapshot: MountPointSnapshot | undefined
+) {
+	if (!snapshot || getNodeType(target, path) !== 'missing') {
+		return;
+	}
+
+	if (snapshot.kind === 'directory') {
+		target.mkdirTree(path);
+		return;
+	}
+
+	target.mkdirTree(dirname(path));
+	if (snapshot.kind === 'symlink') {
+		target.symlink(snapshot.target, path);
+	} else {
+		target.writeFile(path, new Uint8Array());
+	}
+}
+
+/**
+ * Indicates whether a mount handler reported that its backing source is gone.
+ */
+function isMissingMountSourceError(error: unknown) {
+	const maybeMissingSourceError = error as {
+		phpWasmMountSourceMissing?: boolean;
+	};
+	return maybeMissingSourceError.phpWasmMountSourceMissing === true;
+}
+
+/**
+ * Indicates whether a mount failed because its target path does not exist yet
+ * inside PHP's filesystem.
+ *
+ * Emscripten reports this as errno 44. Rotation handles it by creating that
+ * target path and trying the mount again; other mount failures should bubble up.
+ */
+function isMissingMountTargetPathError(error: unknown) {
+	const maybeErrnoError = error as { errno?: number };
+	return maybeErrnoError.errno === 44;
 }
 
 /**


### PR DESCRIPTION
## What it does

Prevents PHP runtime rotation from crashing when:

1. Host directory is mounted into MEMFS via NODEFS a mount.
2. The directory is deleted in the host filesystem.
3. The PHP runtime rotates and tries to mount that same host path again.

With this PR, the runtime rotation tolerates deleted host directories. The VFS node structure is preserved throughout the rotation. Any mount targets seen as a VFS file before the rotation are still seen as a file after the rotation, and any targets seen as a directory before the rotation are still seen a directory after the rotation.

## Testing instructions

```bash
npm exec -- nx run php-wasm-node:typecheck
npm exec -- nx run php-wasm-node:lint
npm exec -- nx run php-wasm-node:test-group-3-asyncify --testFiles=mount.spec.ts --testFiles=rotate-php-runtime.spec.ts
```