### PR TITLE
[CI] Tolerate auto-label failures on large PR diffs

### DIFF
--- a/.github/workflows/auto-label-prs.yml
+++ b/.github/workflows/auto-label-prs.yml
@@ -40,7 +40,7 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 10
         permissions:
-            contents: read       # Required for actions/labeler to read the configuration file.
+            contents: read # Required for actions/labeler to read the configuration file.
             pull-requests: write # Required to apply labels to pull requests.
         steps:
             # Pinned to a commit SHA, not a tag: this job runs with
@@ -120,8 +120,15 @@ jobs:
                               { owner: context.repo.owner, repo: context.repo.repo, pull_number: pr.number, per_page: 100 }
                           );
                       } catch (err) {
+                          const status = err?.status;
+                          const message = err?.message ?? String(err);
+
+                          if (status !== 422 || !/diff is taking too long to generate/i.test(message)) {
+                              throw err;
+                          }
+
                           core.warning(
-                              `Could not list PR files (status ${err.status}): ${err.message}. ` +
+                              `Could not list PR files (status ${status}): ${message}. ` +
                               `Skipping package/type labeling for this PR.`
                           );
                           return;

--- a/.github/workflows/auto-label-prs.yml
+++ b/.github/workflows/auto-label-prs.yml
@@ -106,10 +106,26 @@ jobs:
                       ];
 
                       const pr = context.payload.pull_request;
-                      const files = await github.paginate(
-                          github.rest.pulls.listFiles,
-                          { owner: context.repo.owner, repo: context.repo.repo, pull_number: pr.number, per_page: 100 }
-                      );
+
+                      // Very large PRs (e.g. recompiled WASM binaries) make
+                      // GitHub's diff generation time out, so listFiles returns
+                      // 422 "Sorry, this diff is taking too long to generate."
+                      // That failure is persistent for such PRs — retrying just
+                      // loads their servers without helping. Package/type labels
+                      // are cosmetic, so skip them rather than fail the job.
+                      let files;
+                      try {
+                          files = await github.paginate(
+                              github.rest.pulls.listFiles,
+                              { owner: context.repo.owner, repo: context.repo.repo, pull_number: pr.number, per_page: 100 }
+                          );
+                      } catch (err) {
+                          core.warning(
+                              `Could not list PR files (status ${err.status}): ${err.message}. ` +
+                              `Skipping package/type labeling for this PR.`
+                          );
+                          return;
+                      }
 
                       // Tally lines + file count per package label.
                       const stats = new Map();


### PR DESCRIPTION
## Summary

Prevents the `Auto-label PRs` workflow from failing when GitHub cannot generate the file list for a very large PR diff. The package/type labeling job now logs a warning and skips those cosmetic labels only for the known oversized-diff failure.

## Motivation for the change, related issues

The `package-and-type` job calls `pulls.listFiles` to infer package labels from changed paths. On very large/generated PR diffs, GitHub can return `422` with `Sorry, this diff is taking too long to generate.` This is not WASM-specific, but WASM-heavy PHP rebuild PRs are a likely trigger because they include large generated artifacts.

Observed example: #3337 changed 73 files, including 33 `.wasm` artifacts, with roughly 77k additions and 93k deletions. The auto-label workflow failed repeatedly while requesting `pulls/3337/files`:

- https://github.com/WordPress/wordpress-playground/actions/runs/27665477418
- https://github.com/WordPress/wordpress-playground/actions/runs/27679416402
- https://github.com/WordPress/wordpress-playground/actions/runs/27680788985
- https://github.com/WordPress/wordpress-playground/actions/runs/27751421657
- https://github.com/WordPress/wordpress-playground/actions/runs/27757286243

Earlier, smaller WASM-touching PRs passed under the same workflow, so this fix is about tolerating GitHub diff-generation failures rather than treating WASM PRs as inherently broken.

Those labels are helpful metadata, but they should not block CI on PRs where GitHub cannot provide the diff-derived file list.

## Implementation details

Wraps the `github.paginate(github.rest.pulls.listFiles, ...)` call in `try`/`catch`. When the API returns the known `422` oversized-diff response, the workflow emits a warning with the status and message, then returns from the labeling script without applying package/type labels.

Unexpected API failures are rethrown so the workflow still surfaces real errors. The path-based `actions/labeler` job is unchanged.

## Testing Instructions

```bash
npx prettier --check .github/workflows/auto-label-prs.yml
```

Latest PR checks:

- `package-and-type`: pass
- `paths`: pass