### PR TITLE
[codex] Bucket autosave status announcements

### DIFF
--- a/packages/playground/website/playwright/e2e/website-ui.spec.ts
+++ b/packages/playground/website/playwright/e2e/website-ui.spec.ts
@@ -760,9 +760,9 @@ test.describe('Default Playground storage', () => {
 			null
 		);
 		await expect(website.page.getByText('Autosaving')).toHaveCount(0);
-		await expect(
-			website.page.getByText('Finalizing autosave')
-		).toHaveCount(0);
+		await expect(website.page.getByText('Finalizing autosave')).toHaveCount(
+			0
+		);
 		await expect(
 			website.page.getByRole('button', { name: 'Unsaved' })
 		).toHaveCount(0);
@@ -791,15 +791,23 @@ test.describe('Default Playground storage', () => {
 				}
 			)
 		);
-		expect(
-			saveStatusSamples.some(({ text }) => text === 'Autosaved')
-		).toBe(true);
+		expect(saveStatusSamples.some(({ text }) => text === 'Autosaved')).toBe(
+			true
+		);
 		expect(
 			saveStatusSamples.some(({ text }) => text === 'Autosaving')
 		).toBe(false);
+		const progressAriaLabels = saveStatusSamples
+			.map(({ ariaLabel }) => ariaLabel)
+			.filter((ariaLabel): ariaLabel is string =>
+				/^Autosaved \d+%$/.test(ariaLabel ?? '')
+			);
+		expect(progressAriaLabels.length).toBeGreaterThan(0);
 		expect(
-			saveStatusSamples.some(({ ariaLabel }) =>
-				/^Autosaved [1-9]\d*%$/.test(ariaLabel ?? '')
+			progressAriaLabels.every((ariaLabel) =>
+				['0', '25', '50', '75', '100'].includes(
+					ariaLabel.match(/^Autosaved (\d+)%$/)?.[1] ?? ''
+				)
 			)
 		).toBe(true);
 	});

--- a/packages/playground/website/src/components/browser-chrome/save-status-indicator.tsx
+++ b/packages/playground/website/src/components/browser-chrome/save-status-indicator.tsx
@@ -134,13 +134,15 @@ export function SaveStatusIndicator() {
 		const progress =
 			opfsSync?.status === 'syncing' ? opfsSync.progress : undefined;
 		const progressPercent = getProgressPercent(progress);
+		const announcedProgressPercent =
+			getAnnouncedProgressPercent(progressPercent);
 		return (
 			<div
 				className={classNames(css.indicator, css.saving)}
 				aria-label={`${getSyncLabel({
 					site: activeSite,
 					opfsSync,
-				})} ${progressPercent}%`}
+				})} ${announcedProgressPercent}%`}
 				role="status"
 			>
 				<span
@@ -291,4 +293,8 @@ function getProgressPercent(
 		return 0;
 	}
 	return Math.min(100, Math.round((progress.files / progress.total) * 100));
+}
+
+function getAnnouncedProgressPercent(progressPercent: number) {
+	return Math.min(100, Math.floor(progressPercent / 25) * 25);
 }


### PR DESCRIPTION
## What changed

This is the minimal fix for #3815. The save/autosave indicator keeps the existing `role="status"` live region, but the accessible `aria-label` no longer changes for every visual progress percentage. The visible progress ring still updates with exact progress, while the spoken label is bucketed to 0%, 25%, 50%, 75%, and 100%.

The existing Playwright autosave status sampling was updated to assert that progress labels only use those buckets.

## Approach

The implementation adds a small `getAnnouncedProgressPercent()` helper and uses it only for the `aria-label`. `getProgressPercent()` is unchanged and continues to drive the visual ring.

## Pros

- Smallest code change.
- Low behavioral risk because it preserves the current `role="status"` structure.
- Reduces screen reader announcement frequency from every percent to at most five progress labels.
- Does not affect visual progress fidelity.

## Cons

- Still uses a live status region to expose progress.
- The accessible label is intentionally stale between 25% buckets.
- Screen reader users cannot query the exact current percentage from the live region unless it happens to be on a bucket.
- This mitigates the verbosity but does not model the indicator as a semantic progressbar.

## Validation

- `npm exec nx -- run playground-website:typecheck`
- `npm exec nx -- run playground-website:lint`