### PR TITLE
[Website] Keep autosave progress out of live announcements

### DIFF
--- a/packages/playground/website/playwright/e2e/website-ui.spec.ts
+++ b/packages/playground/website/playwright/e2e/website-ui.spec.ts
@@ -753,8 +753,22 @@ test.describe('Default Playground storage', () => {
 			(window as any).__saveStatusSamples = [];
 			let installed = false;
 			const sampleStatus = () => {
+				const statusAnnouncement = [
+					...document.querySelectorAll('[role="status"]'),
+				]
+					.map((node) => (node.textContent || '').trim())
+					.find((text) =>
+						[
+							'Save complete',
+							'Autosave complete',
+							'Save failed',
+							'Autosave failed',
+						].includes(text)
+					);
 				const statusButton = [
-					...document.querySelectorAll('[role="status"], button'),
+					...document.querySelectorAll(
+						'[role="progressbar"], button'
+					),
 				].find((node) => {
 					const label = (node.textContent || '').trim();
 					return (
@@ -770,7 +784,10 @@ test.describe('Default Playground storage', () => {
 				}
 				(window as any).__saveStatusSamples.push({
 					text: (statusButton.textContent || '').trim(),
+					role: statusButton.getAttribute('role'),
 					ariaLabel: statusButton.getAttribute('aria-label'),
+					ariaValueNow: statusButton.getAttribute('aria-valuenow'),
+					statusAnnouncement: statusAnnouncement ?? null,
 					color: getComputedStyle(statusButton).color,
 				});
 			};
@@ -823,13 +840,19 @@ test.describe('Default Playground storage', () => {
 				(
 					sample: {
 						text: string;
+						role: string | null;
 						ariaLabel: string | null;
+						ariaValueNow: string | null;
+						statusAnnouncement: string | null;
 						color: string;
 					},
 					index: number,
 					all: {
 						text: string;
+						role: string | null;
 						ariaLabel: string | null;
+						ariaValueNow: string | null;
+						statusAnnouncement: string | null;
 						color: string;
 					}[]
 				) => {
@@ -837,7 +860,11 @@ test.describe('Default Playground storage', () => {
 					return (
 						!previous ||
 						previous.text !== sample.text ||
+						previous.role !== sample.role ||
 						previous.ariaLabel !== sample.ariaLabel ||
+						previous.ariaValueNow !== sample.ariaValueNow ||
+						previous.statusAnnouncement !==
+							sample.statusAnnouncement ||
 						previous.color !== sample.color
 					);
 				}
@@ -849,11 +876,31 @@ test.describe('Default Playground storage', () => {
 		expect(
 			saveStatusSamples.some(({ text }) => text === 'Autosaving')
 		).toBe(false);
+		const progressbarSamples = saveStatusSamples.filter(
+			({ role }) => role === 'progressbar'
+		);
+		expect(progressbarSamples.length).toBeGreaterThan(0);
 		expect(
-			saveStatusSamples.some(({ ariaLabel }) =>
-				/^Autosaved [1-9]\d*%$/.test(ariaLabel ?? '')
+			progressbarSamples.every(
+				({ ariaLabel }) => ariaLabel === 'Autosave progress'
 			)
 		).toBe(true);
+		expect(
+			progressbarSamples.some(({ ariaValueNow }) =>
+				/^[1-9]\d*$/.test(ariaValueNow ?? '')
+			)
+		).toBe(true);
+		expect(
+			saveStatusSamples.some(
+				({ statusAnnouncement }) =>
+					statusAnnouncement === 'Autosave complete'
+			)
+		).toBe(true);
+		expect(
+			saveStatusSamples.some(({ statusAnnouncement }) =>
+				/\d+%/.test(statusAnnouncement ?? '')
+			)
+		).toBe(false);
 	});
 
 	test('should edit a Blueprint for an autosaved Playground and recreate the same autosave', async ({
@@ -1414,7 +1461,9 @@ test.describe('Default Playground storage', () => {
 			(window as any).__siteSwitchStatusSamples = [];
 			const sampleStatus = () => {
 				const status = [
-					...document.querySelectorAll('[role="status"], button'),
+					...document.querySelectorAll(
+						'[role="status"], [role="progressbar"], button'
+					),
 				]
 					.map((node) => (node.textContent || '').trim())
 					.find((text) =>
@@ -1461,6 +1510,11 @@ test.describe('Default Playground storage', () => {
 			return (window as any).__siteSwitchStatusSamples;
 		});
 		expect(switchStatusSamples).not.toContain('Autosaving');
+		await expect(
+			website.page
+				.getByRole('status')
+				.filter({ hasText: /Save complete|Autosave complete/ })
+		).toHaveCount(0);
 	});
 
 	test('should show autosave browser storage details in the Site Manager by default', async ({
@@ -1827,7 +1881,9 @@ echo get_option('blogname');
 			(window as any).__keepNewStatusSamples = [];
 			const sampleStatus = () => {
 				const status = [
-					...document.querySelectorAll('[role="status"], button'),
+					...document.querySelectorAll(
+						'[role="status"], [role="progressbar"], button'
+					),
 				]
 					.map((node) => (node.textContent || '').trim())
 					.find((text) =>

--- a/packages/playground/website/src/components/browser-chrome/save-status-indicator.tsx
+++ b/packages/playground/website/src/components/browser-chrome/save-status-indicator.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import css from './save-status-indicator.module.css';
 import classNames from 'classnames';
 import {
@@ -24,6 +24,7 @@ import { isOpfsAvailable } from '../../lib/state/opfs/opfs-site-storage';
 import { useLocalFsAvailability } from '../../lib/hooks/use-local-fs-availability';
 
 type SaveStatus = 'saved' | 'autosaved' | 'unsaved' | 'saving' | 'error';
+type SyncOperation = 'save' | 'autosave';
 
 export function SaveStatusIndicator() {
 	const clientInfo = useAppSelector(getActiveClientInfo);
@@ -31,14 +32,63 @@ export function SaveStatusIndicator() {
 	const dispatch = useAppDispatch();
 	const statusButtonRef = useRef<HTMLButtonElement>(null);
 	const suppressNextTriggerClickRef = useRef(false);
+	const previousStatusRef = useRef<{
+		status: SaveStatus | undefined;
+		siteSlug: string | undefined;
+	}>();
 	const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+	const [statusAnnouncement, setStatusAnnouncement] = useState('');
 
 	const opfsSync = clientInfo?.opfsSync;
 	const status = getSaveStatus(activeSite, clientInfo);
-	const isAutosaved = activeSite ? isAutosavedSite(activeSite) : false;
+	const siteSlug = activeSite?.slug;
+	const syncOperation = getSyncOperation({ site: activeSite, opfsSync });
 	const localFsAvailability = useLocalFsAvailability(clientInfo?.client);
 	const canStorePermanently =
 		isOpfsAvailable || localFsAvailability === 'available';
+
+	useEffect(() => {
+		const previousStatus = previousStatusRef.current;
+		previousStatusRef.current = {
+			status,
+			siteSlug,
+		};
+
+		// Do not describe an already-finished save as a new completion when the
+		// user switches Playgrounds. The next real sync will populate the region.
+		if (
+			!status ||
+			!previousStatus?.status ||
+			previousStatus.siteSlug !== siteSlug
+		) {
+			setStatusAnnouncement('');
+			return;
+		}
+
+		// Clear the previous result while a new sync runs. This prevents stale
+		// status text and makes a repeated message such as "Autosave complete" a
+		// new live-region update when the operation finishes.
+		if (status === 'saving') {
+			setStatusAnnouncement('');
+			return;
+		}
+
+		const message = getStatusAnnouncement({
+			previousStatus: previousStatus.status,
+			status,
+			syncOperation,
+		});
+		if (message) {
+			setStatusAnnouncement(message);
+		}
+	}, [siteSlug, status, syncOperation]);
+
+	const withStatusAnnouncement = (indicator: React.ReactElement) => (
+		<>
+			<SaveStatusAnnouncement announcement={statusAnnouncement} />
+			{indicator}
+		</>
+	);
 
 	const openSaveModal = () => {
 		setIsPopoverOpen(false);
@@ -74,7 +124,7 @@ export function SaveStatusIndicator() {
 	}
 
 	if (status === 'saved') {
-		return (
+		return withStatusAnnouncement(
 			<div className={classNames(css.indicator, css.saved)}>
 				<Icon icon={check} size={18} />
 				<span className={css.label}>Saved Playground</span>
@@ -83,7 +133,7 @@ export function SaveStatusIndicator() {
 	}
 
 	if (status === 'autosaved') {
-		return (
+		return withStatusAnnouncement(
 			<>
 				<button
 					ref={statusButtonRef}
@@ -134,14 +184,21 @@ export function SaveStatusIndicator() {
 		const progress =
 			opfsSync?.status === 'syncing' ? opfsSync.progress : undefined;
 		const progressPercent = getProgressPercent(progress);
-		return (
+		const syncLabel = getSyncLabel({ site: activeSite, opfsSync });
+		// A progressbar exposes exact progress when a screen reader user
+		// navigates to it without broadcasting every file-count update.
+		return withStatusAnnouncement(
 			<div
 				className={classNames(css.indicator, css.saving)}
-				aria-label={`${getSyncLabel({
-					site: activeSite,
-					opfsSync,
-				})} ${progressPercent}%`}
-				role="status"
+				aria-label={
+					syncOperation === 'autosave'
+						? 'Autosave progress'
+						: 'Save progress'
+				}
+				aria-valuemax={100}
+				aria-valuemin={0}
+				aria-valuenow={progressPercent}
+				role="progressbar"
 			>
 				<span
 					className={css.progressRing}
@@ -152,15 +209,13 @@ export function SaveStatusIndicator() {
 					}
 					aria-hidden="true"
 				/>
-				<span className={css.label}>
-					{getSyncLabel({ site: activeSite, opfsSync })}
-				</span>
+				<span className={css.label}>{syncLabel}</span>
 			</div>
 		);
 	}
 
 	if (status === 'error') {
-		return (
+		return withStatusAnnouncement(
 			<button
 				className={classNames(css.indicator, css.error)}
 				onClick={openSaveModal}
@@ -168,15 +223,13 @@ export function SaveStatusIndicator() {
 			>
 				<Icon icon={cautionFilled} size={18} />
 				<span className={css.label}>
-					{opfsSync?.operation === 'autosave' || isAutosaved
-						? 'Autosave failed'
-						: 'Save failed'}
+					{getFailedSyncLabel(syncOperation)}
 				</span>
 			</button>
 		);
 	}
 
-	return (
+	return withStatusAnnouncement(
 		<>
 			<button
 				ref={statusButtonRef}
@@ -221,6 +274,50 @@ export function SaveStatusIndicator() {
 			)}
 		</>
 	);
+}
+
+/**
+ * Keeps completion and failure announcements separate from queryable progress.
+ *
+ * The region stays mounted while the visual indicator changes. `role="status"`
+ * is implicitly polite and atomic, so only changes to `announcement` are spoken.
+ */
+function SaveStatusAnnouncement({ announcement }: { announcement: string }) {
+	return (
+		<div className="sr-only" role="status">
+			{announcement}
+		</div>
+	);
+}
+
+/**
+ * Returns the result to announce for a save lifecycle transition.
+ *
+ * Progress updates keep `status` at `saving` and never enter this live region.
+ * Errors are announced only when entered so later state updates cannot repeat
+ * the same failure indefinitely.
+ */
+function getStatusAnnouncement({
+	previousStatus,
+	status,
+	syncOperation,
+}: {
+	previousStatus: SaveStatus;
+	status: SaveStatus;
+	syncOperation: SyncOperation;
+}) {
+	if (status === 'error' && previousStatus !== 'error') {
+		return getFailedSyncLabel(syncOperation);
+	}
+	if (previousStatus !== 'saving') {
+		return undefined;
+	}
+	if (status === 'saved' || status === 'autosaved') {
+		return syncOperation === 'autosave'
+			? 'Autosave complete'
+			: 'Save complete';
+	}
+	return undefined;
 }
 
 /**
@@ -279,6 +376,27 @@ function getSyncLabel({
 		return 'Autosaved';
 	}
 	return opfsSync?.operation === 'autosave' ? 'Autosaving' : 'Saving';
+}
+
+/**
+ * Uses the explicit sync operation when available and falls back to the stored
+ * site lifecycle while the initial client is still booting.
+ */
+function getSyncOperation({
+	site,
+	opfsSync,
+}: {
+	site: SiteInfo | undefined;
+	opfsSync: OpfsSync | undefined;
+}): SyncOperation {
+	return (
+		opfsSync?.operation ??
+		(site && isAutosavedSite(site) ? 'autosave' : 'save')
+	);
+}
+
+function getFailedSyncLabel(syncOperation: SyncOperation) {
+	return syncOperation === 'autosave' ? 'Autosave failed' : 'Save failed';
 }
 
 /**


### PR DESCRIPTION
## Why

The save indicator used `role="status"` while changing its percentage for every
OPFS file. Because that role is a polite, atomic live region, screen readers
announced the entire label continuously during autosave.

## What changed

Expose in-progress saves as a non-live `progressbar` with an exact
`aria-valuenow`. Keep a separate, stable `status` region for completion and
failure only. Clear that result when a new sync starts, announce failures only
when entering the error state, and suppress stale completion announcements when
switching Playgrounds.

The inline comments document why progress and result announcements are separate
and why the transition state is reset at those lifecycle boundaries.

Closes #3815.

## Validation

- `npm exec nx -- run playground-website:test --output-style=static`
- `npm exec nx -- run playground-website:typecheck --output-style=static`
- `npm exec nx -- run playground-website:lint --output-style=static`
- `npm exec nx -- run playground-website:e2e:playwright --args='--project=chromium --grep="should create and finish autosaving a Playground from the root URL"' --output-style=static`
- `npm exec nx -- run playground-website:e2e:playwright --args='--project=chromium --grep="should treat New Playground as an explicit fresh start"' --output-style=static`
