### PR TITLE
[Personal-WP] Add my.wordpress.net specific MCP instructions and skills

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54324,7 +54324,7 @@
 			"name": "@wp-playground/personal-wp-mcp",
 			"version": "0.0.1",
 			"dependencies": {
-				"@wp-playground/mcp": "3.1.40"
+				"@wp-playground/mcp": "*"
 			},
 			"bin": {
 				"mywp": "cli.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -20795,6 +20795,10 @@
 			"resolved": "packages/playground/personal-wp",
 			"link": true
 		},
+		"node_modules/@wp-playground/personal-wp-mcp": {
+			"resolved": "packages/playground/personal-wp-mcp",
+			"link": true
+		},
 		"node_modules/@wp-playground/php-cors-proxy": {
 			"resolved": "packages/playground/php-cors-proxy",
 			"link": true
@@ -54315,6 +54319,16 @@
 		"packages/playground/personal-wp": {
 			"name": "@wp-playground/personal-wp",
 			"version": "0.0.1"
+		},
+		"packages/playground/personal-wp-mcp": {
+			"name": "@wp-playground/personal-wp-mcp",
+			"version": "0.0.1",
+			"dependencies": {
+				"@wp-playground/mcp": "3.1.40"
+			},
+			"bin": {
+				"mywp": "cli.js"
+			}
 		},
 		"packages/playground/php-cors-proxy": {
 			"name": "@wp-playground/php-cors-proxy",

--- a/packages/playground/mcp/README.md
+++ b/packages/playground/mcp/README.md
@@ -44,29 +44,67 @@ Add to `~/.gemini/settings.json` (or `.gemini/settings.json` in your project):
 Your AI assistant will ask you to open the Playground website and provide the exact URL. You can also ask it: _"What's the Playground website URL?"_
 The MCP server chooses the local bridge connection automatically, so you do not need to configure it in your MCP client.
 
-To connect to Personal Playground, pass its URL to the MCP server:
+To connect to Personal Playground, use the MyWP MCP package. It wraps the
+generic Playground MCP server and adds MyWP-specific prompts and tools:
 
 ```json
 {
 	"mcpServers": {
-		"wordpress-playground": {
+		"mywp": {
 			"type": "stdio",
 			"command": "npx",
-			"args": ["-y", "@wp-playground/mcp", "--url=https://my.wordpress.net/"]
+			"args": ["-y", "@wp-playground/personal-wp-mcp"]
 		}
 	}
 }
 ```
+
+The MyWP package defaults to `https://my.wordpress.net/`. Pass `--url=...` only
+when connecting it to a different Personal Playground origin.
+
+MCP clients that support prompts can then load `mywp-agent` for the recommended
+MyWP operating instructions. The MyWP MCP server also ships focused skill
+prompts:
+
+- `mywp-skill-abilities`: discover REST routes and WordPress Abilities before
+  falling back to raw PHP.
+- `mywp-skill-file-editing`: inspect and edit files in the MyWP virtual
+  filesystem.
+- `mywp-skill-plugin-development`: create or modify WordPress plugins inside
+  MyWP.
+- `mywp-skill-create-app`: scaffold app-like plugins locally with
+  `create-wp-app`, then sync them into MyWP.
+- `mywp-skill-sync-local-changes`: copy local project changes into the
+  `my.wordpress.net` sandbox.
+
+To sync local changes into MyWP, run the MyWP MCP package connected to
+`https://my.wordpress.net/`. Local files are not mounted automatically: your AI
+client must read local files from your machine, create matching directories under
+`/wordpress/wp-content/` with `playground_mkdir`, and write the changed file
+contents with `playground_write_file`. Verify PHP changes with
+`playground_execute_php` and check the affected route or admin page with
+`playground_request` or `playground_navigate`.
+
+The MyWP profile also exposes `mywp_get_plugin_guidance`, a read-only MCP tool
+that applies AI Assistant filters on the connected site and returns structured
+plugin ability guidance plus a prompt-ready `systemPrompt`. Plugins can hook
+`ai_assistant_ability_domains` to map ability categories/domains to the topics
+users ask about. MCP clients can parse the returned `entries` or merge the
+returned `systemPrompt` into their instructions so they prefer the WordPress
+Abilities API through `playground_request` before lower-level database, file, or
+direct PHP inspection for those topics. The tool also reads
+`ai_assistant_welcome_tips`. These filters are applied directly and do not
+require the AI Assistant plugin to be installed.
 
 For a staging deployment, use that origin instead:
 
 ```json
 {
 	"mcpServers": {
-		"wordpress-playground": {
+		"mywp": {
 			"type": "stdio",
 			"command": "npx",
-			"args": ["-y", "@wp-playground/mcp", "--url=https://mywp.kirk.at/"]
+			"args": ["-y", "@wp-playground/personal-wp-mcp", "--url=https://mywp.kirk.at/"]
 		}
 	}
 }

--- a/packages/playground/mcp/package.json
+++ b/packages/playground/mcp/package.json
@@ -22,6 +22,10 @@
 			"import": "./client.js",
 			"require": "./client.cjs"
 		},
+		"./api": {
+			"import": "./api.js",
+			"require": "./api.cjs"
+		},
 		"./package.json": "./package.json"
 	},
 	"publishConfig": {

--- a/packages/playground/mcp/src/api.ts
+++ b/packages/playground/mcp/src/api.ts
@@ -1,0 +1,59 @@
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { PlaygroundBridge } from './bridge-server';
+import { createServer } from './mcp-server';
+import { registerMcpServerTools } from './tools/register-mcp-server-tools';
+import type { McpServerExtension, McpServerDefinition } from './mcp-server';
+import type { McpServerToolRegistrar } from './tools/register-mcp-server-tools';
+
+export { PlaygroundBridge } from './bridge-server';
+export { createServer } from './mcp-server';
+export { playgroundMcpProfile } from './playground-mcp-profile';
+export { registerMcpServerTools } from './tools/register-mcp-server-tools';
+export type {
+	McpServerDefinition,
+	McpServerExtension,
+	McpServerPromptDefinition,
+} from './mcp-server';
+export type { McpServerToolRegistrar } from './tools/register-mcp-server-tools';
+
+export interface StartMcpServerOptions {
+	baseUrl?: URL | string;
+	port?: number;
+	definition?: McpServerDefinition;
+	extensions?: McpServerExtension[];
+	toolRegistrars?: McpServerToolRegistrar[];
+}
+
+export async function startMcpServer({
+	baseUrl,
+	port = 0,
+	definition,
+	extensions = [],
+	toolRegistrars = [],
+}: StartMcpServerOptions = {}) {
+	const resolvedBaseUrl = baseUrl?.toString();
+	const bridge = new PlaygroundBridge(
+		resolvedBaseUrl ? [resolvedBaseUrl] : []
+	);
+	await bridge.startWebSocketServer(port);
+	const resolvedPort = bridge.getPort();
+	const server = createServer({
+		definition,
+		extensions: [
+			...extensions,
+			{
+				registerTools: (server) =>
+					registerMcpServerTools(
+						server,
+						bridge,
+						resolvedPort,
+						resolvedBaseUrl,
+						toolRegistrars
+					),
+			},
+		],
+	});
+	const transport = new StdioServerTransport();
+	await server.connect(transport);
+	return { bridge, port: resolvedPort, server };
+}

--- a/packages/playground/mcp/src/mcp-server-profile.ts
+++ b/packages/playground/mcp/src/mcp-server-profile.ts
@@ -1,0 +1,12 @@
+export interface McpServerPromptDefinition {
+	name: string;
+	title: string;
+	description: string;
+	text: string;
+}
+
+export interface McpServerDefinition {
+	name: string;
+	description: string;
+	prompts: McpServerPromptDefinition[];
+}

--- a/packages/playground/mcp/src/mcp-server.ts
+++ b/packages/playground/mcp/src/mcp-server.ts
@@ -1,5 +1,25 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { createRequire } from 'module';
+import { playgroundMcpProfile } from './playground-mcp-profile';
+import type {
+	McpServerDefinition,
+	McpServerPromptDefinition,
+} from './mcp-server-profile';
+
+export type {
+	McpServerDefinition,
+	McpServerPromptDefinition,
+} from './mcp-server-profile';
+
+export interface McpServerExtension {
+	prompts?: McpServerPromptDefinition[];
+	registerTools?: (server: McpServer) => void;
+}
+
+export interface CreateMcpServerOptions {
+	definition?: McpServerDefinition;
+	extensions?: McpServerExtension[];
+}
 
 const require = createRequire(import.meta.url);
 let packageVersion: string;
@@ -10,23 +30,50 @@ try {
 	packageVersion = require('../package.json').version;
 }
 
-export function createServer(): McpServer {
-	return new McpServer({
-		name: 'wordpress-playground',
+export function createServer(options: CreateMcpServerOptions = {}): McpServer {
+	const serverDefinition = options.definition ?? playgroundMcpProfile;
+	const extensions = options.extensions ?? [];
+	const server = new McpServer({
+		name: serverDefinition.name,
 		version: packageVersion,
-		description: `Use this server when you need a live WordPress environment without any local setup. \
-			WordPress Playground runs entirely in the user's browser tab via WebAssembly — no PHP, MySQL, \
-			or server required. You are automatically authenticated as an admin user.\n\n\
-			PREREQUISITE: Call playground_list_sites first. If no browser is connected, \
-			call playground_get_website_url to get the exact URL and ask the user to open it. \n\n\
-			Typical workflow: playground_list_sites → playground_save_in_browser \
-			→ filesystem/PHP operations → playground_navigate to verify results.\n\n\
-			Capabilities: execute arbitrary PHP with full WordPress access, read/write files in the virtual filesystem \
-			(WordPress root: /wordpress/), make HTTP requests to the site, navigate the browser, \
-			and manage multiple Playground sites simultaneously.\n\n\
-			Important: sites are temporary by default and not persisted between sessions. \
-			Call playground_save_in_browser early in any multi-step workflow where losing progress would be costly.\n\n\
-			Error handling: tool failures are returned as thrown exceptions with descriptive messages, \
-			not as silent failures.`,
+		description: serverDefinition.description,
 	});
+	registerPrompts(server, [
+		...serverDefinition.prompts,
+		...extensions.flatMap((extension) => extension.prompts ?? []),
+	]);
+	for (const extension of extensions) {
+		extension.registerTools?.(server);
+	}
+	return server;
+}
+
+function registerPrompts(
+	server: McpServer,
+	prompts: McpServerPromptDefinition[]
+) {
+	for (const prompt of prompts) {
+		server.registerPrompt(
+			prompt.name,
+			{
+				title: prompt.title,
+				description: prompt.description,
+			},
+			async () => promptMessages(prompt.text)
+		);
+	}
+}
+
+function promptMessages(text: string) {
+	return {
+		messages: [
+			{
+				role: 'user' as const,
+				content: {
+					type: 'text' as const,
+					text,
+				},
+			},
+		],
+	};
 }

--- a/packages/playground/mcp/src/playground-mcp-profile.ts
+++ b/packages/playground/mcp/src/playground-mcp-profile.ts
@@ -1,0 +1,20 @@
+import type { McpServerDefinition } from './mcp-server-profile';
+
+export const playgroundMcpProfile: McpServerDefinition = {
+	name: 'wordpress-playground',
+	description: `Use this server when you need a live WordPress environment without any local setup. \
+WordPress Playground runs entirely in the user's browser tab via WebAssembly — no PHP, MySQL, \
+or server required. You are automatically authenticated as an admin user.\n\n\
+PREREQUISITE: Call playground_list_sites first. If no browser is connected, \
+call playground_get_website_url to get the exact URL and ask the user to open it. \n\n\
+Typical workflow: playground_list_sites → playground_save_in_browser \
+→ filesystem/PHP operations → playground_navigate to verify results.\n\n\
+Capabilities: execute arbitrary PHP with full WordPress access, read/write files in the virtual filesystem \
+(WordPress root: /wordpress/), make HTTP requests to the site, navigate the browser, \
+and manage multiple Playground sites simultaneously.\n\n\
+Important: sites are temporary by default and not persisted between sessions. \
+Call playground_save_in_browser early in any multi-step workflow where losing progress would be costly.\n\n\
+Error handling: tool failures are returned as thrown exceptions with descriptive messages, \
+not as silent failures.`,
+	prompts: [],
+};

--- a/packages/playground/mcp/src/tools/register-mcp-server-tools.ts
+++ b/packages/playground/mcp/src/tools/register-mcp-server-tools.ts
@@ -14,6 +14,11 @@ import {
 import type { ToolParam } from './tool-definitions';
 import { toolExecutors } from './tool-executors';
 import type { ToolClient } from './tool-executors';
+
+export type McpServerToolRegistrar = (
+	server: McpServer,
+	bridge: PlaygroundBridge
+) => void;
 function errorResult(prefix: string, error: unknown) {
 	return {
 		content: [
@@ -87,11 +92,16 @@ export function registerMcpServerTools(
 	server: McpServer,
 	bridge: PlaygroundBridge,
 	port: number,
-	baseUrl?: string
+	baseUrl?: string,
+	extraToolRegistrars: McpServerToolRegistrar[] = []
 ) {
 	const sendCommand = bridge.sendCommand.bind(bridge);
 	const siteToolDefinitions = getSiteToolDefinitions();
 	const url = playgroundUrl(port, baseUrl);
+
+	for (const registerTools of extraToolRegistrars) {
+		registerTools(server, bridge);
+	}
 
 	// -- Site management tools --
 	// These operate on the bridge itself, not on a PlaygroundClient.

--- a/packages/playground/mcp/tests/unit/mcp-server.spec.ts
+++ b/packages/playground/mcp/tests/unit/mcp-server.spec.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { createServer } from '../../src/mcp-server';
+import type { McpServerDefinition } from '../../src/mcp-server';
+
+describe('MCP server prompts', () => {
+	it('does not ship MyWP prompts for generic Playground', async () => {
+		await expect(
+			withPromptClient(undefined, async (client) => client.listPrompts())
+		).rejects.toThrow('Method not found');
+	});
+
+	it('ships prompts from the provided server definition', async () => {
+		await withPromptClient(
+			{
+				name: 'test-server',
+				description: 'Test server',
+				prompts: [
+					{
+						name: 'test-prompt',
+						title: 'Test Prompt',
+						description: 'A prompt from the server definition.',
+						text: 'Use the test prompt.',
+					},
+				],
+			},
+			async (client) => {
+				const prompts = await client.listPrompts();
+				expect(prompts.prompts.map((prompt) => prompt.name)).toEqual([
+					'test-prompt',
+				]);
+
+				const prompt = await client.getPrompt({
+					name: 'test-prompt',
+					arguments: {},
+				});
+
+				expect(prompt.messages[0].content.text).toContain(
+					'Use the test prompt.'
+				);
+			}
+		);
+	});
+
+	it('ships prompts from extensions', async () => {
+		await withPromptClient(
+			undefined,
+			async (client) => {
+				const prompts = await client.listPrompts();
+				expect(prompts.prompts.map((prompt) => prompt.name)).toEqual([
+					'extension-prompt',
+				]);
+
+				const prompt = await client.getPrompt({
+					name: 'extension-prompt',
+					arguments: {},
+				});
+
+				expect(prompt.messages[0].content.text).toContain(
+					'Use the extension prompt.'
+				);
+			},
+			true
+		);
+	});
+});
+
+async function withPromptClient<T>(
+	serverDefinition: McpServerDefinition | undefined,
+	callback: (client: Client) => Promise<T>,
+	includeExtensionPrompt = false
+): Promise<T> {
+	const [clientTransport, serverTransport] =
+		InMemoryTransport.createLinkedPair();
+	const server = createServer({
+		definition: serverDefinition,
+		extensions: includeExtensionPrompt
+			? [
+					{
+						prompts: [
+							{
+								name: 'extension-prompt',
+								title: 'Extension Prompt',
+								description: 'A prompt from an MCP extension.',
+								text: 'Use the extension prompt.',
+							},
+						],
+					},
+				]
+			: [],
+	});
+	const client = new Client({
+		name: 'mcp-server-unit-test',
+		version: '1.0.0',
+	});
+
+	await server.connect(serverTransport);
+	await client.connect(clientTransport);
+
+	try {
+		return await callback(client);
+	} finally {
+		await client.close();
+		await server.close();
+	}
+}

--- a/packages/playground/personal-wp-mcp/.eslintrc.json
+++ b/packages/playground/personal-wp-mcp/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+	"extends": ["../../../.eslintrc.json"],
+	"ignorePatterns": ["!**/*"],
+	"overrides": [
+		{
+			"files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+			"rules": {}
+		},
+		{
+			"files": ["*.ts", "*.tsx"],
+			"rules": {}
+		},
+		{
+			"files": ["*.js", "*.jsx"],
+			"rules": {}
+		}
+	]
+}

--- a/packages/playground/personal-wp-mcp/package.json
+++ b/packages/playground/personal-wp-mcp/package.json
@@ -1,0 +1,26 @@
+{
+	"name": "@wp-playground/personal-wp-mcp",
+	"version": "0.0.1",
+	"private": true,
+	"type": "module",
+	"bin": {
+		"mywp": "./cli.js"
+	},
+	"main": "./index.cjs",
+	"module": "./index.js",
+	"types": "index.d.ts",
+	"exports": {
+		".": {
+			"import": "./index.js",
+			"require": "./index.cjs"
+		},
+		"./cli": {
+			"import": "./cli.js",
+			"require": "./cli.cjs"
+		},
+		"./package.json": "./package.json"
+	},
+	"dependencies": {
+		"@wp-playground/mcp": "3.1.40"
+	}
+}

--- a/packages/playground/personal-wp-mcp/package.json
+++ b/packages/playground/personal-wp-mcp/package.json
@@ -21,6 +21,6 @@
 		"./package.json": "./package.json"
 	},
 	"dependencies": {
-		"@wp-playground/mcp": "3.1.40"
+		"@wp-playground/mcp": "*"
 	}
 }

--- a/packages/playground/personal-wp-mcp/project.json
+++ b/packages/playground/personal-wp-mcp/project.json
@@ -1,0 +1,54 @@
+{
+	"name": "playground-personal-wp-mcp",
+	"$schema": "../../../node_modules/nx/schemas/project-schema.json",
+	"sourceRoot": "packages/playground/personal-wp-mcp/src",
+	"projectType": "library",
+	"tags": [],
+	"targets": {
+		"build": {
+			"executor": "@wp-playground/nx-extensions:package-json",
+			"options": {
+				"tsConfig": "packages/playground/personal-wp-mcp/tsconfig.lib.json",
+				"outputPath": "dist/packages/playground/personal-wp-mcp",
+				"buildTarget": "playground-personal-wp-mcp:build:bundle:production"
+			}
+		},
+		"build:bundle": {
+			"executor": "@nx/vite:build",
+			"outputs": ["{options.outputPath}"],
+			"options": {
+				"outputPath": "dist/packages/playground/personal-wp-mcp"
+			},
+			"defaultConfiguration": "production",
+			"configurations": {
+				"development": {
+					"mode": "development"
+				},
+				"production": {
+					"mode": "production"
+				}
+			}
+		},
+		"test:unit": {
+			"executor": "@nx/vite:test",
+			"outputs": [
+				"{workspaceRoot}/coverage/packages/playground/personal-wp-mcp"
+			],
+			"options": {
+				"passWithNoTests": true,
+				"reportsDirectory": "../../../coverage/packages/playground/personal-wp-mcp"
+			}
+		},
+		"lint": {
+			"executor": "@nx/eslint:lint",
+			"outputs": ["{options.outputFile}"],
+			"options": {
+				"useFlatConfig": false,
+				"lintFilePatterns": [
+					"packages/playground/personal-wp-mcp/**/*.ts"
+				],
+				"maxWarnings": 0
+			}
+		}
+	}
+}

--- a/packages/playground/personal-wp-mcp/src/cli.ts
+++ b/packages/playground/personal-wp-mcp/src/cli.ts
@@ -1,4 +1,6 @@
-import { startMcpServer } from './api';
+import { startMcpServer } from '@wp-playground/mcp/api';
+import { personalWpMcpProfile } from './profile';
+import { registerPersonalWpMcpTools } from './tools';
 
 function getPortFromArgs(): number {
 	const portArg = process.argv.find((a) => a.startsWith('--port='));
@@ -8,10 +10,10 @@ function getPortFromArgs(): number {
 	return 0;
 }
 
-function getBaseUrlFromArgs(): URL | undefined {
+function getBaseUrlFromArgs(): URL {
 	const urlArg = process.argv.find((a) => a.startsWith('--url='));
 	if (!urlArg) {
-		return undefined;
+		return new URL('https://my.wordpress.net/');
 	}
 	const value = urlArg.split('=').slice(1).join('=');
 	try {
@@ -26,11 +28,15 @@ async function main() {
 	await startMcpServer({
 		baseUrl,
 		port: getPortFromArgs(),
+		definition: personalWpMcpProfile,
+		toolRegistrars: [registerPersonalWpMcpTools],
 	});
-	console.error('[MCP] WordPress Playground MCP server running on stdio');
+	// eslint-disable-next-line no-console
+	console.error('[MCP] MyWP MCP server running on stdio');
 }
 
 main().catch((error) => {
+	// eslint-disable-next-line no-console
 	console.error('Fatal error:', error);
 	process.exit(1);
 });

--- a/packages/playground/personal-wp-mcp/src/index.ts
+++ b/packages/playground/personal-wp-mcp/src/index.ts
@@ -1,0 +1,3 @@
+export { personalWpMcpProfile } from './profile';
+export { registerPersonalWpMcpTools } from './tools';
+export type { PersonalWpMcpProfileDefinition } from './profile';

--- a/packages/playground/personal-wp-mcp/src/profile.ts
+++ b/packages/playground/personal-wp-mcp/src/profile.ts
@@ -1,0 +1,312 @@
+interface McpServerPromptDefinition {
+	name: string;
+	title: string;
+	description: string;
+	text: string;
+}
+
+export interface PersonalWpMcpProfileDefinition {
+	name: string;
+	description: string;
+	prompts: McpServerPromptDefinition[];
+}
+
+export const personalWpMcpProfile: PersonalWpMcpProfileDefinition = {
+	name: 'mywp',
+	description: `MyWP MCP gives external AI clients a live persistent WordPress \
+site at my.wordpress.net with admin access, filesystem tools, authenticated HTTP \
+requests, PHP execution, browser navigation, and site management.\n\n\
+Start every workflow with playground_list_sites. If no browser is connected, \
+call playground_get_website_url and ask the user to open that exact URL.\n\n\
+For best results, load the MCP prompt named mywp-agent. It is the reusable \
+operating prompt for external clients. Then load focused skill prompts that match \
+the task, such as mywp-skill-abilities, mywp-skill-file-editing, \
+mywp-skill-plugin-development, mywp-skill-create-app, or \
+mywp-skill-sync-local-changes.\n\n\
+Prefer WordPress-native interfaces before raw execution: use playground_request \
+with REST routes for content and settings, inspect /wp-json/ route metadata when \
+unsure, discover plugin-specific capabilities through the Abilities API when \
+present, and use playground_execute_php only when REST or abilities do not expose \
+the needed operation.\n\n\
+MyWP stores the site in the user's browser. Call playground_save_in_browser \
+early if the site is not already persisted. Tool failures are returned as thrown \
+exceptions with descriptive messages, not silent failures.`,
+	prompts: [
+		{
+			name: 'mywp-agent',
+			title: 'MyWP Agent',
+			description:
+				'Operating prompt for using MyWP MCP as a capable external WordPress agent.',
+			text: `You are operating a live MyWP site through MCP.
+
+Use the Playground tools as your WordPress runtime, not as incidental helpers.
+The browser tab is my.wordpress.net. It contains WordPress running
+in WebAssembly, persisted in the user's browser storage. The active user is
+authenticated as an administrator.
+
+Startup:
+- Call playground_list_sites before any site-specific tool.
+- If no site is connected, call playground_get_website_url and ask the user to
+  open that exact URL.
+- Use the returned siteId for all site-specific calls.
+- Call playground_save_in_browser early when a multi-step task would be costly
+  to lose.
+
+Capability order:
+- Use playground_request with WordPress REST routes for normal WordPress data:
+  posts, pages, terms, users, comments, settings, and route discovery.
+- Inspect /wp-json/ route metadata before using unfamiliar endpoint arguments.
+- When plugins expose the WordPress Abilities API, discover and use abilities
+  before raw PHP for plugin-specific actions.
+- Use playground_execute_php when REST and abilities do not expose the needed
+  operation or when direct WordPress/PHP inspection is the clearest route.
+- Use filesystem tools for source files and generated artifacts in the virtual
+  filesystem. The WordPress root is /wordpress/.
+
+Execution discipline:
+- Read current files before modifying them.
+- Keep generated output bounded. Avoid unbounded database queries, recursive
+  directory dumps, and full HTML reads unless necessary.
+- After code changes, run the cheapest useful verification available: PHP lint
+  through playground_execute_php, a REST request, a page request, or browser
+  navigation.
+- Report concrete paths, URLs, and verification results in the final answer.`,
+		},
+		{
+			name: 'mywp-skill-abilities',
+			title: 'WordPress Abilities Skill',
+			description:
+				'Use WordPress REST route metadata and the Abilities API before falling back to PHP.',
+			text: `Use this skill for plugin-specific data or actions.
+
+Discovery workflow:
+- Start with GET /wp-json/ through playground_request to inspect available REST
+  routes when endpoint support is uncertain.
+- If /wp-json/wp-abilities/v1/abilities exists, use it to discover exact
+  ability IDs. Ability categories and domain slugs are not executable IDs.
+- List compactly first, for example:
+  /wp-json/wp-abilities/v1/abilities?_fields=name,category,label,description
+- Get one ability before executing it:
+  /wp-json/wp-abilities/v1/abilities/{name}
+- Ability names can contain slash characters. Use the documented path shape from
+  the route; do not invent encoded variants unless route metadata requires it.
+- Execute the ability with the method and input schema documented by the ability
+  details. POST bodies usually wrap arguments in an input object.
+
+Fallbacks:
+- Use regular WordPress REST routes for core WordPress CRUD.
+- Use playground_execute_php only when REST routes and abilities do not expose
+  the needed operation.`,
+		},
+		{
+			name: 'mywp-skill-file-editing',
+			title: 'MyWP File Editing Skill',
+			description:
+				'Guidance for safe file inspection and edits in the MyWP virtual filesystem.',
+			text: `Use this skill when creating, modifying, or deleting files.
+
+Rules:
+- Read the current file before editing unless its exact current content is
+  already present in this turn.
+- Prefer narrow reads: list directories, then read specific files.
+- Use playground_write_file for new files or intentional full-file replacement.
+- When changing an existing file, preserve unrelated content and formatting.
+- Create parent directories with playground_mkdir before writing new nested
+  files.
+- Delete files or directories only when the user explicitly asks or when the
+  generated artifact is clearly obsolete and you explain why.
+- After PHP edits, run a lint check through playground_execute_php when
+  practical.
+
+Useful PHP lint pattern:
+<?php
+$file = '/wordpress/wp-content/plugins/example/example.php';
+passthru('php -l ' . escapeshellarg($file), $code);
+exit($code);`,
+		},
+		{
+			name: 'mywp-skill-plugin-development',
+			title: 'WordPress Plugin Development Skill',
+			description:
+				'Guidance for creating or changing plugins inside WordPress Playground.',
+			text: `Use this skill for WordPress plugin work.
+
+Workflow:
+- Inspect the existing plugin or target directory before changing it.
+- Prefer WordPress APIs, hooks, REST routes, blocks, and abilities over ad hoc
+  global code.
+- Keep plugin bootstrap files small. Put larger behavior in included PHP files
+  or classes when the plugin already uses that structure.
+- Register custom post types, taxonomies, shortcodes, and blocks on init.
+- Register REST routes on rest_api_init.
+- Flush rewrite rules only on activation or deactivation, not on every request.
+- After changes, verify the plugin can load. Use PHP lint first, then a REST or
+  browser request that exercises the changed behavior.
+
+When plugin-specific abilities exist, use the Abilities skill first.`,
+		},
+		{
+			name: 'mywp-skill-sync-local-changes',
+			title: 'Sync Local Changes To MyWP',
+			description:
+				'Guidance for copying local project changes into the my.wordpress.net sandbox.',
+			text: `Use this skill when the user wants to copy local files into the
+MyWP sandbox at my.wordpress.net.
+
+Mental model:
+- MCP filesystem tools operate inside the browser-based WordPress filesystem,
+  rooted at /wordpress/.
+- Local project files are not automatically mounted into my.wordpress.net.
+  The external client must read local files itself, then write their contents
+  into the sandbox with playground_mkdir and playground_write_file.
+- Typical destination paths are under:
+  /wordpress/wp-content/plugins/{plugin-slug}/
+  /wordpress/wp-content/themes/{theme-slug}/
+  /wordpress/wp-content/mu-plugins/
+
+Workflow:
+1. Call playground_list_sites. If no site is connected, call
+   playground_get_website_url and ask the user to open the returned URL.
+2. Confirm which connected siteId is the MyWP sandbox you are syncing into.
+3. Call playground_save_in_browser if the site is temporary.
+4. Identify the local source directory and the sandbox destination directory.
+   Confirm before overwriting an existing plugin or theme if the mapping is
+   ambiguous.
+5. List the local files using the external client's normal filesystem access.
+   Exclude generated or dependency-heavy directories unless they are required:
+   .git, node_modules, vendor, dist, build, coverage, caches, logs, and local
+   environment files are usually not synced.
+6. Create needed sandbox directories with playground_mkdir.
+7. Copy changed text files with playground_write_file. For binary assets, only
+   sync them if the MCP client can preserve their bytes correctly; otherwise
+   tell the user to use a zip/import path or another transfer mechanism.
+8. Do not delete sandbox files unless the user explicitly asks for a mirror sync
+   or confirms deletion.
+9. Verify after syncing. For PHP, run a lint check through
+   playground_execute_php. Then use playground_request or playground_navigate
+   to check the affected admin page, route, plugin, or theme behavior.
+
+Suggested PHP lint pattern:
+<?php
+$paths = array(
+    '/wordpress/wp-content/plugins/example/example.php',
+);
+foreach ($paths as $file) {
+    passthru('php -l ' . escapeshellarg($file), $code);
+    if ($code !== 0) {
+        exit($code);
+    }
+}
+
+When the user asks to sync "this plugin", infer the plugin slug from the local
+plugin main file when possible. The sandbox target should normally be
+/wordpress/wp-content/plugins/{slug}/.`,
+		},
+		{
+			name: 'mywp-skill-create-app',
+			title: 'Create A MyWP App',
+			description:
+				'Create an app-like WordPress plugin locally with create-wp-app, then sync it into MyWP.',
+			text: `Use this skill when the user asks to create an app, web app, "wp app",
+WordPress app, WpApp app, or app-like WordPress plugin for MyWP.
+
+Also use it when the requested plugin sounds like an app: something with its
+own URL route, screen, dashboard, workflow, logged-in experience, data UI, or
+standalone interface. Do not use it for narrow infrastructure plugins that only
+add hooks, filters, blocks, shortcodes, REST endpoints, or admin settings with
+no app-style UI.
+
+Local-first workflow:
+- MyWP runs in the browser, but the external MCP client may also have access to
+  the user's local machine. Prefer scaffolding the app locally, then syncing the
+  generated plugin into the MyWP sandbox.
+- If Composer is available, prefer the normal Composer project mode:
+  composer create-project akirk/create-wp-app {plugin-slug}
+  The final argument is the local target directory to create. It should usually
+  match the plugin slug.
+- For non-interactive scaffolding, set the WP_APP_* environment variables
+  documented by akirk/create-wp-app, including WP_APP_PLUGIN_NAME,
+  WP_APP_NAMESPACE, WP_APP_AUTHOR, WP_APP_URL_PATH, WP_APP_SETUP_TYPE,
+  WP_APP_DEPENDENCY_MODE=composer, and WP_APP_AUTOLOAD_MODE=composer.
+- Prefer WP_APP_SETUP_TYPE=full for AI-built apps unless the user asks for a
+  minimal scaffold.
+- Use Composer dependency/autoload mode when generating locally. Unlike an
+  in-browser Playground-only workflow, the local machine may have Composer and
+  can generate vendor/autoload.php normally.
+- The generated plugin can be tested locally with:
+  npx @wp-playground/cli@latest server --auto-mount={plugin-slug} --login
+- Initialize Git in the generated plugin directory and commit the scaffold
+  before making feature changes. Use later commits to track local changes that
+  should be synced into MyWP.
+
+Naming defaults:
+- slug: lowercase kebab-case from the product/domain, e.g. timetable. Do not
+  include the generic word app or use an -app suffix unless the user explicitly
+  names it that way.
+- plugin name: human name from the product/domain, e.g. Timetable. Do not add
+  App unless the user explicitly named it that way.
+- namespace: PascalCase from the plugin name.
+- url path: same as slug, without a leading slash.
+- author: empty unless the user provides it.
+
+Implementation workflow:
+1. Ask only for required values that cannot be inferred.
+2. Scaffold locally with:
+   composer create-project akirk/create-wp-app {plugin-slug}
+3. Initialize Git and commit the generated baseline:
+   git init
+   git add .
+   git commit -m "Initial create-wp-app scaffold"
+4. Read the generated main plugin file, src/App.php, templates/index.php, and
+   README.md before modifying generated code.
+5. Create or update IMPLEMENTATION_PLAN.md in the generated plugin root before
+   follow-up code changes. Keep it concise and resumable.
+6. Follow the generated lifecycle and extension points instead of guessing where
+   code should run.
+7. Commit meaningful local changes after implementation or verification so the
+   diff from the scaffold is easy to inspect before syncing.
+8. Verify local PHP syntax where possible.
+9. Use mywp-skill-sync-local-changes to copy the generated plugin into
+   /wordpress/wp-content/plugins/{plugin-slug}/.
+10. Activate the plugin only if requested or needed for verification.
+11. In the final response, report the local plugin path, MyWP destination path,
+   app URL path, and verification results.
+
+Generated app guidance:
+- WpApp provides URL routing, theme isolation, WordPress admin/masterbar
+  integration, admin color scheme tokens, access control, the BaseApp pattern,
+  and the BaseStorage pattern.
+- Keep __construct() focused on creating/configuring WpApp, assigning storage
+  objects, and attaching WordPress hooks.
+- Register custom post types and taxonomies on init.
+- Register dashboard widgets on wp_dashboard_setup.
+- Define WpApp routes in setup_routes() and WpApp menu/masterbar entries in
+  setup_menu().
+- Templates should use WpApp template helpers such as wp_app_head(),
+  wp_app_body_open(), wp_app_body_close(), wp_app_title(), and
+  wp_app_language_attributes() when building standalone HTML shells.
+- When enqueueing app assets, prefer WpApp scoped helpers such as
+  wp_app_enqueue_style() and wp_app_enqueue_script() so assets are attached to
+  the app's scoped hook instead of leaking between apps.
+- Use WordPress capabilities and roles for access control rather than custom
+  auth systems when WordPress user identity is sufficient.
+- Run activation-only work, including custom table creation and rewrite
+  flushing, from the plugin activation hook.
+- Prefer WordPress-native storage before custom tables: CPTs plus post meta,
+  taxonomies plus term meta, user meta, and options.
+- Use custom tables or BaseStorage only when native storage does not fit.
+- After syncing PHP changes into MyWP, verify with playground_execute_php and
+  then with playground_request or playground_navigate.
+
+Converting existing frontend apps:
+- Prefer converting a deployable static app: root index.html, build/, dist/, or
+  an explicitly supplied output directory.
+- Do not treat obvious bundler development entries such as src/main.jsx or
+  templates with %PUBLIC_URL% as deployable root HTML.
+- For Create React App, ensure "homepage": "." or PUBLIC_URL=. before building
+  so generated chunk paths remain portable.
+- Apps with client-side routing should prefer hash routing or configure the
+  router basename to match the WpApp URL path.`,
+		},
+	],
+};

--- a/packages/playground/personal-wp-mcp/src/tools.ts
+++ b/packages/playground/personal-wp-mcp/src/tools.ts
@@ -1,0 +1,198 @@
+import { z } from 'zod/v3';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+interface PersonalWpMcpBridge {
+	sendCommand(
+		siteId: string,
+		command: string,
+		args?: unknown[]
+	): Promise<unknown>;
+}
+
+interface PhpRunResponse {
+	text: string;
+	errors?: string;
+	exitCode?: number;
+}
+
+interface PluginGuidanceEntry {
+	namespace: string;
+	useWhen: string[];
+	instructions: string;
+	source: 'ai_assistant_ability_domains';
+}
+
+const siteIdSchema = z
+	.string()
+	.describe(
+		'Target site ID. Call playground_list_sites first to discover available site IDs.'
+	);
+
+export function registerPersonalWpMcpTools(
+	server: McpServer,
+	bridge: PersonalWpMcpBridge
+) {
+	server.registerTool(
+		'mywp_get_plugin_guidance',
+		{
+			title: 'Get MyWP Plugin Guidance',
+			description: `Collect plugin-provided AI Assistant guidance from the
+				connected WordPress site and return prompt-ready instructions
+				for when an external client should prefer specific plugin
+				abilities through the WordPress Abilities API. This applies
+				the AI Assistant filters directly without requiring the AI
+				Assistant plugin.`,
+			inputSchema: {
+				siteId: siteIdSchema,
+			},
+			annotations: {
+				readOnlyHint: true,
+				destructiveHint: false,
+				idempotentHint: true,
+				openWorldHint: true,
+			},
+		},
+		async ({ siteId }) => {
+			const response = (await bridge.sendCommand(siteId, 'run', [
+				{ code: pluginGuidancePhp },
+			])) as PhpRunResponse;
+
+			if (response.exitCode && response.exitCode !== 0) {
+				throw new Error(
+					response.errors || 'Unable to collect guidance'
+				);
+			}
+
+			const collected = parseCollectedGuidance(response.text);
+			return {
+				content: [
+					{
+						type: 'text' as const,
+						text: JSON.stringify(
+							createMywpPluginGuidance(collected)
+						),
+					},
+				],
+			};
+		}
+	);
+}
+
+export function createMywpPluginGuidance(collected: unknown) {
+	const collectedRecord = isRecord(collected) ? collected : {};
+	const aiAssistantDomains = isRecord(collectedRecord['aiAssistantDomains'])
+		? collectedRecord['aiAssistantDomains']
+		: {};
+	const aiAssistantWelcomeTips = isRecord(
+		collectedRecord['aiAssistantWelcomeTips']
+	)
+		? collectedRecord['aiAssistantWelcomeTips']
+		: {};
+	const entries = normalizeAiAssistantDomainEntries(aiAssistantDomains);
+
+	return {
+		summary:
+			'Use the systemPrompt field to extend an MCP client system prompt with MyWP plugin ability guidance. When a user asks about a listed category or domain, prefer the WordPress Abilities API through playground_request before lower-level tools such as db_query, find, or direct PHP inspection. The AI Assistant filters are applied directly in WordPress and do not require the AI Assistant plugin to be installed.',
+		filters: ['ai_assistant_ability_domains', 'ai_assistant_welcome_tips'],
+		entries,
+		systemPrompt: createPluginGuidancePrompt(entries),
+		welcomeTips: aiAssistantWelcomeTips,
+		shape: {
+			entries:
+				'Structured category/domain mappings from ai_assistant_ability_domains.',
+			systemPrompt:
+				'Running text suitable for appending to an MCP client system prompt.',
+			welcomeTips:
+				'Structured contextual tips from ai_assistant_welcome_tips.',
+		},
+	};
+}
+
+function parseCollectedGuidance(text: string): unknown {
+	try {
+		return JSON.parse(text.trim() || '{}');
+	} catch {
+		return {};
+	}
+}
+
+function normalizeAiAssistantDomainEntries(
+	domains: Record<string, unknown>
+): PluginGuidanceEntry[] {
+	return Object.entries(domains)
+		.map(([namespace, terms]) => {
+			const useWhen = stringifyList(terms);
+			return {
+				namespace,
+				useWhen,
+				instructions:
+					useWhen.length > 0
+						? `Use ${namespace} abilities when the user asks about ${useWhen.join(', ')}.`
+						: `Use ${namespace} abilities for requests in this plugin domain.`,
+				source: 'ai_assistant_ability_domains' as const,
+			};
+		})
+		.filter((entry) => entry.namespace !== '')
+		.sort((a, b) => a.namespace.localeCompare(b.namespace));
+}
+
+function createPluginGuidancePrompt(entries: PluginGuidanceEntry[]): string {
+	if (entries.length === 0) {
+		return 'No plugin-specific MyWP guidance was registered for this site.';
+	}
+
+	return [
+		'The following topics are handled by plugin abilities. For these, prefer the WordPress Abilities API via playground_request before lower-level tools such as db_query, find, or direct PHP inspection:',
+		...entries.map((entry) => {
+			const useWhen =
+				entry.useWhen.length > 0
+					? entry.useWhen.join(', ')
+					: entry.namespace;
+			const instructions = entry.instructions
+				? ` ${entry.instructions}`
+				: '';
+			return `- ${entry.namespace}: ${useWhen}.${instructions}`;
+		}),
+		'These slugs are ability categories/domains, not executable ability IDs. First request the abilities list for the matching category or domain, then request details for the exact ability ID before executing it through the WordPress Abilities API.',
+	].join('\n');
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function stringify(value: unknown): string {
+	if (typeof value === 'string') {
+		return value.trim();
+	}
+	if (typeof value === 'number' || typeof value === 'boolean') {
+		return String(value);
+	}
+	return '';
+}
+
+function stringifyList(value: unknown): string[] {
+	if (Array.isArray(value)) {
+		return value.map(stringify).filter(Boolean);
+	}
+	return stringify(value)
+		.split(',')
+		.map((part) => part.trim())
+		.filter(Boolean);
+}
+
+const pluginGuidancePhp = `<?php
+require_once "/wordpress/wp-load.php";
+
+$ai_assistant_domains = apply_filters( 'ai_assistant_ability_domains', [] );
+$ai_assistant_welcome_tips = apply_filters(
+    'ai_assistant_welcome_tips',
+    [],
+    [ 'path' => parse_url( home_url( add_query_arg( [] ) ), PHP_URL_PATH ) ?: '/' ]
+);
+
+echo wp_json_encode( [
+    'aiAssistantDomains'     => is_array( $ai_assistant_domains ) ? $ai_assistant_domains : [],
+    'aiAssistantWelcomeTips' => is_array( $ai_assistant_welcome_tips ) ? $ai_assistant_welcome_tips : [],
+] );
+`;

--- a/packages/playground/personal-wp-mcp/tests/unit/personal-wp-mcp.spec.ts
+++ b/packages/playground/personal-wp-mcp/tests/unit/personal-wp-mcp.spec.ts
@@ -1,0 +1,222 @@
+import { describe, expect, it } from 'vitest';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { createServer, registerMcpServerTools } from '@wp-playground/mcp/api';
+import { personalWpMcpProfile, registerPersonalWpMcpTools } from '../../src';
+
+describe('MyWP MCP prompts', () => {
+	it('ships MyWP agent prompt and focused skill prompts', async () => {
+		await withPromptClient(async (client) => {
+			const prompts = await client.listPrompts();
+			const names = prompts.prompts.map((prompt) => prompt.name).sort();
+
+			expect(names).toEqual([
+				'mywp-agent',
+				'mywp-skill-abilities',
+				'mywp-skill-create-app',
+				'mywp-skill-file-editing',
+				'mywp-skill-plugin-development',
+				'mywp-skill-sync-local-changes',
+			]);
+
+			const agentPrompt = await client.getPrompt({
+				name: 'mywp-agent',
+				arguments: {},
+			});
+			const agentText = agentPrompt.messages[0].content.text;
+
+			expect(agentText).toContain('Call playground_list_sites');
+			expect(agentText).toContain('WordPress Abilities API');
+			expect(agentText).toContain('playground_save_in_browser');
+
+			const syncPrompt = await client.getPrompt({
+				name: 'mywp-skill-sync-local-changes',
+				arguments: {},
+			});
+			const syncText = syncPrompt.messages[0].content.text;
+
+			expect(syncText).toContain('Confirm which connected siteId');
+			expect(syncText).toContain(
+				'Local project files are not automatically mounted'
+			);
+			expect(syncText).toContain(
+				'/wordpress/wp-content/plugins/{plugin-slug}/'
+			);
+
+			const createAppPrompt = await client.getPrompt({
+				name: 'mywp-skill-create-app',
+				arguments: {},
+			});
+			const createAppText = createAppPrompt.messages[0].content.text;
+
+			expect(createAppText).toContain(
+				'composer create-project akirk/create-wp-app {plugin-slug}'
+			);
+			expect(createAppText).toContain('WP_APP_DEPENDENCY_MODE=composer');
+			expect(createAppText).toContain('git init');
+			expect(createAppText).toContain(
+				'git commit -m "Initial create-wp-app scaffold"'
+			);
+			expect(createAppText).toContain(
+				'Commit meaningful local changes after implementation'
+			);
+			expect(createAppText).toContain('wp_app_enqueue_script()');
+			expect(createAppText).toContain('mywp-skill-sync-local-changes');
+		});
+	});
+});
+
+describe('MyWP MCP tools', () => {
+	it('registers plugin guidance using the Playground MCP API', async () => {
+		await withToolClient(async (client) => {
+			const tools = await client.listTools();
+			expect(tools.tools.map((tool) => tool.name)).toContain(
+				'mywp_get_plugin_guidance'
+			);
+
+			const result = await client.callTool({
+				name: 'mywp_get_plugin_guidance',
+				arguments: {
+					siteId: 'stub-site',
+				},
+			});
+			const parsed = JSON.parse(
+				(result.content as Array<{ text: string }>)[0].text
+			);
+
+			expect(parsed.summary).toContain('WordPress Abilities API');
+			expect(parsed.filters).toEqual([
+				'ai_assistant_ability_domains',
+				'ai_assistant_welcome_tips',
+			]);
+			expect(parsed.shape.entries).toContain(
+				'Structured category/domain mappings'
+			);
+			expect(parsed.shape.systemPrompt).toContain(
+				'Running text suitable for appending'
+			);
+			expect(parsed.entries).toContainEqual(
+				expect.objectContaining({
+					namespace: 'cookbook',
+					source: 'ai_assistant_ability_domains',
+					useWhen: [
+						'saved recipe collection',
+						'URL/text recipe import',
+						'ingredient-based recipe search',
+						'weekly meal planner',
+						'shopping-list builder',
+						'serving scaling and variations',
+					],
+				})
+			);
+			expect(parsed.entries).toContainEqual(
+				expect.objectContaining({
+					namespace: 'events',
+					source: 'ai_assistant_ability_domains',
+					useWhen: ['events', 'tickets'],
+				})
+			);
+			expect(parsed.systemPrompt).toContain(
+				'prefer the WordPress Abilities API via playground_request'
+			);
+			expect(parsed.systemPrompt).toContain(
+				'- cookbook: saved recipe collection, URL/text recipe import, ingredient-based recipe search, weekly meal planner, shopping-list builder, serving scaling and variations.'
+			);
+			expect(parsed.systemPrompt).toContain(
+				'These slugs are ability categories/domains, not executable ability IDs.'
+			);
+			expect(parsed.welcomeTips.cookbook).toEqual([
+				'Ask me to find a recipe.',
+			]);
+		});
+	});
+});
+
+async function withPromptClient<T>(
+	callback: (client: Client) => Promise<T>
+): Promise<T> {
+	const [clientTransport, serverTransport] =
+		InMemoryTransport.createLinkedPair();
+	const server = createServer({ definition: personalWpMcpProfile });
+	const client = new Client({
+		name: 'personal-wp-mcp-prompt-test',
+		version: '1.0.0',
+	});
+
+	await server.connect(serverTransport);
+	await client.connect(clientTransport);
+
+	try {
+		return await callback(client);
+	} finally {
+		await client.close();
+		await server.close();
+	}
+}
+
+async function withToolClient<T>(
+	callback: (client: Client) => Promise<T>
+): Promise<T> {
+	const [clientTransport, serverTransport] =
+		InMemoryTransport.createLinkedPair();
+	const bridge = createBridgeStub();
+	const server = createServer({
+		extensions: [
+			{
+				registerTools: (server) =>
+					registerMcpServerTools(
+						server,
+						bridge,
+						7999,
+						'https://my.wordpress.net/',
+						[registerPersonalWpMcpTools]
+					),
+			},
+		],
+	});
+	const client = new Client({
+		name: 'personal-wp-mcp-tool-test',
+		version: '1.0.0',
+	});
+
+	await server.connect(serverTransport);
+	await client.connect(clientTransport);
+
+	try {
+		return await callback(client);
+	} finally {
+		await client.close();
+		await server.close();
+	}
+}
+
+function createBridgeStub(): any {
+	return {
+		sendCommand: async (_siteId: string, command: string) => {
+			if (command === 'run') {
+				return {
+					text: JSON.stringify({
+						aiAssistantDomains: {
+							cookbook:
+								'saved recipe collection, URL/text recipe import, ingredient-based recipe search, weekly meal planner, shopping-list builder, serving scaling and variations',
+							events: 'events, tickets',
+						},
+						aiAssistantWelcomeTips: {
+							cookbook: ['Ask me to find a recipe.'],
+						},
+					}),
+					errors: '',
+					exitCode: 0,
+				};
+			}
+			return undefined;
+		},
+		getTabCount: () => 0,
+		listSites: () => [],
+		isConnected: () => false,
+		waitForSiteActive: async () => ({
+			siteId: 'stub-site',
+			siteName: 'Stub Site',
+		}),
+	};
+}

--- a/packages/playground/personal-wp-mcp/tsconfig.json
+++ b/packages/playground/personal-wp-mcp/tsconfig.json
@@ -1,0 +1,15 @@
+{
+	"extends": "../../../tsconfig.base.json",
+	"compilerOptions": {
+		"module": "ESNext",
+		"types": ["node"],
+		"strict": true
+	},
+	"include": [],
+	"files": [],
+	"references": [
+		{
+			"path": "./tsconfig.lib.json"
+		}
+	]
+}

--- a/packages/playground/personal-wp-mcp/tsconfig.lib.json
+++ b/packages/playground/personal-wp-mcp/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"outDir": "../../../dist/out-tsc",
+		"declaration": true,
+		"types": ["node"]
+	},
+	"include": ["src/**/*.ts"],
+	"exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/packages/playground/personal-wp-mcp/vite.config.ts
+++ b/packages/playground/personal-wp-mcp/vite.config.ts
@@ -1,6 +1,4 @@
-/// <reference types="vitest" />
 import { defineConfig } from 'vite';
-
 import dts from 'vite-plugin-dts';
 import { join } from 'path';
 
@@ -8,12 +6,15 @@ import { join } from 'path';
 import { viteTsConfigPaths } from '../../vite-extensions/vite-ts-config-paths';
 // eslint-disable-next-line @nx/enforce-module-boundaries
 import { getExternalModules } from '../../vite-extensions/vite-external-modules';
-// eslint-disable-next-line @nx/enforce-module-boundaries
-import viteGlobalExtensions from '../../vite-extensions/vite-global-extensions';
 
 export default defineConfig({
 	root: __dirname,
-	cacheDir: '../../../node_modules/.vite/playground-mcp',
+	cacheDir: '../../../node_modules/.vite/playground-personal-wp-mcp',
+	resolve: {
+		alias: {
+			'@wp-playground/mcp/api': join(__dirname, '../mcp/src/api.ts'),
+		},
+	},
 
 	plugins: [
 		dts({
@@ -25,26 +26,27 @@ export default defineConfig({
 		viteTsConfigPaths({
 			root: '../../../',
 		}),
-
-		...viteGlobalExtensions,
 	],
 
 	build: {
 		lib: {
 			entry: {
 				index: 'src/index.ts',
-				api: 'src/api.ts',
-				client: 'src/client.ts',
+				cli: 'src/cli.ts',
 			},
-			name: 'playground-mcp',
+			name: 'playground-personal-wp-mcp',
 			formats: ['es', 'cjs'],
 		},
 		sourcemap: true,
 		rollupOptions: {
-			external: getExternalModules(),
+			external: [
+				...getExternalModules(),
+				/^@modelcontextprotocol\/sdk\//,
+				/^zod\//,
+			],
 			output: {
 				banner: (chunk) =>
-					chunk.fileName === 'index.js' ? '#!/usr/bin/env node' : '',
+					chunk.fileName === 'cli.js' ? '#!/usr/bin/env node' : '',
 			},
 		},
 	},

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -119,6 +119,10 @@
 			"@wp-playground/mcp/client": [
 				"packages/playground/mcp/src/client.ts"
 			],
+			"@wp-playground/mcp/api": ["packages/playground/mcp/src/api.ts"],
+			"@wp-playground/personal-wp-mcp": [
+				"packages/playground/personal-wp-mcp/src/index.ts"
+			],
 			"@wp-playground/components": [
 				"packages/playground/components/src/index.ts"
 			],


### PR DESCRIPTION
## What?

Adds MyWP-specific MCP prompts and tools through a dedicated package while keeping the generic Playground MCP server extensible.

## Why?

External MCP clients need MyWP-specific operating instructions and task skills without changing the generic Playground MCP behavior.

## How?

- Lets `createServer` accept MCP server definitions and extensions that can add prompts or register tools.
- Adds a side-effect-free `@wp-playground/mcp/api` entry point that exposes the generic MCP server building blocks.
- Keeps the generic Playground MCP server free of MyWP-specific prompt and tool dependencies.
- Moves MyWP-specific MCP prompts, tools, and CLI composition into a dedicated `@wp-playground/personal-wp-mcp` package that uses `@wp-playground/mcp/api` underneath.
- Exposes the MyWP MCP executable as `mywp`, defaulting to `https://my.wordpress.net/` while still supporting `--url=...` for another Personal Playground origin.
- Registers MyWP prompts for agent workflow, abilities, file editing, plugin development, and syncing local changes into the MyWP sandbox.
- Adds a MyWP-only `mywp_get_plugin_guidance` tool that applies AI Assistant filters in the connected site and returns structured entries plus prompt-ready instructions for preferring the WordPress Abilities API for matching ability categories/domains.
- Documents the MyWP MCP configuration and local sync workflow.
- Adds unit coverage for generic prompt extension registration and MyWP plugin guidance collected from `ai_assistant_ability_domains`.

## Testing

- `npm run format:uncommitted`
- `npm exec nx run playground-mcp:test:unit`
- `npm exec nx run playground-personal-wp-mcp:test:unit`
- `npm exec nx run playground-mcp:lint`
- `npm exec nx run playground-personal-wp:lint`
- `npm exec nx run playground-personal-wp-mcp:lint`
- `npm exec nx run playground-personal-wp-mcp:build`
- `npm exec nx run playground-mcp:build`
