### PR TITLE
[Docs] Add initial setup instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ tests, or dev servers:
 ```bash
 nvm use
 git submodule update --init --recursive
-npm install
+npm ci
 ```
 
 This is especially important for worktree-based agent tools, which may create a

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,20 @@ This is an NX monorepo with npm workspaces. All commands use NX for task orchest
 
 **Node.js version**: This project requires a specific Node.js version (defined in `.nvmrc` and the `engines` field in root `package.json`). Before running any commands, ensure the correct version is active (e.g., via `nvm use` or other version manager).
 
+### Initial Setup
+
+From a fresh clone or new worktree, set up the repository before running builds,
+tests, or dev servers:
+
+```bash
+nvm use
+git submodule update --init --recursive
+npm install
+```
+
+This is especially important for worktree-based agent tools, which may create a
+working tree without fully initializing submodules or installing dependencies.
+
 ### Common Commands
 
 ```bash


### PR DESCRIPTION
## Summary

Adds an initial setup section to the root `AGENTS.md` for fresh clones and new
worktrees.

## Motivation for the change, related issues

Agents need the repository setup steps before running builds, tests, or dev
servers. Worktree-based tools such as Conductor can otherwise create
partially-working environments when submodules and dependencies are not fully set
up. This makes the expected setup order explicit: activate the configured Node.js
version, initialize submodules, and install npm dependencies.

## Implementation details

The new section lives near the existing Node.js version guidance and documents:

- `nvm use`
- `git submodule update --init --recursive`
- `npm ci`

It also calls out why this matters for worktree-based agent environments. No
runtime code or package behavior changes are included.

## Testing Instructions

1. Open `AGENTS.md`.
2. Review the new `Initial Setup` section
