### PR TITLE
Avoid remote progress calls when progress bar is disabled

### DIFF
--- a/packages/playground/client/src/blueprints-v1-handler.spec.ts
+++ b/packages/playground/client/src/blueprints-v1-handler.spec.ts
@@ -97,6 +97,7 @@ describe('BlueprintsV1Handler', () => {
 
 	it('boots WordPress setup when only installation is disabled', async () => {
 		const iframe = createIframe();
+		const progressTracker = createProgressTracker();
 		const handler = new BlueprintsV1Handler({
 			iframe,
 			remoteUrl: 'http://example.com/remote.html',
@@ -104,13 +105,29 @@ describe('BlueprintsV1Handler', () => {
 			shouldInstallWordPress: false,
 		});
 
-		await handler.bootPlayground(iframe, createProgressTracker());
+		await handler.bootPlayground(iframe, progressTracker);
 
 		expect(mocks.playground.boot).toHaveBeenCalledWith(
 			expect.objectContaining({
 				wordpressInstallMode: 'install-from-existing-files-if-needed',
 			})
 		);
+		expect(progressTracker.pipe).toHaveBeenCalledWith(mocks.playground);
+	});
+
+	it('does not pipe progress to the remote when progress bar is disabled', async () => {
+		const iframe = createIframe();
+		const progressTracker = createProgressTracker();
+		const handler = new BlueprintsV1Handler({
+			iframe,
+			remoteUrl: 'http://example.com/remote.html',
+			blueprint: {},
+			disableProgressBar: true,
+		});
+
+		await handler.bootPlayground(iframe, progressTracker);
+
+		expect(progressTracker.pipe).not.toHaveBeenCalled();
 	});
 
 	it('passes query API PHP extension requests to the runtime', async () => {

--- a/packages/playground/client/src/blueprints-v1-handler.ts
+++ b/packages/playground/client/src/blueprints-v1-handler.ts
@@ -38,6 +38,7 @@ export class BlueprintsV1Handler {
 			wordpressInstallMode,
 			onClientConnected,
 			pathAliases,
+			disableProgressBar,
 		} = this.options;
 		const executionProgress = progressTracker!.stage(0.5);
 		const downloadProgress = progressTracker!.stage();
@@ -52,7 +53,9 @@ export class BlueprintsV1Handler {
 			iframe.ownerDocument!.defaultView!
 		) as PlaygroundClient;
 		await playground.isConnected();
-		progressTracker.pipe(playground);
+		if (!disableProgressBar) {
+			progressTracker.pipe(playground);
+		}
 
 		const runtimeConfiguration =
 			await resolveRuntimeConfiguration(blueprint);

--- a/packages/playground/client/src/blueprints-v2-handler.ts
+++ b/packages/playground/client/src/blueprints-v2-handler.ts
@@ -22,6 +22,7 @@ export class BlueprintsV2Handler {
 			sapiName,
 			scope,
 			pathAliases,
+			disableProgressBar,
 		} = this.options;
 		const downloadProgress = progressTracker!.stage(0.25);
 		const executionProgress = progressTracker!.stage(0.75);
@@ -33,7 +34,9 @@ export class BlueprintsV2Handler {
 			iframe.ownerDocument!.defaultView!
 		) as PlaygroundClient;
 		await playground.isConnected();
-		progressTracker.pipe(playground);
+		if (!disableProgressBar) {
+			progressTracker.pipe(playground);
+		}
 
 		// Connect the Comlink API client to the remote worker download monitor
 		await playground.onDownloadProgress(downloadProgress.loadingListener);


### PR DESCRIPTION
## Motivation for the change, related issues

Personal WP renders its own boot progress UI and starts Playground with the remote progress bar disabled. The client still piped the boot progress tracker into the remote iframe, which caused remote.html to receive setProgress and setLoaded calls even though its ProgressBar instance was intentionally absent. In that state the remote threw repeated "Progress bar not available" promise rejections during boot.

Example of an error message while booting my.wordpress.net:
```
Uncaught (in promise) Error: Progress bar not available
    setProgress boot-playground-remote.ts:160
    get api.ts:687
    s comlink-sync.ts:664
    B comlink-sync.ts:628
    et api.ts:162
    vt boot-playground-remote.ts:561
    async* remote.html:7
Caused by: Error: Comlink method call failed
    deserialize api.ts:668
    rc comlink-sync.ts:958
    promise callback*apply comlink-sync.ts:878
    pipe progress-tracker.ts:301
    bootPlayground blueprints-v1-handler.ts:55
    Aue index.ts:169
    Redux 2
    bLe index.tsx:2170
    React 11
    notify Redux
    Ck React
    Redux 13
    bj ensure-playground-site-is-selected.tsx:173
    f ensure-playground-site-is-selected.tsx:115
    ZMe ensure-playground-site-is-selected.tsx:118
    React 5
```

This is rather janitorial. Everything works but the error is in the console.log.

## Implementation details

The Blueprint V1 and V2 client handlers now honor disableProgressBar before piping the ProgressTracker into the remote Playground client. Local progress listeners still receive updates, so callers such as Personal WP can continue rendering their own loading experience without also requiring the remote iframe progress bar.

## Testing Instructions (or ideally a Blueprint)

I verified the client package with npm exec nx test playground-client. The added regression coverage confirms the V1 handler still pipes progress by default and skips that remote pipe when disableProgressBar is true.