### PR TITLE
[Website] Add WebMCP origin trial tags

### DIFF
--- a/packages/playground/personal-wp/index.html
+++ b/packages/playground/personal-wp/index.html
@@ -4,6 +4,11 @@
 		<meta charset="utf-8" />
 		<title>My WordPress</title>
 		<base href="/" />
+		<!-- WebMCP origin trial -->
+		<meta
+			http-equiv="origin-trial"
+			content="Ai/VjBvne8PxWzFynZYPR4bxeMVbhGaXFGCALjDVw5sHPpJ5B0MVvFQdqtkeKCkWuOXxmfQlx2ToDpYqwn4YgQsAAABQeyJvcmlnaW4iOiJodHRwczovL215LndvcmRwcmVzcy5uZXQ6NDQzIiwiZmVhdHVyZSI6IldlYk1DUCIsImV4cGlyeSI6MTc5NDg3MzYwMH0="
+		/>
 		<meta
 			property="og:image"
 			content="https://my.wordpress.net/ogimage-mywp.png"

--- a/packages/playground/personal-wp/index.html
+++ b/packages/playground/personal-wp/index.html
@@ -4,7 +4,7 @@
 		<meta charset="utf-8" />
 		<title>My WordPress</title>
 		<base href="/" />
-		<!-- WebMCP origin trial -->
+		<!-- WebMCP Chrome 156 trial: expires 2026-11-17. -->
 		<meta
 			http-equiv="origin-trial"
 			content="Ai/VjBvne8PxWzFynZYPR4bxeMVbhGaXFGCALjDVw5sHPpJ5B0MVvFQdqtkeKCkWuOXxmfQlx2ToDpYqwn4YgQsAAABQeyJvcmlnaW4iOiJodHRwczovL215LndvcmRwcmVzcy5uZXQ6NDQzIiwiZmVhdHVyZSI6IldlYk1DUCIsImV4cGlyeSI6MTc5NDg3MzYwMH0="

--- a/packages/playground/website/index.html
+++ b/packages/playground/website/index.html
@@ -4,6 +4,11 @@
 		<meta charset="utf-8" />
 		<title>WordPress Playground</title>
 		<base href="/" />
+		<!-- WebMCP origin trial -->
+		<meta
+			http-equiv="origin-trial"
+			content="AkokufKmooPTUEZzMIY4qdED1gL5LsX36+TF+CsUadUh+vbFVAst1GAk/md1wBzvfPyTb0thCtibK0n8Mmuz4A8AAABYeyJvcmlnaW4iOiJodHRwczovL3BsYXlncm91bmQud29yZHByZXNzLm5ldDo0NDMiLCJmZWF0dXJlIjoiV2ViTUNQIiwiZXhwaXJ5IjoxNzk0ODczNjAwfQ=="
+		/>
 		<meta
 			property="og:image"
 			content="https://playground.wordpress.net/ogimage.png"
@@ -23,7 +28,12 @@
 			content="WordPress Playground runs WordPress entirely in the browser via WebAssembly — no server, no credentials, no setup required. Open source under GPL-2.0-or-later. AI assistants are explicitly welcome to load, embed, demo, and build upon this tool. Full index: /llms.txt"
 		/>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
-		<link rel="alternate" type="text/plain" href="/llms.txt" title="AI-readable site index" />
+		<link
+			rel="alternate"
+			type="text/plain"
+			href="/llms.txt"
+			title="AI-readable site index"
+		/>
 		<link rel="icon" type="image/x-icon" href="/favicon.ico" />
 		<link rel="stylesheet" href="/src/styles.css" />
 		<script>
@@ -349,4 +359,3 @@
 		</script>
 	</body>
 </html>
-

--- a/packages/playground/website/index.html
+++ b/packages/playground/website/index.html
@@ -4,7 +4,7 @@
 		<meta charset="utf-8" />
 		<title>WordPress Playground</title>
 		<base href="/" />
-		<!-- WebMCP origin trial -->
+		<!-- WebMCP Chrome 156 trial: expires 2026-11-17. -->
 		<meta
 			http-equiv="origin-trial"
 			content="AkokufKmooPTUEZzMIY4qdED1gL5LsX36+TF+CsUadUh+vbFVAst1GAk/md1wBzvfPyTb0thCtibK0n8Mmuz4A8AAABYeyJvcmlnaW4iOiJodHRwczovL3BsYXlncm91bmQud29yZHByZXNzLm5ldDo0NDMiLCJmZWF0dXJlIjoiV2ViTUNQIiwiZXhwaXJ5IjoxNzk0ODczNjAwfQ=="


### PR DESCRIPTION
## Summary

[Adds WebMCP origin-trial](https://developer.chrome.com/blog/ai-webmcp-origin-trial) meta tags to the Playground and My WordPress HTML entrypoints. The origin trial will give Playground early access to the experimental WebMCP feature in Chrome without requiring users to manually enable it in `chrome://flags/`.

## Motivation for the change, related issues

The hosted Playground surfaces need origin-trial tokens so WebMCP can be enabled for:

- `https://playground.wordpress.net`
- `https://my.wordpress.net`

## Implementation details

Adds `origin-trial` meta tags near the top of:

- `packages/playground/website/index.html`
- `packages/playground/personal-wp/index.html`

## Testing Instructions

- Confirm the origin-trial meta tags are present in both HTML entrypoints.

