### PR TITLE
[Website] Delay autosave nudge until dismissal can save the new Playground

### DIFF
--- a/packages/playground/website/src/components/ensure-playground-site/ensure-playground-site-is-selected.tsx
+++ b/packages/playground/website/src/components/ensure-playground-site/ensure-playground-site-is-selected.tsx
@@ -64,6 +64,9 @@ export function EnsurePlaygroundSiteIsSelected({
 			requestedSiteSlug &&
 			selectClientBySiteSlug(state, requestedSiteSlug)
 	);
+	const activeClientInfo = useAppSelector((state) =>
+		activeSite ? selectClientBySiteSlug(state, activeSite.slug) : undefined
+	);
 	const [needMissingSitePromptForSlug, setNeedMissingSitePromptForSlug] =
 		useState<false | string>(false);
 	const [autosaveNudge, setAutosaveNudge] = useState<{
@@ -81,6 +84,13 @@ export function EnsurePlaygroundSiteIsSelected({
 		() => getAutosaveFingerprintFromURL(url),
 		[url.href]
 	);
+	const canShowAutosaveNudge =
+		autosaveNudge &&
+		activeSite &&
+		activeSite.slug !== autosaveNudge.site.slug &&
+		!!activeClientInfo &&
+		getAutosaveFingerprintFromSite(activeSite) ===
+			autosaveNudge.setupUrlFingerprint;
 
 	const prevUrl = usePrevious(url);
 
@@ -264,7 +274,7 @@ export function EnsurePlaygroundSiteIsSelected({
 	return (
 		<>
 			{children}
-			{autosaveNudge && (
+			{canShowAutosaveNudge && (
 				<RestoreAutosaveNudge
 					site={autosaveNudge.site}
 					error={autosaveNudgeError}


### PR DESCRIPTION
## What it does

Delays the autosave restore nudge until the fresh matching Playground can be saved, so `No, thanks` no longer runs before the new Playground has an active client.

The site-selection flow and popover actions are unchanged. This PR only gates rendering of the nudge until the active site:

- is not the autosave being offered for restore;
- has a `PlaygroundClient`;
- matches the nudge’s setup URL fingerprint.

## Rationale

When a matching autosave exists, the restore nudge could appear before the fresh temporary Playground had an active `PlaygroundClient`. If the user clicked `No, thanks` during that window, `autosaveTemporarySite()` tried to save before `persistTemporarySite()` could find a client.

That produced:

```text
must have an active client to be saved
```

and left the user at the same restore prompt.

Waiting to show the nudge keeps the fix local to the popover display and avoids changing the app’s site-selection flow.

## Testing instructions

```bash
npm exec nx run playground-website:lint
npm exec nx run playground-website:typecheck
```
