### PR TITLE
Improve OPFS sync copy error messages

### DIFF
--- a/packages/php-wasm/web/src/lib/directory-handle-mount.spec.ts
+++ b/packages/php-wasm/web/src/lib/directory-handle-mount.spec.ts
@@ -39,6 +39,12 @@ class MemoryFileHandle {
 			seek: async () => {},
 		};
 	}
+
+	async getFile() {
+		return {
+			arrayBuffer: async () => this.bytes.buffer.slice(0),
+		};
+	}
 }
 
 class MemoryDirectoryHandle {
@@ -80,6 +86,11 @@ class MemoryDirectoryHandle {
 	async removeEntry(name: string) {
 		this.files.delete(name);
 		this.directories.delete(name);
+	}
+
+	async *values() {
+		yield* this.directories.values();
+		yield* this.files.values();
 	}
 }
 
@@ -546,6 +557,93 @@ describe('createDirectoryHandleMountHandler', () => {
 			vi.useRealTimers();
 		}
 	});
+
+	it('reports the failed OPFS entry when initial OPFS to MEMFS sync fails', async () => {
+		const rootCause = new Error('file could not be read');
+		const { FS, php } = createFakePhp();
+		FS.lookupPath.mockImplementation((path: string) => {
+			if (path === '/wordpress') {
+				throw new Error(`Missing file: ${path}`);
+			}
+			return {
+				path,
+				node: { mode: 0, path },
+			};
+		});
+		const opfsRoot = new MemoryDirectoryHandle('root');
+		const brokenFile = new MemoryFileHandle('database.sqlite');
+		vi.spyOn(brokenFile, 'getFile').mockRejectedValue(rootCause);
+		opfsRoot.files.set('database.sqlite', brokenFile);
+
+		const mountHandler = createDirectoryHandleMountHandler(
+			opfsRoot as unknown as FileSystemDirectoryHandle,
+			{
+				initialSync: {
+					direction: 'opfs-to-memfs',
+				},
+			}
+		);
+
+		await expect(
+			mountHandler(php, FS as any, '/wordpress')
+		).rejects.toMatchObject({
+			message:
+				'Failed to copy OPFS entry to MEMFS path ' +
+				'"/wordpress/database.sqlite": file could not be read',
+			cause: rootCause,
+		});
+	});
+
+	it('observes pending OPFS copy operations before reporting a sync failure', async () => {
+		const rootCause = new Error('file could not be read');
+		const pendingRead = deferred<void>();
+		const { FS, php } = createFakePhp();
+		FS.lookupPath.mockImplementation((path: string) => {
+			if (path === '/wordpress') {
+				throw new Error(`Missing file: ${path}`);
+			}
+			return {
+				path,
+				node: { mode: 0, path },
+			};
+		});
+		const opfsRoot = new MemoryDirectoryHandle('root');
+		const brokenFile = new MemoryFileHandle('database.sqlite');
+		const pendingFile = new MemoryFileHandle('pending.txt');
+		vi.spyOn(brokenFile, 'getFile').mockRejectedValue(rootCause);
+		vi.spyOn(pendingFile, 'getFile').mockImplementation(async () => {
+			await pendingRead.promise;
+			return {
+				arrayBuffer: async () => new Uint8Array().buffer,
+			};
+		});
+		opfsRoot.files.set('database.sqlite', brokenFile);
+		opfsRoot.files.set('pending.txt', pendingFile);
+
+		const mountHandler = createDirectoryHandleMountHandler(
+			opfsRoot as unknown as FileSystemDirectoryHandle,
+			{
+				initialSync: {
+					direction: 'opfs-to-memfs',
+				},
+			}
+		);
+		let rejected = false;
+		const syncPromise = Promise.resolve(
+			mountHandler(php, FS as any, '/wordpress')
+		).catch((error: unknown) => {
+			rejected = true;
+			throw error;
+		});
+
+		await Promise.resolve();
+		expect(rejected).toBe(false);
+
+		pendingRead.resolve();
+		await expect(syncPromise).rejects.toMatchObject({
+			cause: rootCause,
+		});
+	});
 });
 
 function createFakePhp() {
@@ -574,6 +672,11 @@ function createFakePhp() {
 			}
 			return file;
 		}),
+		createDataFile: vi.fn(
+			(parentPath: string, name: string, bytes: Uint8Array) => {
+				files.set(`${parentPath}/${name}`, bytes);
+			}
+		),
 	};
 	const listeners = new Map<string, Set<(event: { type: string }) => void>>();
 	const addEventListener = vi.fn(

--- a/packages/php-wasm/web/src/lib/directory-handle-mount.ts
+++ b/packages/php-wasm/web/src/lib/directory-handle-mount.ts
@@ -134,7 +134,11 @@ async function copyOpfsToMemfs(
 		concurrency: 40,
 	});
 
-	const ops: Array<Promise<void>> = [];
+	type CopyOperationResult =
+		| { status: 'fulfilled' }
+		| { status: 'rejected'; reason: unknown };
+	const ops: Array<Promise<CopyOperationResult>> = [];
+	let firstError: unknown;
 	const stack: Array<[FileSystemDirectoryHandle, string]> = [
 		[opfsRoot, memfsRoot],
 	];
@@ -142,44 +146,79 @@ async function copyOpfsToMemfs(
 		const [opfsParent, memfsParentPath] = stack.pop()!;
 
 		for await (const opfsHandle of opfsParent.values()) {
-			const op = semaphore.run(async () => {
-				const memfsEntryPath = joinPaths(
-					memfsParentPath,
-					opfsHandle.name
-				);
-				if (opfsHandle.kind === 'directory') {
+			const memfsEntryPath = joinPaths(memfsParentPath, opfsHandle.name);
+			const op = semaphore
+				.run(async () => {
 					try {
-						FS.mkdir(memfsEntryPath);
-					} catch (e) {
-						if ((e as any)?.errno !== 20) {
-							logger.error(e);
-							// We ignore the error if the directory already exists,
-							// and throw otherwise.
-							throw e;
+						if (opfsHandle.kind === 'directory') {
+							try {
+								FS.mkdir(memfsEntryPath);
+							} catch (e) {
+								if ((e as any)?.errno !== 20) {
+									logger.error(e);
+									// We ignore the error if the directory
+									// already exists, and throw otherwise.
+									throw e;
+								}
+							}
+							stack.push([opfsHandle, memfsEntryPath]);
+						} else if (opfsHandle.kind === 'file') {
+							const file = await opfsHandle.getFile();
+							const byteArray = new Uint8Array(
+								await file.arrayBuffer()
+							);
+							FS.createDataFile(
+								memfsParentPath,
+								opfsHandle.name,
+								byteArray,
+								true,
+								true,
+								true
+							);
 						}
+					} catch (error) {
+						throw new Error(
+							`Failed to copy OPFS entry to MEMFS path "${memfsEntryPath}"` +
+								`: ${getErrorMessage(error)}`,
+							{ cause: error }
+						);
 					}
-					stack.push([opfsHandle, memfsEntryPath]);
-				} else if (opfsHandle.kind === 'file') {
-					const file = await opfsHandle.getFile();
-					const byteArray = new Uint8Array(await file.arrayBuffer());
-					FS.createDataFile(
-						memfsParentPath,
-						opfsHandle.name,
-						byteArray,
-						true,
-						true,
-						true
-					);
+				})
+				.then(
+					() => ({ status: 'fulfilled' }) as const,
+					(error) => {
+						firstError ??= error;
+						return { status: 'rejected', reason: error } as const;
+					}
+				);
+			const trackedOp = op.finally(() => {
+				const opIndex = ops.indexOf(trackedOp);
+				if (opIndex !== -1) {
+					ops.splice(opIndex, 1);
 				}
-				ops.splice(ops.indexOf(op), 1);
 			});
-			ops.push(op);
+			ops.push(trackedOp);
 		}
 		// Let the ongoing operations catch-up to the stack.
 		while (stack.length === 0 && ops.length > 0) {
-			await Promise.any(ops);
+			if (firstError) {
+				await Promise.allSettled(ops);
+				throw firstError;
+			}
+			const result = await Promise.race(ops);
+			if (result.status === 'rejected') {
+				await Promise.allSettled(ops);
+				throw result.reason;
+			}
 		}
 	}
+}
+
+function getErrorMessage(error: unknown) {
+	if (error instanceof Error) {
+		return error.message;
+	}
+	return String(error);
 }
 
 export async function copyMemfsToOpfs(


### PR DESCRIPTION
## Motivation for the change, related issues

Persistent Playground sites can fail while copying an OPFS/local-fs mount into
MEMFS during boot. The sync loop previously waited with `Promise.any()`, so
when all pending copy operations rejected, Firefox surfaced the generic message:

```
No Promise in Promise.any was resolved
```

That message hides the entry that failed and the underlying read/write error,
making submitted crash reports hard to diagnose.

## Implementation details

- Wrap initial OPFS-to-MEMFS copy failures with the failed MEMFS path and root
  error message.
- Preserve the original error via `cause`.
- Use `Promise.race()` while waiting for pending copy operations so the first
  real rejection is surfaced instead of a generic `Promise.any()` aggregate.
- Add regression coverage for a failed OPFS file read during initial sync.

Example new message:

```
Failed to copy OPFS entry to MEMFS path "/wordpress/database.sqlite": file could not be read
```

## Testing Instructions

```bash
npm exec nx test php-wasm-web -- --runInBand
npm exec nx typecheck php-wasm-web
npm exec nx lint php-wasm-web
```

Both pass locally.

Note: the test run still prints an existing unrelated Vitest warning from
`tcp-over-fetch-websocket.spec.ts` about an unawaited assertion.
