### PR TITLE
[Tests] Fix legacy WP plugin activation selector

### DIFF
--- a/packages/playground/wordpress/tests/test-legacy-wp-version-boot.mjs
+++ b/packages/playground/wordpress/tests/test-legacy-wp-version-boot.mjs
@@ -791,7 +791,7 @@ for (const { wp, php } of MATRIX) {
 				const wp4 = await navigateViaUrlBar(
 					page,
 					'/wp-admin/plugins.php',
-					30
+					TIMEOUT_S
 				);
 				if (!wp4) {
 					pluginStatus = { status: 'TIMEOUT' };

--- a/packages/playground/wordpress/tests/test-legacy-wp-version-boot.mjs
+++ b/packages/playground/wordpress/tests/test-legacy-wp-version-boot.mjs
@@ -796,51 +796,35 @@ for (const { wp, php } of MATRIX) {
 				if (!wp4) {
 					pluginStatus = { status: 'TIMEOUT' };
 				} else {
-					// Target Hello Dolly specifically via its href. Clicking
-					// the *first* Activate link lands on Akismet's setup
-					// page on modern WP, which doesn't include the
-					// "Deactivate"/"Plugin activated" indicators this phase
-					// looks for. Hello Dolly ("hello.php") ships with every
-					// modern WordPress release and activates in-place with
-					// no follow-up screen, so the resulting plugins.php
-					// reliably shows the expected confirmation.
-					// Fall back to the first Activate link for very old WP
-					// where Hello Dolly may not be present or the href
-					// format differs.
-					// Wait for any Activate link to render — navigateViaUrlBar
-					// returns as soon as plugins.php has *any* body text, which
-					// on slow CI boots can be just the admin shell before the
-					// plugin list renders.
-					const anyActivate = wp4.frame
-						.locator('a')
+					// Target Hello Dolly specifically. Clicking the first
+					// Activate link can land on Akismet's setup page on modern
+					// WP, which doesn't include the expected activation
+					// indicators. Waiting for Hello Dolly avoids racing against
+					// a partially rendered plugin list.
+					const helloActivate = wp4.frame
+						.locator(
+							'a[href*="action=activate"][href*="hello.php"]'
+						)
 						.filter({ hasText: 'Activate' })
 						.first();
 					try {
-						await anyActivate.waitFor({
+						await helloActivate.waitFor({
 							state: 'visible',
 							timeout: 15000,
 						});
 					} catch {}
-					const helloActivate = wp4.frame
-						.locator('a[href*="hello.php"]')
-						.filter({ hasText: 'Activate' })
-						.first();
-					const activateLink =
-						(await helloActivate.count()) > 0
-							? helloActivate
-							: anyActivate;
-					if ((await activateLink.count()) > 0) {
+					if ((await helloActivate.count()) > 0) {
 						const bodyBeforeActivation = await wp4.frame
 							.locator('body')
 							.innerText({ timeout: 2000 })
 							.catch(() => wp4.body);
 						const prevFrameUrl = wp4.frame.url();
 						const pluginFile = getPluginFileFromActivationHref(
-							await activateLink
+							await helloActivate
 								.getAttribute('href')
 								.catch(() => null)
 						);
-						await activateLink.click({ timeout: 5000 });
+						await helloActivate.click({ timeout: 5000 });
 						const wp4b = await waitForPluginActivation(page, {
 							previousFrameUrl: prevFrameUrl,
 							previousBody: bodyBeforeActivation,

--- a/packages/playground/wordpress/tests/test-legacy-wp-version-boot.mjs
+++ b/packages/playground/wordpress/tests/test-legacy-wp-version-boot.mjs
@@ -807,13 +807,14 @@ for (const { wp, php } of MATRIX) {
 						)
 						.filter({ hasText: 'Activate' })
 						.first();
-					try {
-						await helloActivate.waitFor({
+					const hasHelloActivate = await helloActivate
+						.waitFor({
 							state: 'visible',
 							timeout: 15000,
-						});
-					} catch {}
-					if ((await helloActivate.count()) > 0) {
+						})
+						.then(() => true)
+						.catch(() => false);
+					if (hasHelloActivate) {
 						const bodyBeforeActivation = await wp4.frame
 							.locator('body')
 							.innerText({ timeout: 2000 })


### PR DESCRIPTION
## Summary

Fixes the legacy WordPress boot test plugin activation phase so it waits for and clicks the Hello Dolly activation link specifically.

## Motivation for the change, related issues

The `test-legacy-wp-version-boot` CI job can fail when the plugins page renders Akismet's activation link before Hello Dolly. The old fallback clicked the first `Activate` link, which can land on Akismet's setup screen and then time out while waiting for the Hello Dolly-style activation indicators.

Related failing job: https://github.com/WordPress/wordpress-playground/actions/runs/28081251039/job/83136494931?pr=3824

## Implementation details

- Removes the generic first-`Activate` fallback.
- Waits for `a[href*="action=activate"][href*="hello.php"]` before clicking.
- Keeps the existing `SKIP` / `no activate link found` status when no activation link is available.

## Testing Instructions

- CI