### PR TITLE
[docs] Updating MCP README

### DIFF
--- a/packages/playground/mcp/README.md
+++ b/packages/playground/mcp/README.md
@@ -94,7 +94,7 @@ The MCP bridge runs locally and is only accessible from your machine — connect
 
 ## Available tools
 
-**Site management**: `playground_get_website_url`, `playground_list_sites`, `playground_open_site`, `playground_rename_site`, `playground_save_site`
+**Site management**: `playground_get_website_url`, `playground_list_sites`, `playground_open_site_in_new_tab`, `playground_rename_site`, `playground_save_in_browser`
 
 **Code execution**: `playground_execute_php`, `playground_request`
 

--- a/packages/playground/mcp/tests/unit/tool-definitions.spec.ts
+++ b/packages/playground/mcp/tests/unit/tool-definitions.spec.ts
@@ -1,5 +1,8 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import {
+	getSiteToolDefinitions,
 	paramsToJsonSchema,
 	playgroundUrl,
 	toolDefinitions,
@@ -22,6 +25,28 @@ describe('playgroundUrl', () => {
 		expect(playgroundUrl(7999, 'https://example.com/?foo=bar')).toBe(
 			'https://example.com/?foo=bar&mcp-port=7999'
 		);
+	});
+});
+
+describe('README tool list', () => {
+	// Guards against the README "Available tools" section drifting out of
+	// sync with the registered tools. The README is hand-maintained, so this
+	// fails whenever a tool is added, removed, or renamed without an update.
+	it('lists exactly the registered tools', () => {
+		const registered = [
+			...Object.keys(toolDefinitions),
+			...Object.keys(getSiteToolDefinitions()),
+		].sort();
+
+		const readme = readFileSync(
+			fileURLToPath(new URL('../../README.md', import.meta.url)),
+			'utf8'
+		);
+		const documented = [
+			...new Set(readme.match(/playground_[a-z_]+/g) ?? []),
+		].sort();
+
+		expect(documented).toEqual(registered);
 	});
 });
 


### PR DESCRIPTION
This pull request improves the synchronization between registered tool definitions and their documentation in `README.md`. It updates the tool names in the README to match the code and adds a test to ensure the README stays up to date with any future changes.

**Documentation updates:**

* Updated the "Available tools" section in `README.md` to use the correct tool names: replaced `playground_open_site` with `playground_open_site_in_new_tab` and `playground_save_site` with `playground_save_in_browser`.

**Testing and validation:**

* Added a unit test in `tool-definitions.spec.ts` to verify that all registered tools are listed in the README, preventing documentation from getting out of sync with the code.
* Imported necessary modules and tool definitions in the test file to support the new validation.
