### PR TITLE
Fix Site Manager header and file browser tab layout

### DIFF
--- a/packages/playground/website/src/components/blueprint-editor/BlueprintBundleEditor.tsx
+++ b/packages/playground/website/src/components/blueprint-editor/BlueprintBundleEditor.tsx
@@ -258,6 +258,7 @@ export type BlueprintBundleEditorProps = {
 	site?: SiteInfo;
 	autoRunToken?: number;
 	readOnly?: boolean;
+	hideSidebar?: boolean;
 };
 
 export interface BlueprintBundleEditorHandle {
@@ -270,7 +271,7 @@ export const BlueprintBundleEditor = forwardRef<
 	BlueprintBundleEditorHandle,
 	BlueprintBundleEditorProps
 >(function BlueprintFilesystemEditor(
-	{ filesystem, className, site, autoRunToken, readOnly },
+	{ filesystem, className, site, autoRunToken, readOnly, hideSidebar },
 	ref
 ) {
 	const [selectedDirPath, setSelectedDirPath] = useState<string | null>('/');
@@ -673,44 +674,50 @@ export const BlueprintBundleEditor = forwardRef<
 						[styles.sidebarOpen]: showExplorerOnMobile,
 					})}
 				>
-					<div
-						className={styles.mobileOverlay}
-						onClick={() => setShowExplorerOnMobile(false)}
-					/>
-					<aside
-						className={classNames(
-							styles.sidebarWrapper,
-							hideRootStyles.hideRoot
-						)}
-					>
-						<FileExplorerSidebar
-							filesystem={filesystem}
-							currentPath={currentPath}
-							selectedDirPath={selectedDirPath}
-							setSelectedDirPath={setSelectedDirPath}
-							focusPath={treeFocusPath}
-							onFileOpened={handleFileOpened}
-							onSelectionCleared={handleClearSelection}
-							onShowMessage={handleShowMessage}
-							documentRoot="/"
-							readOnly={readOnly}
-						/>
-					</aside>
+					{!hideSidebar && (
+						<>
+							<div
+								className={styles.mobileOverlay}
+								onClick={() => setShowExplorerOnMobile(false)}
+							/>
+							<aside
+								className={classNames(
+									styles.sidebarWrapper,
+									hideRootStyles.hideRoot
+								)}
+							>
+								<FileExplorerSidebar
+									filesystem={filesystem}
+									currentPath={currentPath}
+									selectedDirPath={selectedDirPath}
+									setSelectedDirPath={setSelectedDirPath}
+									focusPath={treeFocusPath}
+									onFileOpened={handleFileOpened}
+									onSelectionCleared={handleClearSelection}
+									onShowMessage={handleShowMessage}
+									documentRoot="/"
+									readOnly={readOnly}
+								/>
+							</aside>
+						</>
+					)}
 					<section className={styles.editorWrapper}>
 						<div className={styles.editorHeader}>
-							<Button
-								className={styles.mobileToggle}
-								variant="secondary"
-								onClick={() =>
-									setShowExplorerOnMobile(
-										(previous) => !previous
-									)
-								}
-							>
-								{showExplorerOnMobile
-									? 'Hide files'
-									: 'Browse files'}
-							</Button>
+							{!hideSidebar && (
+								<Button
+									className={styles.mobileToggle}
+									variant="secondary"
+									onClick={() =>
+										setShowExplorerOnMobile(
+											(previous) => !previous
+										)
+									}
+								>
+									{showExplorerOnMobile
+										? 'Hide files'
+										: 'Browse files'}
+								</Button>
+							)}
 							<div
 								className={classNames(styles.editorPath, {
 									[styles.editorPathPlaceholder]:

--- a/packages/playground/website/src/components/blueprint-editor/SiteBlueprintBundleEditor.tsx
+++ b/packages/playground/website/src/components/blueprint-editor/SiteBlueprintBundleEditor.tsx
@@ -267,6 +267,7 @@ export const SiteBlueprintBundleEditor = forwardRef<
 					site={site}
 					className={className}
 					readOnly={readOnly}
+					hideSidebar={true}
 				/>
 			)}
 		</div>

--- a/packages/playground/website/src/components/blueprint-editor/blueprint-bundle-editor.module.css
+++ b/packages/playground/website/src/components/blueprint-editor/blueprint-bundle-editor.module.css
@@ -47,14 +47,16 @@
 }
 
 .editorPath {
-	flex: 1;
-	min-width: 0;
+	flex: 1 1 16rem;
+	min-width: min(100%, 12rem);
 	font-family:
 		'SFMono-Regular', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
 		'Liberation Mono', 'Courier New', monospace;
 	font-size: 12px;
 	color: var(--color-gray-700);
-	word-break: break-all;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 }
 
 .editorPathPlaceholder {

--- a/packages/playground/website/src/components/site-manager/site-info-panel/index.tsx
+++ b/packages/playground/website/src/components/site-manager/site-info-panel/index.tsx
@@ -387,7 +387,7 @@ export function SiteInfoPanel({
 						</FlexItem>
 					</Flex>
 				</FlexItem>
-				<FlexItem style={{ flexGrow: 1 }}>
+				<FlexItem className={css.tabPanelWrapper}>
 					<TabPanel
 						className={css.tabs}
 						initialTabName={initialTabName}

--- a/packages/playground/website/src/components/site-manager/site-info-panel/index.tsx
+++ b/packages/playground/website/src/components/site-manager/site-info-panel/index.tsx
@@ -191,18 +191,19 @@ export function SiteInfoPanel({
 				)
 			)
 		: '';
+	const createdAgoSuffix = createdAgo ? ` ${createdAgo}` : '';
 	let siteSavedStatus: string | undefined;
 	switch (site.metadata.storage) {
 		case 'local-fs':
 			siteSavedStatus =
 				'Saved in a local directory' +
 				(localDirName ? ` (${localDirName})` : '') +
-				` ${createdAgo}`;
+				createdAgoSuffix;
 			break;
 		case 'opfs':
 			siteSavedStatus = isAutosaved
-				? `Autosaved in this browser ${createdAgo}. Removed after ${MAX_AUTOSAVED_SITES} newer autosaves unless saved.`
-				: `Saved in this browser ${createdAgo}`;
+				? `Autosaved in this browser${createdAgoSuffix}. Removed after ${MAX_AUTOSAVED_SITES} newer autosaves unless saved.`
+				: `Saved in this browser${createdAgoSuffix}`;
 			break;
 	}
 	const headerActions: HeaderAction[] = [];
@@ -337,13 +338,8 @@ export function SiteInfoPanel({
 				className={css.siteInfoPanelContent}
 			>
 				<FlexItem style={{ flexShrink: 0 }}>
-					<Flex
+					<div
 						ref={headerRef}
-						direction="row"
-						gap={2}
-						justify="space-between"
-						align="flex-start"
-						expanded={true}
 						className={`${css.padded} ${css.siteInfoHeader}`}
 						style={{ paddingBottom: 10 }}
 					>
@@ -512,9 +508,12 @@ export function SiteInfoPanel({
 								</span>
 							)}
 						</FlexItem>
-					</Flex>
+					</div>
 				</FlexItem>
-				<FlexItem className={css.tabPanelWrapper}>
+				<FlexItem
+					className={css.tabPanelWrapper}
+					style={{ flexGrow: 1 }}
+				>
 					<TabPanel
 						className={css.tabs}
 						initialTabName={initialTabName}

--- a/packages/playground/website/src/components/site-manager/site-info-panel/index.tsx
+++ b/packages/playground/website/src/components/site-manager/site-info-panel/index.tsx
@@ -254,6 +254,7 @@ export function SiteInfoPanel({
 
 		headerWidthRef.current = null;
 		setVisibleHeaderActionCount(headerActions.length);
+		let animationFrame: number | undefined;
 		const updateHeaderActionVisibility = (width: number) => {
 			if (headerWidthRef.current === width) {
 				return;
@@ -269,10 +270,19 @@ export function SiteInfoPanel({
 
 		updateHeaderActionVisibility(header.getBoundingClientRect().width);
 		const observer = new ResizeObserver((entries) => {
-			updateHeaderActionVisibility(entries[0].contentRect.width);
+			if (animationFrame !== undefined) {
+				cancelAnimationFrame(animationFrame);
+			}
+			animationFrame = requestAnimationFrame(() => {
+				updateHeaderActionVisibility(entries[0].contentRect.width);
+				animationFrame = undefined;
+			});
 		});
 		observer.observe(header);
 		return () => {
+			if (animationFrame !== undefined) {
+				cancelAnimationFrame(animationFrame);
+			}
 			observer.disconnect();
 		};
 	}, [headerActions.length, mobileUi, title]);

--- a/packages/playground/website/src/components/site-manager/site-info-panel/index.tsx
+++ b/packages/playground/website/src/components/site-manager/site-info-panel/index.tsx
@@ -11,7 +11,14 @@ import {
 import { chevronLeft, edit, moreVertical } from '@wordpress/icons';
 import { getLogoDataURL, WordPressIcon } from '@wp-playground/components';
 import classNames from 'classnames';
-import { lazy, Suspense, useEffect, useState } from 'react';
+import {
+	lazy,
+	Suspense,
+	useEffect,
+	useLayoutEffect,
+	useRef,
+	useState,
+} from 'react';
 import { getRelativeDate } from '../../../lib/get-relative-date';
 import { selectClientInfoBySiteSlug } from '../../../lib/state/redux/slice-clients';
 import type { SiteInfo } from '../../../lib/state/redux/slice-sites';
@@ -50,6 +57,16 @@ const SiteBlueprintBundleEditor = lazy(() =>
 );
 
 const LAST_TAB_STORAGE_KEY = 'playground-site-last-tabs';
+type HeaderAction = {
+	key: string;
+	label: string;
+	variant: 'primary' | 'secondary' | 'tertiary';
+	disabled?: boolean;
+	onClick: () => void;
+};
+const HEADER_ACTIONS_TITLE_GAP = 32;
+const HEADER_TITLE_MIN_WIDTH_WITH_ACTIONS = 224;
+const MOBILE_HEADER_TITLE_MIN_WIDTH_WITH_ACTIONS = 160;
 
 function getSiteLastTab(siteSlug: string): string | null {
 	try {
@@ -93,6 +110,13 @@ export function SiteInfoPanel({
 		const lastTab = getSiteLastTab(site.slug);
 		return lastTab || 'settings';
 	});
+	const [visibleHeaderActionCount, setVisibleHeaderActionCount] = useState(
+		Number.MAX_SAFE_INTEGER
+	);
+	const headerRef = useRef<HTMLDivElement>(null);
+	const titleRef = useRef<HTMLHeadingElement>(null);
+	const headerWidthRef = useRef<number | null>(null);
+	const [headerResizeTick, setHeaderResizeTick] = useState(0);
 
 	// Resolve documentRoot from playground client
 	const [documentRoot, setDocumentRoot] = useState<string | null>(null);
@@ -114,6 +138,9 @@ export function SiteInfoPanel({
 	const openSaveModal = () => {
 		dispatch(setSiteSlugToSave(site.slug));
 		dispatch(setActiveModal(modalSlugs.SAVE_SITE));
+	};
+	const openSite = () => {
+		dispatch(setSiteManagerOpen(false));
 	};
 	const clientInfo = useAppSelector((state) =>
 		selectClientInfoBySiteSlug(state, site.slug)
@@ -154,6 +181,147 @@ export function SiteInfoPanel({
 	const titleWords = title.split(' ');
 	const titleStart = titleWords.slice(0, -1).join(' ');
 	const titleEnd = titleWords[titleWords.length - 1];
+	const createdAgo = site.metadata.whenCreated
+		? getRelativeDate(
+				new Date(
+					// -2 to make sure it's in the past. We want to avoid
+					// accidentally signaling this happened in the future,
+					// e.g. "in 1 seconds"
+					site.metadata.whenCreated - 2
+				)
+			)
+		: '';
+	let siteSavedStatus: string | undefined;
+	switch (site.metadata.storage) {
+		case 'local-fs':
+			siteSavedStatus =
+				'Saved in a local directory' +
+				(localDirName ? ` (${localDirName})` : '') +
+				` ${createdAgo}`;
+			break;
+		case 'opfs':
+			siteSavedStatus = isAutosaved
+				? `Autosaved in this browser ${createdAgo}. Removed after ${MAX_AUTOSAVED_SITES} newer autosaves unless saved.`
+				: `Saved in this browser ${createdAgo}`;
+			break;
+	}
+	const headerActions: HeaderAction[] = [];
+	if (isAutosaved) {
+		headerActions.push({
+			key: 'store-permanently',
+			label: 'Store permanently',
+			variant: 'primary',
+			onClick: openSaveModal,
+		});
+	}
+	if (mobileUi) {
+		headerActions.push({
+			key: 'open-site',
+			label: 'Open site',
+			variant: 'primary',
+			onClick: openSite,
+		});
+	} else {
+		headerActions.push(
+			{
+				key: 'wp-admin',
+				label: 'WP Admin',
+				variant: 'tertiary',
+				disabled: !playground,
+				onClick: () => navigateTo('/wp-admin/'),
+			},
+			{
+				key: 'homepage',
+				label: 'Homepage',
+				variant: 'secondary',
+				disabled: !playground,
+				onClick: () => navigateTo('/'),
+			}
+		);
+	}
+	const visibleHeaderActions = headerActions.slice(
+		0,
+		visibleHeaderActionCount
+	);
+	const overflowHeaderActions = headerActions.slice(visibleHeaderActionCount);
+
+	useLayoutEffect(() => {
+		const header = headerRef.current;
+		if (!header || typeof ResizeObserver === 'undefined') {
+			return;
+		}
+
+		headerWidthRef.current = null;
+		setVisibleHeaderActionCount(headerActions.length);
+		const updateHeaderActionVisibility = (width: number) => {
+			if (headerWidthRef.current === width) {
+				return;
+			}
+			const previousWidth = headerWidthRef.current;
+			headerWidthRef.current = width;
+			setHeaderResizeTick((tick) => tick + 1);
+
+			if (previousWidth !== null && width > previousWidth) {
+				setVisibleHeaderActionCount(headerActions.length);
+			}
+		};
+
+		updateHeaderActionVisibility(header.getBoundingClientRect().width);
+		const observer = new ResizeObserver((entries) => {
+			updateHeaderActionVisibility(entries[0].contentRect.width);
+		});
+		observer.observe(header);
+		return () => {
+			observer.disconnect();
+		};
+	}, [headerActions.length, mobileUi, title]);
+
+	useLayoutEffect(() => {
+		if (visibleHeaderActionCount === 0) {
+			return;
+		}
+
+		const titleBox = titleRef.current?.getBoundingClientRect();
+		const actionButtons = Array.from(
+			headerRef.current?.querySelectorAll(
+				'[data-header-primary-actions] button'
+			) || []
+		);
+		if (!titleBox || !actionButtons.length) {
+			return;
+		}
+
+		const minTitleWidth = mobileUi
+			? MOBILE_HEADER_TITLE_MIN_WIDTH_WITH_ACTIONS
+			: HEADER_TITLE_MIN_WIDTH_WITH_ACTIONS;
+		const headerIsCramped =
+			titleBox.width < minTitleWidth ||
+			actionButtons.some((button) => {
+				const buttonBox = button.getBoundingClientRect();
+				return (
+					titleBox.left < buttonBox.right &&
+					titleBox.right > buttonBox.left &&
+					titleBox.right + HEADER_ACTIONS_TITLE_GAP >
+						buttonBox.left &&
+					titleBox.top < buttonBox.bottom &&
+					titleBox.bottom > buttonBox.top
+				);
+			});
+
+		if (!headerIsCramped) {
+			return;
+		}
+
+		setVisibleHeaderActionCount((current) =>
+			Math.max(0, Math.min(current, headerActions.length) - 1)
+		);
+	}, [
+		headerActions.length,
+		headerResizeTick,
+		mobileUi,
+		title,
+		visibleHeaderActionCount,
+	]);
 
 	return (
 		<section
@@ -170,6 +338,7 @@ export function SiteInfoPanel({
 			>
 				<FlexItem style={{ flexShrink: 0 }}>
 					<Flex
+						ref={headerRef}
 						direction="row"
 						gap={2}
 						justify="space-between"
@@ -179,7 +348,10 @@ export function SiteInfoPanel({
 						style={{ paddingBottom: 10 }}
 					>
 						{mobileUi && (
-							<FlexItem style={{ marginLeft: -20 }}>
+							<FlexItem
+								className={css.siteInfoHeaderBack}
+								style={{ marginLeft: -20 }}
+							>
 								<Button
 									variant="link"
 									label="Back to Playground"
@@ -205,146 +377,70 @@ export function SiteInfoPanel({
 								/>
 							)}
 						</FlexItem>
-						<FlexItem style={{ flexGrow: 1 }}>
-							<Flex direction="column" gap={0.25} expanded={true}>
-								<Flex
-									direction="row"
-									align="flex-start"
-									className={css.siteInfoHeaderTitleRow}
+						<FlexItem className={css.siteInfoHeaderDetails}>
+							<h1
+								ref={titleRef}
+								className={css.siteInfoHeaderDetailsName}
+								aria-label="Playground title"
+							>
+								<span
+									className={
+										css.siteInfoHeaderDetailsNameText
+									}
 								>
-									<FlexItem
-										className={css.siteInfoHeaderTitle}
-									>
-										<h1
-											className={
-												css.siteInfoHeaderDetailsName
-											}
-											aria-label="Playground title"
-										>
-											<span
-												className={
-													css.siteInfoHeaderDetailsNameText
-												}
-											>
-												{titleStart}{' '}
-												<span
-													className={
-														css.siteInfoHeaderDetailsNameTextEnd
-													}
-												>
-													{titleEnd}
-													{!isTemporary && (
-														<Button
-															className={
-																css.siteInfoRenameButton
-															}
-															icon={edit}
-															label="Rename Playground"
-															showTooltip={true}
-															variant="tertiary"
-															isSmall={true}
-															onClick={() => {
-																dispatch(
-																	setSiteSlugToRename(
-																		site.slug
-																	)
-																);
-																dispatch(
-																	setActiveModal(
-																		modalSlugs.RENAME_SITE
-																	)
-																);
-															}}
-														/>
-													)}
-												</span>
-											</span>
-										</h1>
-									</FlexItem>
-								</Flex>
-								{!isTemporary && (
+									{titleStart}{' '}
 									<span
 										className={
-											css.siteInfoHeaderDetailsCreatedAt
+											css.siteInfoHeaderDetailsNameTextEnd
 										}
 									>
-										{(function () {
-											const createdAgo = site.metadata
-												.whenCreated
-												? getRelativeDate(
-														new Date(
-															// -2 to make sure it's in the past. We want to
-															// avoid accidentally signaling this happened in
-															// the future, e.g. "in 1 seconds"
-															site.metadata
-																.whenCreated - 2
+										{titleEnd}
+										{!isTemporary && (
+											<Button
+												className={
+													css.siteInfoRenameButton
+												}
+												icon={edit}
+												label="Rename Playground"
+												showTooltip={true}
+												variant="tertiary"
+												isSmall={true}
+												onClick={() => {
+													dispatch(
+														setSiteSlugToRename(
+															site.slug
 														)
-													)
-												: '';
-											switch (site.metadata.storage) {
-												case 'local-fs':
-													return (
-														'Saved in a local directory' +
-														(localDirName
-															? ` (${localDirName})`
-															: '') +
-														` ${createdAgo}`
 													);
-												case 'opfs':
-													if (isAutosaved) {
-														return `Autosaved in this browser ${createdAgo}. Removed after ${MAX_AUTOSAVED_SITES} newer autosaves unless saved.`;
-													}
-													return `Saved in this browser ${createdAgo}`;
-											}
-										})()}{' '}
+													dispatch(
+														setActiveModal(
+															modalSlugs.RENAME_SITE
+														)
+													);
+												}}
+											/>
+										)}
 									</span>
-								)}
-							</Flex>
+								</span>
+							</h1>
 						</FlexItem>
-						{isAutosaved && (
-							<FlexItem className={css.siteInfoHeaderAction}>
-								<Button
-									variant="primary"
-									onClick={openSaveModal}
-								>
-									Store permanently
-								</Button>
-							</FlexItem>
-						)}
-						{mobileUi ? (
-							<FlexItem style={{ flexShrink: 0 }}>
-								<Button
-									variant="primary"
-									onClick={() => {
-										dispatch(setSiteManagerOpen(false));
-									}}
-								>
-									Open site
-								</Button>
-							</FlexItem>
-						) : (
-							<>
-								<FlexItem className={css.siteInfoHeaderAction}>
+						<FlexItem className={css.siteInfoHeaderPrimaryActions}>
+							<div
+								className={css.siteInfoHeaderPrimaryActionsList}
+								data-header-primary-actions
+							>
+								{visibleHeaderActions.map((action) => (
 									<Button
-										variant="tertiary"
-										disabled={!playground}
-										onClick={() => navigateTo('/wp-admin/')}
+										key={action.key}
+										variant={action.variant}
+										disabled={action.disabled}
+										onClick={action.onClick}
 									>
-										WP Admin
+										{action.label}
 									</Button>
-								</FlexItem>
-								<FlexItem className={css.siteInfoHeaderAction}>
-									<Button
-										variant="secondary"
-										disabled={!playground}
-										onClick={() => navigateTo('/')}
-									>
-										Homepage
-									</Button>
-								</FlexItem>
-							</>
-						)}
-						<FlexItem className={css.siteInfoHeaderAction}>
+								))}
+							</div>
+						</FlexItem>
+						<FlexItem className={css.siteInfoHeaderMenu}>
 							<DropdownMenu
 								icon={moreVertical}
 								label="Additional actions"
@@ -354,6 +450,26 @@ export function SiteInfoPanel({
 							>
 								{({ onClose }) => (
 									<>
+										{overflowHeaderActions.length > 0 && (
+											<MenuGroup>
+												{overflowHeaderActions.map(
+													(action) => (
+														<MenuItem
+															key={action.key}
+															disabled={
+																action.disabled
+															}
+															onClick={() => {
+																action.onClick();
+																onClose();
+															}}
+														>
+															{action.label}
+														</MenuItem>
+													)
+												)}
+											</MenuGroup>
+										)}
 										{!isTemporary && (
 											<MenuGroup>
 												<MenuItem
@@ -384,6 +500,17 @@ export function SiteInfoPanel({
 									</>
 								)}
 							</DropdownMenu>
+						</FlexItem>
+						<FlexItem className={css.siteInfoHeaderDescription}>
+							{!isTemporary && siteSavedStatus && (
+								<span
+									className={
+										css.siteInfoHeaderDetailsCreatedAt
+									}
+								>
+									{siteSavedStatus}
+								</span>
+							)}
 						</FlexItem>
 					</Flex>
 				</FlexItem>
@@ -470,6 +597,7 @@ export function SiteInfoPanel({
 								</div>
 								<div
 									className={classNames(
+										css.tabContents,
 										css.blueprintWrapper,
 										{
 											[css.tabHidden]:

--- a/packages/playground/website/src/components/site-manager/site-info-panel/style.module.css
+++ b/packages/playground/website/src/components/site-manager/site-info-panel/style.module.css
@@ -21,9 +21,18 @@
 	padding: var(--padding-size);
 }
 
+.tabPanelWrapper {
+	display: flex;
+	flex: 1 1 auto;
+	min-height: 0;
+	min-width: 0;
+}
+
 .tabs {
 	width: 100%;
 	height: 100%;
+	flex: 1 1 auto;
+	min-height: 0;
 	display: flex;
 	flex-direction: column;
 

--- a/packages/playground/website/src/components/site-manager/site-info-panel/style.module.css
+++ b/packages/playground/website/src/components/site-manager/site-info-panel/style.module.css
@@ -130,7 +130,7 @@
 
 .site-info-header {
 	color: inherit;
-	display: grid !important;
+	display: grid;
 	grid-template-columns: 48px minmax(10rem, 1fr) auto auto;
 	grid-template-areas:
 		'icon details actions menu'

--- a/packages/playground/website/src/components/site-manager/site-info-panel/style.module.css
+++ b/packages/playground/website/src/components/site-manager/site-info-panel/style.module.css
@@ -38,6 +38,10 @@
 
 	& :global(.components-tab-panel__tabs) {
 		--wp-components-color-accent: var(--color-gray-900);
+		position: relative;
+		z-index: 4;
+		flex: none;
+		background: #ffffff;
 		border-bottom: 1px solid var(--color-gray-200);
 		max-width: 100%;
 		overflow-x: auto;
@@ -51,6 +55,8 @@
 		white-space: nowrap;
 	}
 	& :global(.components-tab-panel__tab-content) {
+		position: relative;
+		z-index: 1;
 		display: flex;
 		flex-direction: column;
 		flex-grow: 1;
@@ -124,12 +130,34 @@
 
 .site-info-header {
 	color: inherit;
+	display: grid !important;
+	grid-template-columns: 48px minmax(10rem, 1fr) auto auto;
+	grid-template-areas:
+		'icon details actions menu'
+		'icon description description description';
+	column-gap: 12px;
+	row-gap: 4px;
+	align-items: start;
 
 	&:has(.site-info-header-details-created-at:empty),
 	&:not(:has(.site-info-header-details-created-at)) {
-		justify-content: center;
+		justify-content: stretch;
 		align-items: center;
 	}
+}
+
+.siteInfoHeaderDetails {
+	grid-area: details;
+	min-width: 0;
+}
+
+.siteInfoHeaderDescription {
+	grid-area: description;
+	min-width: 0;
+}
+
+.siteInfoHeaderBack {
+	grid-area: back;
 }
 
 .site-info-header-icon {
@@ -137,12 +165,13 @@
 
 	width: 48px;
 	height: 48px;
-	margin-right: 8px;
+	margin-right: 0;
 
 	background: #ffffff;
 	border: 1px solid rgba(0, 0, 0, 0.1);
 	border-radius: 4px;
 
+	grid-area: icon;
 	flex: none;
 	flex-grow: 0;
 }
@@ -176,11 +205,6 @@
 	max-width: 100%;
 }
 
-.siteInfoHeaderTitle {
-	min-width: 0;
-	flex: 1 1 auto;
-}
-
 .siteInfoHeaderDetailsNameText {
 	flex: 0 1 auto;
 	min-width: 0;
@@ -188,15 +212,12 @@
 	word-break: break-word;
 }
 
-.siteInfoRenameButton {
-	vertical-align: middle;
-}
-
 .siteInfoHeaderDetailsNameTextEnd {
 	white-space: nowrap;
 }
 
 .site-info-header-details-created-at {
+	display: block;
 	width: 100%;
 	font-size: 14px;
 	line-height: 20px;
@@ -204,26 +225,38 @@
 
 	/* Gutenberg/Gray 700 */
 	color: #757575;
-}
-
-.siteInfoHeaderTitleRow {
-	align-items: flex-start;
-	gap: 8px;
+	overflow-wrap: normal;
 }
 
 .siteInfoHeaderPrimaryActions {
-	display: flex;
-	flex-wrap: wrap;
-	justify-content: flex-end;
-	align-items: stretch;
-	gap: 8px;
-	flex: 0 1 auto;
+	grid-area: actions;
 	min-width: 0;
 }
 
-.siteInfoHeaderAction {
+.siteInfoHeaderPrimaryActionsList {
+	display: flex;
+	flex-wrap: nowrap;
+	justify-content: flex-end;
+	align-items: center;
+	gap: 8px;
+	min-width: 0;
+}
+
+.siteInfoHeaderMenu {
+	grid-area: menu;
 	flex: none;
-	flex-shrink: 0;
+}
+
+.isMobile .site-info-header {
+	grid-template-columns: auto 48px minmax(8rem, 1fr) auto auto;
+	grid-template-areas:
+		'back icon details actions menu'
+		'back icon description description description';
+	column-gap: 8px;
+}
+
+.isMobile .siteInfoHeaderPrimaryActions {
+	justify-content: flex-end;
 }
 
 .siteInfoRenameButton {
@@ -254,8 +287,8 @@
 .blueprint-wrapper {
 	display: flex;
 	flex-direction: column;
-	height: 100%;
 	min-height: 0;
+	overflow: hidden;
 }
 
 .blueprint-header {


### PR DESCRIPTION
## What

This PR fixes the Site Manager layout so the tab bar remains visible and usable when the File browser tab is selected.

The file browser and blueprint panes now stay bounded inside the tab panel, while the tab strip keeps its own background and stacking context so editor content cannot draw behind or over it.

## Header Layout

It also refines the Site Manager header layout. The logo, title, description, primary actions, and overflow menu are split into explicit grid areas.

As the available width gets tighter, the primary action buttons move progressively into the Additional actions overflow menu instead of wrapping into the title or forcing the title into an awkward line flow.

This keeps the WordPress logo anchored at the top left, keeps the description beside and below the title area, and avoids action buttons colliding with the title during resize.

## Blueprint Editor

The Blueprint tab now uses the available panel width for the editor instead of showing the file explorer sidebar. The current Blueprint path stays in a single line with ellipsis behavior, so it no longer collapses into a vertical column when space gets tight.

## Screen Recording

https://github.com/user-attachments/assets/c133e87b-314d-4000-941a-4804af1c180b

## Verification

Verified with `npm run format:uncommitted` and `npm exec nx lint playground-website -- --files=packages/playground/website/src/components/blueprint-editor/BlueprintBundleEditor.tsx,packages/playground/website/src/components/blueprint-editor/SiteBlueprintBundleEditor.tsx,packages/playground/website/src/components/blueprint-editor/blueprint-bundle-editor.module.css,packages/playground/website/src/components/site-manager/site-info-panel/index.tsx,packages/playground/website/src/components/site-manager/site-info-panel/style.module.css`.

cc @apermo who pointed the problem out to me.