### PR TITLE
[CLI] Fix stale POSIX file-lock bookkeeping

### DIFF
--- a/packages/php-wasm/node/src/lib/file-lock-manager-for-posix.ts
+++ b/packages/php-wasm/node/src/lib/file-lock-manager-for-posix.ts
@@ -2,11 +2,15 @@ import type {
 	FileLockManager,
 	WholeFileLockOp,
 	RequestedRangeLock,
+	LockedRange,
 	Pid,
 	Fd,
 	Path,
 } from '@php-wasm/universal';
-import { MAX_ADDRESSABLE_FILE_OFFSET } from '@php-wasm/universal';
+import {
+	FileLockIntervalTree,
+	MAX_ADDRESSABLE_FILE_OFFSET,
+} from '@php-wasm/universal';
 import { constants, fcntlSync, flockSync } from 'fs-ext-extra-prebuilt';
 import { logger } from '@php-wasm/logger';
 
@@ -26,7 +30,7 @@ type StoredWholeFileLock = WholeFileLockOp & { path: Path };
 
 export class FileLockManagerForPosix implements FileLockManager {
 	wholeFileLockMap = new Map<Pid, Map<Fd, StoredWholeFileLock>>();
-	rangeLockedFds = new Map<Pid, Map<Path, Set<Fd>>>();
+	rangeLocksByPath = new Map<Path, FileLockIntervalTree>();
 
 	lockWholeFile(path: string, op: WholeFileLockOp): boolean {
 		const opType =
@@ -102,17 +106,7 @@ export class FileLockManagerForPosix implements FileLockManager {
 				Number(op.end - op.start)
 			);
 
-			// Remember that we have seen range locks for this PID and FD.
-			// It should be enough to release all locks with a single fcntl() call
-			// to unlock the entire file range when the FD is closed or the process exits.
-			if (!this.rangeLockedFds.has(op.pid)) {
-				this.rangeLockedFds.set(op.pid, new Map());
-			}
-			const pidMap = this.rangeLockedFds.get(op.pid)!;
-			if (!pidMap.has(path)) {
-				pidMap.set(path, new Set());
-			}
-			pidMap.get(path)!.add(op.fd);
+			this.recordRangeLockOp(path, op);
 
 			return true;
 		} catch (e) {
@@ -174,36 +168,39 @@ export class FileLockManagerForPosix implements FileLockManager {
 			this.wholeFileLockMap.delete(targetPid);
 		}
 
-		for (const [path, fdSet] of this.rangeLockedFds.get(targetPid) ?? []) {
-			for (const fd of fdSet) {
-				/*
-				 * fcntl() lets us request to unlock the entire byte range for this process,
-				 * so we do that instead of tracking and unlocking specific ranges.
-				 * NOTE: Actually, the native OS is not aware of the php-wasm process ID,
-				 * but since we track which FDs are associated with each process,
-				 * we can simply unlock for all FDs associated with the php-wasm process.
-				 */
-				try {
-					this.lockFileByteRange(
-						path,
-						{
-							pid: targetPid,
-							fd,
-							type: 'unlocked',
-							start: 0n,
-							end: MAX_ADDRESSABLE_FILE_OFFSET,
-						},
-						false
-					);
-				} catch (e) {
-					logger.error(
-						`releaseLocksForProcess: failed to unlock byte range for pid=${targetPid} fd=${fd} path=${path}`,
-						e
-					);
-				}
+		for (const [path, rangeLocks] of this.rangeLocksByPath) {
+			const locksForProcess = rangeLocks.findLocksForProcess(targetPid);
+			if (locksForProcess.length === 0) {
+				continue;
+			}
+
+			/*
+			 * fcntl() lets us request to unlock the entire byte range for this process,
+			 * so we do that instead of tracking and unlocking specific ranges.
+			 * NOTE: Actually, the native OS is not aware of the php-wasm process ID,
+			 * but since we track live locks associated with each process and path,
+			 * we can unlock using any FD that currently represents one of those locks.
+			 */
+			const fd = locksForProcess[0].fd;
+			try {
+				this.lockFileByteRange(
+					path,
+					{
+						pid: targetPid,
+						fd,
+						type: 'unlocked',
+						start: 0n,
+						end: MAX_ADDRESSABLE_FILE_OFFSET,
+					},
+					false
+				);
+			} catch (e) {
+				logger.error(
+					`releaseLocksForProcess: failed to unlock byte range for pid=${targetPid} fd=${fd} path=${path}`,
+					e
+				);
 			}
 		}
-		this.rangeLockedFds.delete(targetPid);
 	}
 
 	releaseLocksOnFdClose(
@@ -218,6 +215,93 @@ export class FileLockManagerForPosix implements FileLockManager {
 
 		// fcntl()-based locks are released whenever any file descriptor for the
 		// target file is closed, regardless of which FD was used to obtain the lock.
-		this.rangeLockedFds.get(targetPid)?.delete(targetPath);
+		this.recordRangeLockOp(targetPath, {
+			pid: targetPid,
+			fd: targetFd,
+			type: 'unlocked',
+			start: 0n,
+			end: MAX_ADDRESSABLE_FILE_OFFSET,
+		});
+	}
+
+	private normalizeRangeLockOp(op: RequestedRangeLock): RequestedRangeLock {
+		if (op.start !== op.end) {
+			return op;
+		}
+
+		return {
+			...op,
+			end: MAX_ADDRESSABLE_FILE_OFFSET,
+		};
+	}
+
+	private recordRangeLockOp(path: Path, op: RequestedRangeLock): void {
+		op = this.normalizeRangeLockOp(op);
+
+		let rangeLocks = this.rangeLocksByPath.get(path);
+		if (!rangeLocks) {
+			if (op.type === 'unlocked') {
+				return;
+			}
+
+			rangeLocks = new FileLockIntervalTree();
+			this.rangeLocksByPath.set(path, rangeLocks);
+		}
+
+		if (op.type === 'unlocked') {
+			const overlappingLocksForProcess = rangeLocks
+				.findOverlapping(op)
+				.filter((lock) => lock.pid === op.pid);
+
+			for (const overlappingLock of overlappingLocksForProcess) {
+				rangeLocks.remove(overlappingLock);
+
+				if (overlappingLock.start < op.start) {
+					rangeLocks.insert({
+						...overlappingLock,
+						end: op.start,
+					});
+				}
+
+				if (overlappingLock.end > op.end) {
+					rangeLocks.insert({
+						...overlappingLock,
+						start: op.end,
+					});
+				}
+			}
+
+			this.forgetPathIfNoRangeLocks(path);
+			return;
+		}
+
+		const overlappingLocksForProcess = rangeLocks
+			.findOverlapping(op)
+			.filter((lock) => lock.pid === op.pid);
+
+		let minStart = op.start;
+		let maxEnd = op.end;
+		for (const overlappingLock of overlappingLocksForProcess) {
+			rangeLocks.remove(overlappingLock);
+
+			if (overlappingLock.start < minStart) {
+				minStart = overlappingLock.start;
+			}
+			if (overlappingLock.end > maxEnd) {
+				maxEnd = overlappingLock.end;
+			}
+		}
+
+		rangeLocks.insert({
+			...(op as LockedRange),
+			start: minStart,
+			end: maxEnd,
+		});
+	}
+
+	private forgetPathIfNoRangeLocks(path: Path): void {
+		if (this.rangeLocksByPath.get(path)?.isEmpty()) {
+			this.rangeLocksByPath.delete(path);
+		}
 	}
 }

--- a/packages/php-wasm/node/src/lib/wasm-user-space.ts
+++ b/packages/php-wasm/node/src/lib/wasm-user-space.ts
@@ -913,6 +913,13 @@ export function bindUserSpace(
 			);
 			return fdCloseResult;
 		}
+		/*
+		 * maybeLockedFds is only a lossy optimization hint. It is not
+		 * authoritative lock state: F_GETLK probes and successful unlocks may
+		 * touch native locking without leaving live locks, while POSIX fcntl()
+		 * locks are process/file scoped and closing any fd for the same file may
+		 * release locks even if that exact fd did not acquire them.
+		 */
 		if (!locking.maybeLockedFds.has(nativeFd)) {
 			js_wasm_trace(
 				'fd_close(%d) not in maybe-locked-list %s result %d',

--- a/packages/php-wasm/node/src/test/file-lock-manager-test-utils.ts
+++ b/packages/php-wasm/node/src/test/file-lock-manager-test-utils.ts
@@ -1,4 +1,5 @@
 import { closeSync, openSync } from 'fs';
+import { logger } from '@php-wasm/logger';
 import {
 	type FileLockManager,
 	type RequestedRangeLock,
@@ -32,6 +33,7 @@ export type TestWorkerAPI = Omit<
 	) => Omit<RequestedRangeLockWithNonBigIntAddresses, 'fd'> | undefined;
 	openSync: typeof openSync;
 	closeSync: typeof closeSync;
+	getLogs: () => string[];
 };
 
 /**
@@ -88,6 +90,7 @@ export function createRemoteProcessAPIFromFileLockManager(
 			return openSync(name, flags, mode);
 		}) as typeof openSync,
 		closeSync,
+		getLogs: logger.getLogs.bind(logger),
 	};
 	return api;
 }

--- a/packages/php-wasm/node/src/test/file-lock-manager-tests.ts
+++ b/packages/php-wasm/node/src/test/file-lock-manager-tests.ts
@@ -1402,6 +1402,33 @@ export function declareFileLockManagerTests({
 
 				expect(conflict).toBeUndefined();
 			});
+
+			it('does not leave stale native fd bookkeeping after a no-conflict probe', async () => {
+				const logsBeforeProbe = await remoteProcessApi1.getLogs();
+				const conflict =
+					await remoteProcessApi1.findFirstConflictingByteRangeLock(
+						TEST_FILE1_URL.pathname,
+						{
+							type: 'shared',
+							start: 20,
+							end: 30,
+							pid: PROCESS1_PID,
+							fd: process1TestFile1Fd,
+						}
+					);
+				expect(conflict).toBeUndefined();
+
+				await remoteProcessApi1.closeSync(process1TestFile1Fd);
+				await remoteProcessApi1.releaseLocksForProcess(PROCESS1_PID);
+
+				const newLogs = (await remoteProcessApi1.getLogs()).slice(
+					logsBeforeProbe.length
+				);
+				expect(newLogs.join('\n')).not.toContain('EBADF');
+				expect(newLogs.join('\n')).not.toContain(
+					'fcntl(): unexpected error'
+				);
+			});
 		});
 
 		describe('releaseLocksForProcess', () => {


### PR DESCRIPTION
## Why
Playground CLI can intermittently crash on Linux with `EBADF` from native `fcntl` cleanup after file-lock probes. The POSIX lock manager was retaining fd bookkeeping for temporary probe/unlock flows, so later process cleanup could try to unlock through a descriptor that PHP/Emscripten had already closed.

## What
- Track live POSIX byte-range locks by path/range instead of retaining every fd touched by successful `fcntl`.
- Remove live range bookkeeping when unlock/probe cleanup succeeds.
- Add a caution near `maybeLockedFds` that it is only a lossy optimization hint, not authoritative POSIX lock state.
- Add shared regression coverage for no-conflict probe, fd close, and `releaseLocksForProcess()` cleanup.

## Testing
- `npm ci`
- `npx vitest run --config packages/php-wasm/node/vite.config.ts packages/php-wasm/node/src/test/file-lock-manager-for-posix.spec.ts packages/php-wasm/node/src/test/file-lock-manager-composite.spec.ts`
- `npx nx run php-wasm-node:typecheck`
- `npx nx run php-wasm-node:lint`
- `npx vitest run --config packages/php-wasm/node/vite.config.ts packages/php-wasm/node/src/test/file-lock-manager-for-windows.spec.ts` (skipped on non-Windows host)

Fixes #3830