### PR TITLE
[AI] Add Windows Playground debugging skill

### DIFF
--- a/.agents/skills/windows-playground-debugging/SKILL.md
+++ b/.agents/skills/windows-playground-debugging/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: windows-playground-debugging
+description: >
+  Guide for testing and debugging WordPress Playground on Windows using Parallels Desktop from macOS.
+  Use when: running Playground CLI on Windows, building Playground from source on Windows,
+  running tests on Windows via prlctl, debugging Windows-specific issues (symlinks, network drives,
+  path conversion), or setting up Node.js in a Windows VM.
+  Triggers on mentions of Parallels, prlctl, Windows VM, Windows debugging,
+  or cross-platform Playground testing.
+---
+
+# Windows Playground Debugging
+
+Test and debug WordPress Playground on Windows using Parallels Desktop (`prlctl exec`) from macOS.
+
+## Prerequisites
+
+- **Parallels Desktop Pro or Business Edition** (Standard lacks `prlctl exec`)
+- Windows VM with Parallels Tools installed
+- Node.js installed in the VM (v20.18.3+ for CLI, v22+ for dev CLI)
+
+## Core Command Pattern
+
+All commands follow this pattern — run from macOS, execute inside Windows VM:
+
+```bash
+prlctl exec "Windows 11 (1)" cmd /c "command here"
+# Or for complex operations:
+prlctl exec "Windows 11 (1)" powershell -Command "script here"
+```
+
+Commands run as SYSTEM user, which has symlink privileges but lacks user drive mappings and npm directories.
+
+## Accessing macOS Files from Windows
+
+Parallels shares macOS directories as network paths (`\\Mac\<folder>`). To use them in Windows, map a drive letter:
+
+```bash
+prlctl exec "Windows 11 (1)" cmd /c "net use Z: \"\\\\Mac\\wordpress-playground\" /persistent:yes"
+```
+
+This makes the macOS `wordpress-playground` repo available as `Z:\` inside Windows. The drive letter is arbitrary — examples in this skill use `Z:\` but any letter works. The SYSTEM user (used by `prlctl exec`) doesn't inherit user drive mappings, so this must be done explicitly.
+
+**Important:** These are network drives (SMB shares), which means symlinks don't work and NX needs special configuration. See environment variables and common issues below.
+
+To run a script from the repo inside Windows, reference it via the mapped drive:
+
+```bash
+# Run a script from the repo
+prlctl exec "Windows 11 (1)" cmd /c "\"C:\\Program Files\\nodejs\\node.exe\" Z:\path\to\script.mjs"
+```
+
+## Key Workflows
+
+### 1. Run Published CLI
+
+```bash
+prlctl exec "Windows 11 (1)" cmd /c "\"C:\\Program Files\\nodejs\\npx.cmd\" @wp-playground/cli server --wp=6.7 --php=8.2"
+```
+
+Server at `http://127.0.0.1:9400` inside the VM.
+
+### 2. Run Dev CLI from Source
+
+Requires Node.js 22+ (for `--experimental-strip-types`) and initialized isomorphic-git submodule (`git submodule update --init --recursive` from macOS).
+
+```bash
+prlctl exec "Windows 11 (1)" powershell -Command "
+  cd Z:\;
+  \$env:NX_WORKSPACE_ROOT_PATH = 'Z:\';
+  \$env:NX_DAEMON = 'false';
+  & 'C:\\Program Files\\nodejs\\npx.cmd' nx run playground-cli:dev -- server --wp=6.8 --php=8.4
+"
+```
+
+To convert a published CLI command to dev CLI: replace `@wp-playground/cli@latest` with `nx run playground-cli:dev --`.
+
+### 3. Build from Source
+
+Requires VC++ Redistributable, Git for Windows, and environment setup for network drive issues.
+
+```bash
+prlctl exec "Windows 11 (1)" powershell -Command "
+  cd Z:\;
+  \$env:PATH = 'C:\\Program Files\\Git\\usr\\bin;' + \$env:PATH;
+  \$env:NX_WORKSPACE_ROOT_PATH = 'Z:\';
+  \$env:NX_DAEMON = 'false';
+  \$env:ComSpec = 'C:\\Program Files\\Git\\bin\\bash.exe';
+  & 'C:\\Program Files\\nodejs\\node.exe' node_modules\\nx\\bin\\nx.js run-many --all --target=build
+"
+```
+
+### 4. Run Tests
+
+```bash
+prlctl exec "Windows 11 (1)" powershell -Command "
+  cd Z:\packages\php-wasm\node;
+  \$env:NX_WORKSPACE_ROOT_PATH = 'Z:\';
+  \$env:NX_DAEMON = 'false';
+  & 'C:\\Program Files\\nodejs\\npx.cmd' vitest run --config vite.config.ts src/test/symlinks.spec.ts
+"
+```
+
+## Critical Environment Variables
+
+| Variable | Value | Purpose |
+|----------|-------|---------|
+| `NX_WORKSPACE_ROOT_PATH` | Mapped drive letter (e.g. `Z:\`) | Force NX workspace root on network drives |
+| `NX_DAEMON` | `false` | Disable NX daemon (required for network drives) |
+| `ComSpec` | `C:\Program Files\Git\bin\bash.exe` | Use bash for Unix commands (mkdir -p, cp, rm -rf) |
+| `PATH` | Prepend `C:\Program Files\Git\usr\bin;` | Make Unix utilities available |
+
+## Common Issues Quick Reference
+
+For detailed troubleshooting, setup instructions, and Windows-specific implementation details, see [references/details.md](references/details.md).
+
+| Problem | Cause | Fix |
+|---------|-------|-----|
+| `prlctl exec` unavailable | Standard edition license | Upgrade to Pro/Business |
+| ENOENT for npm | SYSTEM user missing npm dir | `mkdir C:\WINDOWS\system32\config\systemprofile\AppData\Roaming\npm` |
+| `--experimental-strip-types` error | Node.js < 22 | Install Node.js 22+ |
+| Missing isomorphic-git module | Submodule not initialized | `git submodule update --init --recursive` from macOS |
+| Symlinks fail on network drive | Windows/SMB limitation | Tests auto-fallback to local temp dir |
+| MSYS path conversion (`/wordpress` → `C:/Program Files/Git/wordpress`) | Git Bash path mangling | Set `MSYS_NO_PATHCONV=1` and `MSYS2_ARG_CONV_EXCL='*'` |
+| NX can't detect workspace | Network drive issue | Set `NX_WORKSPACE_ROOT_PATH` |
+| `npm install` symlink failures | Network drive limitation | Use `npm install --install-links` |
+| NX WASM fallback fails | Network paths unsupported | `npm install @nx/nx-win32-x64-msvc` |
+| Port 9400 in use | Previous node still running | `taskkill /IM node.exe /F` |
+
+## Windows Symlink Behavior
+
+- `'file'` symlinks: default type
+- `'dir'` symlinks: require admin or Developer Mode
+- `'junction'`: works without admin, but only on local NTFS drives
+- SYSTEM user (via prlctl): has symlink privileges
+- Network drives: symlinks unsupported — tests auto-copy to local temp dir

--- a/.agents/skills/windows-playground-debugging/SKILL.md
+++ b/.agents/skills/windows-playground-debugging/SKILL.md
@@ -13,192 +13,180 @@ description: >
 
 Test and debug WordPress Playground on Windows using Parallels Desktop (`prlctl exec`) from macOS.
 
+## Placeholders
+
+Use placeholders instead of hardcoded local names:
+
+- `<VM_NAME>`: Windows VM name from `prlctl list -a`.
+- `<SHARE_NAME>`: Parallels host shared folder name for the checkout under test.
+- `<REPO_UNC>`: Windows UNC path for the shared checkout, usually `\\Mac\<SHARE_NAME>`.
+- `<DRIVE>`: Temporary Windows drive letter for source workflows, such as `U:`.
+
+If any value is unclear, discover it with the commands below or ask the user.
+
 ## Prerequisites
 
-- **Parallels Desktop Pro or Business Edition** (Standard lacks `prlctl exec`)
-- Windows VM with Parallels Tools installed
-- Node.js installed in the VM (v20.18.3+ for CLI, v22+ for dev CLI)
+- Parallels Desktop Pro or Business Edition. Standard lacks `prlctl exec`.
+- Windows VM with Parallels Tools installed.
+- Node.js 22+ installed in the VM for source workflows. Published CLI testing can use
+  the current supported CLI Node.js version, but Node.js 22+ is a simple default.
 
-## Setup Checklist
+## Minimal Setup
 
-Use this minimal setup for testing Playground from macOS against a Windows VM:
+Discover the VM name and confirm the VM is usable:
 
 ```bash
-# Discover the VM name and confirm Parallels Tools/license.
 prlctl list -a
-prlctl list -i "Windows 11"
+prlctl list -i "<VM_NAME>"
 "/Applications/Parallels Desktop.app/Contents/MacOS/prlsrvctl" info --license
-
-# Confirm the Windows CPU architecture. Our Parallels VM is ARM64.
-prlctl exec "Windows 11" cmd /c "echo %PROCESSOR_ARCHITECTURE%"
-
-# Install Node.js 22 for the VM architecture. Use x64 instead of arm64 on x64 VMs.
-prlctl exec "Windows 11" powershell -NoProfile -Command "Invoke-WebRequest -Uri 'https://nodejs.org/dist/v22.14.0/node-v22.14.0-arm64.msi' -OutFile 'C:\Users\Public\node22-arm64-install.msi'; Start-Process -FilePath 'msiexec.exe' -ArgumentList '/i','C:\Users\Public\node22-arm64-install.msi','/qn','/norestart' -Wait"
-
-# prlctl exec runs as SYSTEM; create SYSTEM's npm directory if it is missing.
-prlctl exec "Windows 11" cmd /c "if not exist C:\WINDOWS\system32\config\systemprofile\AppData\Roaming\npm mkdir C:\WINDOWS\system32\config\systemprofile\AppData\Roaming\npm"
-
-# Verify Node and the shared checkout.
-prlctl exec "Windows 11" cmd /c "node --version && npm --version && npx --version"
-prlctl exec "Windows 11" cmd /c "dir \\\\Mac\\wordpress-playground\\package.json"
 ```
 
-If testing a Conductor workspace, share that workspace path, not just another root
-checkout of `wordpress-playground`:
+Confirm the Windows CPU architecture and install Node.js for that architecture if needed:
 
 ```bash
-prlctl set "Windows 11" --shf-host-add wordpress-playground-davis --path "$(pwd)" --mode rw --enable
-prlctl exec "Windows 11" cmd /c "dir \\\\Mac\\wordpress-playground-davis\\package.json"
+prlctl exec "<VM_NAME>" cmd /c "echo %PROCESSOR_ARCHITECTURE%"
+prlctl exec "<VM_NAME>" cmd /c "node --version && npm --version && npx --version"
+```
+
+If Node.js is missing, install Node.js 22+ inside the VM using the official Windows
+installer or the user's preferred Windows package manager. Match the VM architecture
+(ARM64 vs x64). After installing, rerun the version check.
+
+`prlctl exec` runs as SYSTEM. Create SYSTEM's npm directory if it is missing:
+
+```bash
+prlctl exec "<VM_NAME>" cmd /c "if not exist C:\WINDOWS\system32\config\systemprofile\AppData\Roaming\npm mkdir C:\WINDOWS\system32\config\systemprofile\AppData\Roaming\npm"
+```
+
+Share the exact checkout or Conductor workspace under test. If the user has not already
+configured a Parallels share for it, create one from the macOS checkout directory:
+
+```bash
+prlctl set "<VM_NAME>" --shf-host-add <SHARE_NAME> --path "$(pwd)" --mode rw --enable
+```
+
+Verify Windows can read that checkout. In macOS shell strings, escape UNC paths with
+double backslashes:
+
+```bash
+prlctl exec "<VM_NAME>" cmd /c "dir \\\\Mac\\<SHARE_NAME>\\package.json"
 ```
 
 Before testing a macOS change in Windows, verify Windows sees the changed workspace. For
-example, create or edit a file on macOS under `.context/`, then read it from Windows:
+example, create or edit a temporary file on macOS under `.context/`, then read it from
+Windows:
 
 ```bash
-prlctl exec "Windows 11" cmd /c "type \\\\Mac\\wordpress-playground-davis\\.context\\windows-share-smoke.txt"
+prlctl exec "<VM_NAME>" cmd /c "type \\\\Mac\\<SHARE_NAME>\\.context\\windows-share-smoke.txt"
 ```
 
 For source workflows, use a mapped drive instead of a UNC working directory. `cmd.exe`
 falls back to `C:\Windows` when started in a UNC path. Do not reuse macOS `node_modules`
 for source workflows; install dependencies from Windows on the checkout under test.
 
-After setup, smoke-test the published CLI:
-
-```bash
-prlctl exec "Windows 11" cmd /c "\"C:\Program Files\nodejs\npx.cmd\" -y @wp-playground/cli@latest server --wp=6.7 --php=8.2 --port=9400"
-```
-
-In another terminal, verify the server from inside Windows:
-
-```bash
-prlctl exec "Windows 11" powershell -NoProfile -Command "\$response = Invoke-WebRequest -Uri 'http://127.0.0.1:9400' -UseBasicParsing -TimeoutSec 20; Write-Host ('Status=' + \$response.StatusCode); Write-Host ('Length=' + \$response.Content.Length)"
-```
-
 ## Core Command Pattern
 
-All commands follow this pattern — run from macOS, execute inside Windows VM:
+All commands run from macOS and execute inside the Windows VM:
 
 ```bash
-prlctl exec "Windows 11 (1)" cmd /c "command here"
-# Or for complex operations:
-prlctl exec "Windows 11 (1)" powershell -Command "script here"
+prlctl exec "<VM_NAME>" cmd /c "command here"
+prlctl exec "<VM_NAME>" powershell -NoProfile -Command "script here"
 ```
 
-Replace `Windows 11 (1)` with the VM name from `prlctl list -a`.
-
-Commands run as SYSTEM user, which has symlink privileges but lacks user drive mappings and npm directories.
+Commands run as SYSTEM, which has symlink privileges but does not inherit user drive
+mappings or npm profile directories.
 
 ## Accessing macOS Files from Windows
 
-Parallels shares macOS directories as network paths (`\\Mac\<folder>`). First confirm the
-repo is available as a shared folder:
+Discover existing shares:
 
 ```bash
-prlctl exec "Windows 11 (1)" cmd /c "dir \\\\Mac"
+prlctl list -i "<VM_NAME>"
+prlctl exec "<VM_NAME>" cmd /c "dir \\\\Mac"
+prlctl exec "<VM_NAME>" cmd /c "net use"
 ```
 
-If the repo is not listed, enable or add a host shared folder in Parallels before mapping
-it. To use an available share in Windows, map a drive letter:
+If a suitable share already exists, use its name as `<SHARE_NAME>`. If not, create one
+with `prlctl set ... --shf-host-add` as shown above. When a share name is unavailable or
+ambiguous, ask the user which macOS checkout should be tested.
+
+If a mapped drive is listed by `net use` but later `dir <DRIVE>\` fails, map the drive
+inside the same command or use the UNC path directly:
 
 ```bash
-prlctl exec "Windows 11 (1)" cmd /c "net use Z: \"\\\\Mac\\wordpress-playground\" /persistent:yes"
+prlctl exec "<VM_NAME>" cmd /c "net use <DRIVE> \"\\\\Mac\\<SHARE_NAME>\" /persistent:no && dir <DRIVE>\\package.json"
+prlctl exec "<VM_NAME>" cmd /c "dir \\\\Mac\\<SHARE_NAME>\\package.json"
 ```
 
-This makes the macOS `wordpress-playground` repo available as `Z:\` inside Windows. Replace
-`\\Mac\wordpress-playground` with the actual shared-folder name. The drive letter is
-arbitrary — examples in this skill use `Z:\` but any letter works. The SYSTEM user (used
-by `prlctl exec`) doesn't inherit user drive mappings, so this must be done explicitly.
-
-If a mapped drive is listed by `net use` but `dir Z:\` fails in a later `prlctl exec`, map
-the drive inside the same command or use the UNC path directly:
-
-```bash
-prlctl exec "Windows 11 (1)" cmd /c "net use U: \"\\\\Mac\\wordpress-playground\" /persistent:no && dir U:\\package.json"
-prlctl exec "Windows 11 (1)" cmd /c "dir \\\\Mac\\wordpress-playground\\package.json"
-```
-
-**Important:** These are network drives (SMB shares), which means symlinks don't work and NX needs special configuration. See environment variables and common issues below.
-
-To run a script from the repo inside Windows, reference it via the mapped drive:
-
-```bash
-# Run a script from the repo
-prlctl exec "Windows 11 (1)" cmd /c "\"C:\\Program Files\\nodejs\\node.exe\" Z:\path\to\script.mjs"
-```
+Network drives are SMB shares. Symlinks do not work there, and Nx needs the environment
+variables below for source workflows.
 
 ## Key Workflows
 
 ### 1. Run Published CLI
 
 ```bash
-prlctl exec "Windows 11 (1)" cmd /c "\"C:\Program Files\nodejs\npx.cmd\" -y @wp-playground/cli@latest server --wp=6.7 --php=8.2 --port=9400"
+prlctl exec "<VM_NAME>" cmd /c "\"C:\Program Files\nodejs\npx.cmd\" -y @wp-playground/cli@latest server --wp=6.7 --php=8.2 --port=9400"
 ```
 
-Server at `http://127.0.0.1:9400` inside the VM.
+Server at `http://127.0.0.1:9400` inside the VM. Verify from inside Windows:
+
+```bash
+prlctl exec "<VM_NAME>" powershell -NoProfile -Command "\$response = Invoke-WebRequest -Uri 'http://127.0.0.1:9400' -UseBasicParsing -TimeoutSec 20; Write-Host ('Status=' + \$response.StatusCode); Write-Host ('Length=' + \$response.Content.Length)"
+```
 
 ### 2. Run Dev CLI from Source
 
-Requires Node.js 22+ (for `--experimental-strip-types`), an initialized
-isomorphic-git submodule (`git submodule update --init --recursive` from macOS), and a
-Windows-side dependency install. On network shares, use `npm ci --install-links` or
-`npm install --install-links`.
+Requires Node.js 22+, initialized submodules, and a Windows-side dependency install. On
+network shares, use `npm ci --install-links` or `npm install --install-links`.
 
 ```bash
-prlctl exec "Windows 11 (1)" cmd /c "net use U: \"\\\\Mac\\wordpress-playground\" /persistent:no && cd /d U:\ && set NX_WORKSPACE_ROOT_PATH=U:\ && set NX_DAEMON=false && call \"C:\Program Files\nodejs\npx.cmd\" nx run playground-cli:dev -- server --wp=6.8 --php=8.4"
+prlctl exec "<VM_NAME>" cmd /c "net use <DRIVE> \"\\\\Mac\\<SHARE_NAME>\" /persistent:no && cd /d <DRIVE>\ && set NX_WORKSPACE_ROOT_PATH=<DRIVE>\ && set NX_DAEMON=false && call \"C:\Program Files\nodejs\npx.cmd\" nx run playground-cli:dev -- server --wp=6.8 --php=8.4"
 ```
 
-To convert a published CLI command to dev CLI: replace `@wp-playground/cli@latest` with `nx run playground-cli:dev --`.
+To convert a published CLI command to dev CLI, replace `@wp-playground/cli@latest` with
+`nx run playground-cli:dev --`.
 
 ### 3. Build from Source
 
-Requires VC++ Redistributable, Git for Windows, and environment setup for network drive issues.
+Requires VC++ Redistributable, Git for Windows, and environment setup for network drive
+issues:
 
 ```bash
-prlctl exec "Windows 11 (1)" powershell -Command "
-  cd Z:\;
-  \$env:PATH = 'C:\\Program Files\\Git\\usr\\bin;' + \$env:PATH;
-  \$env:NX_WORKSPACE_ROOT_PATH = 'Z:\';
-  \$env:NX_DAEMON = 'false';
-  \$env:ComSpec = 'C:\\Program Files\\Git\\bin\\bash.exe';
-  & 'C:\\Program Files\\nodejs\\node.exe' node_modules\\nx\\bin\\nx.js run-many --all --target=build
-"
+prlctl exec "<VM_NAME>" cmd /c "net use <DRIVE> \"\\\\Mac\\<SHARE_NAME>\" /persistent:no && cd /d <DRIVE>\ && set NX_WORKSPACE_ROOT_PATH=<DRIVE>\ && set NX_DAEMON=false && set ComSpec=C:\Program Files\Git\bin\bash.exe && set PATH=C:\Program Files\Git\usr\bin;%PATH% && call \"C:\Program Files\nodejs\npx.cmd\" nx run-many --all --target=build"
 ```
 
 ### 4. Run Tests
 
 ```bash
-prlctl exec "Windows 11 (1)" powershell -Command "
-  cd Z:\packages\php-wasm\node;
-  \$env:NX_WORKSPACE_ROOT_PATH = 'Z:\';
-  \$env:NX_DAEMON = 'false';
-  & 'C:\\Program Files\\nodejs\\npx.cmd' vitest run --config vite.config.ts src/test/symlinks.spec.ts
-"
+prlctl exec "<VM_NAME>" cmd /c "net use <DRIVE> \"\\\\Mac\\<SHARE_NAME>\" /persistent:no && cd /d <DRIVE>\packages\php-wasm\node && set NX_WORKSPACE_ROOT_PATH=<DRIVE>\ && set NX_DAEMON=false && call \"C:\Program Files\nodejs\npx.cmd\" vitest run --config vite.config.ts src/test/symlinks.spec.ts"
 ```
 
 ## Critical Environment Variables
 
 | Variable | Value | Purpose |
 |----------|-------|---------|
-| `NX_WORKSPACE_ROOT_PATH` | Mapped drive letter (e.g. `Z:\`) | Force NX workspace root on network drives |
-| `NX_DAEMON` | `false` | Disable NX daemon (required for network drives) |
-| `ComSpec` | `C:\Program Files\Git\bin\bash.exe` | Use bash for Unix commands (mkdir -p, cp, rm -rf) |
+| `NX_WORKSPACE_ROOT_PATH` | Mapped drive root, e.g. `<DRIVE>\` | Force Nx workspace root on network drives |
+| `NX_DAEMON` | `false` | Disable Nx daemon on network drives |
+| `ComSpec` | `C:\Program Files\Git\bin\bash.exe` | Use bash for Unix commands |
 | `PATH` | Prepend `C:\Program Files\Git\usr\bin;` | Make Unix utilities available |
 
 ## Common Issues Quick Reference
 
-For detailed troubleshooting, setup instructions, and Windows-specific implementation details, see [references/details.md](references/details.md).
+For detailed troubleshooting, setup instructions, and Windows-specific implementation
+details, see [references/details.md](references/details.md).
 
 | Problem | Cause | Fix |
 |---------|-------|-----|
 | `prlctl exec` unavailable | Standard edition license | Upgrade to Pro/Business |
-| ENOENT for npm | SYSTEM user missing npm dir | `mkdir C:\WINDOWS\system32\config\systemprofile\AppData\Roaming\npm` |
+| ENOENT for npm | SYSTEM user missing npm dir | Create `C:\WINDOWS\system32\config\systemprofile\AppData\Roaming\npm` |
 | `--experimental-strip-types` error | Node.js < 22 | Install Node.js 22+ |
 | Missing isomorphic-git module | Submodule not initialized | `git submodule update --init --recursive` from macOS |
 | Symlinks fail on network drive | Windows/SMB limitation | Tests auto-fallback to local temp dir |
-| MSYS path conversion (`/wordpress` → `C:/Program Files/Git/wordpress`) | Git Bash path mangling | Set `MSYS_NO_PATHCONV=1` and `MSYS2_ARG_CONV_EXCL='*'` |
-| NX can't detect workspace | Network drive issue | Set `NX_WORKSPACE_ROOT_PATH` |
+| MSYS path conversion | Git Bash path mangling | Set `MSYS_NO_PATHCONV=1` and `MSYS2_ARG_CONV_EXCL='*'` |
+| Nx can't detect workspace | Network drive issue | Set `NX_WORKSPACE_ROOT_PATH` |
 | `npm install` symlink failures | Network drive limitation | Use `npm install --install-links` |
-| NX WASM fallback fails | Network paths unsupported | Install the matching Nx native package, e.g. `@nx/nx-win32-arm64-msvc` on ARM64 or `@nx/nx-win32-x64-msvc` on x64 |
+| Nx WASM fallback fails | Network paths unsupported | Install the matching Nx native package for the VM architecture |
 | Port 9400 in use | Previous node still running | `taskkill /IM node.exe /F` |
 
 ## Windows Symlink Behavior
@@ -206,5 +194,5 @@ For detailed troubleshooting, setup instructions, and Windows-specific implement
 - `'file'` symlinks: default type
 - `'dir'` symlinks: require admin or Developer Mode
 - `'junction'`: works without admin, but only on local NTFS drives
-- SYSTEM user (via prlctl): has symlink privileges
-- Network drives: symlinks unsupported — tests auto-copy to local temp dir
+- SYSTEM user via `prlctl`: has symlink privileges
+- Network drives: symlinks unsupported; tests should copy to local temp when needed

--- a/.agents/skills/windows-playground-debugging/SKILL.md
+++ b/.agents/skills/windows-playground-debugging/SKILL.md
@@ -29,8 +29,8 @@ If any value is unclear, discover it with the commands below or ask the user.
 
 - Parallels Desktop Pro or Business Edition. Standard lacks `prlctl exec`.
 - Windows VM with Parallels Tools installed.
-- Node.js 22+ installed in the VM for source workflows. Published CLI testing can use
-  the current supported CLI Node.js version, but Node.js 22+ is a simple default.
+- Node.js installed in the VM. Use the version from the repo's `.nvmrc`; source
+  workflows need at least Node.js 22 for type stripping.
 
 ## Minimal Setup
 
@@ -141,8 +141,9 @@ prlctl exec "<VM_NAME>" powershell -NoProfile -Command "\$response = Invoke-WebR
 
 ### 2. Run Source CLI Directly Through Node
 
-Use this before Nx when debugging startup. Requires Node.js 22+, initialized submodules,
-and a Windows-side dependency install. On network shares, use
+Use this before Nx when debugging startup. Requires the `.nvmrc` Node.js version (at
+least 22 for type stripping), initialized submodules, and a Windows-side dependency
+install. On network shares, use
 `npm ci --install-links` or `npm install --install-links`.
 
 ```bash
@@ -221,7 +222,7 @@ details, see [references/details.md](references/details.md).
 | ----------------------------------------- | --------------------------------------------- | -------------------------------------------------------------------------------------------------- |
 | `prlctl exec` unavailable                 | Standard edition license                      | Upgrade to Pro/Business                                                                            |
 | ENOENT for npm                            | SYSTEM user missing npm dir                   | Create `C:\WINDOWS\system32\config\systemprofile\AppData\Roaming\npm`                              |
-| `--experimental-strip-types` error        | Node.js < 22                                  | Install Node.js 22+                                                                                |
+| `--experimental-strip-types` error        | Node.js < 22                                  | Install the `.nvmrc` Node.js version (22+)                                                         |
 | Missing isomorphic-git module             | Submodule not initialized                     | `git submodule update --init --recursive` from macOS                                               |
 | Windows cannot see edits                  | Share points at another checkout              | Run the `.context/windows-share-smoke.txt` test                                                    |
 | Symlinks fail on network drive            | Windows/SMB limitation                        | Use local NTFS for symlink-sensitive workflows                                                     |

--- a/.agents/skills/windows-playground-debugging/SKILL.md
+++ b/.agents/skills/windows-playground-debugging/SKILL.md
@@ -43,8 +43,20 @@ prlctl exec "Windows 11" cmd /c "node --version && npm --version && npx --versio
 prlctl exec "Windows 11" cmd /c "dir \\\\Mac\\wordpress-playground\\package.json"
 ```
 
-If testing a Conductor workspace, make sure the Parallels share points at that workspace
-path, not just another root checkout of `wordpress-playground`.
+If testing a Conductor workspace, share that workspace path, not just another root
+checkout of `wordpress-playground`:
+
+```bash
+prlctl set "Windows 11" --shf-host-add wordpress-playground-davis --path "$(pwd)" --mode rw --enable
+prlctl exec "Windows 11" cmd /c "dir \\\\Mac\\wordpress-playground-davis\\package.json"
+```
+
+Before testing a macOS change in Windows, verify Windows sees the changed workspace. For
+example, create or edit a file on macOS under `.context/`, then read it from Windows:
+
+```bash
+prlctl exec "Windows 11" cmd /c "type \\\\Mac\\wordpress-playground-davis\\.context\\windows-share-smoke.txt"
+```
 
 For source workflows, use a mapped drive instead of a UNC working directory. `cmd.exe`
 falls back to `C:\Windows` when started in a UNC path. Do not reuse macOS `node_modules`

--- a/.agents/skills/windows-playground-debugging/SKILL.md
+++ b/.agents/skills/windows-playground-debugging/SKILL.md
@@ -1,17 +1,18 @@
 ---
 name: windows-playground-debugging
 description: >
-  Guide for testing and debugging WordPress Playground on Windows using Parallels Desktop from macOS.
-  Use when: running Playground CLI on Windows, building Playground from source on Windows,
-  running tests on Windows via prlctl, debugging Windows-specific issues (symlinks, network drives,
-  path conversion), or setting up Node.js in a Windows VM.
-  Triggers on mentions of Parallels, prlctl, Windows VM, Windows debugging,
-  or cross-platform Playground testing.
+    Guide for testing and debugging WordPress Playground on Windows using Parallels Desktop from macOS.
+    Use when: running Playground CLI on Windows, building Playground from source on Windows,
+    running tests on Windows via prlctl, debugging Windows-specific issues (symlinks, network drives,
+    path conversion), or setting up Node.js in a Windows VM.
+    Triggers on mentions of Parallels, prlctl, Windows VM, Windows debugging,
+    or cross-platform Playground testing.
 ---
 
 # Windows Playground Debugging
 
-Test and debug WordPress Playground on Windows using Parallels Desktop (`prlctl exec`) from macOS.
+Test and debug WordPress Playground on Windows using Parallels Desktop (`prlctl exec`)
+from macOS.
 
 ## Placeholders
 
@@ -48,35 +49,32 @@ prlctl exec "<VM_NAME>" cmd /c "echo %PROCESSOR_ARCHITECTURE%"
 prlctl exec "<VM_NAME>" cmd /c "node --version && npm --version && npx --version"
 ```
 
-If Node.js is missing, install Node.js 22+ inside the VM using the official Windows
-installer or the user's preferred Windows package manager. Match the VM architecture
-(ARM64 vs x64). After installing, rerun the version check.
-
 `prlctl exec` runs as SYSTEM. Create SYSTEM's npm directory if it is missing:
 
 ```bash
 prlctl exec "<VM_NAME>" cmd /c "if not exist C:\WINDOWS\system32\config\systemprofile\AppData\Roaming\npm mkdir C:\WINDOWS\system32\config\systemprofile\AppData\Roaming\npm"
 ```
 
-Share the exact checkout or Conductor workspace under test. If the user has not already
-configured a Parallels share for it, create one from the macOS checkout directory:
+Share the exact macOS checkout under test. If using an agent or worktree tool, verify
+the share points to that exact worktree, not another clone. If needed, create a share
+from the macOS checkout directory:
 
 ```bash
 prlctl set "<VM_NAME>" --shf-host-add <SHARE_NAME> --path "$(pwd)" --mode rw --enable
 ```
 
-Verify Windows can read that checkout. In macOS shell strings, escape UNC paths with
+Verify Windows can read the checkout. In macOS shell strings, escape UNC paths with
 double backslashes:
 
 ```bash
 prlctl exec "<VM_NAME>" cmd /c "dir \\\\Mac\\<SHARE_NAME>\\package.json"
 ```
 
-Before testing a macOS change in Windows, verify Windows sees the changed workspace. For
-example, create or edit a temporary file on macOS under `.context/`, then read it from
-Windows:
+Before testing a macOS change in Windows, run an exact-checkout smoke test:
 
 ```bash
+mkdir -p .context
+printf "%s\n" "$(pwd)" > .context/windows-share-smoke.txt
 prlctl exec "<VM_NAME>" cmd /c "type \\\\Mac\\<SHARE_NAME>\\.context\\windows-share-smoke.txt"
 ```
 
@@ -94,7 +92,10 @@ prlctl exec "<VM_NAME>" powershell -NoProfile -Command "script here"
 ```
 
 Commands run as SYSTEM, which has symlink privileges but does not inherit user drive
-mappings or npm profile directories.
+mappings or npm profile directories. Avoid complex inline PowerShell through
+`prlctl exec`; put complex commands in a temporary `.cmd` or `.ps1` file under a
+gitignored directory such as `.context/windows-debug/`, then invoke that file from
+Windows.
 
 ## Accessing macOS Files from Windows
 
@@ -118,15 +119,18 @@ prlctl exec "<VM_NAME>" cmd /c "net use <DRIVE> \"\\\\Mac\\<SHARE_NAME>\" /persi
 prlctl exec "<VM_NAME>" cmd /c "dir \\\\Mac\\<SHARE_NAME>\\package.json"
 ```
 
-Network drives are SMB shares. Symlinks do not work there, and Nx needs the environment
-variables below for source workflows.
+Network drives are SMB shares. Symlinks do not work there, and Nx may still fail even
+with the network-drive environment variables below.
 
-## Key Workflows
+## Debugging Path
 
-### 1. Run Published CLI
+### 1. Run Published CLI Baseline
+
+Use the published CLI first to separate VM, Node.js, networking, and WordPress runtime
+issues from source-checkout issues:
 
 ```bash
-prlctl exec "<VM_NAME>" cmd /c "\"C:\Program Files\nodejs\npx.cmd\" -y @wp-playground/cli@latest server --wp=6.7 --php=8.2 --port=9400"
+prlctl exec "<VM_NAME>" cmd /c "\"C:\Program Files\nodejs\npx.cmd\" -y @wp-playground/cli@latest server --wp=6.8 --php=8.4 --port=9400"
 ```
 
 Server at `http://127.0.0.1:9400` inside the VM. Verify from inside Windows:
@@ -135,64 +139,94 @@ Server at `http://127.0.0.1:9400` inside the VM. Verify from inside Windows:
 prlctl exec "<VM_NAME>" powershell -NoProfile -Command "\$response = Invoke-WebRequest -Uri 'http://127.0.0.1:9400' -UseBasicParsing -TimeoutSec 20; Write-Host ('Status=' + \$response.StatusCode); Write-Host ('Length=' + \$response.Content.Length)"
 ```
 
-### 2. Run Dev CLI from Source
+### 2. Run Source CLI Directly Through Node
 
-Requires Node.js 22+, initialized submodules, and a Windows-side dependency install. On
-network shares, use `npm ci --install-links` or `npm install --install-links`.
+Use this before Nx when debugging startup. Requires Node.js 22+, initialized submodules,
+and a Windows-side dependency install. On network shares, use
+`npm ci --install-links` or `npm install --install-links`.
 
 ```bash
-prlctl exec "<VM_NAME>" cmd /c "net use <DRIVE> \"\\\\Mac\\<SHARE_NAME>\" /persistent:no && cd /d <DRIVE>\ && set NX_WORKSPACE_ROOT_PATH=<DRIVE>\ && set NX_DAEMON=false && call \"C:\Program Files\nodejs\npx.cmd\" nx run playground-cli:dev -- server --wp=6.8 --php=8.4"
+prlctl exec "<VM_NAME>" cmd /c "net use <DRIVE> \"\\\\Mac\\<SHARE_NAME>\" /persistent:no && cd /d <DRIVE>\ && \"C:\Program Files\nodejs\node.exe\" --experimental-strip-types --experimental-transform-types --disable-warning=ExperimentalWarning --import ./packages/meta/src/node-es-module-loader/register.mts ./packages/playground/cli/src/cli.ts server --wp=6.8 --php=8.4 --port=9400"
 ```
 
-To convert a published CLI command to dev CLI, replace `@wp-playground/cli@latest` with
-`nx run playground-cli:dev --`.
+For a temporary `.cmd` file, use the easier-to-read multiline command:
 
-### 3. Build from Source
-
-Requires VC++ Redistributable, Git for Windows, and environment setup for network drive
-issues:
-
-```bash
-prlctl exec "<VM_NAME>" cmd /c "net use <DRIVE> \"\\\\Mac\\<SHARE_NAME>\" /persistent:no && cd /d <DRIVE>\ && set NX_WORKSPACE_ROOT_PATH=<DRIVE>\ && set NX_DAEMON=false && set ComSpec=C:\Program Files\Git\bin\bash.exe && set PATH=C:\Program Files\Git\usr\bin;%PATH% && call \"C:\Program Files\nodejs\npx.cmd\" nx run-many --all --target=build"
+```cmd
+cd /d <DRIVE>\
+node --experimental-strip-types --experimental-transform-types ^
+  --disable-warning=ExperimentalWarning ^
+  --import ./packages/meta/src/node-es-module-loader/register.mts ^
+  ./packages/playground/cli/src/cli.ts server --wp=6.8 --php=8.4 --port=9400
 ```
 
-### 4. Run Tests
+### 3. Run Source CLI Through Nx
+
+Only use Nx after confirming it can see the workspace from Windows:
 
 ```bash
-prlctl exec "<VM_NAME>" cmd /c "net use <DRIVE> \"\\\\Mac\\<SHARE_NAME>\" /persistent:no && cd /d <DRIVE>\packages\php-wasm\node && set NX_WORKSPACE_ROOT_PATH=<DRIVE>\ && set NX_DAEMON=false && call \"C:\Program Files\nodejs\npx.cmd\" vitest run --config vite.config.ts src/test/symlinks.spec.ts"
+prlctl exec "<VM_NAME>" cmd /c "net use <DRIVE> \"\\\\Mac\\<SHARE_NAME>\" /persistent:no && cd /d <DRIVE>\ && set \"NX_WORKSPACE_ROOT_PATH=<DRIVE>\\\" && set \"NX_DAEMON=false\" && call \"C:\Program Files\nodejs\npx.cmd\" nx show projects --json"
+```
+
+If Nx returns no projects or says the workspace root does not exist, use the direct Node
+workflow above or copy the repo to a Windows-local NTFS path and install dependencies
+there.
+
+```bash
+prlctl exec "<VM_NAME>" cmd /c "net use <DRIVE> \"\\\\Mac\\<SHARE_NAME>\" /persistent:no && cd /d <DRIVE>\ && set \"NX_WORKSPACE_ROOT_PATH=<DRIVE>\\\" && set \"NX_DAEMON=false\" && call \"C:\Program Files\nodejs\npx.cmd\" nx run playground-cli:dev -- server --wp=6.8 --php=8.4 --port=9400"
+```
+
+### 4. Build From Source
+
+Prefer a Windows-local NTFS checkout for full builds. If using a shared checkout, first
+verify `nx show projects --json` works as shown above. Detailed prerequisites for Git
+Bash, Visual C++ Redistributable, native packages, and symlinks live in
+[references/details.md](references/details.md).
+
+```bash
+prlctl exec "<VM_NAME>" cmd /c "net use <DRIVE> \"\\\\Mac\\<SHARE_NAME>\" /persistent:no && cd /d <DRIVE>\ && set \"NX_WORKSPACE_ROOT_PATH=<DRIVE>\\\" && set \"NX_DAEMON=false\" && set \"ComSpec=C:\Program Files\Git\bin\bash.exe\" && set \"PATH=C:\Program Files\Git\usr\bin;%PATH%\" && call \"C:\Program Files\nodejs\npx.cmd\" nx run-many --all --target=build"
+```
+
+### 5. Run Tests
+
+Use Nx for tests after `nx show projects --json` works. If testing a package directly is
+part of the debugging, keep the command scoped to the package under investigation.
+
+```bash
+prlctl exec "<VM_NAME>" cmd /c "net use <DRIVE> \"\\\\Mac\\<SHARE_NAME>\" /persistent:no && cd /d <DRIVE>\ && set \"NX_WORKSPACE_ROOT_PATH=<DRIVE>\\\" && set \"NX_DAEMON=false\" && call \"C:\Program Files\nodejs\npx.cmd\" nx test <package-name> --testFile=<test-file-name>"
+```
+
+## Cleanup
+
+After server tests, stop the captured server PID or clear stale Node processes:
+
+```bash
+prlctl exec "<VM_NAME>" cmd /c "taskkill /F /IM node.exe /T"
 ```
 
 ## Critical Environment Variables
 
-| Variable | Value | Purpose |
-|----------|-------|---------|
-| `NX_WORKSPACE_ROOT_PATH` | Mapped drive root, e.g. `<DRIVE>\` | Force Nx workspace root on network drives |
-| `NX_DAEMON` | `false` | Disable Nx daemon on network drives |
-| `ComSpec` | `C:\Program Files\Git\bin\bash.exe` | Use bash for Unix commands |
-| `PATH` | Prepend `C:\Program Files\Git\usr\bin;` | Make Unix utilities available |
+| Variable                 | Value                                   | Purpose                                              |
+| ------------------------ | --------------------------------------- | ---------------------------------------------------- |
+| `NX_WORKSPACE_ROOT_PATH` | Mapped drive root, e.g. `<DRIVE>\`      | Helps Nx resolve the workspace root on mapped drives |
+| `NX_DAEMON`              | `false`                                 | Disables the Nx daemon on network drives             |
+| `ComSpec`                | `C:\Program Files\Git\bin\bash.exe`     | Uses bash for Unix commands                          |
+| `PATH`                   | Prepend `C:\Program Files\Git\usr\bin;` | Makes Unix utilities available                       |
 
 ## Common Issues Quick Reference
 
 For detailed troubleshooting, setup instructions, and Windows-specific implementation
 details, see [references/details.md](references/details.md).
 
-| Problem | Cause | Fix |
-|---------|-------|-----|
-| `prlctl exec` unavailable | Standard edition license | Upgrade to Pro/Business |
-| ENOENT for npm | SYSTEM user missing npm dir | Create `C:\WINDOWS\system32\config\systemprofile\AppData\Roaming\npm` |
-| `--experimental-strip-types` error | Node.js < 22 | Install Node.js 22+ |
-| Missing isomorphic-git module | Submodule not initialized | `git submodule update --init --recursive` from macOS |
-| Symlinks fail on network drive | Windows/SMB limitation | Tests auto-fallback to local temp dir |
-| MSYS path conversion | Git Bash path mangling | Set `MSYS_NO_PATHCONV=1` and `MSYS2_ARG_CONV_EXCL='*'` |
-| Nx can't detect workspace | Network drive issue | Set `NX_WORKSPACE_ROOT_PATH` |
-| `npm install` symlink failures | Network drive limitation | Use `npm install --install-links` |
-| Nx WASM fallback fails | Network paths unsupported | Install the matching Nx native package for the VM architecture |
-| Port 9400 in use | Previous node still running | `taskkill /IM node.exe /F` |
-
-## Windows Symlink Behavior
-
-- `'file'` symlinks: default type
-- `'dir'` symlinks: require admin or Developer Mode
-- `'junction'`: works without admin, but only on local NTFS drives
-- SYSTEM user via `prlctl`: has symlink privileges
-- Network drives: symlinks unsupported; tests should copy to local temp when needed
+| Problem                                   | Cause                                         | Fix                                                                                                |
+| ----------------------------------------- | --------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| `prlctl exec` unavailable                 | Standard edition license                      | Upgrade to Pro/Business                                                                            |
+| ENOENT for npm                            | SYSTEM user missing npm dir                   | Create `C:\WINDOWS\system32\config\systemprofile\AppData\Roaming\npm`                              |
+| `--experimental-strip-types` error        | Node.js < 22                                  | Install Node.js 22+                                                                                |
+| Missing isomorphic-git module             | Submodule not initialized                     | `git submodule update --init --recursive` from macOS                                               |
+| Windows cannot see edits                  | Share points at another checkout              | Run the `.context/windows-share-smoke.txt` test                                                    |
+| Symlinks fail on network drive            | Windows/SMB limitation                        | Use local NTFS for symlink-sensitive workflows                                                     |
+| MSYS path conversion                      | Git Bash path mangling                        | Set `MSYS_NO_PATHCONV=1` and `MSYS2_ARG_CONV_EXCL='*'`                                             |
+| Nx cannot detect workspace                | Network drive issue                           | Set `NX_WORKSPACE_ROOT_PATH`, set `NX_DAEMON=false`, verify `nx show projects --json`              |
+| `npm install` symlink failures            | Network drive limitation                      | Use `npm install --install-links`                                                                  |
+| Native npm install fails on Windows ARM64 | Missing prebuild for packages such as `sharp` | Use native build tools for full builds/tests; `--ignore-scripts` only for profiling-only workflows |
+| Port 9400 in use                          | Previous node still running                   | `taskkill /F /IM node.exe /T`                                                                      |

--- a/.agents/skills/windows-playground-debugging/SKILL.md
+++ b/.agents/skills/windows-playground-debugging/SKILL.md
@@ -19,6 +19,21 @@ Test and debug WordPress Playground on Windows using Parallels Desktop (`prlctl 
 - Windows VM with Parallels Tools installed
 - Node.js installed in the VM (v20.18.3+ for CLI, v22+ for dev CLI)
 
+## Setup Checklist
+
+Before running Playground commands, verify the Windows environment:
+
+```bash
+prlctl list -a
+prlctl list -i "Windows 11"
+"/Applications/Parallels Desktop.app/Contents/MacOS/prlsrvctl" info --license
+prlctl exec "Windows 11" cmd /c "where node || echo node-missing"
+prlctl exec "Windows 11" cmd /c "dir \\\\Mac\\wordpress-playground\\package.json"
+```
+
+If testing a Conductor workspace, make sure the Parallels share points at that workspace
+path, not just another root checkout of `wordpress-playground`.
+
 ## Core Command Pattern
 
 All commands follow this pattern — run from macOS, execute inside Windows VM:
@@ -39,7 +54,7 @@ Parallels shares macOS directories as network paths (`\\Mac\<folder>`). First co
 repo is available as a shared folder:
 
 ```bash
-prlctl exec "Windows 11 (1)" cmd /c "dir \\Mac"
+prlctl exec "Windows 11 (1)" cmd /c "dir \\\\Mac"
 ```
 
 If the repo is not listed, enable or add a host shared folder in Parallels before mapping
@@ -53,6 +68,14 @@ This makes the macOS `wordpress-playground` repo available as `Z:\` inside Windo
 `\\Mac\wordpress-playground` with the actual shared-folder name. The drive letter is
 arbitrary — examples in this skill use `Z:\` but any letter works. The SYSTEM user (used
 by `prlctl exec`) doesn't inherit user drive mappings, so this must be done explicitly.
+
+If a mapped drive is listed by `net use` but `dir Z:\` fails in a later `prlctl exec`, map
+the drive inside the same command or use the UNC path directly:
+
+```bash
+prlctl exec "Windows 11 (1)" cmd /c "net use U: \"\\\\Mac\\wordpress-playground\" /persistent:no && dir U:\\package.json"
+prlctl exec "Windows 11 (1)" cmd /c "dir \\\\Mac\\wordpress-playground\\package.json"
+```
 
 **Important:** These are network drives (SMB shares), which means symlinks don't work and NX needs special configuration. See environment variables and common issues below.
 

--- a/.agents/skills/windows-playground-debugging/SKILL.md
+++ b/.agents/skills/windows-playground-debugging/SKILL.md
@@ -29,17 +29,30 @@ prlctl exec "Windows 11 (1)" cmd /c "command here"
 prlctl exec "Windows 11 (1)" powershell -Command "script here"
 ```
 
+Replace `Windows 11 (1)` with the VM name from `prlctl list -a`.
+
 Commands run as SYSTEM user, which has symlink privileges but lacks user drive mappings and npm directories.
 
 ## Accessing macOS Files from Windows
 
-Parallels shares macOS directories as network paths (`\\Mac\<folder>`). To use them in Windows, map a drive letter:
+Parallels shares macOS directories as network paths (`\\Mac\<folder>`). First confirm the
+repo is available as a shared folder:
+
+```bash
+prlctl exec "Windows 11 (1)" cmd /c "dir \\Mac"
+```
+
+If the repo is not listed, enable or add a host shared folder in Parallels before mapping
+it. To use an available share in Windows, map a drive letter:
 
 ```bash
 prlctl exec "Windows 11 (1)" cmd /c "net use Z: \"\\\\Mac\\wordpress-playground\" /persistent:yes"
 ```
 
-This makes the macOS `wordpress-playground` repo available as `Z:\` inside Windows. The drive letter is arbitrary — examples in this skill use `Z:\` but any letter works. The SYSTEM user (used by `prlctl exec`) doesn't inherit user drive mappings, so this must be done explicitly.
+This makes the macOS `wordpress-playground` repo available as `Z:\` inside Windows. Replace
+`\\Mac\wordpress-playground` with the actual shared-folder name. The drive letter is
+arbitrary — examples in this skill use `Z:\` but any letter works. The SYSTEM user (used
+by `prlctl exec`) doesn't inherit user drive mappings, so this must be done explicitly.
 
 **Important:** These are network drives (SMB shares), which means symlinks don't work and NX needs special configuration. See environment variables and common issues below.
 

--- a/.agents/skills/windows-playground-debugging/SKILL.md
+++ b/.agents/skills/windows-playground-debugging/SKILL.md
@@ -21,18 +21,46 @@ Test and debug WordPress Playground on Windows using Parallels Desktop (`prlctl 
 
 ## Setup Checklist
 
-Before running Playground commands, verify the Windows environment:
+Use this minimal setup for testing Playground from macOS against a Windows VM:
 
 ```bash
+# Discover the VM name and confirm Parallels Tools/license.
 prlctl list -a
 prlctl list -i "Windows 11"
 "/Applications/Parallels Desktop.app/Contents/MacOS/prlsrvctl" info --license
-prlctl exec "Windows 11" cmd /c "where node || echo node-missing"
+
+# Confirm the Windows CPU architecture. Our Parallels VM is ARM64.
+prlctl exec "Windows 11" cmd /c "echo %PROCESSOR_ARCHITECTURE%"
+
+# Install Node.js 22 for the VM architecture. Use x64 instead of arm64 on x64 VMs.
+prlctl exec "Windows 11" powershell -NoProfile -Command "Invoke-WebRequest -Uri 'https://nodejs.org/dist/v22.14.0/node-v22.14.0-arm64.msi' -OutFile 'C:\Users\Public\node22-arm64-install.msi'; Start-Process -FilePath 'msiexec.exe' -ArgumentList '/i','C:\Users\Public\node22-arm64-install.msi','/qn','/norestart' -Wait"
+
+# prlctl exec runs as SYSTEM; create SYSTEM's npm directory if it is missing.
+prlctl exec "Windows 11" cmd /c "if not exist C:\WINDOWS\system32\config\systemprofile\AppData\Roaming\npm mkdir C:\WINDOWS\system32\config\systemprofile\AppData\Roaming\npm"
+
+# Verify Node and the shared checkout.
+prlctl exec "Windows 11" cmd /c "node --version && npm --version && npx --version"
 prlctl exec "Windows 11" cmd /c "dir \\\\Mac\\wordpress-playground\\package.json"
 ```
 
 If testing a Conductor workspace, make sure the Parallels share points at that workspace
 path, not just another root checkout of `wordpress-playground`.
+
+For source workflows, use a mapped drive instead of a UNC working directory. `cmd.exe`
+falls back to `C:\Windows` when started in a UNC path. Do not reuse macOS `node_modules`
+for source workflows; install dependencies from Windows on the checkout under test.
+
+After setup, smoke-test the published CLI:
+
+```bash
+prlctl exec "Windows 11" cmd /c "\"C:\Program Files\nodejs\npx.cmd\" -y @wp-playground/cli@latest server --wp=6.7 --php=8.2 --port=9400"
+```
+
+In another terminal, verify the server from inside Windows:
+
+```bash
+prlctl exec "Windows 11" powershell -NoProfile -Command "\$response = Invoke-WebRequest -Uri 'http://127.0.0.1:9400' -UseBasicParsing -TimeoutSec 20; Write-Host ('Status=' + \$response.StatusCode); Write-Host ('Length=' + \$response.Content.Length)"
+```
 
 ## Core Command Pattern
 
@@ -91,22 +119,20 @@ prlctl exec "Windows 11 (1)" cmd /c "\"C:\\Program Files\\nodejs\\node.exe\" Z:\
 ### 1. Run Published CLI
 
 ```bash
-prlctl exec "Windows 11 (1)" cmd /c "\"C:\\Program Files\\nodejs\\npx.cmd\" @wp-playground/cli server --wp=6.7 --php=8.2"
+prlctl exec "Windows 11 (1)" cmd /c "\"C:\Program Files\nodejs\npx.cmd\" -y @wp-playground/cli@latest server --wp=6.7 --php=8.2 --port=9400"
 ```
 
 Server at `http://127.0.0.1:9400` inside the VM.
 
 ### 2. Run Dev CLI from Source
 
-Requires Node.js 22+ (for `--experimental-strip-types`) and initialized isomorphic-git submodule (`git submodule update --init --recursive` from macOS).
+Requires Node.js 22+ (for `--experimental-strip-types`), an initialized
+isomorphic-git submodule (`git submodule update --init --recursive` from macOS), and a
+Windows-side dependency install. On network shares, use `npm ci --install-links` or
+`npm install --install-links`.
 
 ```bash
-prlctl exec "Windows 11 (1)" powershell -Command "
-  cd Z:\;
-  \$env:NX_WORKSPACE_ROOT_PATH = 'Z:\';
-  \$env:NX_DAEMON = 'false';
-  & 'C:\\Program Files\\nodejs\\npx.cmd' nx run playground-cli:dev -- server --wp=6.8 --php=8.4
-"
+prlctl exec "Windows 11 (1)" cmd /c "net use U: \"\\\\Mac\\wordpress-playground\" /persistent:no && cd /d U:\ && set NX_WORKSPACE_ROOT_PATH=U:\ && set NX_DAEMON=false && call \"C:\Program Files\nodejs\npx.cmd\" nx run playground-cli:dev -- server --wp=6.8 --php=8.4"
 ```
 
 To convert a published CLI command to dev CLI: replace `@wp-playground/cli@latest` with `nx run playground-cli:dev --`.
@@ -160,7 +186,7 @@ For detailed troubleshooting, setup instructions, and Windows-specific implement
 | MSYS path conversion (`/wordpress` → `C:/Program Files/Git/wordpress`) | Git Bash path mangling | Set `MSYS_NO_PATHCONV=1` and `MSYS2_ARG_CONV_EXCL='*'` |
 | NX can't detect workspace | Network drive issue | Set `NX_WORKSPACE_ROOT_PATH` |
 | `npm install` symlink failures | Network drive limitation | Use `npm install --install-links` |
-| NX WASM fallback fails | Network paths unsupported | `npm install @nx/nx-win32-x64-msvc` |
+| NX WASM fallback fails | Network paths unsupported | Install the matching Nx native package, e.g. `@nx/nx-win32-arm64-msvc` on ARM64 or `@nx/nx-win32-x64-msvc` on x64 |
 | Port 9400 in use | Previous node still running | `taskkill /IM node.exe /F` |
 
 ## Windows Symlink Behavior

--- a/.agents/skills/windows-playground-debugging/references/details.md
+++ b/.agents/skills/windows-playground-debugging/references/details.md
@@ -3,18 +3,17 @@
 ## VM Management
 
 ```bash
-# List all VMs
+# List all VMs.
 prlctl list -a
 
-# Check VM details and Parallels Tools status
-prlctl list -i "Windows 11 (1)"
+# Check VM details and Parallels Tools status.
+prlctl list -i "<VM_NAME>"
 
-# Check license edition (must be Pro or Business)
+# Check license edition. It must be Pro or Business for prlctl exec.
 "/Applications/Parallels Desktop.app/Contents/MacOS/prlsrvctl" info --license
-# Look for edition="pro" or edition="business"
 ```
 
-Full path to prlctl: `"/Applications/Parallels Desktop.app/Contents/MacOS/prlctl"`
+Full path to `prlctl`: `"/Applications/Parallels Desktop.app/Contents/MacOS/prlctl"`
 
 Use the VM name from `prlctl list -a` in all `prlctl exec` commands.
 
@@ -25,58 +24,74 @@ Use this minimal setup for testing Playground from macOS against a Windows VM:
 ```bash
 # Discover the VM name and confirm Parallels Tools/license.
 prlctl list -a
-prlctl list -i "Windows 11"
+prlctl list -i "<VM_NAME>"
 "/Applications/Parallels Desktop.app/Contents/MacOS/prlsrvctl" info --license
 
-# Confirm the Windows CPU architecture. Our Parallels VM is ARM64.
-prlctl exec "Windows 11" cmd /c "echo %PROCESSOR_ARCHITECTURE%"
+# Confirm the Windows CPU architecture.
+prlctl exec "<VM_NAME>" cmd /c "echo %PROCESSOR_ARCHITECTURE%"
 
-# Install Node.js 22 for the VM architecture. Use x64 instead of arm64 on x64 VMs.
-prlctl exec "Windows 11" powershell -NoProfile -Command "Invoke-WebRequest -Uri 'https://nodejs.org/dist/v22.14.0/node-v22.14.0-arm64.msi' -OutFile 'C:\Users\Public\node22-arm64-install.msi'; Start-Process -FilePath 'msiexec.exe' -ArgumentList '/i','C:\Users\Public\node22-arm64-install.msi','/qn','/norestart' -Wait"
+# Verify Node.js. If it is missing, install Node.js 22+ for the VM architecture.
+prlctl exec "<VM_NAME>" cmd /c "node --version && npm --version && npx --version"
 
 # prlctl exec runs as SYSTEM; create SYSTEM's npm directory if it is missing.
-prlctl exec "Windows 11" cmd /c "if not exist C:\WINDOWS\system32\config\systemprofile\AppData\Roaming\npm mkdir C:\WINDOWS\system32\config\systemprofile\AppData\Roaming\npm"
+prlctl exec "<VM_NAME>" cmd /c "if not exist C:\WINDOWS\system32\config\systemprofile\AppData\Roaming\npm mkdir C:\WINDOWS\system32\config\systemprofile\AppData\Roaming\npm"
 
-# Verify Node and the shared checkout.
-prlctl exec "Windows 11" cmd /c "node --version && npm --version && npx --version"
-prlctl exec "Windows 11" cmd /c "dir \\\\Mac\\wordpress-playground\\package.json"
+# Verify the shared checkout.
+prlctl exec "<VM_NAME>" cmd /c "dir \\\\Mac\\<SHARE_NAME>\\package.json"
 ```
 
 Expected:
+
 - license edition is `pro` or `business`
 - Parallels Tools are installed in the VM
-- Node.js 22 is available for CLI workflows
+- Node.js 22+ is available for source workflows
 - the shared folder resolves to the exact checkout or Conductor workspace under test
+
+## Node.js Setup
+
+Install Node.js 22+ inside the VM if `node --version` fails or if source workflows need
+Node's type-stripping support. Choose the installer or package-manager command that
+matches the VM architecture (`ARM64` vs `AMD64`/x64). Do not hardcode a download URL in
+the skill; use the current official installer or the user's preferred Windows package
+manager.
+
+After installation, verify from the SYSTEM context used by `prlctl exec`:
+
+```bash
+prlctl exec "<VM_NAME>" cmd /c "\"C:\Program Files\nodejs\node.exe\" --version && \"C:\Program Files\nodejs\npx.cmd\" --version"
+```
 
 ## Shared Folder Discovery
 
 Check which macOS shares are visible inside Windows before mapping a drive letter:
 
 ```bash
-prlctl exec "Windows 11 (1)" cmd /c "dir \\\\Mac"
-prlctl exec "Windows 11 (1)" cmd /c "net use"
+prlctl list -i "<VM_NAME>"
+prlctl exec "<VM_NAME>" cmd /c "dir \\\\Mac"
+prlctl exec "<VM_NAME>" cmd /c "net use"
 ```
 
 If the repository is not visible, enable or add a host shared folder in Parallels first.
 Shared Profile may expose only Desktop, Documents, and Downloads, which may not include a
 Conductor workspace.
 
-When testing a Conductor workspace, share that workspace path directly. A share named
-`wordpress-playground` may point at a separate root checkout that does not include the
-workspace branch or unmerged changes.
+When testing a Conductor workspace, share that workspace path directly. A similarly named
+share may point at a separate root checkout that does not include the workspace branch or
+unmerged changes.
 
-The setup used for this workspace was:
+Generic setup:
 
 ```bash
-prlctl set "Windows 11" --shf-host-add wordpress-playground-davis --path "$(pwd)" --mode rw --enable
-prlctl exec "Windows 11" cmd /c "dir \\\\Mac\\wordpress-playground-davis\\package.json"
+prlctl set "<VM_NAME>" --shf-host-add <SHARE_NAME> --path "$(pwd)" --mode rw --enable
+prlctl exec "<VM_NAME>" cmd /c "dir \\\\Mac\\<SHARE_NAME>\\package.json"
 ```
 
 Before testing a macOS change in Windows, verify Windows sees the changed workspace. For
-example, create or edit a file on macOS under `.context/`, then read it from Windows:
+example, create or edit a temporary file on macOS under `.context/`, then read it from
+Windows:
 
 ```bash
-prlctl exec "Windows 11" cmd /c "type \\\\Mac\\wordpress-playground-davis\\.context\\windows-share-smoke.txt"
+prlctl exec "<VM_NAME>" cmd /c "type \\\\Mac\\<SHARE_NAME>\\.context\\windows-share-smoke.txt"
 ```
 
 For source workflows, use a mapped drive instead of a UNC working directory. `cmd.exe`
@@ -87,14 +102,8 @@ If a mapped drive is visible in `net use` but unavailable in a later command, re
 the same `prlctl exec` process or use the UNC path directly:
 
 ```bash
-prlctl exec "Windows 11" cmd /c "net use U: \"\\\\Mac\\wordpress-playground\" /persistent:no && dir U:\\package.json"
-prlctl exec "Windows 11" cmd /c "dir \\\\Mac\\wordpress-playground\\package.json"
-```
-
-## Node.js Verification
-
-```bash
-prlctl exec "Windows 11" cmd /c "\"C:\\Program Files\\nodejs\\node.exe\" --version && \"C:\\Program Files\\nodejs\\npx.cmd\" --version"
+prlctl exec "<VM_NAME>" cmd /c "net use <DRIVE> \"\\\\Mac\\<SHARE_NAME>\" /persistent:no && dir <DRIVE>\\package.json"
+prlctl exec "<VM_NAME>" cmd /c "dir \\\\Mac\\<SHARE_NAME>\\package.json"
 ```
 
 ## SYSTEM User Setup
@@ -102,37 +111,34 @@ prlctl exec "Windows 11" cmd /c "\"C:\\Program Files\\nodejs\\node.exe\" --versi
 `prlctl exec` runs as SYSTEM. One-time setup needed:
 
 ```bash
-# Create npm directory
-prlctl exec "Windows 11" cmd /c "if not exist C:\WINDOWS\system32\config\systemprofile\AppData\Roaming\npm mkdir C:\WINDOWS\system32\config\systemprofile\AppData\Roaming\npm"
+prlctl exec "<VM_NAME>" cmd /c "if not exist C:\WINDOWS\system32\config\systemprofile\AppData\Roaming\npm mkdir C:\WINDOWS\system32\config\systemprofile\AppData\Roaming\npm"
 ```
 
-Always use full paths for executables:
-- Node: `"C:\\Program Files\\nodejs\\node.exe"`
-- npm: `"C:\\Program Files\\nodejs\\npm.cmd"`
-- npx: `"C:\\Program Files\\nodejs\\npx.cmd"`
+Always use full paths for executables when PATH is uncertain:
+
+- Node: `"C:\Program Files\nodejs\node.exe"`
+- npm: `"C:\Program Files\nodejs\npm.cmd"`
+- npx: `"C:\Program Files\nodejs\npx.cmd"`
 
 ## Build Prerequisites
 
 ### Visual C++ Redistributable
 
-Use the redistributable that matches the VM architecture. For ARM64:
-
-```bash
-prlctl exec "Windows 11" powershell -NoProfile -Command "Invoke-WebRequest -Uri 'https://aka.ms/vs/17/release/vc_redist.arm64.exe' -OutFile 'C:\Users\Public\vc_redist.arm64.exe'; Start-Process -FilePath 'C:\Users\Public\vc_redist.arm64.exe' -ArgumentList '/install','/quiet','/norestart' -Wait"
-```
+Use the redistributable that matches the VM architecture. Ask the user before installing
+system components if it is not clear whether they are already present.
 
 ### Network Drive Build Issues
 
-1. **Symlinks** → use `npm install --install-links`
-2. **NX WASM fallback** → install the matching Nx native package, e.g.
-   `@nx/nx-win32-arm64-msvc` on ARM64 or `@nx/nx-win32-x64-msvc` on x64
-3. **Workspace detection** → set `NX_WORKSPACE_ROOT_PATH`
-4. **Unix commands** → set `ComSpec` to Git bash, prepend Git usr/bin to PATH
+1. Symlinks: use `npm install --install-links`.
+2. Nx native package: install the matching package for the VM architecture if Nx falls
+   back to unsupported WASM behavior.
+3. Workspace detection: set `NX_WORKSPACE_ROOT_PATH` to the mapped drive root.
+4. Unix commands: install Git for Windows and set `ComSpec`/`PATH` as needed.
 
 ## Verifying the Server
 
 ```bash
-prlctl exec "Windows 11" powershell -NoProfile -Command "
+prlctl exec "<VM_NAME>" powershell -NoProfile -Command "
   \$response = Invoke-WebRequest -Uri 'http://127.0.0.1:9400' -UseBasicParsing -TimeoutSec 10;
   Write-Host 'Status:' \$response.StatusCode;
   Write-Host 'Size:' \$response.Content.Length 'bytes';
@@ -144,19 +150,21 @@ prlctl exec "Windows 11" powershell -NoProfile -Command "
 | Environment | Symlink Location | Behavior |
 |-------------|------------------|----------|
 | macOS | Local filesystem | Works normally |
-| Windows (local drive) | C:\ or similar | Works with Developer Mode or admin |
-| Windows (network drive) | Z:\ (Parallels share) | Auto-copies to local temp directory |
-| Windows via prlctl | Network drive | Works (SYSTEM user has privileges) |
+| Windows local drive | `C:\` or similar | Works with Developer Mode, admin, or SYSTEM |
+| Windows network drive | Parallels shared folder | Symlinks unsupported; copy to local temp |
+| Windows via `prlctl` | Local NTFS drive | SYSTEM has symlink privileges |
 
-Symlink permissions on Windows require one of: Administrator privileges, Developer Mode enabled, or SYSTEM user (via prlctl).
+Symlink permissions on Windows require one of: Administrator privileges, Developer Mode
+enabled, or SYSTEM user via `prlctl`.
 
 ## Running Tests Directly in Windows PowerShell
 
-When running directly in PowerShell (not via prlctl), syntax differs slightly — no backslash escaping needed for `$`:
+When running directly in PowerShell, syntax differs slightly because `$` does not need
+escaping:
 
 ```powershell
-cd Z:\packages\php-wasm\node
-$env:NX_WORKSPACE_ROOT_PATH = 'Z:\'
+cd <DRIVE>\packages\php-wasm\node
+$env:NX_WORKSPACE_ROOT_PATH = '<DRIVE>\'
 $env:NX_DAEMON = 'false'
 & 'C:\Program Files\nodejs\npx.cmd' vitest run --config vite.config.ts src/test/symlinks.spec.ts
 ```

--- a/.agents/skills/windows-playground-debugging/references/details.md
+++ b/.agents/skills/windows-playground-debugging/references/details.md
@@ -1,59 +1,23 @@
 # Windows Playground Debugging — Detailed Reference
 
+This file only covers material that goes beyond [../SKILL.md](../SKILL.md). Follow the
+Minimal Setup and Debugging Path there first.
+
 ## VM Management
-
-```bash
-# List all VMs.
-prlctl list -a
-
-# Check VM details and Parallels Tools status.
-prlctl list -i "<VM_NAME>"
-
-# Check license edition. It must be Pro or Business for prlctl exec.
-"/Applications/Parallels Desktop.app/Contents/MacOS/prlsrvctl" info --license
-```
 
 Full path to `prlctl`: `"/Applications/Parallels Desktop.app/Contents/MacOS/prlctl"`
 
-Use the VM name from `prlctl list -a` in all `prlctl exec` commands.
-
-## Setup Checklist
-
-Use this minimal setup for testing Playground from macOS against a Windows VM:
-
-```bash
-# Discover the VM name and confirm Parallels Tools/license.
-prlctl list -a
-prlctl list -i "<VM_NAME>"
-"/Applications/Parallels Desktop.app/Contents/MacOS/prlsrvctl" info --license
-
-# Confirm the Windows CPU architecture.
-prlctl exec "<VM_NAME>" cmd /c "echo %PROCESSOR_ARCHITECTURE%"
-
-# Verify Node.js. If it is missing, install Node.js 22+ for the VM architecture.
-prlctl exec "<VM_NAME>" cmd /c "node --version && npm --version && npx --version"
-
-# prlctl exec runs as SYSTEM; create SYSTEM's npm directory if it is missing.
-prlctl exec "<VM_NAME>" cmd /c "if not exist C:\WINDOWS\system32\config\systemprofile\AppData\Roaming\npm mkdir C:\WINDOWS\system32\config\systemprofile\AppData\Roaming\npm"
-
-# Verify the shared checkout.
-prlctl exec "<VM_NAME>" cmd /c "dir \\\\Mac\\<SHARE_NAME>\\package.json"
-```
-
-Expected:
-
-- license edition is `pro` or `business`
-- Parallels Tools are installed in the VM
-- Node.js 22+ is available for source workflows
-- the shared folder resolves to the exact macOS checkout under test
+Use the VM name from `prlctl list -a` in all `prlctl exec` commands. In
+`prlsrvctl info --license` output, the edition must be `pro` or `business`; Standard
+edition does not support `prlctl exec`.
 
 ## Node.js Setup
 
-Install Node.js 22+ inside the VM if `node --version` fails or if source workflows need
-Node's type-stripping support. Choose the installer or package-manager command that
-matches the VM architecture (`ARM64` vs `AMD64`/x64). Do not hardcode a download URL in
-the skill; use the current official installer or the user's preferred Windows package
-manager.
+Install the Node.js version from the repo's `.nvmrc` inside the VM if `node --version`
+fails. Source workflows need at least Node.js 22 for type stripping. Choose the
+installer or package-manager command that matches the VM architecture (`ARM64` vs
+`AMD64`/x64). Do not hardcode a download URL; use the current official installer or the
+user's preferred Windows package manager.
 
 After installation, verify from the SYSTEM context used by `prlctl exec`:
 
@@ -61,62 +25,21 @@ After installation, verify from the SYSTEM context used by `prlctl exec`:
 prlctl exec "<VM_NAME>" cmd /c "\"C:\Program Files\nodejs\node.exe\" --version && \"C:\Program Files\nodejs\npx.cmd\" --version"
 ```
 
-## Shared Folder Discovery
+## Shared Folder Caveats
 
-Check which macOS shares are visible inside Windows before mapping a drive letter:
-
-```bash
-prlctl list -i "<VM_NAME>"
-prlctl exec "<VM_NAME>" cmd /c "dir \\\\Mac"
-prlctl exec "<VM_NAME>" cmd /c "net use"
-```
-
-If the repository is not visible, enable or add a host shared folder in Parallels first.
-Shared Profile may expose only Desktop, Documents, and Downloads, which may not include
-the checkout under test.
+If the repository is not visible under `\\Mac`, enable or add a host shared folder in
+Parallels first. Shared Profile may expose only Desktop, Documents, and Downloads, which
+may not include the checkout under test.
 
 When using an agent or worktree tool, share that exact worktree path directly. A
 similarly named share may point at a separate root checkout that does not include the
 workspace branch or unmerged changes.
 
-Generic setup:
-
-```bash
-prlctl set "<VM_NAME>" --shf-host-add <SHARE_NAME> --path "$(pwd)" --mode rw --enable
-prlctl exec "<VM_NAME>" cmd /c "dir \\\\Mac\\<SHARE_NAME>\\package.json"
-```
-
-Before testing a macOS change in Windows, verify Windows sees the changed workspace. For
-example, create or edit a temporary file on macOS under `.context/`, then read it from
-Windows:
-
-```bash
-mkdir -p .context
-printf "%s\n" "$(pwd)" > .context/windows-share-smoke.txt
-prlctl exec "<VM_NAME>" cmd /c "type \\\\Mac\\<SHARE_NAME>\\.context\\windows-share-smoke.txt"
-```
-
-For source workflows, use a mapped drive instead of a UNC working directory. `cmd.exe`
-falls back to `C:\Windows` when started in a UNC path. Do not reuse macOS `node_modules`
-for source workflows; install dependencies from Windows on the checkout under test.
-
-If a mapped drive is visible in `net use` but unavailable in a later command, remap it in
-the same `prlctl exec` process or use the UNC path directly:
-
-```bash
-prlctl exec "<VM_NAME>" cmd /c "net use <DRIVE> \"\\\\Mac\\<SHARE_NAME>\" /persistent:no && dir <DRIVE>\\package.json"
-prlctl exec "<VM_NAME>" cmd /c "dir \\\\Mac\\<SHARE_NAME>\\package.json"
-```
-
 ## SYSTEM User Setup
 
-`prlctl exec` runs as SYSTEM. One-time setup needed:
-
-```bash
-prlctl exec "<VM_NAME>" cmd /c "if not exist C:\WINDOWS\system32\config\systemprofile\AppData\Roaming\npm mkdir C:\WINDOWS\system32\config\systemprofile\AppData\Roaming\npm"
-```
-
-Always use full paths for executables when PATH is uncertain:
+`prlctl exec` runs as SYSTEM, so it does not inherit user drive mappings, PATH changes,
+or npm profile directories. Always use full paths for executables when PATH is
+uncertain:
 
 - Node: `"C:\Program Files\nodejs\node.exe"`
 - npm: `"C:\Program Files\nodejs\npm.cmd"`
@@ -134,19 +57,6 @@ debugging problem instead of the Windows issue under investigation. Prefer one o
 
 When using PowerShell directly inside Windows, `$` does not need escaping. When embedding
 PowerShell in a macOS shell string, escape `$` as `\$`.
-
-## Source CLI Without Nx
-
-Use the direct Node entrypoint before Nx when debugging CLI startup. It removes Nx
-workspace detection, daemon, and network-drive behavior from the first source baseline:
-
-```cmd
-cd /d <DRIVE>\
-node --experimental-strip-types --experimental-transform-types ^
-  --disable-warning=ExperimentalWarning ^
-  --import ./packages/meta/src/node-es-module-loader/register.mts ^
-  ./packages/playground/cli/src/cli.ts server --wp=6.8 --php=8.4 --port=9400
-```
 
 ## Build Prerequisites
 
@@ -166,31 +76,13 @@ masking postinstall failures.
 
 ### Network Drive Build Issues
 
-1. Symlinks: use `npm install --install-links`.
-2. Nx native package: install the matching package for the VM architecture if Nx falls
+Beyond the mapped-drive, `--install-links`, and Nx workspace-detection steps in
+SKILL.md:
+
+1. Nx native package: install the matching package for the VM architecture if Nx falls
    back to unsupported WASM behavior.
-3. Workspace detection: set `NX_WORKSPACE_ROOT_PATH` to the mapped drive root and
-   `NX_DAEMON=false`, then verify with `nx show projects --json`.
-4. If Nx returns no projects or says the workspace root does not exist, use the direct
-   Node CLI workflow or copy the repo to Windows-local NTFS.
-5. Unix commands: install Git for Windows and set `ComSpec`/`PATH` as needed.
-
-## Verifying the Server
-
-```bash
-prlctl exec "<VM_NAME>" powershell -NoProfile -Command "
-  \$response = Invoke-WebRequest -Uri 'http://127.0.0.1:9400' -UseBasicParsing -TimeoutSec 10;
-  Write-Host 'Status:' \$response.StatusCode;
-  Write-Host 'Size:' \$response.Content.Length 'bytes';
-"
-```
-
-After server tests, kill the captured PID if you started one explicitly. If not, clear
-stale Node processes before reusing the same port:
-
-```bash
-prlctl exec "<VM_NAME>" cmd /c "taskkill /F /IM node.exe /T"
-```
+2. Unix commands: install Git for Windows and set `ComSpec`/`PATH` as shown in the
+   Build From Source step of SKILL.md.
 
 ## Symlink Test Behavior Matrix
 

--- a/.agents/skills/windows-playground-debugging/references/details.md
+++ b/.agents/skills/windows-playground-debugging/references/details.md
@@ -20,20 +20,32 @@ Use the VM name from `prlctl list -a` in all `prlctl exec` commands.
 
 ## Setup Checklist
 
-Run these checks before starting a Windows debugging session:
+Use this minimal setup for testing Playground from macOS against a Windows VM:
 
 ```bash
+# Discover the VM name and confirm Parallels Tools/license.
 prlctl list -a
 prlctl list -i "Windows 11"
 "/Applications/Parallels Desktop.app/Contents/MacOS/prlsrvctl" info --license
-prlctl exec "Windows 11" cmd /c "where node || echo node-missing"
+
+# Confirm the Windows CPU architecture. Our Parallels VM is ARM64.
+prlctl exec "Windows 11" cmd /c "echo %PROCESSOR_ARCHITECTURE%"
+
+# Install Node.js 22 for the VM architecture. Use x64 instead of arm64 on x64 VMs.
+prlctl exec "Windows 11" powershell -NoProfile -Command "Invoke-WebRequest -Uri 'https://nodejs.org/dist/v22.14.0/node-v22.14.0-arm64.msi' -OutFile 'C:\Users\Public\node22-arm64-install.msi'; Start-Process -FilePath 'msiexec.exe' -ArgumentList '/i','C:\Users\Public\node22-arm64-install.msi','/qn','/norestart' -Wait"
+
+# prlctl exec runs as SYSTEM; create SYSTEM's npm directory if it is missing.
+prlctl exec "Windows 11" cmd /c "if not exist C:\WINDOWS\system32\config\systemprofile\AppData\Roaming\npm mkdir C:\WINDOWS\system32\config\systemprofile\AppData\Roaming\npm"
+
+# Verify Node and the shared checkout.
+prlctl exec "Windows 11" cmd /c "node --version && npm --version && npx --version"
 prlctl exec "Windows 11" cmd /c "dir \\\\Mac\\wordpress-playground\\package.json"
 ```
 
 Expected:
 - license edition is `pro` or `business`
 - Parallels Tools are installed in the VM
-- Node.js is available for CLI workflows
+- Node.js 22 is available for CLI workflows
 - the shared folder resolves to the exact checkout or Conductor workspace under test
 
 ## Shared Folder Discovery
@@ -53,6 +65,10 @@ When testing a Conductor workspace, share that workspace path directly. A share 
 `wordpress-playground` may point at a separate root checkout that does not include the
 workspace branch or unmerged changes.
 
+For source workflows, use a mapped drive instead of a UNC working directory. `cmd.exe`
+falls back to `C:\Windows` when started in a UNC path. Do not reuse macOS `node_modules`
+for source workflows; install dependencies from Windows on the checkout under test.
+
 If a mapped drive is visible in `net use` but unavailable in a later command, remap it in
 the same `prlctl exec` process or use the UNC path directly:
 
@@ -61,35 +77,19 @@ prlctl exec "Windows 11" cmd /c "net use U: \"\\\\Mac\\wordpress-playground\" /p
 prlctl exec "Windows 11" cmd /c "dir \\\\Mac\\wordpress-playground\\package.json"
 ```
 
-## Node.js Installation
-
-### Node.js 20 (for published CLI)
+## Node.js Verification
 
 ```bash
-prlctl exec "Windows 11 (1)" powershell -Command "Invoke-WebRequest -Uri 'https://nodejs.org/dist/v20.18.3/node-v20.18.3-x64.msi' -OutFile 'C:\\Users\\Public\\node-install.msi'"
-prlctl exec "Windows 11 (1)" cmd /c "msiexec /i C:\\Users\\Public\\node-install.msi /qn /norestart"
-```
-
-### Node.js 22 (for dev CLI)
-
-```bash
-prlctl exec "Windows 11 (1)" powershell -Command "Invoke-WebRequest -Uri 'https://nodejs.org/dist/v22.14.0/node-v22.14.0-x64.msi' -OutFile 'C:\\Users\\Public\\node22-install.msi'"
-prlctl exec "Windows 11 (1)" powershell -Command "Start-Process -FilePath 'msiexec.exe' -ArgumentList '/i','C:\\Users\\Public\\node22-install.msi','/qn','/norestart' -Wait"
-```
-
-### Verify
-
-```bash
-prlctl exec "Windows 11 (1)" cmd /c "\"C:\\Program Files\\nodejs\\node.exe\" --version"
+prlctl exec "Windows 11" cmd /c "\"C:\\Program Files\\nodejs\\node.exe\" --version && \"C:\\Program Files\\nodejs\\npx.cmd\" --version"
 ```
 
 ## SYSTEM User Setup
 
-prlctl exec runs as SYSTEM. One-time setup needed:
+`prlctl exec` runs as SYSTEM. One-time setup needed:
 
 ```bash
 # Create npm directory
-prlctl exec "Windows 11 (1)" cmd /c "mkdir C:\\WINDOWS\\system32\\config\\systemprofile\\AppData\\Roaming\\npm"
+prlctl exec "Windows 11" cmd /c "if not exist C:\WINDOWS\system32\config\systemprofile\AppData\Roaming\npm mkdir C:\WINDOWS\system32\config\systemprofile\AppData\Roaming\npm"
 ```
 
 Always use full paths for executables:
@@ -101,21 +101,24 @@ Always use full paths for executables:
 
 ### Visual C++ Redistributable
 
+Use the redistributable that matches the VM architecture. For ARM64:
+
 ```bash
-prlctl exec "Windows 11 (1)" powershell -Command "Invoke-WebRequest -Uri 'https://aka.ms/vs/17/release/vc_redist.x64.exe' -OutFile 'C:\\Users\\Public\\vc_redist.x64.exe'; Start-Process -FilePath 'C:\\Users\\Public\\vc_redist.x64.exe' -ArgumentList '/install','/quiet','/norestart' -Wait"
+prlctl exec "Windows 11" powershell -NoProfile -Command "Invoke-WebRequest -Uri 'https://aka.ms/vs/17/release/vc_redist.arm64.exe' -OutFile 'C:\Users\Public\vc_redist.arm64.exe'; Start-Process -FilePath 'C:\Users\Public\vc_redist.arm64.exe' -ArgumentList '/install','/quiet','/norestart' -Wait"
 ```
 
 ### Network Drive Build Issues
 
 1. **Symlinks** → use `npm install --install-links`
-2. **NX WASM fallback** → `npm install @nx/nx-win32-x64-msvc`
+2. **NX WASM fallback** → install the matching Nx native package, e.g.
+   `@nx/nx-win32-arm64-msvc` on ARM64 or `@nx/nx-win32-x64-msvc` on x64
 3. **Workspace detection** → set `NX_WORKSPACE_ROOT_PATH`
 4. **Unix commands** → set `ComSpec` to Git bash, prepend Git usr/bin to PATH
 
 ## Verifying the Server
 
 ```bash
-prlctl exec "Windows 11 (1)" powershell -Command "
+prlctl exec "Windows 11" powershell -NoProfile -Command "
   \$response = Invoke-WebRequest -Uri 'http://127.0.0.1:9400' -UseBasicParsing -TimeoutSec 10;
   Write-Host 'Status:' \$response.StatusCode;
   Write-Host 'Size:' \$response.Content.Length 'bytes';

--- a/.agents/skills/windows-playground-debugging/references/details.md
+++ b/.agents/skills/windows-playground-debugging/references/details.md
@@ -16,6 +16,21 @@ prlctl list -i "Windows 11 (1)"
 
 Full path to prlctl: `"/Applications/Parallels Desktop.app/Contents/MacOS/prlctl"`
 
+Use the VM name from `prlctl list -a` in all `prlctl exec` commands.
+
+## Shared Folder Discovery
+
+Check which macOS shares are visible inside Windows before mapping a drive letter:
+
+```bash
+prlctl exec "Windows 11 (1)" cmd /c "dir \\Mac"
+prlctl exec "Windows 11 (1)" cmd /c "net use"
+```
+
+If the repository is not visible, enable or add a host shared folder in Parallels first.
+Shared Profile may expose only Desktop, Documents, and Downloads, which may not include a
+Conductor workspace.
+
 ## Node.js Installation
 
 ### Node.js 20 (for published CLI)

--- a/.agents/skills/windows-playground-debugging/references/details.md
+++ b/.agents/skills/windows-playground-debugging/references/details.md
@@ -1,0 +1,102 @@
+# Windows Playground Debugging — Detailed Reference
+
+## VM Management
+
+```bash
+# List all VMs
+prlctl list -a
+
+# Check VM details and Parallels Tools status
+prlctl list -i "Windows 11 (1)"
+
+# Check license edition (must be Pro or Business)
+"/Applications/Parallels Desktop.app/Contents/MacOS/prlsrvctl" info --license
+# Look for edition="pro" or edition="business"
+```
+
+Full path to prlctl: `"/Applications/Parallels Desktop.app/Contents/MacOS/prlctl"`
+
+## Node.js Installation
+
+### Node.js 20 (for published CLI)
+
+```bash
+prlctl exec "Windows 11 (1)" powershell -Command "Invoke-WebRequest -Uri 'https://nodejs.org/dist/v20.18.3/node-v20.18.3-x64.msi' -OutFile 'C:\\Users\\Public\\node-install.msi'"
+prlctl exec "Windows 11 (1)" cmd /c "msiexec /i C:\\Users\\Public\\node-install.msi /qn /norestart"
+```
+
+### Node.js 22 (for dev CLI)
+
+```bash
+prlctl exec "Windows 11 (1)" powershell -Command "Invoke-WebRequest -Uri 'https://nodejs.org/dist/v22.14.0/node-v22.14.0-x64.msi' -OutFile 'C:\\Users\\Public\\node22-install.msi'"
+prlctl exec "Windows 11 (1)" powershell -Command "Start-Process -FilePath 'msiexec.exe' -ArgumentList '/i','C:\\Users\\Public\\node22-install.msi','/qn','/norestart' -Wait"
+```
+
+### Verify
+
+```bash
+prlctl exec "Windows 11 (1)" cmd /c "\"C:\\Program Files\\nodejs\\node.exe\" --version"
+```
+
+## SYSTEM User Setup
+
+prlctl exec runs as SYSTEM. One-time setup needed:
+
+```bash
+# Create npm directory
+prlctl exec "Windows 11 (1)" cmd /c "mkdir C:\\WINDOWS\\system32\\config\\systemprofile\\AppData\\Roaming\\npm"
+```
+
+Always use full paths for executables:
+- Node: `"C:\\Program Files\\nodejs\\node.exe"`
+- npm: `"C:\\Program Files\\nodejs\\npm.cmd"`
+- npx: `"C:\\Program Files\\nodejs\\npx.cmd"`
+
+## Build Prerequisites
+
+### Visual C++ Redistributable
+
+```bash
+prlctl exec "Windows 11 (1)" powershell -Command "Invoke-WebRequest -Uri 'https://aka.ms/vs/17/release/vc_redist.x64.exe' -OutFile 'C:\\Users\\Public\\vc_redist.x64.exe'; Start-Process -FilePath 'C:\\Users\\Public\\vc_redist.x64.exe' -ArgumentList '/install','/quiet','/norestart' -Wait"
+```
+
+### Network Drive Build Issues
+
+1. **Symlinks** → use `npm install --install-links`
+2. **NX WASM fallback** → `npm install @nx/nx-win32-x64-msvc`
+3. **Workspace detection** → set `NX_WORKSPACE_ROOT_PATH`
+4. **Unix commands** → set `ComSpec` to Git bash, prepend Git usr/bin to PATH
+
+## Verifying the Server
+
+```bash
+prlctl exec "Windows 11 (1)" powershell -Command "
+  \$response = Invoke-WebRequest -Uri 'http://127.0.0.1:9400' -UseBasicParsing -TimeoutSec 10;
+  Write-Host 'Status:' \$response.StatusCode;
+  Write-Host 'Size:' \$response.Content.Length 'bytes';
+"
+```
+
+## Symlink Test Behavior Matrix
+
+| Environment | Symlink Location | Behavior |
+|-------------|------------------|----------|
+| macOS | Local filesystem | Works normally |
+| Windows (local drive) | C:\ or similar | Works with Developer Mode or admin |
+| Windows (network drive) | Z:\ (Parallels share) | Auto-copies to local temp directory |
+| Windows via prlctl | Network drive | Works (SYSTEM user has privileges) |
+
+Symlink permissions on Windows require one of: Administrator privileges, Developer Mode enabled, or SYSTEM user (via prlctl).
+
+## Running Tests Directly in Windows PowerShell
+
+When running directly in PowerShell (not via prlctl), syntax differs slightly — no backslash escaping needed for `$`:
+
+```powershell
+cd Z:\packages\php-wasm\node
+$env:NX_WORKSPACE_ROOT_PATH = 'Z:\'
+$env:NX_DAEMON = 'false'
+& 'C:\Program Files\nodejs\npx.cmd' vitest run --config vite.config.ts src/test/symlinks.spec.ts
+```
+
+The `&` operator before the path is required to execute the command.

--- a/.agents/skills/windows-playground-debugging/references/details.md
+++ b/.agents/skills/windows-playground-debugging/references/details.md
@@ -18,18 +18,48 @@ Full path to prlctl: `"/Applications/Parallels Desktop.app/Contents/MacOS/prlctl
 
 Use the VM name from `prlctl list -a` in all `prlctl exec` commands.
 
+## Setup Checklist
+
+Run these checks before starting a Windows debugging session:
+
+```bash
+prlctl list -a
+prlctl list -i "Windows 11"
+"/Applications/Parallels Desktop.app/Contents/MacOS/prlsrvctl" info --license
+prlctl exec "Windows 11" cmd /c "where node || echo node-missing"
+prlctl exec "Windows 11" cmd /c "dir \\\\Mac\\wordpress-playground\\package.json"
+```
+
+Expected:
+- license edition is `pro` or `business`
+- Parallels Tools are installed in the VM
+- Node.js is available for CLI workflows
+- the shared folder resolves to the exact checkout or Conductor workspace under test
+
 ## Shared Folder Discovery
 
 Check which macOS shares are visible inside Windows before mapping a drive letter:
 
 ```bash
-prlctl exec "Windows 11 (1)" cmd /c "dir \\Mac"
+prlctl exec "Windows 11 (1)" cmd /c "dir \\\\Mac"
 prlctl exec "Windows 11 (1)" cmd /c "net use"
 ```
 
 If the repository is not visible, enable or add a host shared folder in Parallels first.
 Shared Profile may expose only Desktop, Documents, and Downloads, which may not include a
 Conductor workspace.
+
+When testing a Conductor workspace, share that workspace path directly. A share named
+`wordpress-playground` may point at a separate root checkout that does not include the
+workspace branch or unmerged changes.
+
+If a mapped drive is visible in `net use` but unavailable in a later command, remap it in
+the same `prlctl exec` process or use the UNC path directly:
+
+```bash
+prlctl exec "Windows 11" cmd /c "net use U: \"\\\\Mac\\wordpress-playground\" /persistent:no && dir U:\\package.json"
+prlctl exec "Windows 11" cmd /c "dir \\\\Mac\\wordpress-playground\\package.json"
+```
 
 ## Node.js Installation
 

--- a/.agents/skills/windows-playground-debugging/references/details.md
+++ b/.agents/skills/windows-playground-debugging/references/details.md
@@ -45,7 +45,7 @@ Expected:
 - license edition is `pro` or `business`
 - Parallels Tools are installed in the VM
 - Node.js 22+ is available for source workflows
-- the shared folder resolves to the exact checkout or Conductor workspace under test
+- the shared folder resolves to the exact macOS checkout under test
 
 ## Node.js Setup
 
@@ -72,12 +72,12 @@ prlctl exec "<VM_NAME>" cmd /c "net use"
 ```
 
 If the repository is not visible, enable or add a host shared folder in Parallels first.
-Shared Profile may expose only Desktop, Documents, and Downloads, which may not include a
-Conductor workspace.
+Shared Profile may expose only Desktop, Documents, and Downloads, which may not include
+the checkout under test.
 
-When testing a Conductor workspace, share that workspace path directly. A similarly named
-share may point at a separate root checkout that does not include the workspace branch or
-unmerged changes.
+When using an agent or worktree tool, share that exact worktree path directly. A
+similarly named share may point at a separate root checkout that does not include the
+workspace branch or unmerged changes.
 
 Generic setup:
 
@@ -91,6 +91,8 @@ example, create or edit a temporary file on macOS under `.context/`, then read i
 Windows:
 
 ```bash
+mkdir -p .context
+printf "%s\n" "$(pwd)" > .context/windows-share-smoke.txt
 prlctl exec "<VM_NAME>" cmd /c "type \\\\Mac\\<SHARE_NAME>\\.context\\windows-share-smoke.txt"
 ```
 
@@ -120,6 +122,32 @@ Always use full paths for executables when PATH is uncertain:
 - npm: `"C:\Program Files\nodejs\npm.cmd"`
 - npx: `"C:\Program Files\nodejs\npx.cmd"`
 
+## Command Quoting
+
+Avoid complex inline PowerShell through `prlctl exec`. Escaping quickly becomes the
+debugging problem instead of the Windows issue under investigation. Prefer one of these:
+
+1. Keep simple commands inline with `cmd /c`.
+2. Put complex commands in a temporary `.cmd` or `.ps1` file under a gitignored
+   directory such as `.context/windows-debug/`.
+3. Invoke that script from Windows through the mapped drive or UNC share.
+
+When using PowerShell directly inside Windows, `$` does not need escaping. When embedding
+PowerShell in a macOS shell string, escape `$` as `\$`.
+
+## Source CLI Without Nx
+
+Use the direct Node entrypoint before Nx when debugging CLI startup. It removes Nx
+workspace detection, daemon, and network-drive behavior from the first source baseline:
+
+```cmd
+cd /d <DRIVE>\
+node --experimental-strip-types --experimental-transform-types ^
+  --disable-warning=ExperimentalWarning ^
+  --import ./packages/meta/src/node-es-module-loader/register.mts ^
+  ./packages/playground/cli/src/cli.ts server --wp=6.8 --php=8.4 --port=9400
+```
+
 ## Build Prerequisites
 
 ### Visual C++ Redistributable
@@ -127,13 +155,25 @@ Always use full paths for executables when PATH is uncertain:
 Use the redistributable that matches the VM architecture. Ask the user before installing
 system components if it is not clear whether they are already present.
 
+### Windows ARM64 npm Caveat
+
+`npm ci --install-links` can still fail on native packages, such as `sharp`, when no
+Node.js, Windows, and ARM64 prebuild exists for the requested package version. For
+profiling-only workflows where dependency postinstall output is not needed,
+`npm install --install-links --ignore-scripts` may be enough. For full builds and tests,
+install Python and native Windows build tooling for the VM architecture instead of
+masking postinstall failures.
+
 ### Network Drive Build Issues
 
 1. Symlinks: use `npm install --install-links`.
 2. Nx native package: install the matching package for the VM architecture if Nx falls
    back to unsupported WASM behavior.
-3. Workspace detection: set `NX_WORKSPACE_ROOT_PATH` to the mapped drive root.
-4. Unix commands: install Git for Windows and set `ComSpec`/`PATH` as needed.
+3. Workspace detection: set `NX_WORKSPACE_ROOT_PATH` to the mapped drive root and
+   `NX_DAEMON=false`, then verify with `nx show projects --json`.
+4. If Nx returns no projects or says the workspace root does not exist, use the direct
+   Node CLI workflow or copy the repo to Windows-local NTFS.
+5. Unix commands: install Git for Windows and set `ComSpec`/`PATH` as needed.
 
 ## Verifying the Server
 
@@ -145,14 +185,21 @@ prlctl exec "<VM_NAME>" powershell -NoProfile -Command "
 "
 ```
 
+After server tests, kill the captured PID if you started one explicitly. If not, clear
+stale Node processes before reusing the same port:
+
+```bash
+prlctl exec "<VM_NAME>" cmd /c "taskkill /F /IM node.exe /T"
+```
+
 ## Symlink Test Behavior Matrix
 
-| Environment | Symlink Location | Behavior |
-|-------------|------------------|----------|
-| macOS | Local filesystem | Works normally |
-| Windows local drive | `C:\` or similar | Works with Developer Mode, admin, or SYSTEM |
-| Windows network drive | Parallels shared folder | Symlinks unsupported; copy to local temp |
-| Windows via `prlctl` | Local NTFS drive | SYSTEM has symlink privileges |
+| Environment           | Symlink Location        | Behavior                                    |
+| --------------------- | ----------------------- | ------------------------------------------- |
+| macOS                 | Local filesystem        | Works normally                              |
+| Windows local drive   | `C:\` or similar        | Works with Developer Mode, admin, or SYSTEM |
+| Windows network drive | Parallels shared folder | Symlinks unsupported; copy to local temp    |
+| Windows via `prlctl`  | Local NTFS drive        | SYSTEM has symlink privileges               |
 
 Symlink permissions on Windows require one of: Administrator privileges, Developer Mode
 enabled, or SYSTEM user via `prlctl`.

--- a/.agents/skills/windows-playground-debugging/references/details.md
+++ b/.agents/skills/windows-playground-debugging/references/details.md
@@ -65,6 +65,20 @@ When testing a Conductor workspace, share that workspace path directly. A share 
 `wordpress-playground` may point at a separate root checkout that does not include the
 workspace branch or unmerged changes.
 
+The setup used for this workspace was:
+
+```bash
+prlctl set "Windows 11" --shf-host-add wordpress-playground-davis --path "$(pwd)" --mode rw --enable
+prlctl exec "Windows 11" cmd /c "dir \\\\Mac\\wordpress-playground-davis\\package.json"
+```
+
+Before testing a macOS change in Windows, verify Windows sees the changed workspace. For
+example, create or edit a file on macOS under `.context/`, then read it from Windows:
+
+```bash
+prlctl exec "Windows 11" cmd /c "type \\\\Mac\\wordpress-playground-davis\\.context\\windows-share-smoke.txt"
+```
+
 For source workflows, use a mapped drive instead of a UNC working directory. `cmd.exe`
 falls back to `C:\Windows` when started in a UNC path. Do not reuse macOS `node_modules`
 for source workflows; install dependencies from Windows on the checkout under test.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -254,6 +254,11 @@ PHP binaries are pre-compiled and committed to the repository. Recompilation is 
 For compilation commands, build flags, and troubleshooting, see the `compile-php-wasm` skill.
 For debugging WASM crashes, see the `debug-php-wasm-main-module` and `debug-php-wasm-side-modules` skills.
 
+### Testing on Windows
+
+For testing and debugging Playground on Windows from macOS via Parallels Desktop,
+see the `windows-playground-debugging` skill.
+
 ### Custom NX Executors
 
 Located in `packages/nx-extensions/src/executors/`:


### PR DESCRIPTION
## Summary

Adds the Windows Playground debugging skill to the repo-local agent skills.

## Motivation for the change, related issues

The Playground agent skills already include debugging guidance for PHP WASM and the Playground website, but the Windows/Parallels workflow was missing. This makes the Windows Playground debugging workflow available to agents through `.agents/skills` and the existing `.claude/skills` symlink.

## Implementation details

Adds `windows-playground-debugging` under `.agents/skills` with:

- a `SKILL.md` covering the core Parallels, Windows VM, Node.js, Nx, and test workflows
- minimal setup instructions based on placeholder values such as `<VM_NAME>`, `<SHARE_NAME>`, and `<DRIVE>` instead of machine-specific names
- guidance to discover or ask for the VM name, share name, and checkout path before running commands
- setup guidance for Node.js 22+, SYSTEM npm directory setup, checkout sharing, and a published CLI smoke test
- a detailed reference file for VM management, Windows setup, build prerequisites, server verification, shared-folder discovery, and PowerShell usage

This PR only adds agent-skill documentation. It does not change runtime code.

## Testing Instructions

1. Confirm `.agents/skills/windows-playground-debugging/SKILL.md` exists.
2. Confirm `.agents/skills/windows-playground-debugging/references/details.md` exists.
3. Start a new agent session and ask about Windows Playground debugging or `prlctl`; confirm the new skill is available.

Manual validation performed:

- Parsed the skill frontmatter with Ruby/YAML.
- Confirmed `.claude/skills` points to `.agents/skills`.
- Confirmed Parallels Pro is installed and a Windows ARM64 VM is running with Parallels Tools installed.
- Installed Node.js 22 in the Windows VM.
- Created SYSTEM's npm profile directory.
- Confirmed `node`, `npm`, and `npx` are available from `prlctl exec` as SYSTEM.
- Confirmed `prlctl exec ... cmd /c ...` runs as `nt authority\system`.
- Confirmed `prlctl exec ... powershell ...` works when `$` is escaped from the macOS shell.
- Confirmed a Parallels share for a checkout can be reached from Windows via a UNC path.
- Confirmed mapping the share to a fresh drive letter inside the same `cmd` invocation works.
- Added a dedicated Parallels share for this Conductor workspace during validation.
- Created and edited a temporary `.context/windows-share-smoke.txt` file on macOS and confirmed Windows read both versions through the workspace share.
- Confirmed Windows can read this branch's live skill edits through the workspace share.
- Ran the published CLI in Windows with `@wp-playground/cli@latest server --wp=6.7 --php=8.2 --port=9400`.
- Confirmed `http://127.0.0.1:9400` returned HTTP 200 and WordPress content from inside Windows.
- Stopped the test server and confirmed no `node.exe` processes remain.
- Confirmed UNC working directories cause `cmd.exe` to fall back to `C:\Windows`, so source workflows now recommend mapped drives.
- Confirmed macOS `node_modules` is not a valid Windows source dependency install, so the skill now tells agents to install dependencies from Windows for source workflows.

Not run: full source dev server/build/test workflows from the shared checkout, because the checkout has macOS-installed `node_modules`; source workflows need a Windows-side dependency install such as `npm ci --install-links` on the checkout under test. During commit, the formatter hook attempted `npm run format:uncommitted`, but Nx modules are not installed in this Conductor workspace, so it could not run.
