### PR TITLE
[CLI] Fix EBADF crash from stale SQLite WAL lock cleanup

### DIFF
--- a/packages/php-wasm/node/src/lib/wasm-user-space.ts
+++ b/packages/php-wasm/node/src/lib/wasm-user-space.ts
@@ -170,20 +170,24 @@ export function bindUserSpace(
 	type FcntlLockState = typeof F_RDLCK | typeof F_WRLCK | typeof F_UNLCK;
 	const locking = {
 		/*
-		 * These are possibly locked file descriptors and their last known
-		 * native paths. The path must be captured when the lock succeeds
-		 * because close-time cleanup may run after the file is unlinked.
+		 * Possibly locked file descriptors and their last known native paths.
+		 * The path must be captured when the lock succeeds because close-time
+		 * cleanup may run after the file is unlinked.
+		 *
+		 * WARNING: This fixes cleanup when a known path disappears before
+		 * close, but it does not make path-keyed lock bookkeeping rename-safe.
+		 * If a locked file is renamed, later lock operations may address the
+		 * same underlying file through a different path than the one stored
+		 * here. Correctly handling that requires stable file identity tracking,
+		 * such as device/inode keys or rename-aware lock manager updates.
 		 */
-		maybeLockedFds: new Set(),
 		maybeLockedFdPaths: new Map<number, string>(),
 
 		remember_maybe_locked_fd(fd: number, nativePath: string) {
-			locking.maybeLockedFds.add(fd);
 			locking.maybeLockedFdPaths.set(fd, nativePath);
 		},
 
 		forget_maybe_locked_fd(fd: number) {
-			locking.maybeLockedFds.delete(fd);
 			locking.maybeLockedFdPaths.delete(fd);
 		},
 
@@ -914,24 +918,10 @@ export function bindUserSpace(
 			locking.get_vfs_path_from_fd(fd);
 		const [nativeFd, nativeFdErrno] =
 			locking.get_native_fd_from_emscripten_fd(fd);
-		let nativeFilePath =
+		const nativeFilePath =
 			nativeFdErrno === 0
 				? locking.maybeLockedFdPaths.get(nativeFd)
 				: undefined;
-		let nativeFilePathError: unknown;
-		if (
-			nativeFilePath === undefined &&
-			vfsPathResolutionErrno === 0 &&
-			nativeFdErrno === 0 &&
-			locking.maybeLockedFds.has(nativeFd) &&
-			locking.is_path_to_shared_fs(vfsPath)
-		) {
-			try {
-				nativeFilePath = locking.get_native_path_from_vfs_path(vfsPath);
-			} catch (e) {
-				nativeFilePathError = e;
-			}
-		}
 
 		const fdCloseResult = builtin_fd_close(fd);
 		if (fdCloseResult !== 0) {
@@ -943,7 +933,18 @@ export function bindUserSpace(
 			);
 			return fdCloseResult;
 		}
-		if (!locking.maybeLockedFds.has(nativeFd)) {
+
+		if (nativeFdErrno !== 0) {
+			js_wasm_trace(
+				'fd_close(%d) %s get_native_fd_from_emscripten_fd error %d',
+				fd,
+				vfsPath,
+				nativeFdErrno
+			);
+			return fdCloseResult;
+		}
+
+		if (nativeFilePath === undefined) {
 			js_wasm_trace(
 				'fd_close(%d) not in maybe-locked-list %s result %d',
 				fd,
@@ -961,39 +962,9 @@ export function bindUserSpace(
 			);
 			/*
 			 * This can happen when a locked file is unlinked before close.
-			 * If we captured the native path when the lock was acquired,
+			 * Since the native path was captured when the lock was acquired,
 			 * close-time cleanup can still release the lock manager state.
 			 */
-			if (nativeFilePath === undefined) {
-				locking.forget_maybe_locked_fd(nativeFd);
-				return fdCloseResult;
-			}
-		}
-
-		if (nativeFdErrno !== 0) {
-			js_wasm_trace(
-				'fd_close(%d) %s get_native_fd_from_emscripten_fd error %d',
-				fd,
-				vfsPath,
-				nativeFdErrno
-			);
-			return fdCloseResult;
-		}
-
-		if (nativeFilePathError) {
-			js_wasm_trace(
-				"fd_close(%d) %s error '%s'",
-				fd,
-				vfsPath,
-				nativeFilePathError
-			);
-			locking.forget_maybe_locked_fd(nativeFd);
-			return fdCloseResult;
-		}
-
-		if (nativeFilePath === undefined) {
-			locking.forget_maybe_locked_fd(nativeFd);
-			return fdCloseResult;
 		}
 
 		try {

--- a/packages/php-wasm/node/src/lib/wasm-user-space.ts
+++ b/packages/php-wasm/node/src/lib/wasm-user-space.ts
@@ -183,14 +183,6 @@ export function bindUserSpace(
 		 */
 		maybeLockedFdPaths: new Map<number, string>(),
 
-		remember_maybe_locked_fd(fd: number, nativePath: string) {
-			locking.maybeLockedFdPaths.set(fd, nativePath);
-		},
-
-		forget_maybe_locked_fd(fd: number) {
-			locking.maybeLockedFdPaths.delete(fd);
-		},
-
 		lockStateToFcntl: {
 			shared: F_RDLCK,
 			exclusive: F_WRLCK,
@@ -740,7 +732,7 @@ export function bindUserSpace(
 						waitForLock
 					);
 					if (succeeded) {
-						locking.remember_maybe_locked_fd(
+						locking.maybeLockedFdPaths.set(
 							nativeFd,
 							nativeFilePath
 						);
@@ -893,7 +885,7 @@ export function bindUserSpace(
 				succeeded
 			);
 			if (succeeded) {
-				locking.remember_maybe_locked_fd(nativeFd, nativeFilePath);
+				locking.maybeLockedFdPaths.set(nativeFd, nativeFilePath);
 			}
 			return succeeded ? 0 : -EWOULDBLOCK;
 		} catch (e) {
@@ -978,7 +970,8 @@ export function bindUserSpace(
 		} catch (e) {
 			js_wasm_trace("fd_close(%d) %s error '%s'", fd, vfsPath, e);
 		} finally {
-			locking.forget_maybe_locked_fd(nativeFd);
+			// The fd is closed now; keeping it would recreate the stale-fd bug.
+			locking.maybeLockedFdPaths.delete(nativeFd);
 		}
 		return fdCloseResult;
 	}

--- a/packages/php-wasm/node/src/lib/wasm-user-space.ts
+++ b/packages/php-wasm/node/src/lib/wasm-user-space.ts
@@ -170,13 +170,22 @@ export function bindUserSpace(
 	type FcntlLockState = typeof F_RDLCK | typeof F_WRLCK | typeof F_UNLCK;
 	const locking = {
 		/*
-		 * This is a set of possibly locked file descriptors.
-		 *
-		 * When a file descriptor is closed, we need to release any associated held by this process.
-		 * Instead of trying remember and forget file descriptors as they are locked and unlocked,
-		 * we just track file descriptors we have locked before and try an unlock when they are closed.
+		 * These are possibly locked file descriptors and their last known
+		 * native paths. The path must be captured when the lock succeeds
+		 * because close-time cleanup may run after the file is unlinked.
 		 */
 		maybeLockedFds: new Set(),
+		maybeLockedFdPaths: new Map<number, string>(),
+
+		remember_maybe_locked_fd(fd: number, nativePath: string) {
+			locking.maybeLockedFds.add(fd);
+			locking.maybeLockedFdPaths.set(fd, nativePath);
+		},
+
+		forget_maybe_locked_fd(fd: number) {
+			locking.maybeLockedFds.delete(fd);
+			locking.maybeLockedFdPaths.delete(fd);
+		},
 
 		lockStateToFcntl: {
 			shared: F_RDLCK,
@@ -727,7 +736,10 @@ export function bindUserSpace(
 						waitForLock
 					);
 					if (succeeded) {
-						locking.maybeLockedFds.add(nativeFd);
+						locking.remember_maybe_locked_fd(
+							nativeFd,
+							nativeFilePath
+						);
 					}
 
 					js_wasm_trace(
@@ -877,7 +889,7 @@ export function bindUserSpace(
 				succeeded
 			);
 			if (succeeded) {
-				locking.maybeLockedFds.add(nativeFd);
+				locking.remember_maybe_locked_fd(nativeFd, nativeFilePath);
 			}
 			return succeeded ? 0 : -EWOULDBLOCK;
 		} catch (e) {
@@ -902,6 +914,24 @@ export function bindUserSpace(
 			locking.get_vfs_path_from_fd(fd);
 		const [nativeFd, nativeFdErrno] =
 			locking.get_native_fd_from_emscripten_fd(fd);
+		let nativeFilePath =
+			nativeFdErrno === 0
+				? locking.maybeLockedFdPaths.get(nativeFd)
+				: undefined;
+		let nativeFilePathError: unknown;
+		if (
+			nativeFilePath === undefined &&
+			vfsPathResolutionErrno === 0 &&
+			nativeFdErrno === 0 &&
+			locking.maybeLockedFds.has(nativeFd) &&
+			locking.is_path_to_shared_fs(vfsPath)
+		) {
+			try {
+				nativeFilePath = locking.get_native_path_from_vfs_path(vfsPath);
+			} catch (e) {
+				nativeFilePathError = e;
+			}
+		}
 
 		const fdCloseResult = builtin_fd_close(fd);
 		if (fdCloseResult !== 0) {
@@ -930,16 +960,14 @@ export function bindUserSpace(
 				vfsPathResolutionErrno
 			);
 			/*
-			 * It looks like the file may have had an associated lock,
-			 * but since we cannot look up the path,
-			 * there is nothing more for us to do.
-			 *
-			 * NOTE: This seems possible for files that are locked and
-			 * then unlinked before close. It is an opportunity for a
-			 * lock to be orphaned in the lock manager.
-			 * @TODO: Explore how to ensure cleanup in this case.
+			 * This can happen when a locked file is unlinked before close.
+			 * If we captured the native path when the lock was acquired,
+			 * close-time cleanup can still release the lock manager state.
 			 */
-			return fdCloseResult;
+			if (nativeFilePath === undefined) {
+				locking.forget_maybe_locked_fd(nativeFd);
+				return fdCloseResult;
+			}
 		}
 
 		if (nativeFdErrno !== 0) {
@@ -952,14 +980,24 @@ export function bindUserSpace(
 			return fdCloseResult;
 		}
 
-		if (!locking.is_path_to_shared_fs(vfsPath)) {
+		if (nativeFilePathError) {
+			js_wasm_trace(
+				"fd_close(%d) %s error '%s'",
+				fd,
+				vfsPath,
+				nativeFilePathError
+			);
+			locking.forget_maybe_locked_fd(nativeFd);
+			return fdCloseResult;
+		}
+
+		if (nativeFilePath === undefined) {
+			locking.forget_maybe_locked_fd(nativeFd);
 			return fdCloseResult;
 		}
 
 		try {
 			js_wasm_trace('fd_close(%d) %s release locks', fd, vfsPath);
-			const nativeFilePath =
-				locking.get_native_path_from_vfs_path(vfsPath);
 			fileLockManager.releaseLocksOnFdClose(
 				pid,
 				nativeFd,
@@ -968,6 +1006,8 @@ export function bindUserSpace(
 			js_wasm_trace('fd_close(%d) %s release locks success', fd, vfsPath);
 		} catch (e) {
 			js_wasm_trace("fd_close(%d) %s error '%s'", fd, vfsPath, e);
+		} finally {
+			locking.forget_maybe_locked_fd(nativeFd);
 		}
 		return fdCloseResult;
 	}

--- a/packages/php-wasm/node/src/lib/wasm-user-space.ts
+++ b/packages/php-wasm/node/src/lib/wasm-user-space.ts
@@ -993,6 +993,11 @@ export function bindUserSpace(
 
 		try {
 			fileLockManager.releaseLocksForProcess(pid);
+			/*
+			 * Process cleanup releases every lock for this pid.
+			 * Any cached fd path would be stale after this point.
+			 */
+			locking.maybeLockedFdPaths.clear();
 			js_wasm_trace('js_release_file_locks succeeded');
 		} catch (e) {
 			js_wasm_trace('js_release_file_locks error %s', e);

--- a/packages/php-wasm/node/src/lib/wasm-user-space.ts
+++ b/packages/php-wasm/node/src/lib/wasm-user-space.ts
@@ -970,7 +970,7 @@ export function bindUserSpace(
 		} catch (e) {
 			js_wasm_trace("fd_close(%d) %s error '%s'", fd, vfsPath, e);
 		} finally {
-			// The fd is closed now; keeping it would recreate the stale-fd bug.
+			// The fd is closed now; keeping it could recreate the stale-fd bug.
 			locking.maybeLockedFdPaths.delete(nativeFd);
 		}
 		return fdCloseResult;

--- a/packages/php-wasm/node/src/test/php-file-locking.spec.ts
+++ b/packages/php-wasm/node/src/test/php-file-locking.spec.ts
@@ -1464,10 +1464,16 @@ error_log = ${errorLogPath}
 				expect.any(Object),
 				expect.any(Boolean)
 			);
+			const shmLockCall = vi
+				.mocked(fileLockManager.lockFileByteRange)
+				.mock.calls.find(([path]) => /\.ht\.sqlite-shm$/.test(path));
+			expect(shmLockCall).toBeDefined();
+			const [shmNativePath, shmLock] = shmLockCall!;
+			expect(shmLock.fd).toEqual(expect.any(Number));
 			expect(fileLockManager.releaseLocksOnFdClose).toHaveBeenCalledWith(
 				expect.any(Number),
-				expect.any(Number),
-				expect.stringMatching(/\.ht\.sqlite-shm$/)
+				shmLock.fd,
+				shmNativePath
 			);
 		});
 
@@ -1543,9 +1549,19 @@ error_log = ${errorLogPath}
 					type: 'exclusive',
 				})
 			);
+			const wholeFileLockCall = vi
+				.mocked(fileLockManager.lockWholeFile)
+				.mock.calls.find(
+					([path, op]) =>
+						path === expectedNativeFilePath &&
+						op.type === 'exclusive'
+				);
+			expect(wholeFileLockCall).toBeDefined();
+			const [, wholeFileLock] = wholeFileLockCall!;
+			expect(wholeFileLock.fd).toEqual(expect.any(Number));
 			expect(fileLockManager.releaseLocksOnFdClose).toHaveBeenCalledWith(
 				expect.any(Number),
-				expect.any(Number),
+				wholeFileLock.fd,
 				expectedNativeFilePath
 			);
 			expect(fileLockManager.releaseLocksForProcess).toHaveBeenCalled();

--- a/packages/php-wasm/node/src/test/php-file-locking.spec.ts
+++ b/packages/php-wasm/node/src/test/php-file-locking.spec.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { mkdtempSync, realpathSync, rmSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import {
@@ -10,6 +10,7 @@ import {
 import {
 	SupportedPHPVersions,
 	type FileLockManager,
+	type WholeFileLockOp,
 	// TODO: Test with native file lock managers?
 	FileLockManagerInMemory,
 } from '@php-wasm/universal';
@@ -1431,6 +1432,8 @@ error_log = ${errorLogPath}
 
 		// TODO: Test fcntl() somehow. The DB tests should use fcntl(), but explicit tests would be better.
 
+		// Regression for https://github.com/WordPress/wordpress-playground/issues/3830.
+		// SQLite WAL unlinks `.ht.sqlite-shm` before its fd is closed.
 		test(`should release SQLite WAL shared-memory byte-range locks when the file descriptor is closed`, async () => {
 			const fileLockManager = createMockFileLockManager();
 			using php = new PHP(
@@ -1466,6 +1469,86 @@ error_log = ${errorLogPath}
 				expect.any(Number),
 				expect.stringMatching(/\.ht\.sqlite-shm$/)
 			);
+		});
+
+		// Cover the same fd-path bookkeeping without involving SQLite.
+		// Shutdown cleanup must not see a stale lock for an unlinked file.
+		test(`should release locks when a locked file is unlinked before the file descriptor closes`, async () => {
+			const lockedWholeFileFds = new Map<number, string>();
+			const remainingLocksAtProcessRelease: string[][] = [];
+			const fileLockManager: FileLockManager = {
+				lockWholeFile: vi.fn((path: string, op: WholeFileLockOp) => {
+					if (op.type === 'unlock') {
+						lockedWholeFileFds.delete(op.fd);
+					} else {
+						lockedWholeFileFds.set(op.fd, path);
+					}
+					return true;
+				}),
+				lockFileByteRange: vi.fn().mockReturnValue(true),
+				findFirstConflictingByteRangeLock: vi
+					.fn()
+					.mockReturnValue(undefined),
+				releaseLocksOnFdClose: vi.fn(
+					(_pid: number, fd: number, path: string) => {
+						if (lockedWholeFileFds.get(fd) === path) {
+							lockedWholeFileFds.delete(fd);
+						}
+					}
+				),
+				releaseLocksForProcess: vi.fn((_pid: number) => {
+					remainingLocksAtProcessRelease.push([
+						...lockedWholeFileFds.values(),
+					]);
+					lockedWholeFileFds.clear();
+				}),
+			};
+			using php = new PHP(
+				await loadNodeRuntime(phpVersion, {
+					fileLockManager,
+					emscriptenOptions: {
+						processId: nextProcessId++,
+					},
+				})
+			);
+			php.mount(vfsMountPoint, createNodeFsMountHandler(tempDir));
+
+			const fileName = 'locked-unlinked.txt';
+			const nativeFilePath = join(tempDir, fileName);
+			const vfsFilePath = `${vfsMountPoint}/${fileName}`;
+			writeFileSync(nativeFilePath, 'test content');
+			const expectedNativeFilePath = realpathSync(nativeFilePath);
+
+			const result = await php.run({
+				code: `<?php
+						$fp = fopen('${vfsFilePath}', 'r+');
+						if ($fp === false) {
+							throw new Error('Failed to open test file');
+						}
+						if (!flock($fp, LOCK_EX | LOCK_NB)) {
+							throw new Error('Failed to lock test file');
+						}
+						if (!unlink('${vfsFilePath}')) {
+							throw new Error('Failed to unlink test file');
+						}
+						// Intentionally leave the file descriptor open until shutdown.
+					`,
+			});
+
+			expect(result.exitCode).toBe(0);
+			expect(fileLockManager.lockWholeFile).toHaveBeenCalledWith(
+				expectedNativeFilePath,
+				expect.objectContaining({
+					type: 'exclusive',
+				})
+			);
+			expect(fileLockManager.releaseLocksOnFdClose).toHaveBeenCalledWith(
+				expect.any(Number),
+				expect.any(Number),
+				expectedNativeFilePath
+			);
+			expect(fileLockManager.releaseLocksForProcess).toHaveBeenCalled();
+			expect(remainingLocksAtProcessRelease).toEqual([[]]);
 		});
 
 		test(`should not attempt to lock a MEMFS file or a PROXYFS node that wraps a MEMFS file`, async () => {

--- a/packages/php-wasm/node/src/test/php-file-locking.spec.ts
+++ b/packages/php-wasm/node/src/test/php-file-locking.spec.ts
@@ -1483,6 +1483,8 @@ error_log = ${errorLogPath}
 		test(`should release whole-file locks when a locked file is unlinked before the file descriptor closes`, async () => {
 			const lockedWholeFileFds = new Map<number, string>();
 			const remainingLocksAtProcessRelease: string[][] = [];
+			const pidsReleasedOnFdClose: number[] = [];
+			const pidsReleasedForProcess: number[] = [];
 			const fileLockManager: FileLockManager = {
 				lockWholeFile: vi.fn((path: string, op: WholeFileLockOp) => {
 					if (op.type === 'unlock') {
@@ -1497,13 +1499,15 @@ error_log = ${errorLogPath}
 					.fn()
 					.mockReturnValue(undefined),
 				releaseLocksOnFdClose: vi.fn(
-					(_pid: number, fd: number, path: string) => {
+					(pid: number, fd: number, path: string) => {
+						pidsReleasedOnFdClose.push(pid);
 						if (lockedWholeFileFds.get(fd) === path) {
 							lockedWholeFileFds.delete(fd);
 						}
 					}
 				),
-				releaseLocksForProcess: vi.fn((_pid: number) => {
+				releaseLocksForProcess: vi.fn((pid: number) => {
+					pidsReleasedForProcess.push(pid);
 					remainingLocksAtProcessRelease.push([
 						...lockedWholeFileFds.values(),
 					]);
@@ -1565,6 +1569,8 @@ error_log = ${errorLogPath}
 				expectedNativeFilePath
 			);
 			expect(fileLockManager.releaseLocksForProcess).toHaveBeenCalled();
+			expect(pidsReleasedOnFdClose).toEqual([expect.any(Number)]);
+			expect(pidsReleasedForProcess).toEqual(pidsReleasedOnFdClose);
 			expect(remainingLocksAtProcessRelease).toEqual([[]]);
 		});
 

--- a/packages/php-wasm/node/src/test/php-file-locking.spec.ts
+++ b/packages/php-wasm/node/src/test/php-file-locking.spec.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, realpathSync, rmSync, writeFileSync } from 'fs';
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import {
@@ -1525,10 +1525,10 @@ error_log = ${errorLogPath}
 			php.mount(vfsMountPoint, createNodeFsMountHandler(tempDir));
 
 			const fileName = 'locked-unlinked.txt';
+			const nativePathPattern = /[\\/]locked-unlinked\.txt$/;
 			const nativeFilePath = join(tempDir, fileName);
 			const vfsFilePath = `${vfsMountPoint}/${fileName}`;
 			writeFileSync(nativeFilePath, 'test content');
-			const expectedNativeFilePath = realpathSync(nativeFilePath);
 
 			const result = await php.run({
 				code: `<?php
@@ -1547,26 +1547,19 @@ error_log = ${errorLogPath}
 			});
 
 			expect(result.exitCode).toBe(0);
-			expect(fileLockManager.lockWholeFile).toHaveBeenCalledWith(
-				expectedNativeFilePath,
-				expect.objectContaining({
-					type: 'exclusive',
-				})
-			);
 			const wholeFileLockCall = vi
 				.mocked(fileLockManager.lockWholeFile)
 				.mock.calls.find(
 					([path, op]) =>
-						path === expectedNativeFilePath &&
-						op.type === 'exclusive'
+						nativePathPattern.test(path) && op.type === 'exclusive'
 				);
 			expect(wholeFileLockCall).toBeDefined();
-			const [, wholeFileLock] = wholeFileLockCall!;
+			const [wholeFileNativePath, wholeFileLock] = wholeFileLockCall!;
 			expect(wholeFileLock.fd).toEqual(expect.any(Number));
 			expect(fileLockManager.releaseLocksOnFdClose).toHaveBeenCalledWith(
 				expect.any(Number),
 				wholeFileLock.fd,
-				expectedNativeFilePath
+				wholeFileNativePath
 			);
 			expect(fileLockManager.releaseLocksForProcess).toHaveBeenCalled();
 			expect(pidsReleasedOnFdClose).toEqual([expect.any(Number)]);

--- a/packages/php-wasm/node/src/test/php-file-locking.spec.ts
+++ b/packages/php-wasm/node/src/test/php-file-locking.spec.ts
@@ -1431,6 +1431,43 @@ error_log = ${errorLogPath}
 
 		// TODO: Test fcntl() somehow. The DB tests should use fcntl(), but explicit tests would be better.
 
+		test(`should release SQLite WAL shared-memory byte-range locks when the file descriptor is closed`, async () => {
+			const fileLockManager = createMockFileLockManager();
+			using php = new PHP(
+				await loadNodeRuntime(phpVersion, {
+					fileLockManager,
+					emscriptenOptions: {
+						processId: nextProcessId++,
+					},
+				})
+			);
+			php.mount(vfsMountPoint, createNodeFsMountHandler(tempDir));
+
+			const vfsDbFilePath = `${vfsMountPoint}/.ht.sqlite`;
+			const result = await php.run({
+				code: `<?php
+						$db = new SQLite3('${vfsDbFilePath}');
+						$db->exec('PRAGMA journal_mode = WAL');
+						$db->exec('CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT)');
+						$db->exec('INSERT INTO test (name) VALUES ("test")');
+						$db->querySingle('SELECT COUNT(*) FROM test');
+						$db->close();
+					`,
+			});
+
+			expect(result.exitCode).toBe(0);
+			expect(fileLockManager.lockFileByteRange).toHaveBeenCalledWith(
+				expect.stringMatching(/\.ht\.sqlite-shm$/),
+				expect.any(Object),
+				expect.any(Boolean)
+			);
+			expect(fileLockManager.releaseLocksOnFdClose).toHaveBeenCalledWith(
+				expect.any(Number),
+				expect.any(Number),
+				expect.stringMatching(/\.ht\.sqlite-shm$/)
+			);
+		});
+
 		test(`should not attempt to lock a MEMFS file or a PROXYFS node that wraps a MEMFS file`, async () => {
 			// NOTE: Normally, we would use a single file lock manager across all runtimes,
 			// but to keep state clearer within this test, we use a separate manager per runtime.

--- a/packages/php-wasm/node/src/test/php-file-locking.spec.ts
+++ b/packages/php-wasm/node/src/test/php-file-locking.spec.ts
@@ -10,6 +10,7 @@ import {
 import {
 	SupportedPHPVersions,
 	type FileLockManager,
+	type RequestedRangeLock,
 	type WholeFileLockOp,
 	// TODO: Test with native file lock managers?
 	FileLockManagerInMemory,
@@ -1471,10 +1472,11 @@ error_log = ${errorLogPath}
 			);
 		});
 
-		// Cover the same fd-path bookkeeping without involving SQLite.
+		// Cover the same fd-path bookkeeping outside the WAL-specific path.
 		// Shutdown cleanup must not see a stale lock for an unlinked file.
-		test(`should release locks when a locked file is unlinked before the file descriptor closes`, async () => {
+		test(`should release whole-file and byte-range locks when a locked file is unlinked before the file descriptor closes`, async () => {
 			const lockedWholeFileFds = new Map<number, string>();
+			const lockedRangePaths = new Set<string>();
 			const remainingLocksAtProcessRelease: string[][] = [];
 			const fileLockManager: FileLockManager = {
 				lockWholeFile: vi.fn((path: string, op: WholeFileLockOp) => {
@@ -1485,7 +1487,14 @@ error_log = ${errorLogPath}
 					}
 					return true;
 				}),
-				lockFileByteRange: vi.fn().mockReturnValue(true),
+				lockFileByteRange: vi.fn(
+					(path: string, op: RequestedRangeLock) => {
+						if (op.type !== 'unlocked') {
+							lockedRangePaths.add(path);
+						}
+						return true;
+					}
+				),
 				findFirstConflictingByteRangeLock: vi
 					.fn()
 					.mockReturnValue(undefined),
@@ -1494,13 +1503,16 @@ error_log = ${errorLogPath}
 						if (lockedWholeFileFds.get(fd) === path) {
 							lockedWholeFileFds.delete(fd);
 						}
+						lockedRangePaths.delete(path);
 					}
 				),
 				releaseLocksForProcess: vi.fn((_pid: number) => {
 					remainingLocksAtProcessRelease.push([
 						...lockedWholeFileFds.values(),
+						...lockedRangePaths.values(),
 					]);
 					lockedWholeFileFds.clear();
+					lockedRangePaths.clear();
 				}),
 			};
 			using php = new PHP(
@@ -1549,6 +1561,42 @@ error_log = ${errorLogPath}
 			);
 			expect(fileLockManager.releaseLocksForProcess).toHaveBeenCalled();
 			expect(remainingLocksAtProcessRelease).toEqual([[]]);
+
+			const rangeLockFileName = 'range-locked-unlinked.sqlite';
+			const nativeRangeLockFilePath = join(tempDir, rangeLockFileName);
+			const vfsRangeLockFilePath = `${vfsMountPoint}/${rangeLockFileName}`;
+			writeFileSync(nativeRangeLockFilePath, '');
+			const expectedRangeLockNativeFilePath = realpathSync(
+				nativeRangeLockFilePath
+			);
+
+			const rangeLockResult = await php.run({
+				code: `<?php
+						$db = new SQLite3('${vfsRangeLockFilePath}');
+						$db->exec('CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT)');
+						$db->exec('BEGIN EXCLUSIVE');
+						$db->querySingle('SELECT COUNT(*) FROM test');
+						if (!unlink('${vfsRangeLockFilePath}')) {
+							throw new Error('Failed to unlink test database');
+						}
+						// Intentionally leave the database connection open until shutdown.
+					`,
+			});
+
+			expect(rangeLockResult.exitCode).toBe(0);
+			expect(fileLockManager.lockFileByteRange).toHaveBeenCalledWith(
+				expectedRangeLockNativeFilePath,
+				expect.objectContaining({
+					type: expect.stringMatching(/^(shared|exclusive)$/),
+				}),
+				expect.any(Boolean)
+			);
+			expect(fileLockManager.releaseLocksOnFdClose).toHaveBeenCalledWith(
+				expect.any(Number),
+				expect.any(Number),
+				expectedRangeLockNativeFilePath
+			);
+			expect(remainingLocksAtProcessRelease).toEqual([[], []]);
 		});
 
 		test(`should not attempt to lock a MEMFS file or a PROXYFS node that wraps a MEMFS file`, async () => {

--- a/packages/php-wasm/node/src/test/php-file-locking.spec.ts
+++ b/packages/php-wasm/node/src/test/php-file-locking.spec.ts
@@ -10,7 +10,6 @@ import {
 import {
 	SupportedPHPVersions,
 	type FileLockManager,
-	type RequestedRangeLock,
 	type WholeFileLockOp,
 	// TODO: Test with native file lock managers?
 	FileLockManagerInMemory,
@@ -1472,11 +1471,11 @@ error_log = ${errorLogPath}
 			);
 		});
 
-		// Cover the same fd-path bookkeeping outside the WAL-specific path.
-		// Shutdown cleanup must not see a stale lock for an unlinked file.
-		test(`should release whole-file and byte-range locks when a locked file is unlinked before the file descriptor closes`, async () => {
+		// Cover the same fd-path bookkeeping with a whole-file lock.
+		// PHP exposes flock(), but not a direct fcntl() byte-range API.
+		// The SQLite WAL regression above covers byte-range locks.
+		test(`should release whole-file locks when a locked file is unlinked before the file descriptor closes`, async () => {
 			const lockedWholeFileFds = new Map<number, string>();
-			const lockedRangePaths = new Set<string>();
 			const remainingLocksAtProcessRelease: string[][] = [];
 			const fileLockManager: FileLockManager = {
 				lockWholeFile: vi.fn((path: string, op: WholeFileLockOp) => {
@@ -1487,14 +1486,7 @@ error_log = ${errorLogPath}
 					}
 					return true;
 				}),
-				lockFileByteRange: vi.fn(
-					(path: string, op: RequestedRangeLock) => {
-						if (op.type !== 'unlocked') {
-							lockedRangePaths.add(path);
-						}
-						return true;
-					}
-				),
+				lockFileByteRange: vi.fn().mockReturnValue(true),
 				findFirstConflictingByteRangeLock: vi
 					.fn()
 					.mockReturnValue(undefined),
@@ -1503,16 +1495,13 @@ error_log = ${errorLogPath}
 						if (lockedWholeFileFds.get(fd) === path) {
 							lockedWholeFileFds.delete(fd);
 						}
-						lockedRangePaths.delete(path);
 					}
 				),
 				releaseLocksForProcess: vi.fn((_pid: number) => {
 					remainingLocksAtProcessRelease.push([
 						...lockedWholeFileFds.values(),
-						...lockedRangePaths.values(),
 					]);
 					lockedWholeFileFds.clear();
-					lockedRangePaths.clear();
 				}),
 			};
 			using php = new PHP(
@@ -1561,42 +1550,6 @@ error_log = ${errorLogPath}
 			);
 			expect(fileLockManager.releaseLocksForProcess).toHaveBeenCalled();
 			expect(remainingLocksAtProcessRelease).toEqual([[]]);
-
-			const rangeLockFileName = 'range-locked-unlinked.sqlite';
-			const nativeRangeLockFilePath = join(tempDir, rangeLockFileName);
-			const vfsRangeLockFilePath = `${vfsMountPoint}/${rangeLockFileName}`;
-			writeFileSync(nativeRangeLockFilePath, '');
-			const expectedRangeLockNativeFilePath = realpathSync(
-				nativeRangeLockFilePath
-			);
-
-			const rangeLockResult = await php.run({
-				code: `<?php
-						$db = new SQLite3('${vfsRangeLockFilePath}');
-						$db->exec('CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT)');
-						$db->exec('BEGIN EXCLUSIVE');
-						$db->querySingle('SELECT COUNT(*) FROM test');
-						if (!unlink('${vfsRangeLockFilePath}')) {
-							throw new Error('Failed to unlink test database');
-						}
-						// Intentionally leave the database connection open until shutdown.
-					`,
-			});
-
-			expect(rangeLockResult.exitCode).toBe(0);
-			expect(fileLockManager.lockFileByteRange).toHaveBeenCalledWith(
-				expectedRangeLockNativeFilePath,
-				expect.objectContaining({
-					type: expect.stringMatching(/^(shared|exclusive)$/),
-				}),
-				expect.any(Boolean)
-			);
-			expect(fileLockManager.releaseLocksOnFdClose).toHaveBeenCalledWith(
-				expect.any(Number),
-				expect.any(Number),
-				expectedRangeLockNativeFilePath
-			);
-			expect(remainingLocksAtProcessRelease).toEqual([[], []]);
 		});
 
 		test(`should not attempt to lock a MEMFS file or a PROXYFS node that wraps a MEMFS file`, async () => {


### PR DESCRIPTION
Fixes #3830.

## Why

SQLite WAL mode opens and byte-range locks `.ht.sqlite-shm`. In the failing path, SQLite can unlink that shm file before the corresponding file descriptor is closed. The old close-time cleanup tried to rediscover the shared filesystem/native path from the fd at close time; after the unlink, that lookup no longer identified `.ht.sqlite-shm`, so `releaseLocksOnFdClose()` was never called for the shm fd.

That left the lock manager with bookkeeping for a file descriptor PHP had already closed. Later, when the PHP-WASM process released all locks, the POSIX lock manager still tried to unlock using that stale native fd and crashed with `EBADF`.

The minimal fix is to remember the native path when a lock is successfully acquired, while the fd/path relationship is still known, and use that cached path for close-time lock cleanup even if the file has since been unlinked.

## Limitation

This does not make the existing path-keyed lock bookkeeping rename-safe. If a locked file is renamed while locking is occurring, later lock operations may refer to the same underlying file through a different path than the one cached here. We are leaving that out of scope for this PR because fixing it correctly in this layer is potentially complicated, and the more complete, POSIX-compliant behavior should be available in Kandelo.

## What changed

- Added a regression test that exercises SQLite WAL on `.ht.sqlite` and verifies `.ht.sqlite-shm` byte-range locks are released when the file descriptor closes.
- Added a generic unlink test for the same fd-path cleanup behavior using whole-file locks. PHP exposes `flock()`, but not a direct non-SQLite `fcntl()` byte-range API, so byte-range coverage remains in the SQLite WAL regression.
- Cached the native path when a fd first acquires a lock, so close-time cleanup can still release lock manager state after SQLite unlinks the shm file.
- Removed cached fd-path entries when the fd closes, and cleared the cache after successful process-level lock cleanup.
- Added an inline warning that this path-keyed cache handles unlinked files, but is not sufficient for rename-safe lock bookkeeping.
- Kept the fix scoped to file-lock bookkeeping in the Node PHP-WASM user-space layer.

## Verification

- Confirmed the new regression test failed before the fix: `releaseLocksOnFdClose` was called for `.ht.sqlite`, but not for `.ht.sqlite-shm`.
- `PHP=8.3 npx nx run php-wasm-node:test-file-locking-asyncify --testFile=php-file-locking.spec.ts --testNamePattern="whole-file locks|SQLite WAL shared-memory"`
- `PHP=8.3 npx nx run php-wasm-node:test-file-locking-jspi --testFile=php-file-locking.spec.ts --testNamePattern="whole-file locks|SQLite WAL shared-memory"`
- `npx nx run php-wasm-node:test-file-locking-asyncify`
- `npx nx run php-wasm-node:test-file-locking-jspi`
- `npx nx run php-wasm-node:typecheck`
