### PR TITLE
[codex] Add durable MEMFS snapshotting for SQLite sync

### DIFF
--- a/packages/php-wasm/universal/src/lib/filesystem-snapshot.spec.ts
+++ b/packages/php-wasm/universal/src/lib/filesystem-snapshot.spec.ts
@@ -1,0 +1,293 @@
+import { describe, expect, it } from 'vitest';
+import {
+	diffSnapshots,
+	hashBytes,
+	restoreFilesystemSnapshot,
+	snapshotFilesystem,
+} from './filesystem-snapshot';
+
+const FILE_TYPE_MODE = 0o100000;
+const DIR_TYPE_MODE = 0o040000;
+const LINK_TYPE_MODE = 0o120000;
+const FILE_MODE = FILE_TYPE_MODE | 0o644;
+const DIR_MODE = DIR_TYPE_MODE | 0o755;
+const LINK_MODE = LINK_TYPE_MODE | 0o777;
+
+describe('filesystem snapshots', () => {
+	it('lists snapshot entries with paths, hashes, and copied bytes', async () => {
+		const FS = createFakeFS({
+			'/wordpress/wp-content/database/.ht.sqlite': bytes('database'),
+			'/wordpress/wp-content/database/.ht.sqlite-wal': bytes('wal'),
+			'/wordpress/wp-content/uploads/image.bin': new Uint8Array([
+				0, 1, 2,
+			]),
+		});
+		FS.symlink('../uploads/image.bin', '/wordpress/wp-content/image-link');
+
+		const snapshot = await snapshotFilesystem(FS as any, '/wordpress', {
+			includeBytes: true,
+			createdAt: '2026-06-25T00:00:00.000Z',
+		});
+		const entriesByPath = new Map(
+			snapshot.entries.map((entry) => [entry.path, entry])
+		);
+
+		expect(snapshot.root).toBe('/wordpress');
+		expect(snapshot.id).toMatch(/^sha256:/);
+		expect(entriesByPath.get('/wordpress')?.type).toBe('directory');
+		expect(
+			entriesByPath.get('/wordpress/wp-content/image-link')
+		).toMatchObject({
+			type: 'symlink',
+			target: '../uploads/image.bin',
+		});
+		const database = entriesByPath.get(
+			'/wordpress/wp-content/database/.ht.sqlite'
+		);
+		expect(database).toMatchObject({
+			type: 'file',
+			size: bytes('database').byteLength,
+			hash: await hashBytes(bytes('database')),
+		});
+		expect(Array.from((database as any).bytes)).toEqual(
+			Array.from(bytes('database'))
+		);
+
+		FS.writeFile('/wordpress/wp-content/database/.ht.sqlite', bytes('new'));
+
+		expect(Array.from((database as any).bytes)).toEqual(
+			Array.from(bytes('database'))
+		);
+	});
+
+	it('diffs snapshots into create, update, delete, and metadata sets', async () => {
+		const FS = createFakeFS({
+			'/site/a.txt': bytes('a'),
+			'/site/delete.txt': bytes('delete'),
+			'/site/same.txt': bytes('same'),
+			'/site/type-change': bytes('file'),
+		});
+		const before = await snapshotFilesystem(FS as any, '/site', {
+			includeBytes: true,
+			createdAt: '2026-06-25T00:00:00.000Z',
+		});
+
+		FS.writeFile('/site/a.txt', bytes('updated'));
+		FS.unlink('/site/delete.txt');
+		FS.unlink('/site/type-change');
+		FS.mkdirTree('/site/type-change');
+		FS.writeFile('/site/create.txt', bytes('create'));
+		FS.symlink('same.txt', '/site/link');
+		const after = await snapshotFilesystem(FS as any, '/site', {
+			includeBytes: true,
+			createdAt: '2026-06-25T00:00:01.000Z',
+		});
+
+		const delta = diffSnapshots(before, after, {
+			includeUnchanged: true,
+		});
+
+		expect(delta.toSnapshotId).toBe(after.id);
+		expect(delta.fromSnapshotId).toBe(before.id);
+		expect(delta.create.map((entry) => entry.path)).toEqual([
+			'/site/create.txt',
+			'/site/link',
+			'/site/type-change',
+		]);
+		expect(delta.update.map((entry) => entry.path)).toEqual([
+			'/site/a.txt',
+		]);
+		expect(delta.delete).toEqual(['/site/delete.txt', '/site/type-change']);
+		expect(delta.metadata).toEqual([]);
+		expect(delta.unchanged?.map((entry) => entry.path)).toContain(
+			'/site/same.txt'
+		);
+	});
+
+	it('restores snapshots to another root', async () => {
+		const source = createFakeFS({
+			'/site/content/file.txt': bytes('file'),
+		});
+		source.symlink('content/file.txt', '/site/link');
+		const snapshot = await snapshotFilesystem(source as any, '/site', {
+			includeBytes: true,
+			createdAt: '2026-06-25T00:00:00.000Z',
+		});
+		const target = createFakeFS({});
+
+		await restoreFilesystemSnapshot(target as any, snapshot, '/restored');
+
+		expect(text(target.readFile('/restored/content/file.txt'))).toBe(
+			'file'
+		);
+		expect(target.readlink('/restored/link')).toBe('content/file.txt');
+	});
+});
+
+type FakeEntry =
+	| {
+			type: 'directory';
+			children: Map<string, FakeEntry>;
+			mode: number;
+	  }
+	| {
+			type: 'file';
+			bytes: Uint8Array;
+			mode: number;
+	  }
+	| {
+			type: 'symlink';
+			target: string;
+			mode: number;
+	  };
+
+class FakeFS {
+	private readonly root: FakeEntry = {
+		type: 'directory',
+		children: new Map(),
+		mode: DIR_MODE,
+	};
+
+	constructor(files: Record<string, Uint8Array>) {
+		for (const [path, contents] of Object.entries(files)) {
+			this.writeFile(path, contents);
+		}
+	}
+
+	lookupPath(path: string) {
+		return {
+			path: normalizeFakePath(path),
+			node: this.getEntry(path),
+		};
+	}
+
+	readdir(path: string) {
+		const entry = this.getEntry(path);
+		if (entry.type !== 'directory') {
+			throw new Error(`Not a directory: ${path}`);
+		}
+		return ['.', '..', ...entry.children.keys()];
+	}
+
+	readFile(path: string) {
+		const entry = this.getEntry(path);
+		if (entry.type !== 'file') {
+			throw new Error(`Not a file: ${path}`);
+		}
+		return new Uint8Array(entry.bytes);
+	}
+
+	writeFile(path: string, data: Uint8Array) {
+		const parent = this.mkdirTree(parentPath(path));
+		parent.children.set(baseName(path), {
+			type: 'file',
+			bytes: new Uint8Array(data),
+			mode: FILE_MODE,
+		});
+	}
+
+	mkdirTree(path: string) {
+		let current = this.root;
+		for (const part of pathParts(path)) {
+			if (current.type !== 'directory') {
+				throw new Error(`Not a directory: ${path}`);
+			}
+			let next = current.children.get(part);
+			if (next === undefined) {
+				next = {
+					type: 'directory',
+					children: new Map(),
+					mode: DIR_MODE,
+				};
+				current.children.set(part, next);
+			}
+			current = next;
+		}
+		if (current.type !== 'directory') {
+			throw new Error(`Not a directory: ${path}`);
+		}
+		return current;
+	}
+
+	unlink(path: string) {
+		const parent = this.getEntry(parentPath(path));
+		if (parent.type !== 'directory') {
+			throw new Error(`Not a directory: ${path}`);
+		}
+		parent.children.delete(baseName(path));
+	}
+
+	symlink(target: string, path: string) {
+		const parent = this.mkdirTree(parentPath(path));
+		parent.children.set(baseName(path), {
+			type: 'symlink',
+			target,
+			mode: LINK_MODE,
+		});
+	}
+
+	readlink(path: string) {
+		const entry = this.getEntry(path);
+		if (entry.type !== 'symlink') {
+			throw new Error(`Not a symlink: ${path}`);
+		}
+		return entry.target;
+	}
+
+	isDir(mode: number) {
+		return (mode & 0o170000) === DIR_TYPE_MODE;
+	}
+
+	isFile(mode: number) {
+		return (mode & 0o170000) === FILE_TYPE_MODE;
+	}
+
+	isLink(mode: number) {
+		return (mode & 0o170000) === LINK_TYPE_MODE;
+	}
+
+	private getEntry(path: string) {
+		let current = this.root;
+		for (const part of pathParts(path)) {
+			if (current.type !== 'directory') {
+				throw new Error(`Not a directory: ${path}`);
+			}
+			const next = current.children.get(part);
+			if (next === undefined) {
+				throw new Error(`Path not found: ${path}`);
+			}
+			current = next;
+		}
+		return current;
+	}
+}
+
+function createFakeFS(files: Record<string, Uint8Array>) {
+	return new FakeFS(files);
+}
+
+function bytes(text: string) {
+	return new TextEncoder().encode(text);
+}
+
+function text(bytes: Uint8Array) {
+	return new TextDecoder().decode(bytes);
+}
+
+function normalizeFakePath(path: string) {
+	return `/${pathParts(path).join('/')}`;
+}
+
+function pathParts(path: string) {
+	return path.split('/').filter(Boolean);
+}
+
+function parentPath(path: string) {
+	const parts = pathParts(path);
+	parts.pop();
+	return `/${parts.join('/')}`;
+}
+
+function baseName(path: string) {
+	return pathParts(path).at(-1) ?? '/';
+}

--- a/packages/php-wasm/universal/src/lib/filesystem-snapshot.ts
+++ b/packages/php-wasm/universal/src/lib/filesystem-snapshot.ts
@@ -1,0 +1,499 @@
+import { dirname, joinPaths, normalizePath } from '@php-wasm/util';
+import type { Emscripten } from './emscripten-types';
+
+export const FILESYSTEM_SNAPSHOT_VERSION = 1;
+const HASH_ALGORITHM = 'sha256';
+
+export type SnapshotEntryType = 'file' | 'directory' | 'symlink';
+
+export type SnapshotEntryBase = {
+	path: string;
+	type: SnapshotEntryType;
+	mode?: number;
+};
+
+export type SnapshotFileEntry = SnapshotEntryBase & {
+	type: 'file';
+	size: number;
+	hash: string;
+	bytes?: Uint8Array;
+};
+
+export type SnapshotDirectoryEntry = SnapshotEntryBase & {
+	type: 'directory';
+};
+
+export type SnapshotSymlinkEntry = SnapshotEntryBase & {
+	type: 'symlink';
+	target: string;
+};
+
+export type SnapshotEntry =
+	| SnapshotFileEntry
+	| SnapshotDirectoryEntry
+	| SnapshotSymlinkEntry;
+
+export type FilesystemSnapshot = {
+	version: typeof FILESYSTEM_SNAPSHOT_VERSION;
+	id: string;
+	root: string;
+	createdAt: string;
+	parentId?: string;
+	entries: SnapshotEntry[];
+};
+
+export type SnapshotFilesystemOptions = {
+	includeBytes?: boolean;
+	parentId?: string;
+	createdAt?: string;
+	ignoreUnsupportedNodes?: boolean;
+	shouldIncludePath?: (
+		path: string,
+		type: SnapshotEntryType
+	) => boolean | Promise<boolean>;
+};
+
+export type SnapshotDelta = {
+	fromSnapshotId?: string;
+	toSnapshotId: string;
+	create: SnapshotEntry[];
+	update: SnapshotFileEntry[];
+	delete: string[];
+	metadata: SnapshotEntry[];
+	unchanged?: SnapshotEntry[];
+};
+
+export type DiffSnapshotsOptions = {
+	includeUnchanged?: boolean;
+};
+
+export type RestoreFilesystemSnapshotOptions = {
+	blobReader?: (entry: SnapshotFileEntry) => Promise<Uint8Array>;
+};
+
+export async function snapshotFilesystem(
+	FS: Emscripten.RootFS,
+	root: string,
+	options: SnapshotFilesystemOptions = {}
+): Promise<FilesystemSnapshot> {
+	root = normalizeSnapshotPath(root);
+	const entries = await snapshotEntries(FS, root, options);
+	const snapshotWithoutId: Omit<FilesystemSnapshot, 'id'> = {
+		version: FILESYSTEM_SNAPSHOT_VERSION,
+		root,
+		createdAt: options.createdAt ?? new Date().toISOString(),
+		parentId: options.parentId,
+		entries,
+	};
+	const id = await snapshotId(snapshotWithoutId);
+	return {
+		...snapshotWithoutId,
+		id,
+	};
+}
+
+export function stripSnapshotBytes(
+	snapshot: FilesystemSnapshot
+): FilesystemSnapshot {
+	return {
+		...snapshot,
+		entries: snapshot.entries.map(stripEntryBytes),
+	};
+}
+
+export function diffSnapshots(
+	before: FilesystemSnapshot | undefined,
+	after: FilesystemSnapshot,
+	options: DiffSnapshotsOptions = {}
+): SnapshotDelta {
+	const beforeEntries = new Map<string, SnapshotEntry>();
+	for (const entry of before?.entries ?? []) {
+		beforeEntries.set(entry.path, entry);
+	}
+
+	const create: SnapshotEntry[] = [];
+	const update: SnapshotFileEntry[] = [];
+	const metadata: SnapshotEntry[] = [];
+	const unchanged: SnapshotEntry[] = [];
+	const seenAfter = new Set<string>();
+	const deleted = new Set<string>();
+
+	for (const afterEntry of after.entries) {
+		seenAfter.add(afterEntry.path);
+		const beforeEntry = beforeEntries.get(afterEntry.path);
+		if (beforeEntry === undefined) {
+			create.push(afterEntry);
+			continue;
+		}
+		if (beforeEntry.type !== afterEntry.type) {
+			deleted.add(beforeEntry.path);
+			create.push(afterEntry);
+			continue;
+		}
+		if (entryContentsChanged(beforeEntry, afterEntry)) {
+			if (afterEntry.type === 'file') {
+				update.push(afterEntry);
+			} else {
+				metadata.push(afterEntry);
+			}
+			continue;
+		}
+		if (entryMetadataChanged(beforeEntry, afterEntry)) {
+			metadata.push(afterEntry);
+			continue;
+		}
+		if (options.includeUnchanged) {
+			unchanged.push(afterEntry);
+		}
+	}
+
+	for (const path of beforeEntries.keys()) {
+		if (!seenAfter.has(path)) {
+			deleted.add(path);
+		}
+	}
+
+	const delta: SnapshotDelta = {
+		fromSnapshotId: before?.id,
+		toSnapshotId: after.id,
+		create,
+		update,
+		delete: Array.from(deleted).sort(deepestPathFirst),
+		metadata,
+	};
+	if (options.includeUnchanged) {
+		delta.unchanged = unchanged;
+	}
+	return delta;
+}
+
+export async function restoreFilesystemSnapshot(
+	FS: Emscripten.RootFS,
+	snapshot: FilesystemSnapshot,
+	targetRoot = snapshot.root,
+	options: RestoreFilesystemSnapshotOptions = {}
+) {
+	targetRoot = normalizeSnapshotPath(targetRoot);
+	const entries = [...snapshot.entries].sort(shallowestPathFirst);
+	for (const entry of entries) {
+		const targetPath = mapSnapshotPathToTarget(
+			snapshot.root,
+			targetRoot,
+			entry.path
+		);
+		if (entry.type === 'directory') {
+			FS.mkdirTree(targetPath);
+		} else if (entry.type === 'file') {
+			FS.mkdirTree(dirname(targetPath));
+			const bytes = await getEntryBytes(entry, options);
+			FS.writeFile(targetPath, bytes);
+		} else {
+			FS.mkdirTree(dirname(targetPath));
+			try {
+				FS.unlink(targetPath);
+			} catch {
+				// It is fine if the link target does not exist yet.
+			}
+			FS.symlink(entry.target, targetPath);
+		}
+	}
+}
+
+export async function hashBytes(bytes: Uint8Array): Promise<string> {
+	const digest = await sha256(bytes);
+	return `${HASH_ALGORITHM}:${bytesToHex(digest)}`;
+}
+
+async function snapshotEntries(
+	FS: Emscripten.RootFS,
+	root: string,
+	options: SnapshotFilesystemOptions
+) {
+	const entries: SnapshotEntry[] = [];
+	const stack = [root];
+	while (stack.length > 0) {
+		const path = stack.pop()!;
+		const entry = await snapshotEntry(FS, path, options);
+		if (entry === undefined) {
+			continue;
+		}
+		entries.push(entry);
+		if (entry.type === 'directory') {
+			const children = FS.readdir(path)
+				.filter((name: string) => name !== '.' && name !== '..')
+				.sort();
+			for (let i = children.length - 1; i >= 0; i--) {
+				stack.push(joinPaths(path, children[i]));
+			}
+		}
+	}
+	return entries;
+}
+
+async function snapshotEntry(
+	FS: Emscripten.RootFS,
+	path: string,
+	options: SnapshotFilesystemOptions
+): Promise<SnapshotEntry | undefined> {
+	const lookup = FS.lookupPath(path, { follow: false });
+	const { mode } = lookup.node;
+	if (FS.isDir(mode)) {
+		return maybeIncludeEntry(options, {
+			type: 'directory',
+			path,
+			mode,
+		});
+	}
+	if (FS.isLink(mode)) {
+		return maybeIncludeEntry(options, {
+			type: 'symlink',
+			path,
+			mode,
+			target: FS.readlink(path),
+		});
+	}
+	if (FS.isFile(mode)) {
+		const bytes = copyBytes(
+			FS.readFile(path, {
+				encoding: 'binary',
+			}) as Uint8Array
+		);
+		return maybeIncludeEntry(options, {
+			type: 'file',
+			path,
+			mode,
+			size: bytes.byteLength,
+			hash: await hashBytes(bytes),
+			...(options.includeBytes ? { bytes } : {}),
+		});
+	}
+	if (options.ignoreUnsupportedNodes) {
+		return undefined;
+	}
+	throw new Error(`Cannot snapshot unsupported filesystem node: ${path}`);
+}
+
+async function maybeIncludeEntry<T extends SnapshotEntry>(
+	options: SnapshotFilesystemOptions,
+	entry: T
+) {
+	if (!(await options.shouldIncludePath?.(entry.path, entry.type))) {
+		if (options.shouldIncludePath !== undefined) {
+			return undefined;
+		}
+	}
+	return entry;
+}
+
+async function snapshotId(
+	snapshot: Omit<FilesystemSnapshot, 'id'>
+): Promise<string> {
+	return await hashBytes(
+		new TextEncoder().encode(
+			JSON.stringify({
+				version: snapshot.version,
+				root: snapshot.root,
+				parentId: snapshot.parentId,
+				entries: snapshot.entries.map(stripEntryBytes),
+			})
+		)
+	);
+}
+
+function stripEntryBytes(entry: SnapshotEntry): SnapshotEntry {
+	if (entry.type !== 'file' || entry.bytes === undefined) {
+		return { ...entry };
+	}
+	const entryWithoutBytes: SnapshotFileEntry = { ...entry };
+	delete entryWithoutBytes.bytes;
+	return entryWithoutBytes;
+}
+
+function entryContentsChanged(
+	before: SnapshotEntry,
+	after: SnapshotEntry
+): boolean {
+	if (before.type !== after.type) {
+		return true;
+	}
+	if (before.type === 'file' && after.type === 'file') {
+		return before.hash !== after.hash;
+	}
+	if (before.type === 'symlink' && after.type === 'symlink') {
+		return before.target !== after.target;
+	}
+	return false;
+}
+
+function entryMetadataChanged(
+	before: SnapshotEntry,
+	after: SnapshotEntry
+): boolean {
+	return before.mode !== after.mode;
+}
+
+async function getEntryBytes(
+	entry: SnapshotFileEntry,
+	options: RestoreFilesystemSnapshotOptions
+): Promise<Uint8Array> {
+	if (entry.bytes !== undefined) {
+		return entry.bytes;
+	}
+	if (options.blobReader !== undefined) {
+		return await options.blobReader(entry);
+	}
+	throw new Error(
+		`Cannot restore ${entry.path}: snapshot entry does not include bytes.`
+	);
+}
+
+function normalizeSnapshotPath(path: string) {
+	return normalizePath(path || '/');
+}
+
+function mapSnapshotPathToTarget(
+	snapshotRoot: string,
+	targetRoot: string,
+	entryPath: string
+) {
+	if (entryPath === snapshotRoot) {
+		return targetRoot;
+	}
+	return joinPaths(targetRoot, entryPath.substring(snapshotRoot.length));
+}
+
+function copyBytes(bytes: Uint8Array) {
+	return new Uint8Array(bytes);
+}
+
+function shallowestPathFirst(a: SnapshotEntry, b: SnapshotEntry) {
+	return (
+		pathDepth(a.path) - pathDepth(b.path) || a.path.localeCompare(b.path)
+	);
+}
+
+function deepestPathFirst(a: string, b: string) {
+	return pathDepth(b) - pathDepth(a) || a.localeCompare(b);
+}
+
+function pathDepth(path: string) {
+	return path.split('/').filter(Boolean).length;
+}
+
+async function sha256(bytes: Uint8Array): Promise<Uint8Array> {
+	if (globalThis.crypto?.subtle !== undefined) {
+		const digest = await globalThis.crypto.subtle.digest('SHA-256', bytes);
+		return new Uint8Array(digest);
+	}
+	return sha256Sync(bytes);
+}
+
+function bytesToHex(bytes: Uint8Array) {
+	return Array.from(bytes)
+		.map((byte) => byte.toString(16).padStart(2, '0'))
+		.join('');
+}
+
+function sha256Sync(bytes: Uint8Array): Uint8Array {
+	const constants = new Uint32Array(64);
+	let prime = 2;
+	let found = 0;
+	while (found < constants.length) {
+		if (isPrime(prime)) {
+			const root = Math.cbrt(prime);
+			const fraction = root - Math.floor(root);
+			constants[found++] = Math.floor(fraction * 0x100000000);
+		}
+		prime++;
+	}
+
+	const hash = new Uint32Array([
+		0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c,
+		0x1f83d9ab, 0x5be0cd19,
+	]);
+	const padded = padSha256(bytes);
+	const words = new Uint32Array(64);
+
+	for (let offset = 0; offset < padded.length; offset += 64) {
+		for (let i = 0; i < 16; i++) {
+			words[i] =
+				(padded[offset + i * 4] << 24) |
+				(padded[offset + i * 4 + 1] << 16) |
+				(padded[offset + i * 4 + 2] << 8) |
+				padded[offset + i * 4 + 3];
+		}
+		for (let i = 16; i < 64; i++) {
+			const s0 =
+				rotateRight(words[i - 15], 7) ^
+				rotateRight(words[i - 15], 18) ^
+				(words[i - 15] >>> 3);
+			const s1 =
+				rotateRight(words[i - 2], 17) ^
+				rotateRight(words[i - 2], 19) ^
+				(words[i - 2] >>> 10);
+			words[i] = words[i - 16] + s0 + words[i - 7] + s1;
+		}
+
+		let [a, b, c, d, e, f, g, h] = hash;
+		for (let i = 0; i < 64; i++) {
+			const s1 =
+				rotateRight(e, 6) ^ rotateRight(e, 11) ^ rotateRight(e, 25);
+			const ch = (e & f) ^ (~e & g);
+			const temp1 = h + s1 + ch + constants[i] + words[i];
+			const s0 =
+				rotateRight(a, 2) ^ rotateRight(a, 13) ^ rotateRight(a, 22);
+			const maj = (a & b) ^ (a & c) ^ (b & c);
+			const temp2 = s0 + maj;
+			h = g;
+			g = f;
+			f = e;
+			e = d + temp1;
+			d = c;
+			c = b;
+			b = a;
+			a = temp1 + temp2;
+		}
+
+		hash[0] += a;
+		hash[1] += b;
+		hash[2] += c;
+		hash[3] += d;
+		hash[4] += e;
+		hash[5] += f;
+		hash[6] += g;
+		hash[7] += h;
+	}
+
+	const digest = new Uint8Array(32);
+	for (let i = 0; i < hash.length; i++) {
+		digest[i * 4] = hash[i] >>> 24;
+		digest[i * 4 + 1] = hash[i] >>> 16;
+		digest[i * 4 + 2] = hash[i] >>> 8;
+		digest[i * 4 + 3] = hash[i];
+	}
+	return digest;
+}
+
+function padSha256(bytes: Uint8Array) {
+	const bitLength = bytes.length * 8;
+	const paddedLength = Math.ceil((bytes.length + 9) / 64) * 64;
+	const padded = new Uint8Array(paddedLength);
+	padded.set(bytes);
+	padded[bytes.length] = 0x80;
+	const view = new DataView(padded.buffer);
+	view.setUint32(paddedLength - 4, bitLength, false);
+	return padded;
+}
+
+function rotateRight(value: number, bits: number) {
+	return (value >>> bits) | (value << (32 - bits));
+}
+
+function isPrime(value: number) {
+	for (let i = 2; i * i <= value; i++) {
+		if (value % i === 0) {
+			return false;
+		}
+	}
+	return true;
+}

--- a/packages/php-wasm/universal/src/lib/index.ts
+++ b/packages/php-wasm/universal/src/lib/index.ts
@@ -100,6 +100,27 @@ export { rotatePHPRuntime } from './rotate-php-runtime';
 export { writeFiles } from './write-files';
 export type { FileTree } from './write-files';
 export {
+	FILESYSTEM_SNAPSHOT_VERSION,
+	diffSnapshots,
+	hashBytes,
+	restoreFilesystemSnapshot,
+	snapshotFilesystem,
+	stripSnapshotBytes,
+} from './filesystem-snapshot';
+export type {
+	DiffSnapshotsOptions,
+	FilesystemSnapshot,
+	RestoreFilesystemSnapshotOptions,
+	SnapshotDelta,
+	SnapshotDirectoryEntry,
+	SnapshotEntry,
+	SnapshotEntryBase,
+	SnapshotEntryType,
+	SnapshotFileEntry,
+	SnapshotFilesystemOptions,
+	SnapshotSymlinkEntry,
+} from './filesystem-snapshot';
+export {
 	withResolvedPHPExtensions,
 	installPHPExtensionFilesSync,
 	PHP_EXTENSIONS_DIR,

--- a/packages/php-wasm/universal/src/lib/php-worker.ts
+++ b/packages/php-wasm/universal/src/lib/php-worker.ts
@@ -1,5 +1,10 @@
 import type { EmscriptenDownloadMonitor } from '@php-wasm/progress';
 import type { ListFilesOptions, RmDirOptions } from './fs-helpers';
+import type {
+	FilesystemSnapshot,
+	RestoreFilesystemSnapshotOptions,
+	SnapshotFilesystemOptions,
+} from './filesystem-snapshot';
 import type { PHP } from './php';
 import type { PHPRequestHandler } from './php-request-handler';
 import type { PHPResponse, StreamedPHPResponse } from './php-response';
@@ -34,6 +39,8 @@ export type LimitedPHPApi = Pick<
 	| 'listFiles'
 	| 'isDir'
 	| 'fileExists'
+	| 'snapshotFilesystem'
+	| 'restoreFilesystemSnapshot'
 	| 'chdir'
 	| 'run'
 	| 'onMessage'
@@ -322,6 +329,25 @@ export class PHPWorker implements LimitedPHPApi, AsyncDisposable {
 	/** @inheritDoc @php-wasm/universal!/PHP.fileExists */
 	fileExists(path: string): boolean {
 		return _private.get(this)!.php!.fileExists(path);
+	}
+
+	/** @inheritDoc @php-wasm/universal!/PHP.snapshotFilesystem */
+	async snapshotFilesystem(
+		root: string,
+		options?: SnapshotFilesystemOptions
+	): Promise<FilesystemSnapshot> {
+		return await _private.get(this)!.php!.snapshotFilesystem(root, options);
+	}
+
+	/** @inheritDoc @php-wasm/universal!/PHP.restoreFilesystemSnapshot */
+	async restoreFilesystemSnapshot(
+		snapshot: FilesystemSnapshot,
+		targetRoot?: string,
+		options?: RestoreFilesystemSnapshotOptions
+	): Promise<void> {
+		await _private
+			.get(this)!
+			.php!.restoreFilesystemSnapshot(snapshot, targetRoot, options);
 	}
 
 	/** @inheritDoc @php-wasm/universal!/PHP.onMessage */

--- a/packages/php-wasm/universal/src/lib/php.ts
+++ b/packages/php-wasm/universal/src/lib/php.ts
@@ -9,6 +9,15 @@ import {
 import type { Emscripten } from './emscripten-types';
 import type { ListFilesOptions, RmDirOptions } from './fs-helpers';
 import { FSHelpers } from './fs-helpers';
+import type {
+	FilesystemSnapshot,
+	RestoreFilesystemSnapshotOptions,
+	SnapshotFilesystemOptions,
+} from './filesystem-snapshot';
+import {
+	restoreFilesystemSnapshot,
+	snapshotFilesystem,
+} from './filesystem-snapshot';
 import { isExitCode } from './is-exit-code';
 import type { PHPRuntimeId } from './load-php-runtime';
 import { popLoadedRuntime } from './load-php-runtime';
@@ -1367,6 +1376,57 @@ export class PHP implements Disposable {
 	 */
 	fileExists(path: string) {
 		return FSHelpers.fileExists(this[__private__dont__use].FS, path);
+	}
+
+	/**
+	 * Creates a byte-level snapshot of a filesystem subtree.
+	 *
+	 * The PHP request semaphore is held for the full traversal, which prevents
+	 * filesystem writes from racing with byte extraction.
+	 *
+	 * @param root The root path to snapshot.
+	 * @param options Snapshot options.
+	 */
+	async snapshotFilesystem(
+		root: string,
+		options?: SnapshotFilesystemOptions
+	): Promise<FilesystemSnapshot> {
+		const release = await this.semaphore.acquire();
+		try {
+			return await snapshotFilesystem(
+				this[__private__dont__use].FS,
+				root,
+				options
+			);
+		} finally {
+			release();
+		}
+	}
+
+	/**
+	 * Restores a byte-level filesystem snapshot into the PHP filesystem.
+	 *
+	 * @param snapshot The snapshot to restore.
+	 * @param targetRoot Optional root path. Defaults to the snapshot root.
+	 * @param options Restore options.
+	 */
+	async restoreFilesystemSnapshot(
+		snapshot: FilesystemSnapshot,
+		targetRoot?: string,
+		options?: RestoreFilesystemSnapshotOptions
+	) {
+		const release = await this.semaphore.acquire();
+		try {
+			await restoreFilesystemSnapshot(
+				this[__private__dont__use].FS,
+				snapshot,
+				targetRoot,
+				options
+			);
+			this.dispatchEvent({ type: 'filesystem.write' });
+		} finally {
+			release();
+		}
 	}
 
 	/**

--- a/packages/php-wasm/universal/src/test/php-worker.spec.ts
+++ b/packages/php-wasm/universal/src/test/php-worker.spec.ts
@@ -1,5 +1,6 @@
 import { PHPWorker } from '../lib/php-worker';
 import { describe, expect, test, vi } from 'vitest';
+import type { FilesystemSnapshot } from '../lib/filesystem-snapshot';
 import type { PHP } from '../lib/php';
 import type { PHPRequestHandler } from '../lib/php-request-handler';
 
@@ -152,6 +153,39 @@ describe('PlaygroundWorkerEndpoint', () => {
 		expect(actualResponse).toBe(response);
 		expect(primaryPhp.cli).toHaveBeenCalledWith(
 			['php', '/tmp/script.php'],
+			undefined
+		);
+	});
+
+	test('forwards filesystem snapshot operations to the primary PHP instance', async () => {
+		const endpoint = new TestEndpoint();
+		const snapshot: FilesystemSnapshot = {
+			version: 1,
+			id: 'snapshot-id',
+			root: '/wordpress',
+			createdAt: '2026-06-25T00:00:00.000Z',
+			entries: [],
+		};
+		const primaryPhp = {
+			...createMockPHP(),
+			snapshotFilesystem: vi.fn().mockResolvedValue(snapshot),
+			restoreFilesystemSnapshot: vi.fn().mockResolvedValue(undefined),
+		};
+
+		await endpoint.setPrimaryPHP(primaryPhp as unknown as PHP);
+		const actualSnapshot = await endpoint.snapshotFilesystem('/wordpress', {
+			includeBytes: true,
+		});
+		await endpoint.restoreFilesystemSnapshot(snapshot, '/restored');
+
+		expect(actualSnapshot).toBe(snapshot);
+		expect(primaryPhp.snapshotFilesystem).toHaveBeenCalledWith(
+			'/wordpress',
+			{ includeBytes: true }
+		);
+		expect(primaryPhp.restoreFilesystemSnapshot).toHaveBeenCalledWith(
+			snapshot,
+			'/restored',
 			undefined
 		);
 	});

--- a/packages/php-wasm/web/src/lib/directory-handle-mount.spec.ts
+++ b/packages/php-wasm/web/src/lib/directory-handle-mount.spec.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it, vi } from 'vitest';
-import { __private__dont__use, type PHP } from '@php-wasm/universal';
-import { Semaphore } from '@php-wasm/util';
+import {
+	__private__dont__use,
+	type FilesystemSnapshot,
+	type PHP,
+} from '@php-wasm/universal';
+import { Semaphore, joinPaths } from '@php-wasm/util';
 import { logger } from '@php-wasm/logger';
 import {
 	copyMemfsToOpfs,
@@ -12,12 +16,40 @@ class MemoryFileHandle {
 	kind = 'file' as const;
 	bytes = new Uint8Array();
 	name: string;
+	private parent: MemoryDirectoryHandle;
 	private onWrite?: () => void | Promise<void>;
 	private truncated = false;
+	move?: (
+		targetOrName: FileSystemDirectoryHandle | string,
+		name?: string
+	) => Promise<void>;
 
-	constructor(name: string, onWrite?: () => void | Promise<void>) {
+	constructor(
+		name: string,
+		parent: MemoryDirectoryHandle,
+		onWrite?: () => void | Promise<void>,
+		supportsMove = true
+	) {
 		this.name = name;
+		this.parent = parent;
 		this.onWrite = onWrite;
+		if (supportsMove) {
+			this.move = async (
+				targetOrName: FileSystemDirectoryHandle | string,
+				name?: string
+			) => {
+				const target =
+					typeof targetOrName === 'string'
+						? this.parent
+						: (targetOrName as unknown as MemoryDirectoryHandle);
+				const targetName =
+					typeof targetOrName === 'string' ? targetOrName : name!;
+				this.parent.files.delete(this.name);
+				this.name = targetName;
+				this.parent = target;
+				target.files.set(targetName, this);
+			};
+		}
 	}
 
 	async createWritable() {
@@ -39,6 +71,13 @@ class MemoryFileHandle {
 			seek: async () => {},
 		};
 	}
+
+	async getFile() {
+		const bytes = this.bytes.slice();
+		return {
+			arrayBuffer: async () => bytes.buffer,
+		};
+	}
 }
 
 class MemoryDirectoryHandle {
@@ -47,10 +86,16 @@ class MemoryDirectoryHandle {
 	directories = new Map<string, MemoryDirectoryHandle>();
 	name: string;
 	private onFileWrite?: () => void | Promise<void>;
+	private supportsMove: boolean;
 
-	constructor(name: string, onFileWrite?: () => void | Promise<void>) {
+	constructor(
+		name: string,
+		onFileWrite?: () => void | Promise<void>,
+		supportsMove = true
+	) {
 		this.name = name;
 		this.onFileWrite = onFileWrite;
+		this.supportsMove = supportsMove;
 	}
 
 	async getFileHandle(name: string, options?: { create?: boolean }) {
@@ -59,7 +104,12 @@ class MemoryDirectoryHandle {
 			if (!options?.create) {
 				throw new Error(`File not found: ${name}`);
 			}
-			handle = new MemoryFileHandle(name, this.onFileWrite);
+			handle = new MemoryFileHandle(
+				name,
+				this,
+				this.onFileWrite,
+				this.supportsMove
+			);
 			this.files.set(name, handle);
 		}
 		return handle as unknown as FileSystemFileHandle;
@@ -71,7 +121,11 @@ class MemoryDirectoryHandle {
 			if (!options?.create) {
 				throw new Error(`Directory not found: ${name}`);
 			}
-			handle = new MemoryDirectoryHandle(name, this.onFileWrite);
+			handle = new MemoryDirectoryHandle(
+				name,
+				this.onFileWrite,
+				this.supportsMove
+			);
 			this.directories.set(name, handle);
 		}
 		return handle as unknown as FileSystemDirectoryHandle;
@@ -80,6 +134,11 @@ class MemoryDirectoryHandle {
 	async removeEntry(name: string) {
 		this.files.delete(name);
 		this.directories.delete(name);
+	}
+
+	async *values() {
+		yield* this.directories.values();
+		yield* this.files.values();
 	}
 }
 
@@ -99,6 +158,182 @@ describe('journalFSEventsToOpfs', () => {
 		await mount.flush();
 
 		expect(decode(opfsRoot.files.get('file.txt')!.bytes)).toBe('saved');
+	});
+
+	it('flushes the live SQLite database when snapshots are not configured', async () => {
+		const { FS, files, php } = createFakePhp();
+		const opfsRoot = new MemoryDirectoryHandle('root');
+		const mount = journalFSEventsToOpfs(
+			php,
+			opfsRoot as unknown as FileSystemDirectoryHandle,
+			'/wordpress'
+		);
+
+		files.set(
+			'/wordpress/wp-content/database/.ht.sqlite',
+			encode('live sqlite bytes')
+		);
+		FS.write({ path: '/wordpress/wp-content/database/.ht.sqlite' });
+
+		await mount.flush();
+
+		const database = opfsRoot.directories
+			.get('wp-content')!
+			.directories.get('database')!;
+		expect(decode(database.files.get('.ht.sqlite')!.bytes)).toBe(
+			'live sqlite bytes'
+		);
+	});
+
+	it('does not flush the live SQLite database or sidecars when snapshots are configured', async () => {
+		const { FS, files, php } = createFakePhp();
+		const opfsRoot = new MemoryDirectoryHandle('root');
+		const onSqliteDatabaseWrite = vi.fn();
+		const mount = journalFSEventsToOpfs(
+			php,
+			opfsRoot as unknown as FileSystemDirectoryHandle,
+			'/wordpress',
+			{
+				onSqliteDatabaseWrite,
+			}
+		);
+
+		for (const path of [
+			'/wordpress/wp-content/database/.ht.sqlite',
+			'/wordpress/wp-content/database/.ht.sqlite-journal',
+			'/wordpress/wp-content/database/.ht.sqlite-wal',
+			'/wordpress/wp-content/database/.ht.sqlite-shm',
+		]) {
+			files.set(path, encode('live sqlite bytes'));
+			FS.write({ path });
+		}
+
+		await mount.flush();
+
+		expect(opfsRoot.directories.has('wp-content')).toBe(false);
+		expect(onSqliteDatabaseWrite).toHaveBeenCalledTimes(1);
+	});
+
+	it('does not notify the snapshot publisher for non-SQLite writes', async () => {
+		const { FS, files, php } = createFakePhp();
+		const opfsRoot = new MemoryDirectoryHandle('root');
+		const onSqliteDatabaseWrite = vi.fn();
+		const mount = journalFSEventsToOpfs(
+			php,
+			opfsRoot as unknown as FileSystemDirectoryHandle,
+			'/wordpress',
+			{
+				onSqliteDatabaseWrite,
+			}
+		);
+
+		files.set('/wordpress/readme.txt', encode('saved'));
+		FS.write({ path: '/wordpress/readme.txt' });
+
+		await mount.flush();
+
+		expect(decode(opfsRoot.files.get('readme.txt')!.bytes)).toBe('saved');
+		expect(onSqliteDatabaseWrite).not.toHaveBeenCalled();
+	});
+
+	it('persists a SQLite snapshot as the canonical OPFS database file', async () => {
+		const { files, php } = createFakePhp();
+		const opfsRoot = new MemoryDirectoryHandle('root');
+		const mount = journalFSEventsToOpfs(
+			php,
+			opfsRoot as unknown as FileSystemDirectoryHandle,
+			'/wordpress'
+		);
+
+		files.set('/tmp/playground-sqlite-snapshot.sqlite', encode('snapshot'));
+		await mount.persistSqliteSnapshot(
+			'/tmp/playground-sqlite-snapshot.sqlite'
+		);
+
+		const database = opfsRoot.directories
+			.get('wp-content')!
+			.directories.get('database')!;
+		expect(decode(database.files.get('.ht.sqlite')!.bytes)).toBe(
+			'snapshot'
+		);
+		expect(database.files.has('.ht.sqlite.copy')).toBe(false);
+	});
+
+	it('persists a SQLite filesystem snapshot with WAL sidecars', async () => {
+		const { php } = createFakePhp();
+		const opfsRoot = new MemoryDirectoryHandle('root');
+		const wpContent = (await opfsRoot.getDirectoryHandle('wp-content', {
+			create: true,
+		})) as unknown as MemoryDirectoryHandle;
+		const database = (await wpContent.getDirectoryHandle('database', {
+			create: true,
+		})) as unknown as MemoryDirectoryHandle;
+		for (const name of ['.ht.sqlite-journal', '.ht.sqlite.tmp']) {
+			const file = (await database.getFileHandle(name, {
+				create: true,
+			})) as unknown as MemoryFileHandle;
+			file.bytes = encode('stale');
+		}
+		const mount = journalFSEventsToOpfs(
+			php,
+			opfsRoot as unknown as FileSystemDirectoryHandle,
+			'/wordpress'
+		);
+
+		await mount.persistSqliteSnapshot(
+			createSqliteFilesystemSnapshot({
+				'.ht.sqlite': 'main',
+				'.ht.sqlite-wal': 'wal',
+				'.ht.sqlite-shm': 'shm',
+			})
+		);
+
+		expect(decode(database.files.get('.ht.sqlite')!.bytes)).toBe('main');
+		expect(decode(database.files.get('.ht.sqlite-wal')!.bytes)).toBe('wal');
+		expect(decode(database.files.get('.ht.sqlite-shm')!.bytes)).toBe('shm');
+		expect(database.files.has('.ht.sqlite-journal')).toBe(false);
+		expect(database.files.has('.ht.sqlite.tmp')).toBe(false);
+		expect(database.files.has('.ht.sqlite.copy')).toBe(false);
+		expect(database.files.has('.ht.sqlite-wal.copy')).toBe(false);
+	});
+
+	it('removes the SQLite snapshot copy after fallback publishing without move()', async () => {
+		const { files, php } = createFakePhp();
+		const opfsRoot = new MemoryDirectoryHandle('root', undefined, false);
+		const wpContent = (await opfsRoot.getDirectoryHandle('wp-content', {
+			create: true,
+		})) as unknown as MemoryDirectoryHandle;
+		const database = (await wpContent.getDirectoryHandle('database', {
+			create: true,
+		})) as unknown as MemoryDirectoryHandle;
+		for (const name of [
+			'.ht.sqlite-journal',
+			'.ht.sqlite-wal',
+			'.ht.sqlite-shm',
+		]) {
+			const file = (await database.getFileHandle(name, {
+				create: true,
+			})) as unknown as MemoryFileHandle;
+			file.bytes = encode('stale sidecar');
+		}
+		const mount = journalFSEventsToOpfs(
+			php,
+			opfsRoot as unknown as FileSystemDirectoryHandle,
+			'/wordpress'
+		);
+
+		files.set('/tmp/playground-sqlite-snapshot.sqlite', encode('snapshot'));
+		await mount.persistSqliteSnapshot(
+			'/tmp/playground-sqlite-snapshot.sqlite'
+		);
+
+		expect(decode(database.files.get('.ht.sqlite')!.bytes)).toBe(
+			'snapshot'
+		);
+		expect(database.files.has('.ht.sqlite.copy')).toBe(false);
+		expect(database.files.has('.ht.sqlite-journal')).toBe(false);
+		expect(database.files.has('.ht.sqlite-wal')).toBe(false);
+		expect(database.files.has('.ht.sqlite-shm')).toBe(false);
 	});
 
 	it.each(['filesystem.write', 'request.end'] as const)(
@@ -360,6 +595,54 @@ describe('journalFSEventsToOpfs', () => {
 });
 
 describe('createDirectoryHandleMountHandler', () => {
+	it('restores existing OPFS SQLite sidecars without scheduling a snapshot', async () => {
+		const { FS, files, php } = createFakePhp();
+		const opfsRoot = new MemoryDirectoryHandle('root');
+		const wpContent = (await opfsRoot.getDirectoryHandle('wp-content', {
+			create: true,
+		})) as unknown as MemoryDirectoryHandle;
+		const database = (await wpContent.getDirectoryHandle('database', {
+			create: true,
+		})) as unknown as MemoryDirectoryHandle;
+		for (const [name, contents] of [
+			['.ht.sqlite', 'main database'],
+			['.ht.sqlite-wal', 'committed wal frames'],
+			['.ht.sqlite-shm', 'wal index'],
+			['.ht.sqlite-journal', 'hot journal'],
+		] as const) {
+			const file = (await database.getFileHandle(name, {
+				create: true,
+			})) as unknown as MemoryFileHandle;
+			file.bytes = encode(contents);
+		}
+		const onSqliteDatabaseWrite = vi.fn();
+
+		const mountHandler = createDirectoryHandleMountHandler(
+			opfsRoot as unknown as FileSystemDirectoryHandle,
+			{
+				initialSync: {
+					direction: 'opfs-to-memfs',
+				},
+				onSqliteDatabaseWrite,
+			}
+		);
+
+		await mountHandler(php, FS as any, '/wordpress');
+
+		expect(
+			decode(files.get('/wordpress/wp-content/database/.ht.sqlite-wal')!)
+		).toBe('committed wal frames');
+		expect(
+			decode(files.get('/wordpress/wp-content/database/.ht.sqlite-shm')!)
+		).toBe('wal index');
+		expect(
+			decode(
+				files.get('/wordpress/wp-content/database/.ht.sqlite-journal')!
+			)
+		).toBe('hot journal');
+		expect(onSqliteDatabaseWrite).not.toHaveBeenCalled();
+	});
+
 	it('flushes changes made while the initial MEMFS to OPFS sync is still running', async () => {
 		let changedDuringInitialSync = false;
 		let mount: { flush(): Promise<void> } | undefined;
@@ -562,9 +845,11 @@ function createFakePhp() {
 		rename: vi.fn(),
 		lookupPath: vi.fn((path: string) => ({
 			path,
-			node: { mode: 0, path },
+			node: { mode: 0, path, mount: { mountpoint: '/' } },
 		})),
 		getPath: vi.fn((node: { path: string }) => node.path),
+		cwd: vi.fn(() => '/'),
+		chdir: vi.fn(),
 		isFile: vi.fn(() => true),
 		isDir: vi.fn(() => false),
 		readFile: vi.fn((path: string) => {
@@ -574,6 +859,11 @@ function createFakePhp() {
 			}
 			return file;
 		}),
+		createDataFile: vi.fn(
+			(parentPath: string, name: string, byteArray: Uint8Array) => {
+				files.set(joinPaths(parentPath, name), byteArray);
+			}
+		),
 	};
 	const listeners = new Map<string, Set<(event: { type: string }) => void>>();
 	const addEventListener = vi.fn(
@@ -608,6 +898,33 @@ function createFakePhp() {
 		files,
 		php,
 		removeEventListener,
+	};
+}
+
+function createSqliteFilesystemSnapshot(
+	files: Record<string, string>
+): FilesystemSnapshot {
+	return {
+		version: 1,
+		id: 'snapshot-id',
+		root: '/wordpress/wp-content/database',
+		createdAt: '2026-06-25T00:00:00.000Z',
+		entries: [
+			{
+				type: 'directory',
+				path: '/wordpress/wp-content/database',
+			},
+			...Object.entries(files).map(([name, contents]) => {
+				const bytes = encode(contents);
+				return {
+					type: 'file' as const,
+					path: `/wordpress/wp-content/database/${name}`,
+					size: bytes.byteLength,
+					hash: `test:${name}`,
+					bytes,
+				};
+			}),
+		],
 	};
 }
 

--- a/packages/php-wasm/web/src/lib/directory-handle-mount.ts
+++ b/packages/php-wasm/web/src/lib/directory-handle-mount.ts
@@ -1,4 +1,10 @@
-import type { Emscripten, MountHandler, PHP } from '@php-wasm/universal';
+import type {
+	Emscripten,
+	FilesystemSnapshot,
+	MountHandler,
+	PHP,
+	SnapshotFileEntry,
+} from '@php-wasm/universal';
 import { FSHelpers, __private__dont__use } from '@php-wasm/universal';
 import { Semaphore, basename, joinPaths } from '@php-wasm/util';
 import { logger } from '@php-wasm/logger';
@@ -36,9 +42,11 @@ export interface MountOptions {
 		onProgress?: SyncProgressCallback;
 	};
 	onMount?: (mount: DirectoryHandleMount) => void;
+	onSqliteDatabaseWrite?: () => void;
 }
 export interface DirectoryHandleMount {
 	flush(): Promise<void>;
+	persistSqliteSnapshot(snapshot: string | FilesystemSnapshot): Promise<void>;
 	unmount(): Promise<void>;
 }
 export type SyncProgress = {
@@ -55,9 +63,21 @@ export type SyncProgressCallback = (
 
 interface JournalFSEventsToOpfsOptions {
 	maxFlushPasses?: number;
+	onSqliteDatabaseWrite?: () => void;
+}
+
+interface CopyMemfsToOpfsOptions {
+	hasSqliteSnapshotPublisher?: boolean;
 }
 
 const DEFAULT_MAX_OPFS_FLUSH_PASSES = 1000;
+const WORDPRESS_MEMFS_PATH = '/wordpress';
+const SQLITE_DB_MEMFS_PATH = '/wordpress/wp-content/database/.ht.sqlite';
+const SQLITE_DB_OPFS_DIR = '/wp-content/database';
+const SQLITE_DB_OPFS_PATH = '/wp-content/database/.ht.sqlite';
+const SQLITE_DB_FILENAME = '.ht.sqlite';
+const SQLITE_DB_COPY_FILENAME = '.ht.sqlite.copy';
+const SQLITE_SIDECAR_SUFFIXES = ['-journal', '-wal', '-shm'];
 
 export function createDirectoryHandleMountHandler(
 	handle: FileSystemDirectoryHandle,
@@ -72,17 +92,31 @@ export function createDirectoryHandleMountHandler(
 	};
 
 	return async function (php, FS, vfsMountPoint) {
+		// Note about SnapshotPublisher:
+		// The mount layer is generic OPFS persistence. It must only suppress
+		// raw SQLite database/sidecar writes when a higher layer registered a
+		// snapshot publisher that will persist a validated .ht.sqlite replacement.
+		// Without that publisher, skipping .ht.sqlite would lose data for direct
+		// OPFS mount users, PHP-only runtimes, tests, or non-standard consumers.
+		// With it, raw SQLite replay stands down and snapshot persistence becomes
+		// the single owner of durable SQLite state.
+		const hasSqliteSnapshotPublisher =
+			options.onSqliteDatabaseWrite !== undefined;
 		if (options.initialSync.direction === 'opfs-to-memfs') {
 			if (FSHelpers.fileExists(FS, vfsMountPoint)) {
 				FSHelpers.rmdir(FS, vfsMountPoint);
 			}
 			FSHelpers.mkdir(FS, vfsMountPoint);
 			await copyOpfsToMemfs(FS, handle, vfsMountPoint);
-			const mount = journalFSEventsToOpfs(php, handle, vfsMountPoint);
+			const mount = journalFSEventsToOpfs(php, handle, vfsMountPoint, {
+				onSqliteDatabaseWrite: options.onSqliteDatabaseWrite,
+			});
 			options.onMount?.(mount);
 			return mount.unmount;
 		} else {
-			const mount = journalFSEventsToOpfs(php, handle, vfsMountPoint);
+			const mount = journalFSEventsToOpfs(php, handle, vfsMountPoint, {
+				onSqliteDatabaseWrite: options.onSqliteDatabaseWrite,
+			});
 			options.onMount?.(mount);
 			let lastProgress: SyncProgress | undefined;
 			try {
@@ -96,6 +130,9 @@ export function createDirectoryHandleMountHandler(
 							phase: 'copying',
 						};
 						await options.initialSync.onProgress?.(lastProgress);
+					},
+					{
+						hasSqliteSnapshotPublisher,
 					}
 				);
 				await options.initialSync.onProgress?.({
@@ -186,7 +223,8 @@ export async function copyMemfsToOpfs(
 	FS: Emscripten.RootFS,
 	opfsRoot: FileSystemDirectoryHandle,
 	memfsRoot: string,
-	onProgress?: SyncProgressCallback
+	onProgress?: SyncProgressCallback,
+	options: CopyMemfsToOpfsOptions = {}
 ) {
 	// Ensure the memfs directory exists.
 	FS.mkdirTree(memfsRoot);
@@ -207,6 +245,12 @@ export async function copyMemfsToOpfs(
 				)
 				.map(async (entryName: string) => {
 					const memfsPath = joinPaths(memfsParent, entryName);
+					if (
+						options.hasSqliteSnapshotPublisher &&
+						isLiveSqliteDatabasePath(memfsPath)
+					) {
+						return;
+					}
 					if (!isMemfsDir(FS, memfsPath)) {
 						filesToCreate.push([opfsDir, memfsPath, entryName]);
 						return;
@@ -291,16 +335,24 @@ async function overwriteOpfsFile(
 	FS: Emscripten.RootFS,
 	memfsPath: string
 ) {
-	let buffer;
+	let buffer: Uint8Array;
 	try {
 		buffer = FS.readFile(memfsPath, {
 			encoding: 'binary',
-		});
+		}) as Uint8Array;
 	} catch {
 		// File was removed, ignore
 		return;
 	}
 
+	await writeOpfsFile(opfsParent, name, buffer);
+}
+
+async function writeOpfsFile(
+	opfsParent: FileSystemDirectoryHandle,
+	name: string,
+	buffer: BufferSource
+) {
 	const opfsFile = await opfsParent.getFileHandle(name, { create: true });
 	const writer =
 		opfsFile.createWritable !== undefined
@@ -316,6 +368,109 @@ async function overwriteOpfsFile(
 	}
 }
 
+async function persistSqliteSnapshotToOpfs(
+	opfsRoot: FileSystemDirectoryHandle,
+	snapshotBytes: Uint8Array
+): Promise<void> {
+	const opfsParent = await resolveParent(opfsRoot, SQLITE_DB_OPFS_PATH);
+	await writeOpfsFile(opfsParent, SQLITE_DB_COPY_FILENAME, snapshotBytes);
+	await publishOpfsFile(
+		opfsParent,
+		SQLITE_DB_COPY_FILENAME,
+		SQLITE_DB_FILENAME,
+		snapshotBytes
+	);
+	await removeSqliteSidecarFiles(opfsParent);
+}
+
+async function persistSqliteFilesystemSnapshotToOpfs(
+	opfsRoot: FileSystemDirectoryHandle,
+	snapshot: FilesystemSnapshot
+): Promise<void> {
+	const files = snapshot.entries.filter(
+		(entry): entry is SnapshotFileEntry =>
+			entry.type === 'file' && isLiveSqliteDatabasePath(entry.path)
+	);
+	const presentFilenames = new Set<string>();
+	for (const entry of files) {
+		if (entry.bytes === undefined) {
+			throw new Error(
+				`Cannot persist SQLite snapshot file ${entry.path}: missing bytes.`
+			);
+		}
+		const opfsPath = memfsPathToOpfsPath(entry.path);
+		const opfsParent = await resolveParent(opfsRoot, opfsPath);
+		const filename = getFilename(opfsPath);
+		presentFilenames.add(filename);
+		await writeOpfsFile(opfsParent, `${filename}.copy`, entry.bytes);
+		await publishOpfsFile(
+			opfsParent,
+			`${filename}.copy`,
+			filename,
+			entry.bytes
+		);
+	}
+
+	const databaseDir = await resolveDirectory(opfsRoot, SQLITE_DB_OPFS_DIR);
+	await removeStaleSqliteFiles(databaseDir, presentFilenames);
+}
+
+async function publishOpfsFile(
+	opfsParent: FileSystemDirectoryHandle,
+	copyName: string,
+	finalName: string,
+	fallbackBytes: Uint8Array
+) {
+	const copyFile = await opfsParent.getFileHandle(copyName);
+	if (typeof copyFile.move === 'function') {
+		try {
+			await copyFile.move(opfsParent, finalName);
+			return;
+		} catch {
+			// Some implementations do not support replacing an existing file.
+		}
+	}
+
+	// Rewriting the final database is not atomic. Keep the completed copy until
+	// the final write closes, so an interrupted rewrite still leaves recovery data.
+	await writeOpfsFile(opfsParent, finalName, fallbackBytes);
+	await opfsParent.removeEntry(copyName);
+}
+
+async function removeSqliteSidecarFiles(opfsParent: FileSystemDirectoryHandle) {
+	await Promise.all(
+		getSqliteSidecarFilenames().map(async (filename) => {
+			try {
+				await opfsParent.removeEntry(filename);
+			} catch {
+				// If the sidecar file is already missing, that's fine.
+			}
+		})
+	);
+}
+
+async function removeStaleSqliteFiles(
+	opfsParent: FileSystemDirectoryHandle,
+	presentFilenames: Set<string>
+) {
+	await Promise.all(
+		[
+			SQLITE_DB_FILENAME,
+			`${SQLITE_DB_FILENAME}.tmp`,
+			...getSqliteSidecarFilenames(),
+		].map(async (filename) => {
+			if (presentFilenames.has(filename)) {
+				return;
+			}
+			try {
+				await opfsParent.removeEntry(filename);
+			} catch {
+				// If the SQLite file is already missing, that's fine.
+			}
+		})
+	);
+}
+
 export function journalFSEventsToOpfs(
 	php: PHP,
 	opfsRoot: FileSystemDirectoryHandle,
@@ -326,7 +481,11 @@ export function journalFSEventsToOpfs(
 	const unbindJournal = journalFSEvents(php, memfsRoot, (entry) => {
 		journal.push(entry);
 	});
-	const rewriter = new OpfsRewriter(php, opfsRoot, memfsRoot);
+	const hasSqliteSnapshotPublisher =
+		options.onSqliteDatabaseWrite !== undefined;
+	const rewriter = new OpfsRewriter(php, opfsRoot, memfsRoot, {
+		hasSqliteSnapshotPublisher,
+	});
 	let flushPromise: Promise<void> | undefined;
 
 	function flush() {
@@ -346,6 +505,22 @@ export function journalFSEventsToOpfs(
 			php.removeEventListener('request.end', flushInBackground);
 			php.removeEventListener('filesystem.write', flushInBackground);
 		}
+	}
+
+	async function persistSqliteSnapshot(
+		snapshot: string | FilesystemSnapshot
+	) {
+		if (typeof snapshot === 'string') {
+			const snapshotBytes = php[__private__dont__use].FS.readFile(
+				snapshot,
+				{
+					encoding: 'binary',
+				}
+			) as Uint8Array;
+			await persistSqliteSnapshotToOpfs(opfsRoot, snapshotBytes);
+			return;
+		}
+		await persistSqliteFilesystemSnapshotToOpfs(opfsRoot, snapshot);
 	}
 
 	function flushInBackground() {
@@ -392,6 +567,9 @@ export function journalFSEventsToOpfs(
 		journal.splice(0, journalEntries.length);
 
 		const compressedJournal = normalizeFilesystemOperations(journalEntries);
+		const hadSqliteDatabaseEntries =
+			hasSqliteSnapshotPublisher &&
+			compressedJournal.some(isLiveSqliteDatabaseEntry);
 		try {
 			// @TODO This is way too slow in practice, we need to batch the
 			// changes into groups of parallelizable operations.
@@ -401,12 +579,16 @@ export function journalFSEventsToOpfs(
 		} finally {
 			release();
 		}
+		if (hadSqliteDatabaseEntries) {
+			options.onSqliteDatabaseWrite?.();
+		}
 	}
 
 	php.addEventListener('request.end', flushInBackground);
 	php.addEventListener('filesystem.write', flushInBackground);
 	return {
 		flush,
+		persistSqliteSnapshot,
 		unmount,
 	};
 }
@@ -417,11 +599,19 @@ class OpfsRewriter {
 	private memfsRoot: string;
 	private php: PHP;
 	private opfs: FileSystemDirectoryHandle;
+	private hasSqliteSnapshotPublisher: boolean;
 
-	constructor(php: PHP, opfs: FileSystemDirectoryHandle, memfsRoot: string) {
+	constructor(
+		php: PHP,
+		opfs: FileSystemDirectoryHandle,
+		memfsRoot: string,
+		options: CopyMemfsToOpfsOptions = {}
+	) {
 		this.php = php;
 		this.opfs = opfs;
 		this.memfsRoot = normalizeMemfsPath(memfsRoot);
+		this.hasSqliteSnapshotPublisher =
+			options.hasSqliteSnapshotPublisher ?? false;
 	}
 
 	private toOpfsPath(path: string) {
@@ -432,6 +622,12 @@ class OpfsRewriter {
 		if (
 			!entry.path.startsWith(this.memfsRoot) ||
 			entry.path === this.memfsRoot
+		) {
+			return;
+		}
+		if (
+			this.hasSqliteSnapshotPublisher &&
+			isLiveSqliteDatabaseEntry(entry)
 		) {
 			return;
 		}
@@ -490,7 +686,12 @@ class OpfsRewriter {
 					await copyMemfsToOpfs(
 						this.php[__private__dont__use].FS,
 						opfsDir,
-						entry.toPath
+						entry.toPath,
+						undefined,
+						{
+							hasSqliteSnapshotPublisher:
+								this.hasSqliteSnapshotPublisher,
+						}
 					);
 					// Then delete the old directory
 					await opfsParent.removeEntry(name, {
@@ -544,12 +745,64 @@ class OpfsRewriter {
 	}
 }
 
+function isLiveSqliteDatabaseEntry(entry: JournalEntry) {
+	return (
+		isLiveSqliteDatabasePath(entry.path) ||
+		(entry.operation === 'RENAME' && isLiveSqliteDatabasePath(entry.toPath))
+	);
+}
+
+function isLiveSqliteDatabasePath(path: string) {
+	return (
+		path === SQLITE_DB_MEMFS_PATH || isSqliteSidecarOrTemporaryPath(path)
+	);
+}
+
+function isSqliteSidecarOrTemporaryPath(path: string) {
+	return (
+		path === `${SQLITE_DB_MEMFS_PATH}.tmp` ||
+		SQLITE_SIDECAR_SUFFIXES.some(
+			(suffix) => path === `${SQLITE_DB_MEMFS_PATH}${suffix}`
+		)
+	);
+}
+
+function getSqliteSidecarFilenames() {
+	return SQLITE_SIDECAR_SUFFIXES.map(
+		(suffix) => `${SQLITE_DB_FILENAME}${suffix}`
+	);
+}
+
 function normalizeMemfsPath(path: string) {
 	return path.replace(/\/$/, '').replace(/\/\/+/g, '/');
 }
 
 function getFilename(path: string) {
 	return path.substring(path.lastIndexOf('/') + 1);
+}
+
+function memfsPathToOpfsPath(path: string) {
+	if (!path.startsWith(WORDPRESS_MEMFS_PATH)) {
+		throw new Error(`Path ${path} is outside the WordPress mount.`);
+	}
+	return normalizeMemfsPath(path.substring(WORDPRESS_MEMFS_PATH.length));
+}
+
+async function resolveDirectory(
+	opfs: FileSystemDirectoryHandle,
+	relativePath: string
+) {
+	const normalizedPath = relativePath
+		.replace(/^\/+|\/+$/g, '')
+		.replace(/\/+/, '/');
+	let handle = opfs;
+	if (!normalizedPath) {
+		return handle;
+	}
+	for (const segment of normalizedPath.split('/')) {
+		handle = await handle.getDirectoryHandle(segment, { create: true });
+	}
+	return handle;
 }
 
 async function resolveParent(

--- a/packages/playground/remote/src/lib/playground-worker-endpoint.spec.ts
+++ b/packages/playground/remote/src/lib/playground-worker-endpoint.spec.ts
@@ -1,11 +1,12 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { __private__dont__use } from '@php-wasm/universal';
-import type { MountHandler } from '@php-wasm/universal';
+import type { FilesystemSnapshot, MountHandler } from '@php-wasm/universal';
 import { Semaphore } from '@php-wasm/util';
 import { logger } from '@php-wasm/logger';
 
 describe('PlaygroundWorkerEndpoint OPFS flushing', () => {
 	afterEach(() => {
+		vi.useRealTimers();
 		vi.unstubAllGlobals();
 	});
 
@@ -39,6 +40,247 @@ describe('PlaygroundWorkerEndpoint OPFS flushing', () => {
 
 		expect(endpoint.opfsMounts['/wordpress'].flush).toHaveBeenCalledTimes(
 			1
+		);
+	});
+
+	it('flushes before snapshotting SQLite and persists the post-flush snapshot', async () => {
+		const opfsMount = createOpfsMount();
+		const php = createFakePhp();
+		php.isFile.mockReturnValue(true);
+		const order: string[] = [];
+		let didFlushBeforeSnapshot = false;
+		let snapshot = createSqliteFilesystemSnapshot('pre-flush');
+		php.snapshotFilesystem.mockImplementation(async () => {
+			expect(didFlushBeforeSnapshot).toBe(true);
+			order.push('snapshot');
+			return snapshot;
+		});
+		opfsMount.flush.mockImplementation(async () => {
+			order.push('flush');
+			didFlushBeforeSnapshot = true;
+			snapshot = createSqliteFilesystemSnapshot('post-flush');
+		});
+		opfsMount.persistSqliteSnapshot.mockImplementation(async () => {
+			order.push('persist');
+		});
+		const endpoint = await createEndpoint({
+			'/wordpress': opfsMount,
+		});
+		endpoint.__internal_getPHP = () => php;
+
+		(endpoint as any).markSqliteSnapshotDirty('/wordpress');
+		await endpoint.flushOpfs('/wordpress');
+
+		expect(order.indexOf('flush')).toBeLessThan(order.indexOf('snapshot'));
+		expect(order.indexOf('snapshot')).toBeLessThan(
+			order.indexOf('persist')
+		);
+		expect(opfsMount.persistSqliteSnapshot).toHaveBeenCalledWith(snapshot);
+	});
+
+	it('debounces multiple SQLite write notifications into one snapshot', async () => {
+		vi.useFakeTimers();
+		const opfsMount = createOpfsMount();
+		const php = createFakePhp();
+		php.isFile.mockReturnValue(true);
+		const endpoint = await createEndpoint({
+			'/wordpress': opfsMount,
+		});
+		endpoint.__internal_getPHP = () => php;
+
+		(endpoint as any).markSqliteSnapshotDirty('/wordpress');
+		(endpoint as any).markSqliteSnapshotDirty('/wordpress');
+		(endpoint as any).markSqliteSnapshotDirty('/wordpress');
+
+		expect(php.snapshotFilesystem).not.toHaveBeenCalled();
+
+		await vi.advanceTimersByTimeAsync(100);
+
+		expect(php.snapshotFilesystem).toHaveBeenCalledTimes(1);
+		expect(opfsMount.persistSqliteSnapshot).toHaveBeenCalledTimes(1);
+	});
+
+	it('runs one trailing snapshot for writes reported during an active snapshot', async () => {
+		const opfsMount = createOpfsMount();
+		const php = createFakePhp();
+		php.isFile.mockReturnValue(true);
+		const firstSnapshotStarted = deferred<void>();
+		const releaseFirstSnapshot = deferred<void>();
+		let activeSnapshots = 0;
+		let maxActiveSnapshots = 0;
+		let snapshotCount = 0;
+		php.snapshotFilesystem.mockImplementation(async () => {
+			const snapshotNumber = ++snapshotCount;
+			activeSnapshots++;
+			maxActiveSnapshots = Math.max(maxActiveSnapshots, activeSnapshots);
+			if (snapshotNumber === 1) {
+				firstSnapshotStarted.resolve(undefined);
+				await releaseFirstSnapshot.promise;
+			}
+			activeSnapshots--;
+			return createSqliteFilesystemSnapshot(`snapshot-${snapshotNumber}`);
+		});
+		const endpoint = await createEndpoint({
+			'/wordpress': opfsMount,
+		});
+		endpoint.__internal_getPHP = () => php;
+
+		(endpoint as any).markSqliteSnapshotDirty('/wordpress');
+		const snapshotPersistence = (
+			endpoint as any
+		).persistSqliteSnapshotsUntilClean('/wordpress', opfsMount);
+		await firstSnapshotStarted.promise;
+		(endpoint as any).markSqliteSnapshotDirty('/wordpress');
+		(endpoint as any).markSqliteSnapshotDirty('/wordpress');
+		releaseFirstSnapshot.resolve(undefined);
+		await snapshotPersistence;
+
+		expect(maxActiveSnapshots).toBe(1);
+		expect(php.snapshotFilesystem).toHaveBeenCalledTimes(2);
+		expect(opfsMount.persistSqliteSnapshot).toHaveBeenNthCalledWith(
+			1,
+			createSqliteFilesystemSnapshot('snapshot-1')
+		);
+		expect(opfsMount.persistSqliteSnapshot).toHaveBeenNthCalledWith(
+			2,
+			createSqliteFilesystemSnapshot('snapshot-2')
+		);
+	});
+
+	it('does not run concurrent snapshots for overlapping flushes', async () => {
+		const opfsMount = createOpfsMount();
+		const php = createFakePhp();
+		php.isFile.mockReturnValue(true);
+		const firstSnapshotStarted = deferred<void>();
+		const releaseFirstSnapshot = deferred<void>();
+		let activeSnapshots = 0;
+		let maxActiveSnapshots = 0;
+		php.snapshotFilesystem.mockImplementation(async () => {
+			activeSnapshots++;
+			maxActiveSnapshots = Math.max(maxActiveSnapshots, activeSnapshots);
+			firstSnapshotStarted.resolve(undefined);
+			await releaseFirstSnapshot.promise;
+			activeSnapshots--;
+			return createSqliteFilesystemSnapshot('snapshot');
+		});
+		const endpoint = await createEndpoint({
+			'/wordpress': opfsMount,
+		});
+		endpoint.__internal_getPHP = () => php;
+
+		(endpoint as any).markSqliteSnapshotDirty('/wordpress');
+		const firstFlush = endpoint.flushOpfs('/wordpress');
+		await firstSnapshotStarted.promise;
+		const secondFlush = endpoint.flushOpfs('/wordpress');
+		releaseFirstSnapshot.resolve(undefined);
+		await Promise.all([firstFlush, secondFlush]);
+
+		expect(maxActiveSnapshots).toBe(1);
+		expect(php.snapshotFilesystem).toHaveBeenCalledTimes(1);
+		expect(opfsMount.persistSqliteSnapshot).toHaveBeenCalledTimes(1);
+	});
+
+	it('flushOpfs cancels the debounce and snapshots immediately', async () => {
+		vi.useFakeTimers();
+		const opfsMount = createOpfsMount();
+		const php = createFakePhp();
+		php.isFile.mockReturnValue(true);
+		const endpoint = await createEndpoint({
+			'/wordpress': opfsMount,
+		});
+		endpoint.__internal_getPHP = () => php;
+
+		(endpoint as any).markSqliteSnapshotDirty('/wordpress');
+
+		await endpoint.flushOpfs('/wordpress');
+
+		expect(php.snapshotFilesystem).toHaveBeenCalledTimes(1);
+		await vi.advanceTimersByTimeAsync(100);
+		expect(php.snapshotFilesystem).toHaveBeenCalledTimes(1);
+	});
+
+	it('unmountOpfs waits for pending and trailing snapshots before unmounting', async () => {
+		const opfsMount = createOpfsMount();
+		const php = createFakePhp();
+		php.isFile.mockReturnValue(true);
+		const firstSnapshotStarted = deferred<void>();
+		const releaseFirstSnapshot = deferred<void>();
+		const order: string[] = [];
+		let snapshotCount = 0;
+		php.snapshotFilesystem.mockImplementation(async () => {
+			const snapshotNumber = ++snapshotCount;
+			order.push(`snapshot ${snapshotNumber}`);
+			if (snapshotNumber === 1) {
+				firstSnapshotStarted.resolve(undefined);
+				await releaseFirstSnapshot.promise;
+			}
+			return createSqliteFilesystemSnapshot(`snapshot-${snapshotNumber}`);
+		});
+		opfsMount.persistSqliteSnapshot.mockImplementation(async () => {
+			order.push(`persist ${snapshotCount}`);
+		});
+		const unmount = vi.fn(async () => {
+			order.push('unmount');
+		});
+		const endpoint = await createEndpoint(
+			{ '/wordpress': opfsMount },
+			{ '/wordpress': unmount }
+		);
+		endpoint.__internal_getPHP = () => php;
+
+		(endpoint as any).markSqliteSnapshotDirty('/wordpress');
+		const unmountPromise = endpoint.unmountOpfs('/wordpress');
+		await firstSnapshotStarted.promise;
+		(endpoint as any).markSqliteSnapshotDirty('/wordpress');
+		expect(unmount).not.toHaveBeenCalled();
+
+		releaseFirstSnapshot.resolve(undefined);
+		await unmountPromise;
+
+		expect(php.snapshotFilesystem).toHaveBeenCalledTimes(2);
+		expect(order).toEqual([
+			'snapshot 1',
+			'persist 1',
+			'snapshot 2',
+			'persist 2',
+			'unmount',
+		]);
+	});
+
+	it('does not snapshot solely because OPFS restore contains SQLite sidecars', async () => {
+		const php = createFakePhp();
+		php.isFile.mockReturnValue(true);
+		const endpoint = await createEndpoint({});
+		endpoint.__internal_getPHP = () => php;
+
+		await endpoint.mountOpfs({
+			device: {
+				type: 'local-fs',
+				handle: createSqliteLegacyDirectoryHandle(),
+			},
+			mountpoint: '/wordpress',
+		});
+
+		expect(php.snapshotFilesystem).not.toHaveBeenCalled();
+		expect(php[__private__dont__use].FS.createDataFile).toHaveBeenCalled();
+	});
+
+	it('does not use SQLite snapshot scheduling for non-WordPress mounts', async () => {
+		const opfsMount = createOpfsMount();
+		const php = createFakePhp();
+		php.isFile.mockReturnValue(true);
+		const endpoint = await createEndpoint({
+			'/plugin': opfsMount,
+		});
+		endpoint.__internal_getPHP = () => php;
+
+		(endpoint as any).markSqliteSnapshotDirty('/plugin');
+		await endpoint.flushOpfs('/plugin');
+
+		expect(opfsMount.flush).toHaveBeenCalledTimes(1);
+		expect(php.snapshotFilesystem).not.toHaveBeenCalled();
+		expect((endpoint as any).opfsSqliteSnapshotStates['/plugin']).toBe(
+			undefined
 		);
 	});
 
@@ -288,6 +530,8 @@ async function createEndpoint(
 	const endpoint = Object.create(PlaygroundWorkerEndpoint.prototype) as any;
 	endpoint.opfsMounts = createNullPrototypeRecord(opfsMounts);
 	endpoint.unmounts = createNullPrototypeRecord(unmounts);
+	endpoint.opfsSqliteSnapshotStates = createNullPrototypeRecord({});
+	endpoint.__internal_getPHP = () => createFakePhp();
 	return endpoint as {
 		__internal_getPHP?: () => ReturnType<typeof createFakePhp>;
 		hasOpfsMount(mountpoint: string): Promise<boolean>;
@@ -312,6 +556,7 @@ function createNullPrototypeRecord<T>(entries: Record<string, T>) {
 function createOpfsMount() {
 	return {
 		flush: vi.fn(async () => {}),
+		persistSqliteSnapshot: vi.fn(async () => {}),
 		unmount: vi.fn(async () => {}),
 	};
 }
@@ -325,6 +570,7 @@ function createFakePhp(options: { skipMountHandler?: boolean } = {}) {
 		mkdir: vi.fn(),
 		rmdir: vi.fn(),
 		rename: vi.fn(),
+		createDataFile: vi.fn(),
 		lookupPath: vi.fn(() => {
 			throw new Error('Not found');
 		}),
@@ -342,8 +588,49 @@ function createFakePhp(options: { skipMountHandler?: boolean } = {}) {
 			}
 			return await mountHandler(php, FS as any, mountpoint);
 		}),
+		isFile: vi.fn(() => false),
+		snapshotFilesystem: vi.fn(async () =>
+			createSqliteFilesystemSnapshot('default')
+		),
+		run: vi.fn(async () => ({
+			text: JSON.stringify({
+				ok: true,
+				path: '/tmp/playground-sqlite-snapshot.sqlite',
+			}),
+		})),
 	};
 	return php;
+}
+
+function createSqliteFilesystemSnapshot(label: string): FilesystemSnapshot {
+	const databaseBytes = new TextEncoder().encode(label);
+	const walBytes = new TextEncoder().encode(`${label}-wal`);
+	return {
+		version: 1,
+		id: `snapshot-${label}`,
+		root: '/wordpress/wp-content/database',
+		createdAt: '2026-06-25T00:00:00.000Z',
+		entries: [
+			{
+				type: 'directory',
+				path: '/wordpress/wp-content/database',
+			},
+			{
+				type: 'file',
+				path: '/wordpress/wp-content/database/.ht.sqlite',
+				size: databaseBytes.byteLength,
+				hash: `test:${label}`,
+				bytes: databaseBytes,
+			},
+			{
+				type: 'file',
+				path: '/wordpress/wp-content/database/.ht.sqlite-wal',
+				size: walBytes.byteLength,
+				hash: `test:${label}-wal`,
+				bytes: walBytes,
+			},
+		],
+	};
 }
 
 function createEmptyDirectoryHandle() {
@@ -352,4 +639,50 @@ function createEmptyDirectoryHandle() {
 		name: 'root',
 		async *values() {},
 	} as unknown as FileSystemDirectoryHandle;
+}
+
+function createSqliteLegacyDirectoryHandle() {
+	return createDirectoryHandle('root', [
+		createDirectoryHandle('wp-content', [
+			createDirectoryHandle('database', [
+				createFileHandle('.ht.sqlite', 'main database'),
+				createFileHandle('.ht.sqlite-wal', 'committed wal frames'),
+				createFileHandle('.ht.sqlite-shm', 'wal index'),
+				createFileHandle('.ht.sqlite-journal', 'hot journal'),
+			]),
+		]),
+	]) as unknown as FileSystemDirectoryHandle;
+}
+
+function createDirectoryHandle(name: string, values: unknown[]) {
+	return {
+		kind: 'directory',
+		name,
+		async *values() {
+			yield* values;
+		},
+	};
+}
+
+function createFileHandle(name: string, contents: string) {
+	return {
+		kind: 'file',
+		name,
+		async getFile() {
+			const bytes = new TextEncoder().encode(contents);
+			return {
+				arrayBuffer: async () => bytes.buffer,
+			};
+		},
+	};
+}
+
+function deferred<T>() {
+	let resolve!: (value: T | PromiseLike<T>) => void;
+	let reject!: (reason?: any) => void;
+	const promise = new Promise<T>((_resolve, _reject) => {
+		resolve = _resolve;
+		reject = _reject;
+	});
+	return { promise, resolve, reject };
 }

--- a/packages/playground/remote/src/lib/playground-worker-endpoint.ts
+++ b/packages/playground/remote/src/lib/playground-worker-endpoint.ts
@@ -32,6 +32,7 @@ import transportDummy from './playground-mu-plugin/playground-includes/wp_http_d
 import { logger } from '@php-wasm/logger';
 import type {
 	AllPHPVersion,
+	FilesystemSnapshot,
 	PathAlias,
 	PHP,
 	PHPRequestHandler,
@@ -66,6 +67,19 @@ export interface MountDescriptor {
 	mountpoint: string;
 	device: MountDevice;
 	initialSyncDirection: 'opfs-to-memfs' | 'memfs-to-opfs';
+}
+
+const WORDPRESS_MOUNTPOINT = '/wordpress';
+const SQLITE_DB_DIR_PATH = '/wordpress/wp-content/database';
+const SQLITE_DB_PATH = '/wordpress/wp-content/database/.ht.sqlite';
+const SQLITE_SNAPSHOT_DEBOUNCE_MS = 100;
+const SQLITE_SNAPSHOT_SIDECAR_SUFFIXES = ['-journal', '-wal', '-shm'];
+
+interface SqliteSnapshotState {
+	dirtyVersion: number;
+	persistedVersion: number;
+	debounceTimer?: ReturnType<typeof setTimeout>;
+	snapshotPromise?: Promise<void>;
 }
 
 export type WorkerBootOptions = {
@@ -121,6 +135,10 @@ export abstract class PlaygroundWorkerEndpoint extends PHPWorker {
 	unmounts: Record<string, () => any> = createNullPrototypeRecord();
 	private opfsMounts: Record<string, DirectoryHandleMount> =
 		createNullPrototypeRecord();
+	private opfsSqliteSnapshotStates: Record<
+		string,
+		SqliteSnapshotState | undefined
+	> = createNullPrototypeRecord();
 
 	private networkTransport: WordPressFetchNetworkTransport | undefined;
 	private requestHandler: PHPRequestHandler | undefined;
@@ -451,7 +469,7 @@ export abstract class PlaygroundWorkerEndpoint extends PHPWorker {
 		if (opfsMount === undefined) {
 			throw new Error(`No OPFS mount found at "${mountpoint}".`);
 		}
-		await opfsMount.flush();
+		await this.flushOpfsMountWithSnapshot(mountpoint, opfsMount);
 	}
 
 	async unmountOpfs(mountpoint: string) {
@@ -462,7 +480,7 @@ export abstract class PlaygroundWorkerEndpoint extends PHPWorker {
 		}
 		let flushError: unknown;
 		try {
-			await opfsMount.flush();
+			await this.flushOpfsMountWithSnapshot(mountpoint, opfsMount);
 		} catch (error) {
 			flushError = error;
 		}
@@ -474,8 +492,10 @@ export abstract class PlaygroundWorkerEndpoint extends PHPWorker {
 			}
 			logger.error(error);
 		} finally {
+			this.clearSqliteSnapshotTimer(mountpoint);
 			delete this.unmounts[mountpoint];
 			delete this.opfsMounts[mountpoint];
+			delete this.opfsSqliteSnapshotStates[mountpoint];
 		}
 		if (flushError !== undefined) {
 			throw flushError;
@@ -545,6 +565,8 @@ export abstract class PlaygroundWorkerEndpoint extends PHPWorker {
 		}
 		const handle = await directoryHandleFromMountDevice(options.device);
 		let opfsMount: DirectoryHandleMount | undefined;
+		const shouldPersistSqliteSnapshots =
+			options.mountpoint === WORDPRESS_MOUNTPOINT;
 		const unmount = await php.mount(
 			options.mountpoint,
 			createDirectoryHandleMountHandler(handle, {
@@ -555,6 +577,11 @@ export abstract class PlaygroundWorkerEndpoint extends PHPWorker {
 				onMount(mount) {
 					opfsMount = mount;
 				},
+				onSqliteDatabaseWrite: shouldPersistSqliteSnapshots
+					? () => {
+							this.markSqliteSnapshotDirty(options.mountpoint);
+						}
+					: undefined,
 			})
 		);
 		if (opfsMount === undefined) {
@@ -569,6 +596,160 @@ export abstract class PlaygroundWorkerEndpoint extends PHPWorker {
 		}
 		this.unmounts[options.mountpoint] = unmount;
 		this.opfsMounts[options.mountpoint] = opfsMount;
+		if (
+			options.initialSyncDirection === 'memfs-to-opfs' &&
+			shouldPersistSqliteSnapshots
+		) {
+			try {
+				this.markSqliteSnapshotDirty(options.mountpoint);
+				await this.flushOpfsMountWithSnapshot(
+					options.mountpoint,
+					opfsMount
+				);
+			} catch (error) {
+				delete this.unmounts[options.mountpoint];
+				delete this.opfsMounts[options.mountpoint];
+				delete this.opfsSqliteSnapshotStates[options.mountpoint];
+				try {
+					await unmount();
+				} catch (unmountError) {
+					logger.error(unmountError);
+				}
+				throw error;
+			}
+		}
+	}
+
+	private async flushOpfsMountWithSnapshot(
+		mountpoint: string,
+		opfsMount: DirectoryHandleMount
+	) {
+		// Explicit flush owns this SQLite persistence turn. The flush below may
+		// discover SQLite journal entries and schedule a fresh debounce timer,
+		// so cancel timers both before and after flushing, then drain dirty state.
+		this.clearSqliteSnapshotTimer(mountpoint);
+		await opfsMount.flush();
+		this.clearSqliteSnapshotTimer(mountpoint);
+		await this.persistSqliteSnapshotsUntilClean(mountpoint, opfsMount);
+	}
+
+	private markSqliteSnapshotDirty(mountpoint: string) {
+		if (mountpoint !== WORDPRESS_MOUNTPOINT) {
+			return;
+		}
+		const state = this.getSqliteSnapshotState(mountpoint);
+		state.dirtyVersion++;
+		if (
+			state.snapshotPromise !== undefined ||
+			state.debounceTimer !== undefined
+		) {
+			return;
+		}
+		state.debounceTimer = setTimeout(() => {
+			delete state.debounceTimer;
+			void this.persistSqliteSnapshotsUntilClean(mountpoint).catch(
+				(error) => logger.error(error)
+			);
+		}, SQLITE_SNAPSHOT_DEBOUNCE_MS);
+	}
+
+	private clearSqliteSnapshotTimer(mountpoint: string) {
+		const state = this.opfsSqliteSnapshotStates[mountpoint];
+		if (state?.debounceTimer === undefined) {
+			return;
+		}
+		clearTimeout(state.debounceTimer);
+		delete state.debounceTimer;
+	}
+
+	private async persistSqliteSnapshotsUntilClean(
+		mountpoint: string,
+		opfsMount = this.opfsMounts[mountpoint]
+	) {
+		const state = this.opfsSqliteSnapshotStates[mountpoint];
+		if (opfsMount === undefined || state === undefined) {
+			return;
+		}
+		if (state.snapshotPromise !== undefined) {
+			await state.snapshotPromise;
+			if (state.dirtyVersion > state.persistedVersion) {
+				await this.persistSqliteSnapshotsUntilClean(
+					mountpoint,
+					opfsMount
+				);
+			}
+			return;
+		}
+		const snapshotPromise = Promise.resolve()
+			.then(() =>
+				this.runSqliteSnapshotLoop(mountpoint, opfsMount, state)
+			)
+			.finally(() => {
+				if (state.snapshotPromise === snapshotPromise) {
+					delete state.snapshotPromise;
+				}
+			});
+		state.snapshotPromise = snapshotPromise;
+		await snapshotPromise;
+	}
+
+	private async runSqliteSnapshotLoop(
+		mountpoint: string,
+		opfsMount: DirectoryHandleMount,
+		state: SqliteSnapshotState
+	) {
+		while (state.dirtyVersion > state.persistedVersion) {
+			const targetVersion = state.dirtyVersion;
+			await opfsMount.flush();
+			const snapshot = await this.snapshotSqliteIfPresent(mountpoint);
+			if (snapshot !== undefined) {
+				await opfsMount.persistSqliteSnapshot(snapshot);
+			}
+			state.persistedVersion = Math.max(
+				state.persistedVersion,
+				targetVersion
+			);
+		}
+	}
+
+	private getSqliteSnapshotState(mountpoint: string) {
+		let state = this.opfsSqliteSnapshotStates[mountpoint];
+		if (state === undefined) {
+			state = {
+				dirtyVersion: 0,
+				persistedVersion: 0,
+			};
+			this.opfsSqliteSnapshotStates[mountpoint] = state;
+		}
+		return state;
+	}
+
+	private async snapshotSqliteIfPresent(mountpoint: string) {
+		if (mountpoint !== WORDPRESS_MOUNTPOINT) {
+			return undefined;
+		}
+		return await this.snapshotSqliteFilesIfPresent();
+	}
+
+	private async snapshotSqliteFilesIfPresent(): Promise<
+		FilesystemSnapshot | undefined
+	> {
+		const php = this.__internal_getPHP()!;
+		if (!php.isFile(SQLITE_DB_PATH)) {
+			return undefined;
+		}
+		return await php.snapshotFilesystem(SQLITE_DB_DIR_PATH, {
+			includeBytes: true,
+			shouldIncludePath(path) {
+				return (
+					path === SQLITE_DB_DIR_PATH ||
+					path === SQLITE_DB_PATH ||
+					SQLITE_SNAPSHOT_SIDECAR_SUFFIXES.some(
+						(suffix) => path === `${SQLITE_DB_PATH}${suffix}`
+					)
+				);
+			},
+		});
 	}
 }
 

--- a/packages/playground/storage/src/index.ts
+++ b/packages/playground/storage/src/index.ts
@@ -6,3 +6,4 @@ export * from './lib/git-sparse-checkout';
 export * from './lib/git-create-dotgit-directory';
 export * from './lib/paths';
 export * from './lib/filesystems';
+export * from './lib/snapshot-publisher';

--- a/packages/playground/storage/src/lib/snapshot-publisher.ts
+++ b/packages/playground/storage/src/lib/snapshot-publisher.ts
@@ -1,0 +1,511 @@
+import type {
+	FilesystemSnapshot,
+	SnapshotEntry,
+	SnapshotFileEntry,
+} from '@php-wasm/universal';
+import { hashBytes, stripSnapshotBytes } from '@php-wasm/universal';
+import { joinPaths, normalizePath } from '@php-wasm/util';
+
+export type SnapshotHead = {
+	siteId: string;
+	snapshotId: string;
+	updatedAt: string;
+};
+
+export type SnapshotPublishResult = {
+	snapshotId: string;
+	uploadedBlobs: string[];
+	skippedBlobs: string[];
+};
+
+export interface SnapshotPublisher {
+	hasBlob(hash: string): Promise<boolean>;
+	putBlob(hash: string, bytes: Uint8Array): Promise<void>;
+	putManifest(
+		snapshotId: string,
+		manifest: FilesystemSnapshot
+	): Promise<void>;
+	publishHead(
+		siteId: string,
+		snapshotId: string,
+		previousHead?: SnapshotHead
+	): Promise<void>;
+	readHead(siteId: string): Promise<SnapshotHead | undefined>;
+	readManifest(snapshotId: string): Promise<FilesystemSnapshot>;
+	readBlob(hash: string): Promise<Uint8Array>;
+}
+
+export async function publishSnapshot(
+	publisher: SnapshotPublisher,
+	siteId: string,
+	snapshot: FilesystemSnapshot
+): Promise<SnapshotPublishResult> {
+	const uploadedBlobs: string[] = [];
+	const skippedBlobs: string[] = [];
+	const seenBlobs = new Set<string>();
+	for (const entry of snapshot.entries) {
+		if (entry.type !== 'file' || seenBlobs.has(entry.hash)) {
+			continue;
+		}
+		seenBlobs.add(entry.hash);
+		if (await publisher.hasBlob(entry.hash)) {
+			skippedBlobs.push(entry.hash);
+			continue;
+		}
+		const bytes = await getFileEntryBytes(entry);
+		await verifyBlobHash(entry.hash, bytes);
+		await publisher.putBlob(entry.hash, bytes);
+		uploadedBlobs.push(entry.hash);
+	}
+
+	const manifest = stripSnapshotBytes(snapshot);
+	await verifyManifestBlobs(publisher, manifest);
+	await publisher.putManifest(snapshot.id, manifest);
+	const previousHead = await publisher.readHead(siteId);
+	await publisher.publishHead(siteId, snapshot.id, previousHead);
+	return {
+		snapshotId: snapshot.id,
+		uploadedBlobs,
+		skippedBlobs,
+	};
+}
+
+export async function restoreSnapshotFromPublisher(
+	publisher: SnapshotPublisher,
+	snapshotId: string
+): Promise<FilesystemSnapshot> {
+	const manifest = await publisher.readManifest(snapshotId);
+	const entries: SnapshotEntry[] = [];
+	for (const entry of manifest.entries) {
+		if (entry.type !== 'file') {
+			entries.push(entry);
+			continue;
+		}
+		const bytes = await publisher.readBlob(entry.hash);
+		await verifyBlobHash(entry.hash, bytes);
+		entries.push({
+			...entry,
+			bytes,
+		});
+	}
+	return {
+		...manifest,
+		entries,
+	};
+}
+
+export class InMemorySnapshotPublisher implements SnapshotPublisher {
+	readonly blobs = new Map<string, Uint8Array>();
+	readonly manifests = new Map<string, FilesystemSnapshot>();
+	readonly heads = new Map<string, SnapshotHead>();
+
+	async hasBlob(hash: string): Promise<boolean> {
+		return this.blobs.has(hash);
+	}
+
+	async putBlob(hash: string, bytes: Uint8Array): Promise<void> {
+		this.blobs.set(hash, new Uint8Array(bytes));
+	}
+
+	async putManifest(
+		snapshotId: string,
+		manifest: FilesystemSnapshot
+	): Promise<void> {
+		this.manifests.set(snapshotId, stripSnapshotBytes(manifest));
+	}
+
+	async publishHead(
+		siteId: string,
+		snapshotId: string,
+		previousHead?: SnapshotHead
+	): Promise<void> {
+		const currentHead = this.heads.get(siteId);
+		if (
+			previousHead !== undefined &&
+			currentHead?.snapshotId !== previousHead.snapshotId
+		) {
+			throw new Error(`Snapshot head changed for site "${siteId}".`);
+		}
+		this.heads.set(siteId, {
+			siteId,
+			snapshotId,
+			updatedAt: new Date().toISOString(),
+		});
+	}
+
+	async readHead(siteId: string): Promise<SnapshotHead | undefined> {
+		return this.heads.get(siteId);
+	}
+
+	async readManifest(snapshotId: string): Promise<FilesystemSnapshot> {
+		const manifest = this.manifests.get(snapshotId);
+		if (manifest === undefined) {
+			throw new Error(`Snapshot manifest not found: ${snapshotId}`);
+		}
+		return manifest;
+	}
+
+	async readBlob(hash: string): Promise<Uint8Array> {
+		const bytes = this.blobs.get(hash);
+		if (bytes === undefined) {
+			throw new Error(`Snapshot blob not found: ${hash}`);
+		}
+		return new Uint8Array(bytes);
+	}
+}
+
+export type S3CompatibleObjectClient = {
+	headObject(key: string): Promise<boolean>;
+	putObject(
+		key: string,
+		body: Uint8Array,
+		options?: { contentType?: string }
+	): Promise<void>;
+	getObject(key: string): Promise<Uint8Array>;
+};
+
+export type S3CompatibleSnapshotPublisherOptions = {
+	prefix?: string;
+};
+
+export function createS3CompatibleSnapshotPublisher(
+	client: S3CompatibleObjectClient,
+	options: S3CompatibleSnapshotPublisherOptions = {}
+): SnapshotPublisher {
+	const prefix = normalizeObjectPrefix(options.prefix ?? '');
+	return {
+		async hasBlob(hash) {
+			return await client.headObject(blobKey(prefix, hash));
+		},
+		async putBlob(hash, bytes) {
+			await client.putObject(blobKey(prefix, hash), bytes, {
+				contentType: 'application/octet-stream',
+			});
+		},
+		async putManifest(snapshotId, manifest) {
+			await client.putObject(
+				manifestKey(prefix, snapshotId),
+				encodeJson(stripSnapshotBytes(manifest)),
+				{
+					contentType: 'application/json',
+				}
+			);
+		},
+		async publishHead(siteId, snapshotId) {
+			await client.putObject(
+				headKey(prefix, siteId),
+				encodeJson({
+					siteId,
+					snapshotId,
+					updatedAt: new Date().toISOString(),
+				}),
+				{
+					contentType: 'application/json',
+				}
+			);
+		},
+		async readHead(siteId) {
+			try {
+				return decodeJson<SnapshotHead>(
+					await client.getObject(headKey(prefix, siteId))
+				);
+			} catch (error) {
+				if (isMissingObjectError(error)) {
+					return undefined;
+				}
+				throw error;
+			}
+		},
+		async readManifest(snapshotId) {
+			return decodeJson<FilesystemSnapshot>(
+				await client.getObject(manifestKey(prefix, snapshotId))
+			);
+		},
+		async readBlob(hash) {
+			return await client.getObject(blobKey(prefix, hash));
+		},
+	};
+}
+
+export type OpfsSnapshotPublisherOptions = {
+	prefix?: string;
+};
+
+export function createOpfsSnapshotPublisher(
+	root: FileSystemDirectoryHandle,
+	options: OpfsSnapshotPublisherOptions = {}
+): SnapshotPublisher {
+	const prefix = normalizeObjectPrefix(options.prefix ?? '');
+	return {
+		async hasBlob(hash) {
+			return await opfsFileExists(root, blobKey(prefix, hash));
+		},
+		async putBlob(hash, bytes) {
+			await writeOpfsFile(root, blobKey(prefix, hash), bytes);
+		},
+		async putManifest(snapshotId, manifest) {
+			await writeOpfsFile(
+				root,
+				manifestKey(prefix, snapshotId),
+				encodeJson(stripSnapshotBytes(manifest))
+			);
+		},
+		async publishHead(siteId, snapshotId) {
+			await writeOpfsFile(
+				root,
+				headKey(prefix, siteId),
+				encodeJson({
+					siteId,
+					snapshotId,
+					updatedAt: new Date().toISOString(),
+				})
+			);
+		},
+		async readHead(siteId) {
+			try {
+				return decodeJson<SnapshotHead>(
+					await readOpfsFile(root, headKey(prefix, siteId))
+				);
+			} catch (error) {
+				if (isMissingObjectError(error)) {
+					return undefined;
+				}
+				throw error;
+			}
+		},
+		async readManifest(snapshotId) {
+			return decodeJson<FilesystemSnapshot>(
+				await readOpfsFile(root, manifestKey(prefix, snapshotId))
+			);
+		},
+		async readBlob(hash) {
+			return await readOpfsFile(root, blobKey(prefix, hash));
+		},
+	};
+}
+
+export type FetchS3CompatibleClientOptions = {
+	endpoint: string;
+	fetch?: typeof fetch;
+	headers?: HeadersInit | (() => HeadersInit | Promise<HeadersInit>);
+};
+
+export function createFetchS3CompatibleClient({
+	endpoint,
+	fetch: fetchImplementation = fetch,
+	headers,
+}: FetchS3CompatibleClientOptions): S3CompatibleObjectClient {
+	const root = endpoint.replace(/\/+$/, '');
+	return {
+		async headObject(key) {
+			const response = await fetchImplementation(objectUrl(root, key), {
+				method: 'HEAD',
+				headers: await resolveHeaders(headers),
+			});
+			if (response.status === 404) {
+				return false;
+			}
+			if (!response.ok) {
+				throw new Error(
+					`Could not check remote object ${key}: ${response.status}`
+				);
+			}
+			return true;
+		},
+		async putObject(key, body, options) {
+			const requestHeaders = new Headers(await resolveHeaders(headers));
+			if (options?.contentType) {
+				requestHeaders.set('content-type', options.contentType);
+			}
+			const response = await fetchImplementation(objectUrl(root, key), {
+				method: 'PUT',
+				headers: requestHeaders,
+				body,
+			});
+			if (!response.ok) {
+				throw new Error(
+					`Could not write remote object ${key}: ${response.status}`
+				);
+			}
+		},
+		async getObject(key) {
+			const response = await fetchImplementation(objectUrl(root, key), {
+				method: 'GET',
+				headers: await resolveHeaders(headers),
+			});
+			if (response.status === 404) {
+				throw missingObjectError(key);
+			}
+			if (!response.ok) {
+				throw new Error(
+					`Could not read remote object ${key}: ${response.status}`
+				);
+			}
+			return new Uint8Array(await response.arrayBuffer());
+		},
+	};
+}
+
+async function getFileEntryBytes(entry: SnapshotFileEntry) {
+	if (entry.bytes === undefined) {
+		throw new Error(
+			`Cannot publish ${entry.path}: snapshot entry does not include bytes.`
+		);
+	}
+	return entry.bytes;
+}
+
+async function verifyBlobHash(expectedHash: string, bytes: Uint8Array) {
+	const actualHash = await hashBytes(bytes);
+	if (actualHash !== expectedHash) {
+		throw new Error(
+			`Snapshot blob hash mismatch. Expected ${expectedHash}, got ${actualHash}.`
+		);
+	}
+}
+
+async function verifyManifestBlobs(
+	publisher: SnapshotPublisher,
+	manifest: FilesystemSnapshot
+) {
+	for (const entry of manifest.entries) {
+		if (entry.type === 'file' && !(await publisher.hasBlob(entry.hash))) {
+			throw new Error(
+				`Cannot publish snapshot manifest: missing blob ${entry.hash}.`
+			);
+		}
+	}
+}
+
+function blobKey(prefix: string, hash: string) {
+	return joinObjectKey(prefix, 'blobs', encodeObjectKeySegment(hash));
+}
+
+function manifestKey(prefix: string, snapshotId: string) {
+	return joinObjectKey(
+		prefix,
+		'snapshots',
+		`${encodeObjectKeySegment(snapshotId)}.json`
+	);
+}
+
+function headKey(prefix: string, siteId: string) {
+	return joinObjectKey(
+		prefix,
+		'heads',
+		`${encodeObjectKeySegment(siteId)}.json`
+	);
+}
+
+function joinObjectKey(...parts: string[]) {
+	return normalizePath(joinPaths(...parts)).replace(/^\/+/, '');
+}
+
+function normalizeObjectPrefix(prefix: string) {
+	return normalizePath(prefix).replace(/^\/+|\/+$/g, '');
+}
+
+function encodeObjectKeySegment(segment: string) {
+	return encodeURIComponent(segment);
+}
+
+function encodeJson(value: unknown) {
+	return new TextEncoder().encode(JSON.stringify(value));
+}
+
+function decodeJson<T>(bytes: Uint8Array): T {
+	return JSON.parse(new TextDecoder().decode(bytes)) as T;
+}
+
+async function resolveHeaders(
+	headers: FetchS3CompatibleClientOptions['headers']
+) {
+	if (headers === undefined) {
+		return {};
+	}
+	return typeof headers === 'function' ? await headers() : headers;
+}
+
+function objectUrl(root: string, key: string) {
+	return `${root}/${key
+		.split('/')
+		.map((part) => encodeURIComponent(part))
+		.join('/')}`;
+}
+
+async function writeOpfsFile(
+	root: FileSystemDirectoryHandle,
+	key: string,
+	bytes: Uint8Array
+) {
+	const { parent, name } = await resolveOpfsParent(root, key, true);
+	const file = await parent.getFileHandle(name, { create: true });
+	const writable = await file.createWritable();
+	try {
+		await writable.write(bytes);
+	} finally {
+		await writable.close();
+	}
+}
+
+async function readOpfsFile(root: FileSystemDirectoryHandle, key: string) {
+	try {
+		const { parent, name } = await resolveOpfsParent(root, key, false);
+		const file = await parent.getFileHandle(name);
+		return new Uint8Array(await (await file.getFile()).arrayBuffer());
+	} catch (error) {
+		if (isOpfsNotFoundError(error)) {
+			throw missingObjectError(key);
+		}
+		throw error;
+	}
+}
+
+async function opfsFileExists(root: FileSystemDirectoryHandle, key: string) {
+	try {
+		const { parent, name } = await resolveOpfsParent(root, key, false);
+		await parent.getFileHandle(name);
+		return true;
+	} catch (error) {
+		if (isOpfsNotFoundError(error)) {
+			return false;
+		}
+		throw error;
+	}
+}
+
+async function resolveOpfsParent(
+	root: FileSystemDirectoryHandle,
+	key: string,
+	create: boolean
+) {
+	const segments = key.split('/').filter(Boolean);
+	const name = segments.pop();
+	if (!name) {
+		throw new Error(`Invalid snapshot object key: ${key}`);
+	}
+	let parent = root;
+	for (const segment of segments) {
+		parent = await parent.getDirectoryHandle(segment, { create });
+	}
+	return { parent, name };
+}
+
+function isOpfsNotFoundError(error: unknown) {
+	return (error as { name?: string })?.name === 'NotFoundError';
+}
+
+function missingObjectError(key: string) {
+	const error = new Error(`Remote object not found: ${key}`) as Error & {
+		code: 'NoSuchKey';
+		status: 404;
+	};
+	error.code = 'NoSuchKey';
+	error.status = 404;
+	return error;
+}
+
+function isMissingObjectError(error: unknown) {
+	const maybeError = error as { code?: string; status?: number };
+	return maybeError?.code === 'NoSuchKey' || maybeError?.status === 404;
+}

--- a/packages/playground/storage/src/test/snapshot-publisher.spec.ts
+++ b/packages/playground/storage/src/test/snapshot-publisher.spec.ts
@@ -1,0 +1,283 @@
+import { describe, expect, it } from 'vitest';
+import type { FilesystemSnapshot } from '@php-wasm/universal';
+import { hashBytes } from '@php-wasm/universal';
+import {
+	InMemorySnapshotPublisher,
+	createOpfsSnapshotPublisher,
+	createS3CompatibleSnapshotPublisher,
+	publishSnapshot,
+	restoreSnapshotFromPublisher,
+} from '../lib/snapshot-publisher';
+
+describe('snapshot publisher', () => {
+	it('publishes only missing blobs and strips bytes from manifests', async () => {
+		const fileBytes = bytes('shared');
+		const fileHash = await hashBytes(fileBytes);
+		const snapshot = createSnapshot('snapshot-1', [
+			{
+				type: 'directory',
+				path: '/site',
+			},
+			{
+				type: 'file',
+				path: '/site/a.txt',
+				size: fileBytes.byteLength,
+				hash: fileHash,
+				bytes: fileBytes,
+			},
+			{
+				type: 'file',
+				path: '/site/b.txt',
+				size: fileBytes.byteLength,
+				hash: fileHash,
+				bytes: fileBytes,
+			},
+		]);
+		const publisher = new InMemorySnapshotPublisher();
+
+		const result = await publishSnapshot(publisher, 'site-id', snapshot);
+
+		expect(result.uploadedBlobs).toEqual([fileHash]);
+		expect(result.skippedBlobs).toEqual([]);
+		expect(publisher.blobs.size).toBe(1);
+		const manifest = await publisher.readManifest(snapshot.id);
+		const fileEntry = manifest.entries.find(
+			(entry) => entry.type === 'file'
+		);
+		expect((fileEntry as any).bytes).toBeUndefined();
+		expect(await publisher.readHead('site-id')).toMatchObject({
+			siteId: 'site-id',
+			snapshotId: snapshot.id,
+		});
+
+		const secondResult = await publishSnapshot(
+			publisher,
+			'site-id',
+			createSnapshot('snapshot-2', snapshot.entries)
+		);
+
+		expect(secondResult.uploadedBlobs).toEqual([]);
+		expect(secondResult.skippedBlobs).toEqual([fileHash]);
+	});
+
+	it('restores manifest-only snapshots by reading blobs', async () => {
+		const fileBytes = bytes('content');
+		const fileHash = await hashBytes(fileBytes);
+		const snapshot = createSnapshot('snapshot-1', [
+			{
+				type: 'directory',
+				path: '/site',
+			},
+			{
+				type: 'file',
+				path: '/site/file.txt',
+				size: fileBytes.byteLength,
+				hash: fileHash,
+				bytes: fileBytes,
+			},
+		]);
+		const publisher = new InMemorySnapshotPublisher();
+		await publishSnapshot(publisher, 'site-id', snapshot);
+
+		const restored = await restoreSnapshotFromPublisher(
+			publisher,
+			snapshot.id
+		);
+
+		const restoredFile = restored.entries.find(
+			(entry) => entry.type === 'file'
+		);
+		expect(Array.from((restoredFile as any).bytes)).toEqual(
+			Array.from(fileBytes)
+		);
+	});
+
+	it('can publish through an S3-compatible object client', async () => {
+		const fileBytes = bytes('remote');
+		const fileHash = await hashBytes(fileBytes);
+		const storedObjects = new Map<string, Uint8Array>();
+		const publisher = createS3CompatibleSnapshotPublisher(
+			{
+				async headObject(key) {
+					return storedObjects.has(key);
+				},
+				async putObject(key, body) {
+					storedObjects.set(key, new Uint8Array(body));
+				},
+				async getObject(key) {
+					const body = storedObjects.get(key);
+					if (body === undefined) {
+						const error = new Error('missing') as Error & {
+							status: 404;
+						};
+						error.status = 404;
+						throw error;
+					}
+					return body;
+				},
+			},
+			{
+				prefix: 'sites/site-id',
+			}
+		);
+		const snapshot = createSnapshot('snapshot-remote', [
+			{
+				type: 'directory',
+				path: '/site',
+			},
+			{
+				type: 'file',
+				path: '/site/file.txt',
+				size: fileBytes.byteLength,
+				hash: fileHash,
+				bytes: fileBytes,
+			},
+		]);
+
+		await publishSnapshot(publisher, 'site-id', snapshot);
+
+		expect(
+			storedObjects.has(
+				`sites/site-id/blobs/${encodeURIComponent(fileHash)}`
+			)
+		).toBe(true);
+		expect(
+			storedObjects.has(
+				`sites/site-id/snapshots/${encodeURIComponent(
+					snapshot.id
+				)}.json`
+			)
+		).toBe(true);
+		expect(storedObjects.has('sites/site-id/heads/site-id.json')).toBe(
+			true
+		);
+	});
+
+	it('can publish through an OPFS object publisher', async () => {
+		const fileBytes = bytes('opfs');
+		const fileHash = await hashBytes(fileBytes);
+		const root = createMemoryDirectoryHandle();
+		const publisher = createOpfsSnapshotPublisher(root as any, {
+			prefix: 'sites/site-id',
+		});
+		const snapshot = createSnapshot('snapshot-opfs', [
+			{
+				type: 'directory',
+				path: '/site',
+			},
+			{
+				type: 'file',
+				path: '/site/file.txt',
+				size: fileBytes.byteLength,
+				hash: fileHash,
+				bytes: fileBytes,
+			},
+		]);
+
+		await publishSnapshot(publisher, 'site-id', snapshot);
+		const restored = await restoreSnapshotFromPublisher(
+			publisher,
+			snapshot.id
+		);
+
+		expect(await publisher.hasBlob(fileHash)).toBe(true);
+		expect(await publisher.readHead('site-id')).toMatchObject({
+			snapshotId: snapshot.id,
+		});
+		const restoredFile = restored.entries.find(
+			(entry) => entry.type === 'file'
+		);
+		expect(Array.from((restoredFile as any).bytes)).toEqual(
+			Array.from(fileBytes)
+		);
+	});
+});
+
+function createSnapshot(
+	id: string,
+	entries: FilesystemSnapshot['entries']
+): FilesystemSnapshot {
+	return {
+		version: 1,
+		id,
+		root: '/site',
+		createdAt: '2026-06-25T00:00:00.000Z',
+		entries,
+	};
+}
+
+function bytes(text: string) {
+	return new TextEncoder().encode(text);
+}
+
+function createMemoryDirectoryHandle(name = 'root') {
+	const directories = new Map<
+		string,
+		ReturnType<typeof createMemoryDirectoryHandle>
+	>();
+	const files = new Map<string, ReturnType<typeof createMemoryFileHandle>>();
+	return {
+		name,
+		kind: 'directory',
+		async getDirectoryHandle(
+			childName: string,
+			options: { create?: boolean } = {}
+		) {
+			let child = directories.get(childName);
+			if (child === undefined) {
+				if (!options.create) {
+					throw notFoundError();
+				}
+				child = createMemoryDirectoryHandle(childName);
+				directories.set(childName, child);
+			}
+			return child;
+		},
+		async getFileHandle(
+			childName: string,
+			options: { create?: boolean } = {}
+		) {
+			let child = files.get(childName);
+			if (child === undefined) {
+				if (!options.create) {
+					throw notFoundError();
+				}
+				child = createMemoryFileHandle(childName);
+				files.set(childName, child);
+			}
+			return child;
+		},
+	};
+}
+
+function createMemoryFileHandle(name: string) {
+	let contents = new Uint8Array();
+	return {
+		name,
+		kind: 'file',
+		async createWritable() {
+			return {
+				async write(bytes: Uint8Array) {
+					contents = new Uint8Array(bytes);
+				},
+				async close() {},
+			};
+		},
+		async getFile() {
+			return {
+				async arrayBuffer() {
+					return contents.buffer.slice(
+						contents.byteOffset,
+						contents.byteOffset + contents.byteLength
+					);
+				},
+			};
+		},
+	};
+}
+
+function notFoundError() {
+	const error = new Error('Not found');
+	error.name = 'NotFoundError';
+	return error;
+}


### PR DESCRIPTION
🚧 Don't review yet

## Branch note

This branch has been rebuilt directly on top of trunk. It intentionally does not include the opfs_sqlite_flush_risk branch stack or the old VACUUM INTO snapshot path.

## What changed

- Added durable byte-level filesystem snapshot, diff, and restore primitives for MEMFS.
- Added snapshot publishing helpers for OPFS and S3-compatible object storage.
- Integrated MEMFS snapshots into OPFS SQLite flushing so .ht.sqlite plus journal/WAL sidecars can be persisted from live bytes.
- Exposed snapshot and restore methods through PHPWorker for client-side remote publishing flows.

## Why

This creates a correctness-oriented snapshot substrate for SQLite sync, including journal and WAL mode sidecar files, and gives callers a direct path to publish snapshots to S3-compatible storage without relying on OPFS as an intermediate.

## Validation

- npm exec nx test php-wasm-universal -- --runInBand
- npm exec nx test playground-storage -- --runInBand
- npm exec nx test php-wasm-web -- --runInBand
- npm exec nx test playground-remote -- --runInBand
- npm exec nx lint php-wasm-universal
- npm exec nx lint playground-storage
- npm exec nx lint php-wasm-web
- npm exec nx lint playground-remote
- npm exec nx run php-wasm-universal:typecheck
- npm exec nx run php-wasm-web:typecheck
- npm exec nx run playground-remote:typecheck
- npm exec -- tsc -p packages/playground/storage/tsconfig.lib.json --noEmit
