### PR TITLE
[Storage] Lazy-load git API modules

### DIFF
--- a/packages/playground/storage/src/index.ts
+++ b/packages/playground/storage/src/index.ts
@@ -2,7 +2,62 @@ export * from './lib/github';
 export * from './lib/changeset';
 export * from './lib/playground';
 export * from './lib/browser-fs';
-export * from './lib/git-sparse-checkout';
-export * from './lib/git-create-dotgit-directory';
 export * from './lib/paths';
 export * from './lib/filesystems';
+export { GitAuthenticationError } from './lib/git-authentication-error';
+import type * as GitCreateDotGitDirectoryModule from './lib/git-create-dotgit-directory';
+import type * as GitSparseCheckoutModule from './lib/git-sparse-checkout';
+export type {
+	GitAdditionalHeaders,
+	GitFileTree,
+	GitFileTreeFile,
+	GitFileTreeFolder,
+	GitRef,
+	SparseCheckoutObject,
+	SparseCheckoutPackfile,
+	SparseCheckoutResult,
+} from './lib/git-sparse-checkout';
+
+function loadGitSparseCheckout(): Promise<typeof GitSparseCheckoutModule> {
+	return import('./lib/git-sparse-checkout');
+}
+
+function loadGitCreateDotGitDirectory(): Promise<
+	typeof GitCreateDotGitDirectoryModule
+> {
+	return import('./lib/git-create-dotgit-directory');
+}
+
+export async function sparseCheckout(
+	...args: Parameters<typeof GitSparseCheckoutModule.sparseCheckout>
+): ReturnType<typeof GitSparseCheckoutModule.sparseCheckout> {
+	return (await loadGitSparseCheckout()).sparseCheckout(...args);
+}
+
+export async function listGitFiles(
+	...args: Parameters<typeof GitSparseCheckoutModule.listGitFiles>
+): ReturnType<typeof GitSparseCheckoutModule.listGitFiles> {
+	return (await loadGitSparseCheckout()).listGitFiles(...args);
+}
+
+export async function resolveCommitHash(
+	...args: Parameters<typeof GitSparseCheckoutModule.resolveCommitHash>
+): ReturnType<typeof GitSparseCheckoutModule.resolveCommitHash> {
+	return (await loadGitSparseCheckout()).resolveCommitHash(...args);
+}
+
+export async function listGitRefs(
+	...args: Parameters<typeof GitSparseCheckoutModule.listGitRefs>
+): ReturnType<typeof GitSparseCheckoutModule.listGitRefs> {
+	return (await loadGitSparseCheckout()).listGitRefs(...args);
+}
+
+export async function createDotGitDirectory(
+	...args: Parameters<
+		typeof GitCreateDotGitDirectoryModule.createDotGitDirectory
+	>
+): ReturnType<typeof GitCreateDotGitDirectoryModule.createDotGitDirectory> {
+	return (await loadGitCreateDotGitDirectory()).createDotGitDirectory(
+		...args
+	);
+}


### PR DESCRIPTION
## What it does

Lazy-loads the git-heavy implementation modules behind the public `@wp-playground/storage` git APIs.

The exported functions keep the same async API surface, but `git-sparse-checkout` and `git-create-dotgit-directory` are loaded only when one of the git APIs is called.

## Rationale

This avoids making every browser consumer of `@wp-playground/storage` pay the git implementation cost up front.

Measured with:

```bash
npm exec nx run playground-storage:build:bundle:production
```

| Build | Initial `index.js` | Gzip |
| --- | ---: | ---: |
| `origin/trunk` | 363.40 kB | 91.87 kB |
| This branch | 25.28 kB | 6.77 kB |
| Change | -338.12 kB | -85.10 kB |

## Testing instructions

```bash
npx nx run playground-storage:test
npx nx run playground-storage:build
```