### PR TITLE
[GitHub Actions] Keep Vite optimizer output out of node_modules cache

### DIFF
--- a/.github/actions/prepare-playground/action.yml
+++ b/.github/actions/prepare-playground/action.yml
@@ -20,10 +20,13 @@ runs:
           id: cache-nodemodules
           uses: actions/cache@v4
           env:
-              cache-name: cache-node-modules-v2
+              cache-name: cache-node-modules-v3
           with:
               # caching node_modules
-              path: node_modules
+              path: |
+                  node_modules
+                  !node_modules/.vite
+                  !node_modules/.vite/**
               key: ${{ runner.os }}-${{ runner.arch }}-node-${{ inputs.node-version }}-build-${{ env.cache-name }}-${{ hashFiles('package-lock.json') }}
               restore-keys: |
                   ${{ runner.os }}-${{ runner.arch }}-node-${{ inputs.node-version }}-build-${{ env.cache-name }}-


### PR DESCRIPTION
## What it does

Prevents CI from restoring stale Vite optimizer output from the shared `node_modules` cache.

The `prepare-playground` action still caches `node_modules`, but keeps `node_modules/.vite` out of the saved and restored archive.

## Rationale

The Blueprints v2 stack was hitting E2E failures where restored cache entries referenced missing files under `node_modules/.vite/playground/deps`. `npx nx reset` clears Nx state, but it does not invalidate Vite's dependency optimizer output.

Caching `node_modules/.vite` makes those optimizer artifacts survive across jobs and commits, where they can point at files that no longer exist. Keeping that directory out of the cache lets Vite rebuild it for the current run.

## Implementation

Adds negative `actions/cache` path patterns for the Vite optimizer directory:

```yaml
path: |
    node_modules
    !node_modules/.vite
    !node_modules/.vite/**
```

Also rotates the cache name from `cache-node-modules-v2` to `cache-node-modules-v3` so existing archives that may already contain `.vite` are not reused as exact hits.

## Testing instructions

CI should recreate `node_modules/.vite` during the affected E2E jobs instead of restoring it from cache.

Local checks run:

```bash
npx prettier --check .github/actions/prepare-playground/action.yml
node -e "const fs = require('fs'); const YAML = require('yaml'); YAML.parse(fs.readFileSync('.github/actions/prepare-playground/action.yml', 'utf8'));"
```