### PR TITLE
[MCP] Update WebMCP registration API

### DIFF
--- a/packages/playground/mcp/README.md
+++ b/packages/playground/mcp/README.md
@@ -82,7 +82,7 @@ The MCP server communicates with AI clients via stdio and with the browser via W
 
 ## WebMCP
 
-The [Playground Website](https://playground.wordpress.net/) also supports [WebMCP](https://github.com/webmachinelearning/webmcp) — a browser-native MCP proposal that exposes tools via `navigator.modelContext`. When a Playground site loads, its tools are registered automatically with no CLI or WebSocket bridge needed.
+The [Playground Website](https://playground.wordpress.net/) also supports [WebMCP](https://github.com/webmachinelearning/webmcp) — a browser-native MCP proposal that exposes tools via `document.modelContext`. When a Playground site loads, its tools are registered automatically with no CLI or WebSocket bridge needed.
 
 > **Note:** WebMCP is still a draft proposal and not widely supported.
 

--- a/packages/playground/mcp/src/webmcp.ts
+++ b/packages/playground/mcp/src/webmcp.ts
@@ -45,7 +45,11 @@ interface ModelContext {
 	readonly tools: ModelContextTool[];
 }
 
-type DocumentWithModelContext = Document & { modelContext?: ModelContext };
+declare global {
+	interface Document {
+		modelContext?: ModelContext;
+	}
+}
 
 // -- Registration --
 
@@ -110,15 +114,38 @@ export async function registerWebMCPTools(
 	// Site management tools
 	tools.push(...createSiteManagementTools(config));
 
-	await Promise.all(
-		tools.map((tool) => modelContext.registerTool(tool, { signal }))
+	const results = await Promise.allSettled(
+		tools.map(async (tool) => {
+			await modelContext.registerTool(tool, { signal });
+		})
 	);
+	const failedRegistrations: Array<{ name: string; reason: unknown }> = [];
+	for (const [index, result] of results.entries()) {
+		if (result.status === 'rejected') {
+			failedRegistrations.push({
+				name: tools[index].name,
+				reason: result.reason,
+			});
+		}
+	}
+	if (failedRegistrations.length > 0) {
+		throw new Error(
+			'Failed to register WebMCP tools: ' +
+				failedRegistrations
+					.map(
+						({ name, reason }) =>
+							`${name} (${stringifyError(reason)})`
+					)
+					.join(', ')
+		);
+	}
 }
 
 function getModelContext(): ModelContext | undefined {
 	if (typeof document !== 'undefined') {
-		return (document as DocumentWithModelContext).modelContext;
+		return document.modelContext;
 	}
+	return undefined;
 }
 
 function createSiteManagementTools(

--- a/packages/playground/mcp/src/webmcp.ts
+++ b/packages/playground/mcp/src/webmcp.ts
@@ -1,7 +1,7 @@
 /**
  * WebMCP registration for WordPress Playground.
  *
- * Registers playground tools with `navigator.modelContext` (the
+ * Registers playground tools with `document.modelContext` (the
  * Chrome WebMCP API) so that browser-side AI agents can interact
  * with the running Playground site.
  */
@@ -41,15 +41,11 @@ interface ModelContext {
 	registerTool(
 		tool: ModelContextTool,
 		options?: { signal?: AbortSignal }
-	): void;
+	): Promise<void> | void;
 	readonly tools: ModelContextTool[];
 }
 
-declare global {
-	interface Navigator {
-		modelContext?: ModelContext;
-	}
-}
+type DocumentWithModelContext = Document & { modelContext?: ModelContext };
 
 // -- Registration --
 
@@ -64,8 +60,11 @@ function getActiveSite(config: PlaygroundBridgeConfig) {
 	return active;
 }
 
-export function registerWebMCPTools(config: PlaygroundBridgeConfig): void {
-	if (typeof navigator === 'undefined' || !navigator.modelContext) {
+export async function registerWebMCPTools(
+	config: PlaygroundBridgeConfig
+): Promise<void> {
+	const modelContext = getModelContext();
+	if (!modelContext) {
 		return;
 	}
 
@@ -111,8 +110,14 @@ export function registerWebMCPTools(config: PlaygroundBridgeConfig): void {
 	// Site management tools
 	tools.push(...createSiteManagementTools(config));
 
-	for (const tool of tools) {
-		navigator.modelContext.registerTool(tool, { signal });
+	await Promise.all(
+		tools.map((tool) => modelContext.registerTool(tool, { signal }))
+	);
+}
+
+function getModelContext(): ModelContext | undefined {
+	if (typeof document !== 'undefined') {
+		return (document as DocumentWithModelContext).modelContext;
 	}
 }
 

--- a/packages/playground/mcp/src/webmcp.ts
+++ b/packages/playground/mcp/src/webmcp.ts
@@ -75,7 +75,6 @@ export async function registerWebMCPTools(
 	// Abort any previous registration before re-registering.
 	registrationController?.abort();
 	registrationController = new AbortController();
-	registrationController = new AbortController();
 	const controller = registrationController;
 	const signal = controller.signal;
 

--- a/packages/playground/mcp/src/webmcp.ts
+++ b/packages/playground/mcp/src/webmcp.ts
@@ -131,6 +131,10 @@ export async function registerWebMCPTools(
 		}
 	}
 	if (failedRegistrations.length > 0) {
+		controller.abort();
+		if (registrationController === controller) {
+			registrationController = null;
+		}
 		throw new Error(
 			'Failed to register WebMCP tools: ' +
 				failedRegistrations

--- a/packages/playground/mcp/src/webmcp.ts
+++ b/packages/playground/mcp/src/webmcp.ts
@@ -142,10 +142,13 @@ export async function registerWebMCPTools(
 }
 
 function getModelContext(): ModelContext | undefined {
-	if (typeof document !== 'undefined') {
-		return document.modelContext;
+	if (typeof document === 'undefined') {
+		return undefined;
 	}
-	return undefined;
+	const modelContext = document.modelContext;
+	return typeof modelContext?.registerTool === 'function'
+		? modelContext
+		: undefined;
 }
 
 function createSiteManagementTools(

--- a/packages/playground/mcp/src/webmcp.ts
+++ b/packages/playground/mcp/src/webmcp.ts
@@ -75,7 +75,9 @@ export async function registerWebMCPTools(
 	// Abort any previous registration before re-registering.
 	registrationController?.abort();
 	registrationController = new AbortController();
-	const signal = registrationController.signal;
+	registrationController = new AbortController();
+	const controller = registrationController;
+	const signal = controller.signal;
 
 	function getActiveClient(): PlaygroundClient {
 		const client = config.getClient();

--- a/packages/playground/mcp/tests/e2e/webmcp.spec.ts
+++ b/packages/playground/mcp/tests/e2e/webmcp.spec.ts
@@ -3,7 +3,7 @@ import type { Page } from '@playwright/test';
 
 const test = base.extend<{ webmcpPage: Page }>({
 	webmcpPage: async ({ page }, use) => {
-		// WebMCP (navigator.modelContext) is only available in
+		// WebMCP (document.modelContext) is only available in
 		// Chrome 148+ Canary behind chrome://flags/#enable-webmcp-testing.
 		// Playwright uses a stock Chromium that doesn't
 		// expose the API, so we inject a mock before the page
@@ -20,7 +20,7 @@ const test = base.extend<{ webmcpPage: Page }>({
 
 			(window as any).__webmcpExecutors = {};
 
-			Object.defineProperty(navigator as any, 'modelContext', {
+			Object.defineProperty(document as any, 'modelContext', {
 				configurable: true,
 				value: {
 					get tools() {
@@ -30,7 +30,7 @@ const test = base.extend<{ webmcpPage: Page }>({
 						registeredTools.length = 0;
 						(window as any).__webmcpExecutors = {};
 					},
-					registerTool(
+					async registerTool(
 						tool: (typeof registeredTools)[0],
 						options?: { signal?: AbortSignal }
 					) {

--- a/packages/playground/personal-wp/src/lib/state/redux/init-mcp-bridge.ts
+++ b/packages/playground/personal-wp/src/lib/state/redux/init-mcp-bridge.ts
@@ -115,11 +115,13 @@ startListening({
 			},
 		};
 
-		try {
-			registerWebMCPTools(mcpConfig);
-		} catch (error) {
-			logger.warn('WebMCP registration failed:', error);
-		}
+		void (async () => {
+			try {
+				await registerWebMCPTools(mcpConfig);
+			} catch (error) {
+				logger.warn('WebMCP registration failed:', error);
+			}
+		})();
 
 		const getRequestedMcpPort = (): number | null => {
 			const mcpPort = new URLSearchParams(window.location.search).get(

--- a/packages/playground/personal-wp/src/lib/state/redux/init-mcp-bridge.ts
+++ b/packages/playground/personal-wp/src/lib/state/redux/init-mcp-bridge.ts
@@ -115,13 +115,9 @@ startListening({
 			},
 		};
 
-		void (async () => {
-			try {
-				await registerWebMCPTools(mcpConfig);
-			} catch (error) {
-				logger.warn('WebMCP registration failed:', error);
-			}
-		})();
+		void registerWebMCPTools(mcpConfig).catch((error) => {
+			logger.warn('WebMCP registration failed:', error);
+		});
 
 		const getRequestedMcpPort = (): number | null => {
 			const mcpPort = new URLSearchParams(window.location.search).get(

--- a/packages/playground/website/src/lib/state/redux/init-mcp-bridge.ts
+++ b/packages/playground/website/src/lib/state/redux/init-mcp-bridge.ts
@@ -36,18 +36,20 @@ startListening({
 		};
 
 		// Register WebMCP tools regardless of ?mcp-port — they only
-		// activate when navigator.modelContext is available.
+		// activate when document.modelContext is available.
 		/**
-		 * Wrapped in try/catch because WebMCP (navigator.modelContext) is an
+		 * Wrapped in try/catch because WebMCP (document.modelContext) is an
 		 * experimental Chrome API that is still evolving. If it changes or
 		 * breaks, we must not let it crash the Playground website — the MCP
 		 * integration is a progressive enhancement, not a critical feature.
 		 */
-		try {
-			registerWebMCPTools(mcpConfig);
-		} catch (error) {
-			logger.warn('WebMCP registration failed:', error);
-		}
+		void (async () => {
+			try {
+				await registerWebMCPTools(mcpConfig);
+			} catch (error) {
+				logger.warn('WebMCP registration failed:', error);
+			}
+		})();
 
 		// Only start the WebSocket bridge when explicitly requested
 		// via ?mcp-port.

--- a/packages/playground/website/src/lib/state/redux/init-mcp-bridge.ts
+++ b/packages/playground/website/src/lib/state/redux/init-mcp-bridge.ts
@@ -38,18 +38,14 @@ startListening({
 		// Register WebMCP tools regardless of ?mcp-port — they only
 		// activate when document.modelContext is available.
 		/**
-		 * Wrapped in try/catch because WebMCP (document.modelContext) is an
+		 * Catch failures because WebMCP (document.modelContext) is an
 		 * experimental Chrome API that is still evolving. If it changes or
 		 * breaks, we must not let it crash the Playground website — the MCP
 		 * integration is a progressive enhancement, not a critical feature.
 		 */
-		void (async () => {
-			try {
-				await registerWebMCPTools(mcpConfig);
-			} catch (error) {
-				logger.warn('WebMCP registration failed:', error);
-			}
-		})();
+		void registerWebMCPTools(mcpConfig).catch((error) => {
+			logger.warn('WebMCP registration failed:', error);
+		});
 
 		// Only start the WebSocket bridge when explicitly requested
 		// via ?mcp-port.


### PR DESCRIPTION
## Summary

Updates WebMCP tool registration to use the current `document.modelContext` API and handle asynchronous tool registration without breaking the Playground website.

## Motivation for the change, related issues

Chrome's WebMCP API has moved away from `navigator.modelContext`; the [Chrome WebMCP Imperative API documentation](https://developer.chrome.com/docs/ai/webmcp/imperative-api) notes that `navigator.modelContext` is deprecated in Chrome 150 and recommends `document.modelContext` instead.

The `registerTool()` API is also asynchronous in newer Chrome builds, so registration failures need to be caught from the returned Promise. WebMCP is still a progressive enhancement, so failed or unavailable WebMCP registration should not break the website.

## Implementation details

- Switches WebMCP registration to `document.modelContext` only.
- Makes `registerWebMCPTools()` return a Promise and await all `registerTool()` calls.
- Updates website and Personal WP initialization to catch async WebMCP registration failures and log them.
- Updates the WebMCP e2e mock and README references to use `document.modelContext`.

## Testing Instructions

- Ran `git diff --check`.
- I could not run Nx lint/tests in this worktree because `node_modules` is missing. The commit hook also attempted `nx format --fix --parallel --uncommitted` and reported that Nx modules could not be found.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated WebMCP integration to use the current `document.modelContext` API.
  - WebMCP tools now support asynchronous registration.
  - Multiple tools are registered reliably during setup.
- **Bug Fixes**
  - Improved registration failure handling and warning reporting.
  - Prevented incomplete registrations when setup encounters an error.
- **Documentation**
  - Updated WebMCP documentation to reflect the current API usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->