### PR TITLE
[Storage] Omit sensitive remotes from materialized git directories

### DIFF
--- a/packages/playground/storage/src/lib/git-create-dotgit-directory.ts
+++ b/packages/playground/storage/src/lib/git-create-dotgit-directory.ts
@@ -13,6 +13,38 @@ type GitHeadInfo = {
 };
 
 const FULL_SHA_REGEX = /^[0-9a-f]{40}$/i;
+const SENSITIVE_URL_PARAM_PATTERN =
+	/(^|[-_])(access[-_]?token|auth[-_]?token|credential|password|refresh[-_]?token|secret|session[-_]?token|signature|token)([-_]|$)/i;
+
+function normalizeUrlParamKey(key: string) {
+	return key.replace(/([a-z0-9])([A-Z])/g, '$1-$2');
+}
+
+function hasSensitiveUrlData(url: string) {
+	let parsedUrl: URL;
+	try {
+		parsedUrl = new URL(url);
+	} catch {
+		return false;
+	}
+
+	const hasSensitiveParam = (params: URLSearchParams) => {
+		for (const [key] of params) {
+			const normalizedKey = normalizeUrlParamKey(key);
+			if (SENSITIVE_URL_PARAM_PATTERN.test(normalizedKey)) {
+				return true;
+			}
+		}
+		return false;
+	};
+
+	if (hasSensitiveParam(parsedUrl.searchParams)) {
+		return true;
+	}
+
+	const fragmentParams = new URLSearchParams(parsedUrl.hash.slice(1));
+	return hasSensitiveParam(fragmentParams);
+}
 
 /**
  * Creates loose Git object files from sparse checkout objects.
@@ -110,9 +142,20 @@ function buildGitConfig(
 	{
 		branchName,
 		partialCloneFilter,
-	}: { branchName?: string; partialCloneFilter?: string }
+		persistRemote,
+	}: {
+		branchName?: string;
+		partialCloneFilter?: string;
+		persistRemote: boolean;
+	}
 ): string {
-	const repositoryFormatVersion = partialCloneFilter ? 1 : 0;
+	if (!persistRemote && partialCloneFilter) {
+		throw new Error(
+			'Cannot write partial clone config without persisting the remote.'
+		);
+	}
+
+	const repositoryFormatVersion = persistRemote && partialCloneFilter ? 1 : 0;
 	const lines = [
 		'[core]',
 		`\trepositoryformatversion = ${repositoryFormatVersion}`,
@@ -121,18 +164,22 @@ function buildGitConfig(
 		'\tlogallrefupdates = true',
 		'\tignorecase = true',
 		'\tprecomposeunicode = true',
-		'[remote "origin"]',
-		`\turl = ${repoUrl}`,
-		'\tfetch = +refs/heads/*:refs/remotes/origin/*',
-		'\tfetch = +refs/tags/*:refs/tags/*',
 	];
-	if (partialCloneFilter) {
-		lines.push('\tpromisor = true');
-		lines.push(`\tpartialclonefilter = ${partialCloneFilter}`);
-		lines.push('[extensions]');
-		lines.push('\tpartialclone = origin');
+	if (persistRemote) {
+		lines.push(
+			'[remote "origin"]',
+			`\turl = ${repoUrl}`,
+			'\tfetch = +refs/heads/*:refs/remotes/origin/*',
+			'\tfetch = +refs/tags/*:refs/tags/*'
+		);
+		if (partialCloneFilter) {
+			lines.push('\tpromisor = true');
+			lines.push(`\tpartialclonefilter = ${partialCloneFilter}`);
+			lines.push('[extensions]');
+			lines.push('\tpartialclone = origin');
+		}
 	}
-	if (branchName) {
+	if (branchName && persistRemote) {
 		lines.push(
 			`[branch "${branchName}"]`,
 			'\tremote = origin',
@@ -165,10 +212,13 @@ export async function createDotGitDirectory({
 }): Promise<Record<string, string | Uint8Array>> {
 	const gitFiles: Record<string, string | Uint8Array> = {};
 	const headInfo = resolveHeadInfo(ref, refType, commitHash);
+	// Credentials belong in request headers, not persisted repository metadata.
+	const persistRemote = !hasSensitiveUrlData(repoUrl);
 
 	gitFiles['.git/HEAD'] = headInfo.headContent;
 	gitFiles['.git/config'] = buildGitConfig(repoUrl, {
 		branchName: headInfo.branchName,
+		persistRemote,
 	});
 	gitFiles['.git/description'] = 'WordPress Playground clone\n';
 	gitFiles['.git/shallow'] = `${commitHash}\n`;
@@ -181,10 +231,12 @@ export async function createDotGitDirectory({
 	if (headInfo.branchRef && headInfo.branchName) {
 		gitFiles['.git/logs/HEAD'] = `ref: ${headInfo.branchRef}\n`;
 		gitFiles[`.git/${headInfo.branchRef}`] = `${commitHash}\n`;
-		gitFiles[`.git/refs/remotes/origin/${headInfo.branchName}`] =
-			`${commitHash}\n`;
-		gitFiles['.git/refs/remotes/origin/HEAD'] =
-			`ref: refs/remotes/origin/${headInfo.branchName}\n`;
+		if (persistRemote) {
+			gitFiles[`.git/refs/remotes/origin/${headInfo.branchName}`] =
+				`${commitHash}\n`;
+			gitFiles['.git/refs/remotes/origin/HEAD'] =
+				`ref: refs/remotes/origin/${headInfo.branchName}\n`;
+		}
 	}
 
 	if (headInfo.tagName) {

--- a/packages/playground/storage/src/test/git-sparse-checkout.spec.ts
+++ b/packages/playground/storage/src/test/git-sparse-checkout.spec.ts
@@ -5,6 +5,7 @@ import {
 	resolveCommitHash,
 	type GitAdditionalHeaders,
 } from '../lib/git-sparse-checkout';
+import { createDotGitDirectory } from '../lib/git-create-dotgit-directory';
 
 describe('listRefs', () => {
 	it('should return the latest commit hash for a given ref', async () => {
@@ -94,6 +95,107 @@ describe('resolveCommitHash', () => {
 				type: 'unsupported' as any,
 			})
 		).rejects.toThrow('Invalid ref type: unsupported');
+	});
+});
+
+describe('createDotGitDirectory', () => {
+	it('omits sensitive URLs from persisted .git config', async () => {
+		const files = await createDotGitDirectory({
+			repoUrl:
+				'https://example.com/private/repo.git?x-amz-signature=secret&sessionToken=session-secret&refreshToken=refresh-secret&keep=1',
+			commitHash: '1234567890abcdef1234567890abcdef12345678',
+			ref: 'trunk',
+			refType: 'branch',
+			objects: [],
+			fileOids: {},
+			pathPrefix: '',
+		});
+
+		const config = String(files['.git/config']);
+		expect(config).not.toContain('REDACTED');
+		expect(config).not.toContain('x-amz-signature=secret');
+		expect(config).not.toContain('sessionToken=session-secret');
+		expect(config).not.toContain('refreshToken=refresh-secret');
+		expect(config).not.toContain('[remote "origin"]');
+		expect(files['.git/refs/remotes/origin/trunk']).toBeUndefined();
+		expect(files['.git/refs/remotes/origin/HEAD']).toBeUndefined();
+	});
+
+	it('persists public remote URLs in .git config', async () => {
+		const files = await createDotGitDirectory({
+			repoUrl: 'https://example.com/public/repo.git',
+			commitHash: '1234567890abcdef1234567890abcdef12345678',
+			ref: 'trunk',
+			refType: 'branch',
+			objects: [],
+			fileOids: {},
+			pathPrefix: '',
+		});
+
+		const config = String(files['.git/config']);
+		expect(config).toContain('[remote "origin"]');
+		expect(config).toContain('url = https://example.com/public/repo.git');
+		expect(files['.git/refs/remotes/origin/trunk']).toBe(
+			'1234567890abcdef1234567890abcdef12345678\n'
+		);
+		expect(files['.git/refs/remotes/origin/HEAD']).toBe(
+			'ref: refs/remotes/origin/trunk\n'
+		);
+	});
+
+	it('omits remote URLs with sensitive fragments from persisted .git config', async () => {
+		const files = await createDotGitDirectory({
+			repoUrl:
+				'https://example.com/private/repo.git#accessToken=secret&keep=1',
+			commitHash: '1234567890abcdef1234567890abcdef12345678',
+			ref: 'trunk',
+			refType: 'branch',
+			objects: [],
+			fileOids: {},
+			pathPrefix: '',
+		});
+
+		const config = String(files['.git/config']);
+		expect(config).not.toContain('accessToken=secret');
+		expect(config).not.toContain('[remote "origin"]');
+		expect(files['.git/refs/remotes/origin/trunk']).toBeUndefined();
+	});
+
+	it('omits remotes with prefixed camelCase sensitive params', async () => {
+		const files = await createDotGitDirectory({
+			repoUrl:
+				'https://example.com/private/repo.git?awsSessionToken=session-secret',
+			commitHash: '1234567890abcdef1234567890abcdef12345678',
+			ref: 'trunk',
+			refType: 'branch',
+			objects: [],
+			fileOids: {},
+			pathPrefix: '',
+		});
+
+		const config = String(files['.git/config']);
+		expect(config).not.toContain('awsSessionToken=session-secret');
+		expect(config).not.toContain('[remote "origin"]');
+		expect(files['.git/refs/remotes/origin/trunk']).toBeUndefined();
+	});
+
+	it('persists scp-style git remote URLs', async () => {
+		const files = await createDotGitDirectory({
+			repoUrl: 'git@example.com:private/repo.git',
+			commitHash: '1234567890abcdef1234567890abcdef12345678',
+			ref: 'trunk',
+			refType: 'branch',
+			objects: [],
+			fileOids: {},
+			pathPrefix: '',
+		});
+
+		const config = String(files['.git/config']);
+		expect(config).toContain('[remote "origin"]');
+		expect(config).toContain('url = git@example.com:private/repo.git');
+		expect(files['.git/refs/remotes/origin/trunk']).toBe(
+			'1234567890abcdef1234567890abcdef12345678\n'
+		);
 	});
 });
 


### PR DESCRIPTION
## What it does

Stops `createDotGitDirectory()` from persisting remote metadata when the source URL contains token-like query or fragment parameters.

Public remotes are still written to `.git/config`, branch config, and `refs/remotes/origin/*`. Sensitive remotes still produce a usable materialized `.git` directory, but without storing the credential-bearing URL or origin refs.

## Rationale

`git:directory` resources can materialize a `.git` directory from a sparse checkout. If the repository URL contains credentials such as signed URL params, access tokens, session tokens, or refresh tokens, writing that URL into `.git/config` would persist secrets into the generated site files.

Dropping the remote is safer than redacting it: a redacted remote would look configured but fail later. With no remote, the materialized checkout still has `HEAD`, refs for the selected branch/tag when appropriate, loose objects, and an index, but it does not claim to know how to fetch from origin.

## Implementation

Detects sensitive URL data by checking query and fragment parameter names for token-like keys, including camelCase variants such as `sessionToken` and prefixed names such as `awsSessionToken`.

When sensitive URL data is found:

- omit `[remote "origin"]` from `.git/config`
- omit branch `remote = origin` metadata
- omit `refs/remotes/origin/*`
- keep local branch/tag refs, loose objects, `.git/index`, `HEAD`, and `.git/shallow`

Non-URL remotes, including scp-style `git@example.com:owner/repo.git`, are left unchanged because there are no parseable URL params to inspect.

## Testing instructions

```bash
npm exec nx run playground-storage:test -- --runInBand=false
npm exec nx run playground-storage:build
```
