### PR TITLE
[Website] Wait for initial OPFS sync before ZIP imports

### DIFF
--- a/packages/playground/website/playwright/e2e/opfs.spec.ts
+++ b/packages/playground/website/playwright/e2e/opfs.spec.ts
@@ -685,20 +685,33 @@ test('should create a saved site when importing ZIP while on a saved site with n
 
 	// Verify the imported files landed in the new saved site and survived a reload.
 	// This catches races where import starts before the initial OPFS sync finishes.
-	await website.page.evaluate(async () => {
-		const api = (window as any).playgroundSites;
-		await api.isReady();
-		await api.getClient().goTo('/wp-content/index.php');
-	});
-	await expect(wordpress.locator('body')).toContainText(importedMarker);
+	await expect(
+		website.page.evaluate(async () => {
+			const api = (window as any).playgroundSites;
+			await api.isReady();
+			return api
+				.getClient()
+				.readFileAsText('/wordpress/wp-content/index.php');
+		})
+	).resolves.toContain(importedMarker);
 	await website.page.reload();
 	await website.waitForNestedIframes();
+	await expect(
+		website.page.evaluate(async () => {
+			const api = (window as any).playgroundSites;
+			await api.isReady();
+			return api
+				.getClient()
+				.readFileAsText('/wordpress/wp-content/index.php');
+		})
+	).resolves.toContain(importedMarker);
+
 	await website.page.evaluate(async () => {
 		const api = (window as any).playgroundSites;
 		await api.isReady();
-		await api.getClient().goTo('/wp-content/index.php');
+		await api.getClient().goTo('/');
 	});
-	await expect(wordpress.locator('body')).toContainText(importedMarker);
+	await website.waitForNestedIframes();
 
 	// Verify the saved site is still intact by switching to it
 	await website.openSavedPlaygroundsOverlay();

--- a/packages/playground/website/playwright/e2e/opfs.spec.ts
+++ b/packages/playground/website/playwright/e2e/opfs.spec.ts
@@ -683,6 +683,23 @@ test('should create a saved site when importing ZIP while on a saved site with n
 		'Unsaved Playground'
 	);
 
+	// Verify the imported files landed in the new saved site and survived a reload.
+	// This catches races where import starts before the initial OPFS sync finishes.
+	await website.page.evaluate(async () => {
+		await (window as any).playgroundSites
+			.getClient()
+			.goTo('/wp-content/index.php');
+	});
+	await expect(wordpress.locator('body')).toContainText(importedMarker);
+	await website.page.reload();
+	await website.waitForNestedIframes();
+	await website.page.evaluate(async () => {
+		await (window as any).playgroundSites
+			.getClient()
+			.goTo('/wp-content/index.php');
+	});
+	await expect(wordpress.locator('body')).toContainText(importedMarker);
+
 	// Verify the saved site is still intact by switching to it
 	await website.openSavedPlaygroundsOverlay();
 

--- a/packages/playground/website/playwright/e2e/opfs.spec.ts
+++ b/packages/playground/website/playwright/e2e/opfs.spec.ts
@@ -686,17 +686,17 @@ test('should create a saved site when importing ZIP while on a saved site with n
 	// Verify the imported files landed in the new saved site and survived a reload.
 	// This catches races where import starts before the initial OPFS sync finishes.
 	await website.page.evaluate(async () => {
-		await (window as any).playgroundSites
-			.getClient()
-			.goTo('/wp-content/index.php');
+		const api = (window as any).playgroundSites;
+		await api.isReady();
+		await api.getClient().goTo('/wp-content/index.php');
 	});
 	await expect(wordpress.locator('body')).toContainText(importedMarker);
 	await website.page.reload();
 	await website.waitForNestedIframes();
 	await website.page.evaluate(async () => {
-		await (window as any).playgroundSites
-			.getClient()
-			.goTo('/wp-content/index.php');
+		const api = (window as any).playgroundSites;
+		await api.isReady();
+		await api.getClient().goTo('/wp-content/index.php');
 	});
 	await expect(wordpress.locator('body')).toContainText(importedMarker);
 

--- a/packages/playground/website/playwright/e2e/opfs.spec.ts
+++ b/packages/playground/website/playwright/e2e/opfs.spec.ts
@@ -5,11 +5,11 @@ import { encodeZip, collectBytes } from '@php-wasm/stream-compression';
 
 /**
  * Creates a minimal WordPress export ZIP file for testing imports.
- * The ZIP contains just an index.php file with the given marker content.
+ * The ZIP contains a marker file with the given content.
  */
 async function createTestWordPressZip(markerContent: string): Promise<Buffer> {
 	const phpContent = `<?php echo '${markerContent}';`;
-	const file = new File([phpContent], 'wp-content/index.php', {
+	const file = new File([phpContent], 'wp-content/import-marker.php', {
 		type: 'text/plain',
 	});
 	const zipStream = encodeZip([file]);
@@ -628,10 +628,13 @@ test('should create a saved site when importing ZIP while on a saved site with n
 		{ timeout: 90000 }
 	);
 
-	// Get the site slug from the URL
-	const urlAfterSave = website.page.url();
-	const urlObj = new URL(urlAfterSave);
-	const siteSlug = urlObj.searchParams.get('site-slug');
+	// Get the site slug from the active saved site.
+	const siteSlug = await website.page.evaluate(() => {
+		const activeSite = (window as any).playgroundSites
+			.list()
+			.find((site: any) => site.isActive);
+		return activeSite?.slug;
+	});
 	expect(siteSlug).toBeTruthy();
 
 	// Now reload the page directly with the site-slug parameter.
@@ -691,7 +694,7 @@ test('should create a saved site when importing ZIP while on a saved site with n
 			await api.isReady();
 			return api
 				.getClient()
-				.readFileAsText('/wordpress/wp-content/index.php');
+				.readFileAsText('/wordpress/wp-content/import-marker.php');
 		})
 	).resolves.toContain(importedMarker);
 	await website.page.reload();
@@ -702,7 +705,7 @@ test('should create a saved site when importing ZIP while on a saved site with n
 			await api.isReady();
 			return api
 				.getClient()
-				.readFileAsText('/wordpress/wp-content/index.php');
+				.readFileAsText('/wordpress/wp-content/import-marker.php');
 		})
 	).resolves.toContain(importedMarker);
 

--- a/packages/playground/website/playwright/e2e/opfs.spec.ts
+++ b/packages/playground/website/playwright/e2e/opfs.spec.ts
@@ -665,10 +665,7 @@ test('should create a saved site when importing ZIP while on a saved site with n
 		'input[type="file"][accept*=".zip"]'
 	);
 
-	// Set up dialog handler
-	website.page.once('dialog', async (dialog) => {
-		await dialog.accept();
-	});
+	const importDoneDialog = website.page.waitForEvent('dialog');
 
 	// Upload the ZIP file
 	await fileInput.setInputFiles({
@@ -676,6 +673,9 @@ test('should create a saved site when importing ZIP while on a saved site with n
 		mimeType: 'application/zip',
 		buffer: zipBuffer,
 	});
+	const dialog = await importDoneDialog;
+	expect(dialog.message()).toContain('File imported!');
+	await dialog.accept();
 
 	// The import should trigger creation of a new saved site by default.
 	await expect(website.page.getByLabel('Playground title')).not.toContainText(

--- a/packages/playground/website/src/lib/state/redux/site-management-api-middleware.ts
+++ b/packages/playground/website/src/lib/state/redux/site-management-api-middleware.ts
@@ -32,7 +32,12 @@ import {
 } from './slice-sites';
 import { randomSiteName } from './random-site-name';
 import { persistTemporarySite } from './persist-temporary-site';
-import { selectClientBySiteSlug } from './slice-clients';
+import {
+	selectClientBySiteSlug,
+	selectClientInfoBySiteSlug,
+	updateClientInfo,
+	type ClientInfo,
+} from './slice-clients';
 import type { PlaygroundClient } from '@wp-playground/remote';
 import type { AllPHPVersion } from '@php-wasm/universal';
 import { opfsSiteStorage } from '../opfs/opfs-site-storage';
@@ -612,6 +617,7 @@ export function createSitesAPI(
 			await api.setActiveSite(newSiteInfo.slug, {
 				updateUrl: options.updateUrl,
 			});
+			await waitForInitialOpfsSync(newSiteInfo.slug, getState);
 			await dispatch(
 				pruneAutosavedSites({
 					excludeSlugs: [
@@ -624,6 +630,49 @@ export function createSitesAPI(
 		},
 	};
 	return api;
+}
+
+/**
+ * New OPFS sites first boot in MEMFS and then copy those files to OPFS.
+ * Wait for that copy before callers mutate /wordpress, otherwise imports can
+ * race the copy and leave the saved site with stale or missing files.
+ */
+async function waitForInitialOpfsSync(
+	siteSlug: string,
+	getState: () => PlaygroundReduxState
+) {
+	let clientInfo: ClientInfo | undefined = selectClientInfoBySiteSlug(
+		getState(),
+		siteSlug
+	);
+	if (clientInfo?.opfsSync?.status !== 'syncing') {
+		return;
+	}
+
+	clientInfo = await new Promise<ClientInfo | undefined>((resolve) => {
+		const unsubscribe = startListening({
+			predicate: (action) =>
+				updateClientInfo.match(action) &&
+				action.payload.siteSlug === siteSlug,
+			effect: (_action, listenerApi) => {
+				const nextClientInfo = selectClientInfoBySiteSlug(
+					listenerApi.getState(),
+					siteSlug
+				);
+				if (nextClientInfo?.opfsSync?.status === 'syncing') {
+					return;
+				}
+				unsubscribe();
+				resolve(nextClientInfo);
+			},
+		});
+	});
+
+	if (clientInfo?.opfsSync?.status === 'error') {
+		throw new Error(
+			`Could not initialize browser storage for site ${siteSlug}.`
+		);
+	}
 }
 
 /**


### PR DESCRIPTION
## What it does

Before this PR, importing a zip file could start while the initial `MEMFS -> OPFS` copy was still running, leaving the saved site's persistent `/wordpress` state stale or partially copied and causing the imported saved site to fail after reload.

After this PR, importing a zip file waits for the initial Autosave OPFS sync before starting the site import from a user-provided ZIP file.

## Rationale

New OPFS-backed Playgrounds first boot WordPress in `MEMFS`, then copy that tree to OPFS in the background. If ZIP import starts during that window, the current `MEMFS` tree may look fine, but OPFS can miss part of the import. On reload, Playground rebuilds `MEMFS` from OPFS, so the imported files can disappear.

## Implementation

`createNewSavedSite()` now waits for the initial OPFS sync to leave `syncing` before returning. The import flow already waits for `createNewSavedSite()`, so it now mutates `/wordpress` only after the saved site's baseline files exist in OPFS.

The OPFS import e2e test now also verifies that imported files:

1. are visible in the newly-created saved site
2. still exist after reloading that saved site

## Testing instructions

Ran successfully:

```bash
npm run format:uncommitted
npm exec nx lint playground-website -- --fix=false
npm exec nx typecheck playground-website
```

Also manually verified the attached Playground export imports through `Import .zip`, loads the imported site, and survives reload.

GitHub CI is passing on this PR, including the Playwright regression test.
