### PR TITLE
[Blueprints] Add Blueprint v2 web declarations

### DIFF
--- a/packages/playground/client/src/blueprints-v2-handler.spec.ts
+++ b/packages/playground/client/src/blueprints-v2-handler.spec.ts
@@ -1,0 +1,170 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ProgressTracker } from '@php-wasm/progress';
+import { BlueprintsV2Handler } from './blueprints-v2-handler';
+
+const mocks = vi.hoisted(() => {
+	return {
+		playground: {
+			boot: vi.fn(),
+			isConnected: vi.fn(),
+			isReady: vi.fn(),
+			onDownloadProgress: vi.fn(),
+		},
+		compileBlueprintForExecution: vi.fn(),
+		resolveRuntimeConfiguration: vi.fn(),
+		consumeAPI: vi.fn(),
+		collectPhpLogs: vi.fn(),
+		compiledRun: vi.fn(),
+	};
+});
+
+vi.mock('@php-wasm/logger', () => ({
+	collectPhpLogs: mocks.collectPhpLogs,
+	logger: {},
+}));
+
+vi.mock('@php-wasm/universal', () => ({
+	consumeAPI: mocks.consumeAPI,
+}));
+
+vi.mock('@wp-playground/blueprints', () => ({
+	compileBlueprintForExecution: mocks.compileBlueprintForExecution,
+	resolveRuntimeConfiguration: mocks.resolveRuntimeConfiguration,
+}));
+
+describe('BlueprintsV2Handler', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mocks.playground.boot.mockResolvedValue(undefined);
+		mocks.playground.isConnected.mockResolvedValue(undefined);
+		mocks.playground.isReady.mockResolvedValue(undefined);
+		mocks.playground.onDownloadProgress.mockResolvedValue(undefined);
+		mocks.compiledRun.mockResolvedValue(undefined);
+		mocks.compileBlueprintForExecution.mockImplementation(
+			async (blueprint) => ({
+				version: 2,
+				declaration: blueprint,
+				compiled: {
+					runtime: {
+						phpVersion: '8.4',
+						wpVersion: 'latest',
+						intl: false,
+						networking: true,
+					},
+				},
+				run: mocks.compiledRun,
+			})
+		);
+		mocks.resolveRuntimeConfiguration.mockResolvedValue({
+			phpVersion: '8.4',
+			wpVersion: 'latest',
+			intl: false,
+			networking: true,
+		});
+		mocks.consumeAPI.mockReturnValue(mocks.playground);
+	});
+
+	it('boots and runs Blueprint v2 declarations through the native compiler', async () => {
+		mocks.compileBlueprintForExecution.mockResolvedValue({
+			version: 2,
+			declaration: {
+				version: 2,
+			},
+			compiled: {
+				runtime: {
+					phpVersion: '8.2',
+					wpVersion: '6.4',
+					intl: true,
+					networking: false,
+				},
+			},
+			run: mocks.compiledRun,
+		});
+		const iframe = createIframe();
+		const onBlueprintValidated = vi.fn();
+		const onBlueprintStepCompleted = vi.fn();
+		const onClientConnected = vi.fn();
+		const blueprint = {
+			version: 2,
+			siteOptions: {
+				blogname: 'V2 site',
+			},
+		};
+		const handler = new BlueprintsV2Handler({
+			iframe,
+			remoteUrl: 'http://example.com/remote.html',
+			blueprint,
+			scope: 'test-scope',
+			corsProxy: 'https://cors.example.test/proxy',
+			onBlueprintValidated,
+			onBlueprintStepCompleted,
+			onClientConnected,
+		});
+
+		await handler.bootPlayground(iframe, createProgressTracker());
+
+		expect(mocks.resolveRuntimeConfiguration).not.toHaveBeenCalled();
+		expect(mocks.playground.boot).toHaveBeenCalledWith(
+			expect.objectContaining({
+				scope: 'test-scope',
+				phpVersion: '8.2',
+				wpVersion: '6.4',
+				extensions: ['intl'],
+				withNetworking: false,
+				corsProxyUrl: 'https://cors.example.test/proxy',
+				wordpressInstallMode: 'download-and-install',
+			})
+		);
+		expect(mocks.compileBlueprintForExecution).toHaveBeenCalledWith(
+			blueprint,
+			expect.objectContaining({
+				onBlueprintValidated,
+				onStepCompleted: onBlueprintStepCompleted,
+				corsProxy: 'https://cors.example.test/proxy',
+			})
+		);
+		expect(mocks.compiledRun).toHaveBeenCalledWith(mocks.playground);
+		expect(onClientConnected).toHaveBeenCalledWith(mocks.playground);
+	});
+
+	it('does not pipe remote progress when progress UI is disabled', async () => {
+		const iframe = createIframe();
+		const blueprint = {
+			version: 2,
+			siteOptions: {
+				blogname: 'V2 site',
+			},
+		};
+		const progressTracker = createProgressTracker();
+		const handler = new BlueprintsV2Handler({
+			iframe,
+			remoteUrl: 'http://example.com/remote.html',
+			blueprint,
+			disableProgressBar: true,
+		});
+
+		await handler.bootPlayground(iframe, progressTracker);
+
+		expect(progressTracker.pipe).not.toHaveBeenCalled();
+	});
+});
+
+function createIframe() {
+	return {
+		contentWindow: {},
+		ownerDocument: {
+			defaultView: {},
+		},
+	} as HTMLIFrameElement;
+}
+
+function createProgressTracker() {
+	const child = {
+		finish: vi.fn(),
+		loadingListener: vi.fn(),
+	};
+	return {
+		pipe: vi.fn(),
+		stage: vi.fn(() => child),
+	} as unknown as ProgressTracker;
+}

--- a/packages/playground/client/src/blueprints-v2-handler.ts
+++ b/packages/playground/client/src/blueprints-v2-handler.ts
@@ -1,12 +1,25 @@
 import type { ProgressTracker } from '@php-wasm/progress';
-import type { PlaygroundClient, StartPlaygroundOptions } from '.';
 import { collectPhpLogs, logger } from '@php-wasm/logger';
 import { consumeAPI } from '@php-wasm/universal';
+import type { PHPWebExtension } from '@php-wasm/web';
+import {
+	compileBlueprintForExecution,
+	resolveRuntimeConfiguration,
+} from '@wp-playground/blueprints';
+import type { PlaygroundClient, StartPlaygroundWebOptions } from '.';
 
+type WordPressInstallMode = NonNullable<
+	StartPlaygroundWebOptions['wordpressInstallMode']
+>;
+
+/**
+ * Boots Playground and runs Blueprint declarations with the native TypeScript
+ * Blueprint compiler.
+ */
 export class BlueprintsV2Handler {
-	private readonly options: StartPlaygroundOptions;
+	private readonly options: StartPlaygroundWebOptions;
 
-	constructor(options: StartPlaygroundOptions) {
+	constructor(options: StartPlaygroundWebOptions) {
 		this.options = options;
 	}
 
@@ -15,17 +28,23 @@ export class BlueprintsV2Handler {
 		progressTracker: ProgressTracker
 	) {
 		const {
-			blueprint,
+			onBlueprintValidated,
+			onBlueprintStepCompleted,
 			onClientConnected,
 			corsProxy,
+			gitAdditionalHeadersCallback,
 			mounts,
 			sapiName,
 			scope,
+			shouldInstallWordPress,
+			sqliteDriverVersion,
+			wordpressInstallMode,
 			pathAliases,
 			disableProgressBar,
 		} = this.options;
-		const downloadProgress = progressTracker!.stage(0.25);
-		const executionProgress = progressTracker!.stage(0.75);
+		const executionProgress = progressTracker.stage(0.5);
+		const downloadProgress = progressTracker.stage();
+		const blueprint = this.options.blueprint || { version: 2 };
 
 		// Connect the Comlink API client to the remote worker,
 		// boot the playground, and run the blueprint steps.
@@ -40,89 +59,64 @@ export class BlueprintsV2Handler {
 
 		// Connect the Comlink API client to the remote worker download monitor
 		await playground.onDownloadProgress(downloadProgress.loadingListener);
-		await playground.addEventListener(
-			'blueprint.message',
-			({ message }: any) => {
-				switch (message.type) {
-					case 'blueprint.target_resolved': {
-						// @TODO: Evaluate consistenty with the CLI worker
-						// if (!this.blueprintTargetResolved) {
-						// 	this.blueprintTargetResolved = true;
-						// 	for (const php of this
-						// 		.phpInstancesThatNeedMountsAfterTargetResolved) {
-						// 		// console.log('mounting resources for php', php);
-						// 		this.phpInstancesThatNeedMountsAfterTargetResolved.delete(
-						// 			php
-						// 		);
-						// 		await mountResources(php, args.mount || []);
-						// 	}
-						// }
-						break;
-					}
-					case 'blueprint.progress': {
-						executionProgress.set(message.progress);
-						executionProgress.setCaption(message.caption);
-						break;
-					}
-					case 'blueprint.error': {
-						// @TODO: Error reporting.
-						const red = '\x1b[31m';
-						const bold = '\x1b[1m';
-						const reset = '\x1b[0m';
-						if (message.details) {
-							logger.error(
-								`${red}${bold}Fatal error:${reset} Uncaught ${message.details.exception}: ${message.details.message}\n` +
-									`  at ${message.details.file}:${message.details.line}\n` +
-									(message.details.trace
-										? message.details.trace + '\n'
-										: '')
-							);
-						} else {
-							logger.error(
-								`${red}${bold}Error:${reset} ${message.message}\n`
-							);
-						}
 
-						// TODO: Should we report the error like that?
-						throw new Error(message.message);
-						break;
-					}
-				}
-			}
-		);
+		const compiled = await compileBlueprintForExecution(blueprint, {
+			progress: executionProgress,
+			onStepCompleted: onBlueprintStepCompleted,
+			onBlueprintValidated,
+			corsProxy,
+			gitAdditionalHeadersCallback,
+		});
+		const runtimeConfiguration =
+			compiled.version === 2
+				? compiled.compiled.runtime
+				: await resolveRuntimeConfiguration(compiled.declaration);
+		const resolvedWordPressInstallMode = resolveWordPressInstallMode({
+			shouldInstallWordPress,
+			wordpressInstallMode,
+		});
+
+		const extensions: PHPWebExtension[] = runtimeConfiguration.intl
+			? ['intl']
+			: [];
+		extensions.push(...(this.options.extensions || []));
 
 		await playground.boot({
 			mounts,
 			sapiName,
 			scope: scope ?? Math.random().toFixed(16),
+			wordpressInstallMode: resolvedWordPressInstallMode,
+			phpVersion: runtimeConfiguration.phpVersion,
+			wpVersion: runtimeConfiguration.wpVersion,
+			extensions,
+			withNetworking: runtimeConfiguration.networking,
 			corsProxyUrl: corsProxy,
-			extensions: this.options.extensions,
-			experimentalBlueprintsV2Runner: true,
-			// Pass the declaration directly – the worker runs the V2 runner.
-			blueprint: blueprint as any,
+			sqliteDriverVersion,
 			pathAliases,
-		} as any);
-
+		});
 		await playground.isReady();
 		downloadProgress.finish();
 
 		collectPhpLogs(logger, playground);
 		onClientConnected?.(playground);
 
-		// @TODO: Get the landing page from the Blueprint.
-		playground.goTo('/');
-
-		/**
-		 * Pre-fetch WordPress update checks to speed up the initial wp-admin load.
-		 *
-		 * @see https://github.com/WordPress/wordpress-playground/pull/2295
-		 */
-		// @TODO get the enabled features somehow – probably using the same
-		//       resolveRuntimeConfiguration() logic as the redux site-slice.ts
-		// if (compiled.features.networking) {
-		// 	await playground.prefetchUpdateChecks();
-		// }
+		await compiled.run(playground);
 
 		return playground;
 	}
+}
+
+function resolveWordPressInstallMode({
+	shouldInstallWordPress,
+	wordpressInstallMode,
+}: {
+	shouldInstallWordPress: StartPlaygroundWebOptions['shouldInstallWordPress'];
+	wordpressInstallMode: StartPlaygroundWebOptions['wordpressInstallMode'];
+}): WordPressInstallMode {
+	return (
+		wordpressInstallMode ??
+		(shouldInstallWordPress === false
+			? 'install-from-existing-files-if-needed'
+			: 'download-and-install')
+	);
 }

--- a/packages/playground/client/src/index.spec.ts
+++ b/packages/playground/client/src/index.spec.ts
@@ -1,0 +1,106 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { ProgressTracker } from '@php-wasm/progress';
+
+const mocks = vi.hoisted(() => {
+	vi.stubGlobal('location', {
+		href: 'http://localhost/',
+		origin: 'http://localhost',
+	});
+	return {
+		bootPlaygroundV1: vi.fn(),
+		bootPlaygroundV2: vi.fn(),
+		BlueprintsV1Handler: vi.fn(),
+		BlueprintsV2Handler: vi.fn(),
+		createBlueprintReflection: vi.fn(),
+	};
+});
+
+vi.mock('@wp-playground/blueprints', () => ({
+	BlueprintReflection: {
+		create: mocks.createBlueprintReflection,
+	},
+	isBlueprintBundle: (blueprint: any) => Boolean(blueprint?.read),
+}));
+
+vi.mock('./blueprints-v1-handler', () => ({
+	BlueprintsV1Handler: mocks.BlueprintsV1Handler,
+}));
+
+vi.mock('./blueprints-v2-handler', () => ({
+	BlueprintsV2Handler: mocks.BlueprintsV2Handler,
+}));
+
+import { startPlaygroundWeb } from './index';
+
+describe('startPlaygroundWeb', () => {
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('routes Blueprint v1 declarations through the v1 handler', async () => {
+		const playground = { connected: true };
+		mocks.BlueprintsV1Handler.mockImplementation(() => ({
+			bootPlayground: mocks.bootPlaygroundV1,
+		}));
+		mocks.bootPlaygroundV1.mockResolvedValue(playground);
+		const iframe = createIframe();
+
+		await expect(
+			startPlaygroundWeb({
+				iframe,
+				remoteUrl: 'http://localhost/remote.html',
+				progressTracker: createProgressTracker(),
+				blueprint: {
+					steps: [],
+				},
+			})
+		).resolves.toBe(playground);
+
+		expect(mocks.BlueprintsV1Handler).toHaveBeenCalledTimes(1);
+		expect(mocks.BlueprintsV2Handler).not.toHaveBeenCalled();
+		expect(iframe.src).toContain('blueprints-runner=v1');
+	});
+
+	it('routes Blueprint v2 declarations through the v2 handler', async () => {
+		const playground = { connected: true };
+		mocks.BlueprintsV2Handler.mockImplementation(() => ({
+			bootPlayground: mocks.bootPlaygroundV2,
+		}));
+		mocks.bootPlaygroundV2.mockResolvedValue(playground);
+		const iframe = createIframe();
+
+		await expect(
+			startPlaygroundWeb({
+				iframe,
+				remoteUrl: 'http://localhost/remote.html',
+				progressTracker: createProgressTracker(),
+				blueprint: {
+					version: 2,
+					siteOptions: {
+						blogname: 'V2 site',
+					},
+				},
+			})
+		).resolves.toBe(playground);
+
+		expect(mocks.BlueprintsV2Handler).toHaveBeenCalledTimes(1);
+		expect(mocks.BlueprintsV1Handler).not.toHaveBeenCalled();
+		expect(iframe.src).toContain('blueprints-runner=v1');
+	});
+});
+
+function createIframe() {
+	return {
+		src: '',
+		addEventListener: vi.fn((_event, callback: () => void) => {
+			callback();
+		}),
+	} as unknown as HTMLIFrameElement;
+}
+
+function createProgressTracker() {
+	return {
+		setCaption: vi.fn(),
+		finish: vi.fn(),
+	} as unknown as ProgressTracker;
+}

--- a/packages/playground/client/src/index.ts
+++ b/packages/playground/client/src/index.ts
@@ -28,6 +28,12 @@ export {
 export { phpVar, phpVars } from '@php-wasm/util';
 export type { PlaygroundClient, MountDescriptor };
 
+import {
+	BlueprintReflection,
+	isBlueprintBundle,
+	type Blueprint,
+	type BlueprintDeclaration,
+} from '@wp-playground/blueprints';
 import type {
 	BlueprintV1,
 	BlueprintV1Declaration,
@@ -57,7 +63,8 @@ export interface StartPlaygroundOptions {
 	 */
 	extensions?: PHPWebExtension[];
 	/**
-	 * Prefer experimental Blueprints v2 PHP runner instead of TypeScript steps
+	 * Run the supplied Blueprint through the native TypeScript v2 compiler.
+	 * Version 2 Blueprints use this path automatically.
 	 */
 	experimentalBlueprintsV2Runner?: boolean;
 	onBlueprintStepCompleted?: OnStepCompleted;
@@ -133,6 +140,14 @@ export interface StartPlaygroundOptions {
 	pathAliases?: PathAlias[];
 }
 
+export interface StartPlaygroundWebOptions extends Omit<
+	StartPlaygroundOptions,
+	'blueprint' | 'onBlueprintValidated'
+> {
+	blueprint?: Blueprint;
+	onBlueprintValidated?: (blueprint: BlueprintDeclaration) => void;
+}
+
 /**
  * Loads playground in iframe and returns a PlaygroundClient instance.
  *
@@ -141,7 +156,7 @@ export interface StartPlaygroundOptions {
  * @returns A PlaygroundClient instance.
  */
 export async function startPlaygroundWeb(
-	options: StartPlaygroundOptions
+	options: StartPlaygroundWebOptions
 ): Promise<PlaygroundClient> {
 	const {
 		iframe,
@@ -151,12 +166,13 @@ export async function startPlaygroundWeb(
 	let { remoteUrl } = options;
 	assertLikelyCompatibleRemoteOrigin(remoteUrl);
 	allowStorageAccessByUserActivation(iframe);
+	const useBlueprintV2Handler = await shouldUseBlueprintV2Handler(options);
 
 	remoteUrl = setQueryParams(remoteUrl, {
 		progressbar: !disableProgressBar,
-		'blueprints-runner': options.experimentalBlueprintsV2Runner
-			? 'v2'
-			: 'v1',
+		// The v2 handler compiles and runs steps in this package. The iframe
+		// only needs the normal remote API.
+		'blueprints-runner': 'v1',
 		[WITH_ADMIN_TRANSITIONS_PARAM]: new URL(
 			globalThis.location.href
 		).searchParams.has(WITH_ADMIN_TRANSITIONS_PARAM)
@@ -170,14 +186,29 @@ export async function startPlaygroundWeb(
 		iframe.addEventListener('load', resolve, false);
 	});
 
-	const handler = options.experimentalBlueprintsV2Runner
+	const handler = useBlueprintV2Handler
 		? new BlueprintsV2Handler(options)
-		: new BlueprintsV1Handler(options);
+		: new BlueprintsV1Handler(options as StartPlaygroundOptions);
 	const playground = await handler.bootPlayground(iframe, progressTracker);
 
 	progressTracker.finish();
 
 	return playground;
+}
+
+async function shouldUseBlueprintV2Handler(options: StartPlaygroundWebOptions) {
+	if (options.experimentalBlueprintsV2Runner) {
+		return true;
+	}
+	const blueprint = options.blueprint;
+	if (!blueprint) {
+		return false;
+	}
+	if (!isBlueprintBundle(blueprint)) {
+		return 'version' in blueprint && blueprint.version === 2;
+	}
+	const reflection = await BlueprintReflection.create(blueprint);
+	return reflection.getVersion() === 2;
 }
 
 /**

--- a/packages/playground/website/src/lib/state/opfs/opfs-site-storage.ts
+++ b/packages/playground/website/src/lib/state/opfs/opfs-site-storage.ts
@@ -269,7 +269,7 @@ async function metadataToStoredFormat(
 			originalBlueprint:
 				originalBlueprintSource?.type === 'opfs-site'
 					? undefined
-					: await getBlueprintDeclaration(originalBlueprint),
+					: await getBlueprintDeclaration(originalBlueprint as any),
 			...metadata,
 		},
 		undefined,

--- a/packages/playground/website/src/lib/state/redux/boot-site-client.ts
+++ b/packages/playground/website/src/lib/state/redux/boot-site-client.ts
@@ -12,6 +12,7 @@ import {
 import { logBlueprintEvents, logTrackingEvent } from '../../tracking';
 import {
 	type Blueprint,
+	type BlueprintDeclaration,
 	BlueprintFilesystemRequiredError,
 	InvalidBlueprintError,
 	isBlueprintBundle,
@@ -152,7 +153,7 @@ export function bootSiteClient(
 				},
 			};
 		} else {
-			blueprint = site.metadata.originalBlueprint;
+			blueprint = site.metadata.originalBlueprint as Blueprint;
 		}
 
 		// PHP-only mode: a Blueprint with `preferredVersions.wp: false`
@@ -161,6 +162,7 @@ export function bootSiteClient(
 		const blueprintRequestedNoWordPress =
 			blueprint &&
 			!isBlueprintBundle(blueprint) &&
+			'preferredVersions' in blueprint &&
 			blueprint.preferredVersions?.wp === false;
 		const wordpressInstallMode = blueprintRequestedNoWordPress
 			? 'do-not-attempt-installing'
@@ -217,7 +219,7 @@ export function bootSiteClient(
 						playgroundClient;
 				},
 				// Log Blueprint events
-				onBlueprintValidated: logBlueprintEvents,
+				onBlueprintValidated: logSupportedBlueprintEvents,
 				mounts,
 				wordpressInstallMode,
 				corsProxy: corsProxyUrl,
@@ -397,6 +399,13 @@ export function bootSiteClient(
 
 		signal.onabort = null;
 	};
+}
+
+function logSupportedBlueprintEvents(blueprint: BlueprintDeclaration) {
+	if ('version' in blueprint && blueprint.version === 2) {
+		return;
+	}
+	return logBlueprintEvents(blueprint as any);
 }
 
 /**

--- a/packages/playground/website/src/lib/state/redux/slice-sites.ts
+++ b/packages/playground/website/src/lib/state/redux/slice-sites.ts
@@ -8,14 +8,12 @@ import type { PlaygroundDispatch, PlaygroundReduxState } from './store';
 import { selectActiveSite, setActiveSite } from './store';
 import { opfsSiteStorage } from '../opfs/opfs-site-storage';
 import {
-	type BlueprintV1,
 	BlueprintReflection,
 	type RuntimeConfiguration,
 	resolveRuntimeConfiguration,
 	InvalidBlueprintError,
 	BlueprintFetchError,
 } from '@wp-playground/blueprints';
-import type { WritableFilesystemBackend } from '@wp-playground/storage';
 import {
 	type BlueprintSource,
 	resolveBlueprintFromURL,
@@ -700,7 +698,7 @@ async function prepareResolvedBlueprint(
 	);
 	if (reflection.getVersion() === 1) {
 		resolvedBlueprint.blueprint = await applyQueryOverrides(
-			resolvedBlueprint.blueprint,
+			resolvedBlueprint.blueprint as any,
 			playgroundUrlWithQueryApiArgs.searchParams
 		);
 	}
@@ -791,7 +789,7 @@ export interface SiteMetadata {
 
 	// @TODO: Accept any string as a php version?
 	runtimeConfiguration: RuntimeConfiguration;
-	originalBlueprint: BlueprintV1 | WritableFilesystemBackend;
+	originalBlueprint: unknown;
 	originalBlueprintSource: BlueprintSource;
 }
 

--- a/packages/playground/website/src/lib/state/url/resolve-blueprint-from-url.ts
+++ b/packages/playground/website/src/lib/state/url/resolve-blueprint-from-url.ts
@@ -2,7 +2,7 @@ import type {
 	BlueprintV1Declaration,
 	BlueprintBundle,
 	StepDefinition,
-	BlueprintV1,
+	Blueprint,
 } from '@wp-playground/client';
 import {
 	getBlueprintDeclaration,
@@ -32,7 +32,7 @@ export type BlueprintSource =
 	  };
 
 export type ResolvedBlueprint = {
-	blueprint: BlueprintV1;
+	blueprint: Blueprint;
 	source: BlueprintSource;
 };
 


### PR DESCRIPTION
## What it does

Allows Blueprint v2 declarations to flow through the Playground website and `@wp-playground/client` web boot path.

When `startPlaygroundWeb()` receives a v2 declaration or v2 bundle, it now uses `BlueprintsV2Handler`. That handler compiles the declaration with `compileBlueprintForExecution()`, boots the remote iframe with the resolved runtime settings, and runs the compiled steps through the normal remote API.

## Rationale

This is the first smaller PR from the broader consumer wiring work. It keeps the scope to the web/client v2 flow so it can be reviewed independently.

It does **not** enable the CLI v2 flow, change v1 Query API behavior, alter package build output, or remove remote worker endpoints.

## Implementation

- Adds `StartPlaygroundWebOptions` so the web entrypoint can accept v1 or v2 Blueprints while preserving the existing v1-only `StartPlaygroundOptions` shape.
- Routes v2 declarations and bundles to `BlueprintsV2Handler` automatically.
- Keeps the iframe on `blueprints-runner=v1`; v2 compilation and execution happen in `@wp-playground/client`, while the iframe only needs the normal remote API.
- Widens website Blueprint pass-through types so v2 declarations from `blueprint-url` or hash fragments can reach the client path.
- Keeps URL query overrides applied only to v1 Blueprints.

## Testing instructions

```bash
npx nx test playground-client --runInBand
npx nx typecheck playground-client
npx nx typecheck playground-website
npx nx lint playground-client
npx nx lint playground-website
```

Part of #2592.