### PR TITLE
[Blueprints] Flush rewrite rules after setting permalink structure

### DIFF
--- a/packages/playground/blueprints/src/lib/steps/site-data.ts
+++ b/packages/playground/blueprints/src/lib/steps/site-data.ts
@@ -37,8 +37,18 @@ export const setSiteOptions: StepHandler<SetSiteOptionsStep> = async (
 		code: `<?php
 		include ${phpVar(docroot)} . '/wp-load.php';
 		$site_options = ${phpVar(options)};
+		$flush_rewrite_rules = (
+			is_array($site_options) &&
+			array_key_exists('permalink_structure', $site_options)
+		) || (
+			is_object($site_options) &&
+			property_exists($site_options, 'permalink_structure')
+		);
 		foreach($site_options as $name => $value) {
 			update_option($name, $value);
+		}
+		if ($flush_rewrite_rules) {
+			flush_rewrite_rules(false);
 		}
 		echo "Success";
 		`,

--- a/packages/playground/blueprints/src/tests/steps/site-data.spec.ts
+++ b/packages/playground/blueprints/src/tests/steps/site-data.spec.ts
@@ -43,4 +43,41 @@ describe('Blueprint step setSiteOptions()', () => {
 		});
 		expect(response.text).toBe('My test site!');
 	});
+
+	it('should flush rewrite rules when setting permalink_structure', async () => {
+		await php.run({
+			code: `<?php
+	                require '/wordpress/wp-load.php';
+	                delete_option('rewrite_rules');
+			`,
+		});
+		const missingRules = await php.run({
+			code: `<?php
+                require '/wordpress/wp-load.php';
+                echo json_encode(get_option('rewrite_rules'));
+			`,
+		});
+		expect(missingRules.json).toBe(false);
+
+		await setSiteOptions(php, {
+			options: {
+				permalink_structure: '/%postname%/',
+			},
+		});
+
+		const response = await php.run({
+			code: `<?php
+                require '/wordpress/wp-load.php';
+                $rewrite_rules = get_option('rewrite_rules');
+                echo json_encode([
+                    'permalink_structure' => get_option('permalink_structure'),
+                    'has_rewrite_rules' => is_array($rewrite_rules) && count($rewrite_rules) > 0,
+                ]);
+			`,
+		});
+		expect(response.json).toEqual({
+			permalink_structure: '/%postname%/',
+			has_rewrite_rules: true,
+		});
+	});
 });


### PR DESCRIPTION
## What it does

Flushes WordPress rewrite rules when the `setSiteOptions` Blueprint step changes `permalink_structure`.

```json
{
  "step": "setSiteOptions",
  "options": {
    "permalink_structure": "/%postname%/"
  }
}
```

Before this change, the option was updated but `rewrite_rules` could remain missing or stale until WordPress regenerated them later. After this change, `setSiteOptions` calls `flush_rewrite_rules(false)` only when `permalink_structure` is present in the options payload.

## Rationale

`permalink_structure` is not just display metadata. It changes how WordPress maps pretty URLs to posts, pages, feeds, embeds, and other routes.

Updating the option without flushing rewrite rules can leave a Playground in a split state: `get_option('permalink_structure')` reports the new structure, but requests still rely on old or missing rewrite rules. That matters for Blueprints that set permalink structure and then immediately import content, run checks, or expect pretty URLs to resolve in the same boot.

This PR extracts one v1 step behavior from #3725 so it can be reviewed on its own.

## Implementation

`setSiteOptions` now checks whether the submitted options include `permalink_structure`:

```php
$flush_rewrite_rules = array_key_exists('permalink_structure', $site_options);
```

After updating all requested options, it calls:

```php
flush_rewrite_rules(false);
```

The `false` argument avoids writing `.htaccess`; Playground only needs WordPress to regenerate the in-database rewrite rules.

## Testing instructions

```bash
npm exec nx run playground-blueprints:test:vite -- --testFiles=packages/playground/blueprints/src/tests/steps/site-data.spec.ts
npm exec nx run playground-blueprints:typecheck
npm exec nx run playground-blueprints:lint
git diff --check
```

The new test deletes the `rewrite_rules` option, runs `setSiteOptions` with `permalink_structure`, and verifies that WordPress stores both the permalink structure and regenerated rewrite rules.
