### PR TITLE
[Blueprints] Support plugin `activationOptions`

### DIFF
--- a/packages/playground/blueprints/public/blueprint-schema-validator.js
+++ b/packages/playground/blueprints/public/blueprint-schema-validator.js
@@ -1199,6 +1199,12 @@ const schema11 = {
 					description:
 						'Whether to activate the plugin after installing it.',
 				},
+				activationOptions: {
+					type: 'object',
+					additionalProperties: {},
+					description:
+						'Parameters to expose to the plugin during its activation hook.',
+				},
 				targetFolderName: {
 					type: 'string',
 					description:
@@ -5198,6 +5204,12 @@ const schema34 = {
 		activate: {
 			type: 'boolean',
 			description: 'Whether to activate the plugin after installing it.',
+		},
+		activationOptions: {
+			type: 'object',
+			additionalProperties: {},
+			description:
+				'Parameters to expose to the plugin during its activation hook.',
 		},
 		targetFolderName: {
 			type: 'string',
@@ -12184,6 +12196,8 @@ function validate28(
 																					key21 ===
 																						'activate' ||
 																					key21 ===
+																						'activationOptions' ||
+																					key21 ===
 																						'targetFolderName'
 																				)
 																			) {
@@ -12252,39 +12266,102 @@ function validate28(
 																				valid34
 																			) {
 																				if (
-																					data59.targetFolderName !==
+																					data59.activationOptions !==
 																					undefined
 																				) {
+																					let data61 =
+																						data59.activationOptions;
 																					const _errs165 =
 																						errors;
 																					if (
-																						typeof data59.targetFolderName !==
-																						'string'
+																						errors ===
+																						_errs165
 																					) {
-																						validate28.errors =
-																							[
-																								{
-																									instancePath:
-																										instancePath +
-																										'/options/targetFolderName',
-																									schemaPath:
-																										'#/definitions/InstallPluginOptions/properties/targetFolderName/type',
-																									keyword:
-																										'type',
-																									params: {
-																										type: 'string',
+																						if (
+																							data61 &&
+																							typeof data61 ==
+																								'object' &&
+																							!Array.isArray(
+																								data61
+																							)
+																						) {
+																							for (const key22 in data61) {
+																								const _errs168 =
+																									errors;
+																								var valid35 =
+																									_errs168 ===
+																									errors;
+																								if (
+																									!valid35
+																								) {
+																									break;
+																								}
+																							}
+																						} else {
+																							validate28.errors =
+																								[
+																									{
+																										instancePath:
+																											instancePath +
+																											'/options/activationOptions',
+																										schemaPath:
+																											'#/definitions/InstallPluginOptions/properties/activationOptions/type',
+																										keyword:
+																											'type',
+																										params: {
+																											type: 'object',
+																										},
+																										message:
+																											'must be object',
 																									},
-																									message:
-																										'must be string',
-																								},
-																							];
-																						return false;
+																								];
+																							return false;
+																						}
 																					}
 																					var valid34 =
 																						_errs165 ===
 																						errors;
 																				} else {
 																					var valid34 = true;
+																				}
+																				if (
+																					valid34
+																				) {
+																					if (
+																						data59.targetFolderName !==
+																						undefined
+																					) {
+																						const _errs169 =
+																							errors;
+																						if (
+																							typeof data59.targetFolderName !==
+																							'string'
+																						) {
+																							validate28.errors =
+																								[
+																									{
+																										instancePath:
+																											instancePath +
+																											'/options/targetFolderName',
+																										schemaPath:
+																											'#/definitions/InstallPluginOptions/properties/targetFolderName/type',
+																										keyword:
+																											'type',
+																										params: {
+																											type: 'string',
+																										},
+																										message:
+																											'must be string',
+																									},
+																								];
+																							return false;
+																						}
+																						var valid34 =
+																							_errs169 ===
+																							errors;
+																					} else {
+																						var valid34 = true;
+																					}
 																				}
 																			}
 																		}
@@ -12336,8 +12413,8 @@ function validate28(
 							}
 						}
 					} else if (tag0 === 'installTheme') {
-						const _errs167 = errors;
-						if (errors === _errs167) {
+						const _errs171 = errors;
+						if (errors === _errs171) {
 							if (
 								data &&
 								typeof data == 'object' &&
@@ -12366,17 +12443,17 @@ function validate28(
 									];
 									return false;
 								} else {
-									const _errs169 = errors;
-									for (const key22 in data) {
+									const _errs173 = errors;
+									for (const key23 in data) {
 										if (
 											!(
-												key22 === 'progress' ||
-												key22 ===
+												key23 === 'progress' ||
+												key23 ===
 													'ifAlreadyInstalled' ||
-												key22 === 'step' ||
-												key22 === 'themeData' ||
-												key22 === 'themeZipFile' ||
-												key22 === 'options'
+												key23 === 'step' ||
+												key23 === 'themeData' ||
+												key23 === 'themeZipFile' ||
+												key23 === 'options'
 											)
 										) {
 											validate28.errors = [
@@ -12388,7 +12465,7 @@ function validate28(
 														'additionalProperties',
 													params: {
 														additionalProperty:
-															key22,
+															key23,
 													},
 													message:
 														'must NOT have additional properties',
@@ -12398,23 +12475,23 @@ function validate28(
 											break;
 										}
 									}
-									if (_errs169 === errors) {
+									if (_errs173 === errors) {
 										if (data.progress !== undefined) {
-											let data62 = data.progress;
-											const _errs170 = errors;
-											if (errors === _errs170) {
+											let data64 = data.progress;
+											const _errs174 = errors;
+											if (errors === _errs174) {
 												if (
-													data62 &&
-													typeof data62 == 'object' &&
-													!Array.isArray(data62)
+													data64 &&
+													typeof data64 == 'object' &&
+													!Array.isArray(data64)
 												) {
-													const _errs172 = errors;
-													for (const key23 in data62) {
+													const _errs176 = errors;
+													for (const key24 in data64) {
 														if (
 															!(
-																key23 ===
+																key24 ===
 																	'weight' ||
-																key23 ===
+																key24 ===
 																	'caption'
 															)
 														) {
@@ -12430,7 +12507,7 @@ function validate28(
 																			'additionalProperties',
 																		params: {
 																			additionalProperty:
-																				key23,
+																				key24,
 																		},
 																		message:
 																			'must NOT have additional properties',
@@ -12440,21 +12517,21 @@ function validate28(
 															break;
 														}
 													}
-													if (_errs172 === errors) {
+													if (_errs176 === errors) {
 														if (
-															data62.weight !==
+															data64.weight !==
 															undefined
 														) {
-															let data63 =
-																data62.weight;
-															const _errs173 =
+															let data65 =
+																data64.weight;
+															const _errs177 =
 																errors;
 															if (
 																!(
-																	typeof data63 ==
+																	typeof data65 ==
 																		'number' &&
 																	isFinite(
-																		data63
+																		data65
 																	)
 																)
 															) {
@@ -12477,21 +12554,21 @@ function validate28(
 																	];
 																return false;
 															}
-															var valid37 =
-																_errs173 ===
+															var valid38 =
+																_errs177 ===
 																errors;
 														} else {
-															var valid37 = true;
+															var valid38 = true;
 														}
-														if (valid37) {
+														if (valid38) {
 															if (
-																data62.caption !==
+																data64.caption !==
 																undefined
 															) {
-																const _errs175 =
+																const _errs179 =
 																	errors;
 																if (
-																	typeof data62.caption !==
+																	typeof data64.caption !==
 																	'string'
 																) {
 																	validate28.errors =
@@ -12513,11 +12590,11 @@ function validate28(
 																		];
 																	return false;
 																}
-																var valid37 =
-																	_errs175 ===
+																var valid38 =
+																	_errs179 ===
 																	errors;
 															} else {
-																var valid37 = true;
+																var valid38 = true;
 															}
 														}
 													}
@@ -12540,20 +12617,20 @@ function validate28(
 													return false;
 												}
 											}
-											var valid36 = _errs170 === errors;
+											var valid37 = _errs174 === errors;
 										} else {
-											var valid36 = true;
+											var valid37 = true;
 										}
-										if (valid36) {
+										if (valid37) {
 											if (
 												data.ifAlreadyInstalled !==
 												undefined
 											) {
-												let data65 =
+												let data67 =
 													data.ifAlreadyInstalled;
-												const _errs177 = errors;
+												const _errs181 = errors;
 												if (
-													typeof data65 !== 'string'
+													typeof data67 !== 'string'
 												) {
 													validate28.errors = [
 														{
@@ -12574,10 +12651,10 @@ function validate28(
 												}
 												if (
 													!(
-														data65 ===
+														data67 ===
 															'overwrite' ||
-														data65 === 'skip' ||
-														data65 === 'error'
+														data67 === 'skip' ||
+														data67 === 'error'
 													)
 												) {
 													validate28.errors = [
@@ -12602,17 +12679,17 @@ function validate28(
 													];
 													return false;
 												}
-												var valid36 =
-													_errs177 === errors;
+												var valid37 =
+													_errs181 === errors;
 											} else {
-												var valid36 = true;
+												var valid37 = true;
 											}
-											if (valid36) {
+											if (valid37) {
 												if (data.step !== undefined) {
-													let data66 = data.step;
-													const _errs179 = errors;
+													let data68 = data.step;
+													const _errs183 = errors;
 													if (
-														typeof data66 !==
+														typeof data68 !==
 														'string'
 													) {
 														validate28.errors = [
@@ -12634,7 +12711,7 @@ function validate28(
 													}
 													if (
 														'installTheme' !==
-														data66
+														data68
 													) {
 														validate28.errors = [
 															{
@@ -12655,25 +12732,25 @@ function validate28(
 														];
 														return false;
 													}
-													var valid36 =
-														_errs179 === errors;
+													var valid37 =
+														_errs183 === errors;
 												} else {
-													var valid36 = true;
+													var valid37 = true;
 												}
-												if (valid36) {
+												if (valid37) {
 													if (
 														data.themeData !==
 														undefined
 													) {
-														let data67 =
+														let data69 =
 															data.themeData;
-														const _errs181 = errors;
-														const _errs182 = errors;
-														let valid38 = false;
-														const _errs183 = errors;
+														const _errs185 = errors;
+														const _errs186 = errors;
+														let valid39 = false;
+														const _errs187 = errors;
 														if (
 															!validate16(
-																data67,
+																data69,
 																{
 																	instancePath:
 																		instancePath +
@@ -12696,15 +12773,15 @@ function validate28(
 																vErrors.length;
 														}
 														var _valid1 =
-															_errs183 === errors;
-														valid38 =
-															valid38 || _valid1;
-														if (!valid38) {
-															const _errs184 =
+															_errs187 === errors;
+														valid39 =
+															valid39 || _valid1;
+														if (!valid39) {
+															const _errs188 =
 																errors;
 															if (
 																!validate18(
-																	data67,
+																	data69,
 																	{
 																		instancePath:
 																			instancePath +
@@ -12728,13 +12805,13 @@ function validate28(
 																	vErrors.length;
 															}
 															var _valid1 =
-																_errs184 ===
+																_errs188 ===
 																errors;
-															valid38 =
-																valid38 ||
+															valid39 =
+																valid39 ||
 																_valid1;
 														}
-														if (!valid38) {
+														if (!valid39) {
 															const err1 = {
 																instancePath:
 																	instancePath +
@@ -12763,30 +12840,30 @@ function validate28(
 																vErrors;
 															return false;
 														} else {
-															errors = _errs182;
+															errors = _errs186;
 															if (
 																vErrors !== null
 															) {
-																if (_errs182) {
+																if (_errs186) {
 																	vErrors.length =
-																		_errs182;
+																		_errs186;
 																} else {
 																	vErrors =
 																		null;
 																}
 															}
 														}
-														var valid36 =
-															_errs181 === errors;
+														var valid37 =
+															_errs185 === errors;
 													} else {
-														var valid36 = true;
+														var valid37 = true;
 													}
-													if (valid36) {
+													if (valid37) {
 														if (
 															data.themeZipFile !==
 															undefined
 														) {
-															const _errs185 =
+															const _errs189 =
 																errors;
 															if (
 																!validate16(
@@ -12813,45 +12890,45 @@ function validate28(
 																errors =
 																	vErrors.length;
 															}
-															var valid36 =
-																_errs185 ===
+															var valid37 =
+																_errs189 ===
 																errors;
 														} else {
-															var valid36 = true;
+															var valid37 = true;
 														}
-														if (valid36) {
+														if (valid37) {
 															if (
 																data.options !==
 																undefined
 															) {
-																let data69 =
+																let data71 =
 																	data.options;
-																const _errs186 =
+																const _errs190 =
 																	errors;
-																const _errs187 =
+																const _errs191 =
 																	errors;
 																if (
 																	errors ===
-																	_errs187
+																	_errs191
 																) {
 																	if (
-																		data69 &&
-																		typeof data69 ==
+																		data71 &&
+																		typeof data71 ==
 																			'object' &&
 																		!Array.isArray(
-																			data69
+																			data71
 																		)
 																	) {
-																		const _errs189 =
+																		const _errs193 =
 																			errors;
-																		for (const key24 in data69) {
+																		for (const key25 in data71) {
 																			if (
 																				!(
-																					key24 ===
+																					key25 ===
 																						'activate' ||
-																					key24 ===
+																					key25 ===
 																						'importStarterContent' ||
-																					key24 ===
+																					key25 ===
 																						'targetFolderName'
 																				)
 																			) {
@@ -12867,7 +12944,7 @@ function validate28(
 																								'additionalProperties',
 																							params: {
 																								additionalProperty:
-																									key24,
+																									key25,
 																							},
 																							message:
 																								'must NOT have additional properties',
@@ -12878,17 +12955,17 @@ function validate28(
 																			}
 																		}
 																		if (
-																			_errs189 ===
+																			_errs193 ===
 																			errors
 																		) {
 																			if (
-																				data69.activate !==
+																				data71.activate !==
 																				undefined
 																			) {
-																				const _errs190 =
+																				const _errs194 =
 																					errors;
 																				if (
-																					typeof data69.activate !==
+																					typeof data71.activate !==
 																					'boolean'
 																				) {
 																					validate28.errors =
@@ -12910,23 +12987,23 @@ function validate28(
 																						];
 																					return false;
 																				}
-																				var valid40 =
-																					_errs190 ===
+																				var valid41 =
+																					_errs194 ===
 																					errors;
 																			} else {
-																				var valid40 = true;
+																				var valid41 = true;
 																			}
 																			if (
-																				valid40
+																				valid41
 																			) {
 																				if (
-																					data69.importStarterContent !==
+																					data71.importStarterContent !==
 																					undefined
 																				) {
-																					const _errs192 =
+																					const _errs196 =
 																						errors;
 																					if (
-																						typeof data69.importStarterContent !==
+																						typeof data71.importStarterContent !==
 																						'boolean'
 																					) {
 																						validate28.errors =
@@ -12948,23 +13025,23 @@ function validate28(
 																							];
 																						return false;
 																					}
-																					var valid40 =
-																						_errs192 ===
+																					var valid41 =
+																						_errs196 ===
 																						errors;
 																				} else {
-																					var valid40 = true;
+																					var valid41 = true;
 																				}
 																				if (
-																					valid40
+																					valid41
 																				) {
 																					if (
-																						data69.targetFolderName !==
+																						data71.targetFolderName !==
 																						undefined
 																					) {
-																						const _errs194 =
+																						const _errs198 =
 																							errors;
 																						if (
-																							typeof data69.targetFolderName !==
+																							typeof data71.targetFolderName !==
 																							'string'
 																						) {
 																							validate28.errors =
@@ -12986,11 +13063,11 @@ function validate28(
 																								];
 																							return false;
 																						}
-																						var valid40 =
-																							_errs194 ===
+																						var valid41 =
+																							_errs198 ===
 																							errors;
 																					} else {
-																						var valid40 = true;
+																						var valid41 = true;
 																					}
 																				}
 																			}
@@ -13016,11 +13093,11 @@ function validate28(
 																		return false;
 																	}
 																}
-																var valid36 =
-																	_errs186 ===
+																var valid37 =
+																	_errs190 ===
 																	errors;
 															} else {
-																var valid36 = true;
+																var valid37 = true;
 															}
 														}
 													}
@@ -13043,8 +13120,8 @@ function validate28(
 							}
 						}
 					} else if (tag0 === 'login') {
-						const _errs196 = errors;
-						if (errors === _errs196) {
+						const _errs200 = errors;
+						if (errors === _errs200) {
 							if (
 								data &&
 								typeof data == 'object' &&
@@ -13071,14 +13148,14 @@ function validate28(
 									];
 									return false;
 								} else {
-									const _errs198 = errors;
-									for (const key25 in data) {
+									const _errs202 = errors;
+									for (const key26 in data) {
 										if (
 											!(
-												key25 === 'progress' ||
-												key25 === 'step' ||
-												key25 === 'username' ||
-												key25 === 'password'
+												key26 === 'progress' ||
+												key26 === 'step' ||
+												key26 === 'username' ||
+												key26 === 'password'
 											)
 										) {
 											validate28.errors = [
@@ -13090,7 +13167,7 @@ function validate28(
 														'additionalProperties',
 													params: {
 														additionalProperty:
-															key25,
+															key26,
 													},
 													message:
 														'must NOT have additional properties',
@@ -13100,23 +13177,23 @@ function validate28(
 											break;
 										}
 									}
-									if (_errs198 === errors) {
+									if (_errs202 === errors) {
 										if (data.progress !== undefined) {
-											let data73 = data.progress;
-											const _errs199 = errors;
-											if (errors === _errs199) {
+											let data75 = data.progress;
+											const _errs203 = errors;
+											if (errors === _errs203) {
 												if (
-													data73 &&
-													typeof data73 == 'object' &&
-													!Array.isArray(data73)
+													data75 &&
+													typeof data75 == 'object' &&
+													!Array.isArray(data75)
 												) {
-													const _errs201 = errors;
-													for (const key26 in data73) {
+													const _errs205 = errors;
+													for (const key27 in data75) {
 														if (
 															!(
-																key26 ===
+																key27 ===
 																	'weight' ||
-																key26 ===
+																key27 ===
 																	'caption'
 															)
 														) {
@@ -13132,7 +13209,7 @@ function validate28(
 																			'additionalProperties',
 																		params: {
 																			additionalProperty:
-																				key26,
+																				key27,
 																		},
 																		message:
 																			'must NOT have additional properties',
@@ -13142,21 +13219,21 @@ function validate28(
 															break;
 														}
 													}
-													if (_errs201 === errors) {
+													if (_errs205 === errors) {
 														if (
-															data73.weight !==
+															data75.weight !==
 															undefined
 														) {
-															let data74 =
-																data73.weight;
-															const _errs202 =
+															let data76 =
+																data75.weight;
+															const _errs206 =
 																errors;
 															if (
 																!(
-																	typeof data74 ==
+																	typeof data76 ==
 																		'number' &&
 																	isFinite(
-																		data74
+																		data76
 																	)
 																)
 															) {
@@ -13179,21 +13256,21 @@ function validate28(
 																	];
 																return false;
 															}
-															var valid43 =
-																_errs202 ===
+															var valid44 =
+																_errs206 ===
 																errors;
 														} else {
-															var valid43 = true;
+															var valid44 = true;
 														}
-														if (valid43) {
+														if (valid44) {
 															if (
-																data73.caption !==
+																data75.caption !==
 																undefined
 															) {
-																const _errs204 =
+																const _errs208 =
 																	errors;
 																if (
-																	typeof data73.caption !==
+																	typeof data75.caption !==
 																	'string'
 																) {
 																	validate28.errors =
@@ -13215,11 +13292,11 @@ function validate28(
 																		];
 																	return false;
 																}
-																var valid43 =
-																	_errs204 ===
+																var valid44 =
+																	_errs208 ===
 																	errors;
 															} else {
-																var valid43 = true;
+																var valid44 = true;
 															}
 														}
 													}
@@ -13242,16 +13319,16 @@ function validate28(
 													return false;
 												}
 											}
-											var valid42 = _errs199 === errors;
+											var valid43 = _errs203 === errors;
 										} else {
-											var valid42 = true;
+											var valid43 = true;
 										}
-										if (valid42) {
+										if (valid43) {
 											if (data.step !== undefined) {
-												let data76 = data.step;
-												const _errs206 = errors;
+												let data78 = data.step;
+												const _errs210 = errors;
 												if (
-													typeof data76 !== 'string'
+													typeof data78 !== 'string'
 												) {
 													validate28.errors = [
 														{
@@ -13270,7 +13347,7 @@ function validate28(
 													];
 													return false;
 												}
-												if ('login' !== data76) {
+												if ('login' !== data78) {
 													validate28.errors = [
 														{
 															instancePath:
@@ -13289,16 +13366,16 @@ function validate28(
 													];
 													return false;
 												}
-												var valid42 =
-													_errs206 === errors;
+												var valid43 =
+													_errs210 === errors;
 											} else {
-												var valid42 = true;
+												var valid43 = true;
 											}
-											if (valid42) {
+											if (valid43) {
 												if (
 													data.username !== undefined
 												) {
-													const _errs208 = errors;
+													const _errs212 = errors;
 													if (
 														typeof data.username !==
 														'string'
@@ -13320,17 +13397,17 @@ function validate28(
 														];
 														return false;
 													}
-													var valid42 =
-														_errs208 === errors;
+													var valid43 =
+														_errs212 === errors;
 												} else {
-													var valid42 = true;
+													var valid43 = true;
 												}
-												if (valid42) {
+												if (valid43) {
 													if (
 														data.password !==
 														undefined
 													) {
-														const _errs210 = errors;
+														const _errs214 = errors;
 														if (
 															typeof data.password !==
 															'string'
@@ -13354,10 +13431,10 @@ function validate28(
 																];
 															return false;
 														}
-														var valid42 =
-															_errs210 === errors;
+														var valid43 =
+															_errs214 === errors;
 													} else {
-														var valid42 = true;
+														var valid43 = true;
 													}
 												}
 											}
@@ -13378,8 +13455,8 @@ function validate28(
 							}
 						}
 					} else if (tag0 === 'mkdir') {
-						const _errs212 = errors;
-						if (errors === _errs212) {
+						const _errs216 = errors;
+						if (errors === _errs216) {
 							if (
 								data &&
 								typeof data == 'object' &&
@@ -13408,13 +13485,13 @@ function validate28(
 									];
 									return false;
 								} else {
-									const _errs214 = errors;
-									for (const key27 in data) {
+									const _errs218 = errors;
+									for (const key28 in data) {
 										if (
 											!(
-												key27 === 'progress' ||
-												key27 === 'step' ||
-												key27 === 'path'
+												key28 === 'progress' ||
+												key28 === 'step' ||
+												key28 === 'path'
 											)
 										) {
 											validate28.errors = [
@@ -13426,7 +13503,7 @@ function validate28(
 														'additionalProperties',
 													params: {
 														additionalProperty:
-															key27,
+															key28,
 													},
 													message:
 														'must NOT have additional properties',
@@ -13436,23 +13513,23 @@ function validate28(
 											break;
 										}
 									}
-									if (_errs214 === errors) {
+									if (_errs218 === errors) {
 										if (data.progress !== undefined) {
-											let data79 = data.progress;
-											const _errs215 = errors;
-											if (errors === _errs215) {
+											let data81 = data.progress;
+											const _errs219 = errors;
+											if (errors === _errs219) {
 												if (
-													data79 &&
-													typeof data79 == 'object' &&
-													!Array.isArray(data79)
+													data81 &&
+													typeof data81 == 'object' &&
+													!Array.isArray(data81)
 												) {
-													const _errs217 = errors;
-													for (const key28 in data79) {
+													const _errs221 = errors;
+													for (const key29 in data81) {
 														if (
 															!(
-																key28 ===
+																key29 ===
 																	'weight' ||
-																key28 ===
+																key29 ===
 																	'caption'
 															)
 														) {
@@ -13468,7 +13545,7 @@ function validate28(
 																			'additionalProperties',
 																		params: {
 																			additionalProperty:
-																				key28,
+																				key29,
 																		},
 																		message:
 																			'must NOT have additional properties',
@@ -13478,21 +13555,21 @@ function validate28(
 															break;
 														}
 													}
-													if (_errs217 === errors) {
+													if (_errs221 === errors) {
 														if (
-															data79.weight !==
+															data81.weight !==
 															undefined
 														) {
-															let data80 =
-																data79.weight;
-															const _errs218 =
+															let data82 =
+																data81.weight;
+															const _errs222 =
 																errors;
 															if (
 																!(
-																	typeof data80 ==
+																	typeof data82 ==
 																		'number' &&
 																	isFinite(
-																		data80
+																		data82
 																	)
 																)
 															) {
@@ -13515,21 +13592,21 @@ function validate28(
 																	];
 																return false;
 															}
-															var valid46 =
-																_errs218 ===
+															var valid47 =
+																_errs222 ===
 																errors;
 														} else {
-															var valid46 = true;
+															var valid47 = true;
 														}
-														if (valid46) {
+														if (valid47) {
 															if (
-																data79.caption !==
+																data81.caption !==
 																undefined
 															) {
-																const _errs220 =
+																const _errs224 =
 																	errors;
 																if (
-																	typeof data79.caption !==
+																	typeof data81.caption !==
 																	'string'
 																) {
 																	validate28.errors =
@@ -13551,11 +13628,11 @@ function validate28(
 																		];
 																	return false;
 																}
-																var valid46 =
-																	_errs220 ===
+																var valid47 =
+																	_errs224 ===
 																	errors;
 															} else {
-																var valid46 = true;
+																var valid47 = true;
 															}
 														}
 													}
@@ -13578,16 +13655,16 @@ function validate28(
 													return false;
 												}
 											}
-											var valid45 = _errs215 === errors;
+											var valid46 = _errs219 === errors;
 										} else {
-											var valid45 = true;
+											var valid46 = true;
 										}
-										if (valid45) {
+										if (valid46) {
 											if (data.step !== undefined) {
-												let data82 = data.step;
-												const _errs222 = errors;
+												let data84 = data.step;
+												const _errs226 = errors;
 												if (
-													typeof data82 !== 'string'
+													typeof data84 !== 'string'
 												) {
 													validate28.errors = [
 														{
@@ -13606,7 +13683,7 @@ function validate28(
 													];
 													return false;
 												}
-												if ('mkdir' !== data82) {
+												if ('mkdir' !== data84) {
 													validate28.errors = [
 														{
 															instancePath:
@@ -13625,14 +13702,14 @@ function validate28(
 													];
 													return false;
 												}
-												var valid45 =
-													_errs222 === errors;
+												var valid46 =
+													_errs226 === errors;
 											} else {
-												var valid45 = true;
+												var valid46 = true;
 											}
-											if (valid45) {
+											if (valid46) {
 												if (data.path !== undefined) {
-													const _errs224 = errors;
+													const _errs228 = errors;
 													if (
 														typeof data.path !==
 														'string'
@@ -13654,10 +13731,10 @@ function validate28(
 														];
 														return false;
 													}
-													var valid45 =
-														_errs224 === errors;
+													var valid46 =
+														_errs228 === errors;
 												} else {
-													var valid45 = true;
+													var valid46 = true;
 												}
 											}
 										}
@@ -13677,8 +13754,8 @@ function validate28(
 							}
 						}
 					} else if (tag0 === 'mv') {
-						const _errs226 = errors;
-						if (errors === _errs226) {
+						const _errs230 = errors;
+						if (errors === _errs230) {
 							if (
 								data &&
 								typeof data == 'object' &&
@@ -13709,14 +13786,14 @@ function validate28(
 									];
 									return false;
 								} else {
-									const _errs228 = errors;
-									for (const key29 in data) {
+									const _errs232 = errors;
+									for (const key30 in data) {
 										if (
 											!(
-												key29 === 'progress' ||
-												key29 === 'step' ||
-												key29 === 'fromPath' ||
-												key29 === 'toPath'
+												key30 === 'progress' ||
+												key30 === 'step' ||
+												key30 === 'fromPath' ||
+												key30 === 'toPath'
 											)
 										) {
 											validate28.errors = [
@@ -13728,7 +13805,7 @@ function validate28(
 														'additionalProperties',
 													params: {
 														additionalProperty:
-															key29,
+															key30,
 													},
 													message:
 														'must NOT have additional properties',
@@ -13738,23 +13815,23 @@ function validate28(
 											break;
 										}
 									}
-									if (_errs228 === errors) {
+									if (_errs232 === errors) {
 										if (data.progress !== undefined) {
-											let data84 = data.progress;
-											const _errs229 = errors;
-											if (errors === _errs229) {
+											let data86 = data.progress;
+											const _errs233 = errors;
+											if (errors === _errs233) {
 												if (
-													data84 &&
-													typeof data84 == 'object' &&
-													!Array.isArray(data84)
+													data86 &&
+													typeof data86 == 'object' &&
+													!Array.isArray(data86)
 												) {
-													const _errs231 = errors;
-													for (const key30 in data84) {
+													const _errs235 = errors;
+													for (const key31 in data86) {
 														if (
 															!(
-																key30 ===
+																key31 ===
 																	'weight' ||
-																key30 ===
+																key31 ===
 																	'caption'
 															)
 														) {
@@ -13770,7 +13847,7 @@ function validate28(
 																			'additionalProperties',
 																		params: {
 																			additionalProperty:
-																				key30,
+																				key31,
 																		},
 																		message:
 																			'must NOT have additional properties',
@@ -13780,21 +13857,21 @@ function validate28(
 															break;
 														}
 													}
-													if (_errs231 === errors) {
+													if (_errs235 === errors) {
 														if (
-															data84.weight !==
+															data86.weight !==
 															undefined
 														) {
-															let data85 =
-																data84.weight;
-															const _errs232 =
+															let data87 =
+																data86.weight;
+															const _errs236 =
 																errors;
 															if (
 																!(
-																	typeof data85 ==
+																	typeof data87 ==
 																		'number' &&
 																	isFinite(
-																		data85
+																		data87
 																	)
 																)
 															) {
@@ -13817,21 +13894,21 @@ function validate28(
 																	];
 																return false;
 															}
-															var valid49 =
-																_errs232 ===
+															var valid50 =
+																_errs236 ===
 																errors;
 														} else {
-															var valid49 = true;
+															var valid50 = true;
 														}
-														if (valid49) {
+														if (valid50) {
 															if (
-																data84.caption !==
+																data86.caption !==
 																undefined
 															) {
-																const _errs234 =
+																const _errs238 =
 																	errors;
 																if (
-																	typeof data84.caption !==
+																	typeof data86.caption !==
 																	'string'
 																) {
 																	validate28.errors =
@@ -13853,11 +13930,11 @@ function validate28(
 																		];
 																	return false;
 																}
-																var valid49 =
-																	_errs234 ===
+																var valid50 =
+																	_errs238 ===
 																	errors;
 															} else {
-																var valid49 = true;
+																var valid50 = true;
 															}
 														}
 													}
@@ -13880,16 +13957,16 @@ function validate28(
 													return false;
 												}
 											}
-											var valid48 = _errs229 === errors;
+											var valid49 = _errs233 === errors;
 										} else {
-											var valid48 = true;
+											var valid49 = true;
 										}
-										if (valid48) {
+										if (valid49) {
 											if (data.step !== undefined) {
-												let data87 = data.step;
-												const _errs236 = errors;
+												let data89 = data.step;
+												const _errs240 = errors;
 												if (
-													typeof data87 !== 'string'
+													typeof data89 !== 'string'
 												) {
 													validate28.errors = [
 														{
@@ -13908,7 +13985,7 @@ function validate28(
 													];
 													return false;
 												}
-												if ('mv' !== data87) {
+												if ('mv' !== data89) {
 													validate28.errors = [
 														{
 															instancePath:
@@ -13927,16 +14004,16 @@ function validate28(
 													];
 													return false;
 												}
-												var valid48 =
-													_errs236 === errors;
+												var valid49 =
+													_errs240 === errors;
 											} else {
-												var valid48 = true;
+												var valid49 = true;
 											}
-											if (valid48) {
+											if (valid49) {
 												if (
 													data.fromPath !== undefined
 												) {
-													const _errs238 = errors;
+													const _errs242 = errors;
 													if (
 														typeof data.fromPath !==
 														'string'
@@ -13958,17 +14035,17 @@ function validate28(
 														];
 														return false;
 													}
-													var valid48 =
-														_errs238 === errors;
+													var valid49 =
+														_errs242 === errors;
 												} else {
-													var valid48 = true;
+													var valid49 = true;
 												}
-												if (valid48) {
+												if (valid49) {
 													if (
 														data.toPath !==
 														undefined
 													) {
-														const _errs240 = errors;
+														const _errs244 = errors;
 														if (
 															typeof data.toPath !==
 															'string'
@@ -13992,10 +14069,10 @@ function validate28(
 																];
 															return false;
 														}
-														var valid48 =
-															_errs240 === errors;
+														var valid49 =
+															_errs244 === errors;
 													} else {
-														var valid48 = true;
+														var valid49 = true;
 													}
 												}
 											}
@@ -14016,8 +14093,8 @@ function validate28(
 							}
 						}
 					} else if (tag0 === 'resetData') {
-						const _errs242 = errors;
-						if (errors === _errs242) {
+						const _errs246 = errors;
+						if (errors === _errs246) {
 							if (
 								data &&
 								typeof data == 'object' &&
@@ -14044,12 +14121,12 @@ function validate28(
 									];
 									return false;
 								} else {
-									const _errs244 = errors;
-									for (const key31 in data) {
+									const _errs248 = errors;
+									for (const key32 in data) {
 										if (
 											!(
-												key31 === 'progress' ||
-												key31 === 'step'
+												key32 === 'progress' ||
+												key32 === 'step'
 											)
 										) {
 											validate28.errors = [
@@ -14061,7 +14138,7 @@ function validate28(
 														'additionalProperties',
 													params: {
 														additionalProperty:
-															key31,
+															key32,
 													},
 													message:
 														'must NOT have additional properties',
@@ -14071,23 +14148,23 @@ function validate28(
 											break;
 										}
 									}
-									if (_errs244 === errors) {
+									if (_errs248 === errors) {
 										if (data.progress !== undefined) {
-											let data90 = data.progress;
-											const _errs245 = errors;
-											if (errors === _errs245) {
+											let data92 = data.progress;
+											const _errs249 = errors;
+											if (errors === _errs249) {
 												if (
-													data90 &&
-													typeof data90 == 'object' &&
-													!Array.isArray(data90)
+													data92 &&
+													typeof data92 == 'object' &&
+													!Array.isArray(data92)
 												) {
-													const _errs247 = errors;
-													for (const key32 in data90) {
+													const _errs251 = errors;
+													for (const key33 in data92) {
 														if (
 															!(
-																key32 ===
+																key33 ===
 																	'weight' ||
-																key32 ===
+																key33 ===
 																	'caption'
 															)
 														) {
@@ -14103,7 +14180,7 @@ function validate28(
 																			'additionalProperties',
 																		params: {
 																			additionalProperty:
-																				key32,
+																				key33,
 																		},
 																		message:
 																			'must NOT have additional properties',
@@ -14113,21 +14190,21 @@ function validate28(
 															break;
 														}
 													}
-													if (_errs247 === errors) {
+													if (_errs251 === errors) {
 														if (
-															data90.weight !==
+															data92.weight !==
 															undefined
 														) {
-															let data91 =
-																data90.weight;
-															const _errs248 =
+															let data93 =
+																data92.weight;
+															const _errs252 =
 																errors;
 															if (
 																!(
-																	typeof data91 ==
+																	typeof data93 ==
 																		'number' &&
 																	isFinite(
-																		data91
+																		data93
 																	)
 																)
 															) {
@@ -14150,21 +14227,21 @@ function validate28(
 																	];
 																return false;
 															}
-															var valid52 =
-																_errs248 ===
+															var valid53 =
+																_errs252 ===
 																errors;
 														} else {
-															var valid52 = true;
+															var valid53 = true;
 														}
-														if (valid52) {
+														if (valid53) {
 															if (
-																data90.caption !==
+																data92.caption !==
 																undefined
 															) {
-																const _errs250 =
+																const _errs254 =
 																	errors;
 																if (
-																	typeof data90.caption !==
+																	typeof data92.caption !==
 																	'string'
 																) {
 																	validate28.errors =
@@ -14186,11 +14263,11 @@ function validate28(
 																		];
 																	return false;
 																}
-																var valid52 =
-																	_errs250 ===
+																var valid53 =
+																	_errs254 ===
 																	errors;
 															} else {
-																var valid52 = true;
+																var valid53 = true;
 															}
 														}
 													}
@@ -14213,16 +14290,16 @@ function validate28(
 													return false;
 												}
 											}
-											var valid51 = _errs245 === errors;
+											var valid52 = _errs249 === errors;
 										} else {
-											var valid51 = true;
+											var valid52 = true;
 										}
-										if (valid51) {
+										if (valid52) {
 											if (data.step !== undefined) {
-												let data93 = data.step;
-												const _errs252 = errors;
+												let data95 = data.step;
+												const _errs256 = errors;
 												if (
-													typeof data93 !== 'string'
+													typeof data95 !== 'string'
 												) {
 													validate28.errors = [
 														{
@@ -14241,7 +14318,7 @@ function validate28(
 													];
 													return false;
 												}
-												if ('resetData' !== data93) {
+												if ('resetData' !== data95) {
 													validate28.errors = [
 														{
 															instancePath:
@@ -14260,10 +14337,10 @@ function validate28(
 													];
 													return false;
 												}
-												var valid51 =
-													_errs252 === errors;
+												var valid52 =
+													_errs256 === errors;
 											} else {
-												var valid51 = true;
+												var valid52 = true;
 											}
 										}
 									}
@@ -14282,8 +14359,8 @@ function validate28(
 							}
 						}
 					} else if (tag0 === 'request') {
-						const _errs254 = errors;
-						if (errors === _errs254) {
+						const _errs258 = errors;
+						if (errors === _errs258) {
 							if (
 								data &&
 								typeof data == 'object' &&
@@ -14312,13 +14389,13 @@ function validate28(
 									];
 									return false;
 								} else {
-									const _errs256 = errors;
-									for (const key33 in data) {
+									const _errs260 = errors;
+									for (const key34 in data) {
 										if (
 											!(
-												key33 === 'progress' ||
-												key33 === 'step' ||
-												key33 === 'request'
+												key34 === 'progress' ||
+												key34 === 'step' ||
+												key34 === 'request'
 											)
 										) {
 											validate28.errors = [
@@ -14330,7 +14407,7 @@ function validate28(
 														'additionalProperties',
 													params: {
 														additionalProperty:
-															key33,
+															key34,
 													},
 													message:
 														'must NOT have additional properties',
@@ -14340,23 +14417,23 @@ function validate28(
 											break;
 										}
 									}
-									if (_errs256 === errors) {
+									if (_errs260 === errors) {
 										if (data.progress !== undefined) {
-											let data94 = data.progress;
-											const _errs257 = errors;
-											if (errors === _errs257) {
+											let data96 = data.progress;
+											const _errs261 = errors;
+											if (errors === _errs261) {
 												if (
-													data94 &&
-													typeof data94 == 'object' &&
-													!Array.isArray(data94)
+													data96 &&
+													typeof data96 == 'object' &&
+													!Array.isArray(data96)
 												) {
-													const _errs259 = errors;
-													for (const key34 in data94) {
+													const _errs263 = errors;
+													for (const key35 in data96) {
 														if (
 															!(
-																key34 ===
+																key35 ===
 																	'weight' ||
-																key34 ===
+																key35 ===
 																	'caption'
 															)
 														) {
@@ -14372,7 +14449,7 @@ function validate28(
 																			'additionalProperties',
 																		params: {
 																			additionalProperty:
-																				key34,
+																				key35,
 																		},
 																		message:
 																			'must NOT have additional properties',
@@ -14382,21 +14459,21 @@ function validate28(
 															break;
 														}
 													}
-													if (_errs259 === errors) {
+													if (_errs263 === errors) {
 														if (
-															data94.weight !==
+															data96.weight !==
 															undefined
 														) {
-															let data95 =
-																data94.weight;
-															const _errs260 =
+															let data97 =
+																data96.weight;
+															const _errs264 =
 																errors;
 															if (
 																!(
-																	typeof data95 ==
+																	typeof data97 ==
 																		'number' &&
 																	isFinite(
-																		data95
+																		data97
 																	)
 																)
 															) {
@@ -14419,21 +14496,21 @@ function validate28(
 																	];
 																return false;
 															}
-															var valid55 =
-																_errs260 ===
+															var valid56 =
+																_errs264 ===
 																errors;
 														} else {
-															var valid55 = true;
+															var valid56 = true;
 														}
-														if (valid55) {
+														if (valid56) {
 															if (
-																data94.caption !==
+																data96.caption !==
 																undefined
 															) {
-																const _errs262 =
+																const _errs266 =
 																	errors;
 																if (
-																	typeof data94.caption !==
+																	typeof data96.caption !==
 																	'string'
 																) {
 																	validate28.errors =
@@ -14455,11 +14532,11 @@ function validate28(
 																		];
 																	return false;
 																}
-																var valid55 =
-																	_errs262 ===
+																var valid56 =
+																	_errs266 ===
 																	errors;
 															} else {
-																var valid55 = true;
+																var valid56 = true;
 															}
 														}
 													}
@@ -14482,16 +14559,16 @@ function validate28(
 													return false;
 												}
 											}
-											var valid54 = _errs257 === errors;
+											var valid55 = _errs261 === errors;
 										} else {
-											var valid54 = true;
+											var valid55 = true;
 										}
-										if (valid54) {
+										if (valid55) {
 											if (data.step !== undefined) {
-												let data97 = data.step;
-												const _errs264 = errors;
+												let data99 = data.step;
+												const _errs268 = errors;
 												if (
-													typeof data97 !== 'string'
+													typeof data99 !== 'string'
 												) {
 													validate28.errors = [
 														{
@@ -14510,7 +14587,7 @@ function validate28(
 													];
 													return false;
 												}
-												if ('request' !== data97) {
+												if ('request' !== data99) {
 													validate28.errors = [
 														{
 															instancePath:
@@ -14529,16 +14606,16 @@ function validate28(
 													];
 													return false;
 												}
-												var valid54 =
-													_errs264 === errors;
+												var valid55 =
+													_errs268 === errors;
 											} else {
-												var valid54 = true;
+												var valid55 = true;
 											}
-											if (valid54) {
+											if (valid55) {
 												if (
 													data.request !== undefined
 												) {
-													const _errs266 = errors;
+													const _errs270 = errors;
 													if (
 														!validate37(
 															data.request,
@@ -14562,10 +14639,10 @@ function validate28(
 																	);
 														errors = vErrors.length;
 													}
-													var valid54 =
-														_errs266 === errors;
+													var valid55 =
+														_errs270 === errors;
 												} else {
-													var valid54 = true;
+													var valid55 = true;
 												}
 											}
 										}
@@ -14585,8 +14662,8 @@ function validate28(
 							}
 						}
 					} else if (tag0 === 'rm') {
-						const _errs267 = errors;
-						if (errors === _errs267) {
+						const _errs271 = errors;
+						if (errors === _errs271) {
 							if (
 								data &&
 								typeof data == 'object' &&
@@ -14615,13 +14692,13 @@ function validate28(
 									];
 									return false;
 								} else {
-									const _errs269 = errors;
-									for (const key35 in data) {
+									const _errs273 = errors;
+									for (const key36 in data) {
 										if (
 											!(
-												key35 === 'progress' ||
-												key35 === 'step' ||
-												key35 === 'path'
+												key36 === 'progress' ||
+												key36 === 'step' ||
+												key36 === 'path'
 											)
 										) {
 											validate28.errors = [
@@ -14633,7 +14710,7 @@ function validate28(
 														'additionalProperties',
 													params: {
 														additionalProperty:
-															key35,
+															key36,
 													},
 													message:
 														'must NOT have additional properties',
@@ -14643,23 +14720,24 @@ function validate28(
 											break;
 										}
 									}
-									if (_errs269 === errors) {
+									if (_errs273 === errors) {
 										if (data.progress !== undefined) {
-											let data99 = data.progress;
-											const _errs270 = errors;
-											if (errors === _errs270) {
+											let data101 = data.progress;
+											const _errs274 = errors;
+											if (errors === _errs274) {
 												if (
-													data99 &&
-													typeof data99 == 'object' &&
-													!Array.isArray(data99)
+													data101 &&
+													typeof data101 ==
+														'object' &&
+													!Array.isArray(data101)
 												) {
-													const _errs272 = errors;
-													for (const key36 in data99) {
+													const _errs276 = errors;
+													for (const key37 in data101) {
 														if (
 															!(
-																key36 ===
+																key37 ===
 																	'weight' ||
-																key36 ===
+																key37 ===
 																	'caption'
 															)
 														) {
@@ -14675,7 +14753,7 @@ function validate28(
 																			'additionalProperties',
 																		params: {
 																			additionalProperty:
-																				key36,
+																				key37,
 																		},
 																		message:
 																			'must NOT have additional properties',
@@ -14685,21 +14763,21 @@ function validate28(
 															break;
 														}
 													}
-													if (_errs272 === errors) {
+													if (_errs276 === errors) {
 														if (
-															data99.weight !==
+															data101.weight !==
 															undefined
 														) {
-															let data100 =
-																data99.weight;
-															const _errs273 =
+															let data102 =
+																data101.weight;
+															const _errs277 =
 																errors;
 															if (
 																!(
-																	typeof data100 ==
+																	typeof data102 ==
 																		'number' &&
 																	isFinite(
-																		data100
+																		data102
 																	)
 																)
 															) {
@@ -14722,21 +14800,21 @@ function validate28(
 																	];
 																return false;
 															}
-															var valid58 =
-																_errs273 ===
+															var valid59 =
+																_errs277 ===
 																errors;
 														} else {
-															var valid58 = true;
+															var valid59 = true;
 														}
-														if (valid58) {
+														if (valid59) {
 															if (
-																data99.caption !==
+																data101.caption !==
 																undefined
 															) {
-																const _errs275 =
+																const _errs279 =
 																	errors;
 																if (
-																	typeof data99.caption !==
+																	typeof data101.caption !==
 																	'string'
 																) {
 																	validate28.errors =
@@ -14758,11 +14836,11 @@ function validate28(
 																		];
 																	return false;
 																}
-																var valid58 =
-																	_errs275 ===
+																var valid59 =
+																	_errs279 ===
 																	errors;
 															} else {
-																var valid58 = true;
+																var valid59 = true;
 															}
 														}
 													}
@@ -14785,16 +14863,16 @@ function validate28(
 													return false;
 												}
 											}
-											var valid57 = _errs270 === errors;
+											var valid58 = _errs274 === errors;
 										} else {
-											var valid57 = true;
+											var valid58 = true;
 										}
-										if (valid57) {
+										if (valid58) {
 											if (data.step !== undefined) {
-												let data102 = data.step;
-												const _errs277 = errors;
+												let data104 = data.step;
+												const _errs281 = errors;
 												if (
-													typeof data102 !== 'string'
+													typeof data104 !== 'string'
 												) {
 													validate28.errors = [
 														{
@@ -14813,7 +14891,7 @@ function validate28(
 													];
 													return false;
 												}
-												if ('rm' !== data102) {
+												if ('rm' !== data104) {
 													validate28.errors = [
 														{
 															instancePath:
@@ -14832,14 +14910,14 @@ function validate28(
 													];
 													return false;
 												}
-												var valid57 =
-													_errs277 === errors;
+												var valid58 =
+													_errs281 === errors;
 											} else {
-												var valid57 = true;
+												var valid58 = true;
 											}
-											if (valid57) {
+											if (valid58) {
 												if (data.path !== undefined) {
-													const _errs279 = errors;
+													const _errs283 = errors;
 													if (
 														typeof data.path !==
 														'string'
@@ -14861,10 +14939,10 @@ function validate28(
 														];
 														return false;
 													}
-													var valid57 =
-														_errs279 === errors;
+													var valid58 =
+														_errs283 === errors;
 												} else {
-													var valid57 = true;
+													var valid58 = true;
 												}
 											}
 										}
@@ -14884,8 +14962,8 @@ function validate28(
 							}
 						}
 					} else if (tag0 === 'rmdir') {
-						const _errs281 = errors;
-						if (errors === _errs281) {
+						const _errs285 = errors;
+						if (errors === _errs285) {
 							if (
 								data &&
 								typeof data == 'object' &&
@@ -14914,13 +14992,13 @@ function validate28(
 									];
 									return false;
 								} else {
-									const _errs283 = errors;
-									for (const key37 in data) {
+									const _errs287 = errors;
+									for (const key38 in data) {
 										if (
 											!(
-												key37 === 'progress' ||
-												key37 === 'step' ||
-												key37 === 'path'
+												key38 === 'progress' ||
+												key38 === 'step' ||
+												key38 === 'path'
 											)
 										) {
 											validate28.errors = [
@@ -14932,7 +15010,7 @@ function validate28(
 														'additionalProperties',
 													params: {
 														additionalProperty:
-															key37,
+															key38,
 													},
 													message:
 														'must NOT have additional properties',
@@ -14942,24 +15020,24 @@ function validate28(
 											break;
 										}
 									}
-									if (_errs283 === errors) {
+									if (_errs287 === errors) {
 										if (data.progress !== undefined) {
-											let data104 = data.progress;
-											const _errs284 = errors;
-											if (errors === _errs284) {
+											let data106 = data.progress;
+											const _errs288 = errors;
+											if (errors === _errs288) {
 												if (
-													data104 &&
-													typeof data104 ==
+													data106 &&
+													typeof data106 ==
 														'object' &&
-													!Array.isArray(data104)
+													!Array.isArray(data106)
 												) {
-													const _errs286 = errors;
-													for (const key38 in data104) {
+													const _errs290 = errors;
+													for (const key39 in data106) {
 														if (
 															!(
-																key38 ===
+																key39 ===
 																	'weight' ||
-																key38 ===
+																key39 ===
 																	'caption'
 															)
 														) {
@@ -14975,7 +15053,7 @@ function validate28(
 																			'additionalProperties',
 																		params: {
 																			additionalProperty:
-																				key38,
+																				key39,
 																		},
 																		message:
 																			'must NOT have additional properties',
@@ -14985,21 +15063,21 @@ function validate28(
 															break;
 														}
 													}
-													if (_errs286 === errors) {
+													if (_errs290 === errors) {
 														if (
-															data104.weight !==
+															data106.weight !==
 															undefined
 														) {
-															let data105 =
-																data104.weight;
-															const _errs287 =
+															let data107 =
+																data106.weight;
+															const _errs291 =
 																errors;
 															if (
 																!(
-																	typeof data105 ==
+																	typeof data107 ==
 																		'number' &&
 																	isFinite(
-																		data105
+																		data107
 																	)
 																)
 															) {
@@ -15022,21 +15100,21 @@ function validate28(
 																	];
 																return false;
 															}
-															var valid61 =
-																_errs287 ===
+															var valid62 =
+																_errs291 ===
 																errors;
 														} else {
-															var valid61 = true;
+															var valid62 = true;
 														}
-														if (valid61) {
+														if (valid62) {
 															if (
-																data104.caption !==
+																data106.caption !==
 																undefined
 															) {
-																const _errs289 =
+																const _errs293 =
 																	errors;
 																if (
-																	typeof data104.caption !==
+																	typeof data106.caption !==
 																	'string'
 																) {
 																	validate28.errors =
@@ -15058,11 +15136,11 @@ function validate28(
 																		];
 																	return false;
 																}
-																var valid61 =
-																	_errs289 ===
+																var valid62 =
+																	_errs293 ===
 																	errors;
 															} else {
-																var valid61 = true;
+																var valid62 = true;
 															}
 														}
 													}
@@ -15085,16 +15163,16 @@ function validate28(
 													return false;
 												}
 											}
-											var valid60 = _errs284 === errors;
+											var valid61 = _errs288 === errors;
 										} else {
-											var valid60 = true;
+											var valid61 = true;
 										}
-										if (valid60) {
+										if (valid61) {
 											if (data.step !== undefined) {
-												let data107 = data.step;
-												const _errs291 = errors;
+												let data109 = data.step;
+												const _errs295 = errors;
 												if (
-													typeof data107 !== 'string'
+													typeof data109 !== 'string'
 												) {
 													validate28.errors = [
 														{
@@ -15113,7 +15191,7 @@ function validate28(
 													];
 													return false;
 												}
-												if ('rmdir' !== data107) {
+												if ('rmdir' !== data109) {
 													validate28.errors = [
 														{
 															instancePath:
@@ -15132,14 +15210,14 @@ function validate28(
 													];
 													return false;
 												}
-												var valid60 =
-													_errs291 === errors;
+												var valid61 =
+													_errs295 === errors;
 											} else {
-												var valid60 = true;
+												var valid61 = true;
 											}
-											if (valid60) {
+											if (valid61) {
 												if (data.path !== undefined) {
-													const _errs293 = errors;
+													const _errs297 = errors;
 													if (
 														typeof data.path !==
 														'string'
@@ -15161,10 +15239,10 @@ function validate28(
 														];
 														return false;
 													}
-													var valid60 =
-														_errs293 === errors;
+													var valid61 =
+														_errs297 === errors;
 												} else {
-													var valid60 = true;
+													var valid61 = true;
 												}
 											}
 										}
@@ -15184,8 +15262,8 @@ function validate28(
 							}
 						}
 					} else if (tag0 === 'runPHP') {
-						const _errs295 = errors;
-						if (errors === _errs295) {
+						const _errs299 = errors;
+						if (errors === _errs299) {
 							if (
 								data &&
 								typeof data == 'object' &&
@@ -15214,13 +15292,13 @@ function validate28(
 									];
 									return false;
 								} else {
-									const _errs297 = errors;
-									for (const key39 in data) {
+									const _errs301 = errors;
+									for (const key40 in data) {
 										if (
 											!(
-												key39 === 'progress' ||
-												key39 === 'step' ||
-												key39 === 'code'
+												key40 === 'progress' ||
+												key40 === 'step' ||
+												key40 === 'code'
 											)
 										) {
 											validate28.errors = [
@@ -15232,7 +15310,7 @@ function validate28(
 														'additionalProperties',
 													params: {
 														additionalProperty:
-															key39,
+															key40,
 													},
 													message:
 														'must NOT have additional properties',
@@ -15242,24 +15320,24 @@ function validate28(
 											break;
 										}
 									}
-									if (_errs297 === errors) {
+									if (_errs301 === errors) {
 										if (data.progress !== undefined) {
-											let data109 = data.progress;
-											const _errs298 = errors;
-											if (errors === _errs298) {
+											let data111 = data.progress;
+											const _errs302 = errors;
+											if (errors === _errs302) {
 												if (
-													data109 &&
-													typeof data109 ==
+													data111 &&
+													typeof data111 ==
 														'object' &&
-													!Array.isArray(data109)
+													!Array.isArray(data111)
 												) {
-													const _errs300 = errors;
-													for (const key40 in data109) {
+													const _errs304 = errors;
+													for (const key41 in data111) {
 														if (
 															!(
-																key40 ===
+																key41 ===
 																	'weight' ||
-																key40 ===
+																key41 ===
 																	'caption'
 															)
 														) {
@@ -15275,7 +15353,7 @@ function validate28(
 																			'additionalProperties',
 																		params: {
 																			additionalProperty:
-																				key40,
+																				key41,
 																		},
 																		message:
 																			'must NOT have additional properties',
@@ -15285,21 +15363,21 @@ function validate28(
 															break;
 														}
 													}
-													if (_errs300 === errors) {
+													if (_errs304 === errors) {
 														if (
-															data109.weight !==
+															data111.weight !==
 															undefined
 														) {
-															let data110 =
-																data109.weight;
-															const _errs301 =
+															let data112 =
+																data111.weight;
+															const _errs305 =
 																errors;
 															if (
 																!(
-																	typeof data110 ==
+																	typeof data112 ==
 																		'number' &&
 																	isFinite(
-																		data110
+																		data112
 																	)
 																)
 															) {
@@ -15322,21 +15400,21 @@ function validate28(
 																	];
 																return false;
 															}
-															var valid64 =
-																_errs301 ===
+															var valid65 =
+																_errs305 ===
 																errors;
 														} else {
-															var valid64 = true;
+															var valid65 = true;
 														}
-														if (valid64) {
+														if (valid65) {
 															if (
-																data109.caption !==
+																data111.caption !==
 																undefined
 															) {
-																const _errs303 =
+																const _errs307 =
 																	errors;
 																if (
-																	typeof data109.caption !==
+																	typeof data111.caption !==
 																	'string'
 																) {
 																	validate28.errors =
@@ -15358,11 +15436,11 @@ function validate28(
 																		];
 																	return false;
 																}
-																var valid64 =
-																	_errs303 ===
+																var valid65 =
+																	_errs307 ===
 																	errors;
 															} else {
-																var valid64 = true;
+																var valid65 = true;
 															}
 														}
 													}
@@ -15385,16 +15463,16 @@ function validate28(
 													return false;
 												}
 											}
-											var valid63 = _errs298 === errors;
+											var valid64 = _errs302 === errors;
 										} else {
-											var valid63 = true;
+											var valid64 = true;
 										}
-										if (valid63) {
+										if (valid64) {
 											if (data.step !== undefined) {
-												let data112 = data.step;
-												const _errs305 = errors;
+												let data114 = data.step;
+												const _errs309 = errors;
 												if (
-													typeof data112 !== 'string'
+													typeof data114 !== 'string'
 												) {
 													validate28.errors = [
 														{
@@ -15413,7 +15491,7 @@ function validate28(
 													];
 													return false;
 												}
-												if ('runPHP' !== data112) {
+												if ('runPHP' !== data114) {
 													validate28.errors = [
 														{
 															instancePath:
@@ -15432,20 +15510,20 @@ function validate28(
 													];
 													return false;
 												}
-												var valid63 =
-													_errs305 === errors;
+												var valid64 =
+													_errs309 === errors;
 											} else {
-												var valid63 = true;
+												var valid64 = true;
 											}
-											if (valid63) {
+											if (valid64) {
 												if (data.code !== undefined) {
-													let data113 = data.code;
-													const _errs307 = errors;
-													const _errs308 = errors;
-													let valid65 = false;
-													const _errs309 = errors;
+													let data115 = data.code;
+													const _errs311 = errors;
+													const _errs312 = errors;
+													let valid66 = false;
+													const _errs313 = errors;
 													if (
-														typeof data113 !==
+														typeof data115 !==
 														'string'
 													) {
 														const err2 = {
@@ -15469,29 +15547,29 @@ function validate28(
 														errors++;
 													}
 													var _valid2 =
-														_errs309 === errors;
-													valid65 =
-														valid65 || _valid2;
-													if (!valid65) {
-														const _errs311 = errors;
+														_errs313 === errors;
+													valid66 =
+														valid66 || _valid2;
+													if (!valid66) {
+														const _errs315 = errors;
 														if (
-															errors === _errs311
+															errors === _errs315
 														) {
 															if (
-																data113 &&
-																typeof data113 ==
+																data115 &&
+																typeof data115 ==
 																	'object' &&
 																!Array.isArray(
-																	data113
+																	data115
 																)
 															) {
 																let missing20;
 																if (
-																	(data113.filename ===
+																	(data115.filename ===
 																		undefined &&
 																		(missing20 =
 																			'filename')) ||
-																	(data113.content ===
+																	(data115.content ===
 																		undefined &&
 																		(missing20 =
 																			'content'))
@@ -15529,14 +15607,14 @@ function validate28(
 																	}
 																	errors++;
 																} else {
-																	const _errs313 =
+																	const _errs317 =
 																		errors;
-																	for (const key41 in data113) {
+																	for (const key42 in data115) {
 																		if (
 																			!(
-																				key41 ===
+																				key42 ===
 																					'filename' ||
-																				key41 ===
+																				key42 ===
 																					'content'
 																			)
 																		) {
@@ -15551,7 +15629,7 @@ function validate28(
 																						'additionalProperties',
 																					params: {
 																						additionalProperty:
-																							key41,
+																							key42,
 																					},
 																					message:
 																						'must NOT have additional properties',
@@ -15574,17 +15652,17 @@ function validate28(
 																		}
 																	}
 																	if (
-																		_errs313 ===
+																		_errs317 ===
 																		errors
 																	) {
 																		if (
-																			data113.filename !==
+																			data115.filename !==
 																			undefined
 																		) {
-																			const _errs314 =
+																			const _errs318 =
 																				errors;
 																			if (
-																				typeof data113.filename !==
+																				typeof data115.filename !==
 																				'string'
 																			) {
 																				const err5 =
@@ -15617,23 +15695,23 @@ function validate28(
 																				}
 																				errors++;
 																			}
-																			var valid66 =
-																				_errs314 ===
+																			var valid67 =
+																				_errs318 ===
 																				errors;
 																		} else {
-																			var valid66 = true;
+																			var valid67 = true;
 																		}
 																		if (
-																			valid66
+																			valid67
 																		) {
 																			if (
-																				data113.content !==
+																				data115.content !==
 																				undefined
 																			) {
-																				const _errs316 =
+																				const _errs320 =
 																					errors;
 																				if (
-																					typeof data113.content !==
+																					typeof data115.content !==
 																					'string'
 																				) {
 																					const err6 =
@@ -15666,11 +15744,11 @@ function validate28(
 																					}
 																					errors++;
 																				}
-																				var valid66 =
-																					_errs316 ===
+																				var valid67 =
+																					_errs320 ===
 																					errors;
 																			} else {
-																				var valid66 = true;
+																				var valid67 = true;
 																			}
 																		}
 																	}
@@ -15706,11 +15784,11 @@ function validate28(
 															}
 														}
 														var _valid2 =
-															_errs311 === errors;
-														valid65 =
-															valid65 || _valid2;
+															_errs315 === errors;
+														valid66 =
+															valid66 || _valid2;
 													}
-													if (!valid65) {
+													if (!valid66) {
 														const err8 = {
 															instancePath:
 																instancePath +
@@ -15732,20 +15810,20 @@ function validate28(
 															vErrors;
 														return false;
 													} else {
-														errors = _errs308;
+														errors = _errs312;
 														if (vErrors !== null) {
-															if (_errs308) {
+															if (_errs312) {
 																vErrors.length =
-																	_errs308;
+																	_errs312;
 															} else {
 																vErrors = null;
 															}
 														}
 													}
-													var valid63 =
-														_errs307 === errors;
+													var valid64 =
+														_errs311 === errors;
 												} else {
-													var valid63 = true;
+													var valid64 = true;
 												}
 											}
 										}
@@ -15765,8 +15843,8 @@ function validate28(
 							}
 						}
 					} else if (tag0 === 'runPHPWithOptions') {
-						const _errs318 = errors;
-						if (errors === _errs318) {
+						const _errs322 = errors;
+						if (errors === _errs322) {
 							if (
 								data &&
 								typeof data == 'object' &&
@@ -15795,13 +15873,13 @@ function validate28(
 									];
 									return false;
 								} else {
-									const _errs320 = errors;
-									for (const key42 in data) {
+									const _errs324 = errors;
+									for (const key43 in data) {
 										if (
 											!(
-												key42 === 'progress' ||
-												key42 === 'step' ||
-												key42 === 'options'
+												key43 === 'progress' ||
+												key43 === 'step' ||
+												key43 === 'options'
 											)
 										) {
 											validate28.errors = [
@@ -15813,7 +15891,7 @@ function validate28(
 														'additionalProperties',
 													params: {
 														additionalProperty:
-															key42,
+															key43,
 													},
 													message:
 														'must NOT have additional properties',
@@ -15823,24 +15901,24 @@ function validate28(
 											break;
 										}
 									}
-									if (_errs320 === errors) {
+									if (_errs324 === errors) {
 										if (data.progress !== undefined) {
-											let data116 = data.progress;
-											const _errs321 = errors;
-											if (errors === _errs321) {
+											let data118 = data.progress;
+											const _errs325 = errors;
+											if (errors === _errs325) {
 												if (
-													data116 &&
-													typeof data116 ==
+													data118 &&
+													typeof data118 ==
 														'object' &&
-													!Array.isArray(data116)
+													!Array.isArray(data118)
 												) {
-													const _errs323 = errors;
-													for (const key43 in data116) {
+													const _errs327 = errors;
+													for (const key44 in data118) {
 														if (
 															!(
-																key43 ===
+																key44 ===
 																	'weight' ||
-																key43 ===
+																key44 ===
 																	'caption'
 															)
 														) {
@@ -15856,7 +15934,7 @@ function validate28(
 																			'additionalProperties',
 																		params: {
 																			additionalProperty:
-																				key43,
+																				key44,
 																		},
 																		message:
 																			'must NOT have additional properties',
@@ -15866,21 +15944,21 @@ function validate28(
 															break;
 														}
 													}
-													if (_errs323 === errors) {
+													if (_errs327 === errors) {
 														if (
-															data116.weight !==
+															data118.weight !==
 															undefined
 														) {
-															let data117 =
-																data116.weight;
-															const _errs324 =
+															let data119 =
+																data118.weight;
+															const _errs328 =
 																errors;
 															if (
 																!(
-																	typeof data117 ==
+																	typeof data119 ==
 																		'number' &&
 																	isFinite(
-																		data117
+																		data119
 																	)
 																)
 															) {
@@ -15903,21 +15981,21 @@ function validate28(
 																	];
 																return false;
 															}
-															var valid69 =
-																_errs324 ===
+															var valid70 =
+																_errs328 ===
 																errors;
 														} else {
-															var valid69 = true;
+															var valid70 = true;
 														}
-														if (valid69) {
+														if (valid70) {
 															if (
-																data116.caption !==
+																data118.caption !==
 																undefined
 															) {
-																const _errs326 =
+																const _errs330 =
 																	errors;
 																if (
-																	typeof data116.caption !==
+																	typeof data118.caption !==
 																	'string'
 																) {
 																	validate28.errors =
@@ -15939,11 +16017,11 @@ function validate28(
 																		];
 																	return false;
 																}
-																var valid69 =
-																	_errs326 ===
+																var valid70 =
+																	_errs330 ===
 																	errors;
 															} else {
-																var valid69 = true;
+																var valid70 = true;
 															}
 														}
 													}
@@ -15966,16 +16044,16 @@ function validate28(
 													return false;
 												}
 											}
-											var valid68 = _errs321 === errors;
+											var valid69 = _errs325 === errors;
 										} else {
-											var valid68 = true;
+											var valid69 = true;
 										}
-										if (valid68) {
+										if (valid69) {
 											if (data.step !== undefined) {
-												let data119 = data.step;
-												const _errs328 = errors;
+												let data121 = data.step;
+												const _errs332 = errors;
 												if (
-													typeof data119 !== 'string'
+													typeof data121 !== 'string'
 												) {
 													validate28.errors = [
 														{
@@ -15996,7 +16074,7 @@ function validate28(
 												}
 												if (
 													'runPHPWithOptions' !==
-													data119
+													data121
 												) {
 													validate28.errors = [
 														{
@@ -16016,16 +16094,16 @@ function validate28(
 													];
 													return false;
 												}
-												var valid68 =
-													_errs328 === errors;
+												var valid69 =
+													_errs332 === errors;
 											} else {
-												var valid68 = true;
+												var valid69 = true;
 											}
-											if (valid68) {
+											if (valid69) {
 												if (
 													data.options !== undefined
 												) {
-													const _errs330 = errors;
+													const _errs334 = errors;
 													if (
 														!validate39(
 															data.options,
@@ -16049,10 +16127,10 @@ function validate28(
 																	);
 														errors = vErrors.length;
 													}
-													var valid68 =
-														_errs330 === errors;
+													var valid69 =
+														_errs334 === errors;
 												} else {
-													var valid68 = true;
+													var valid69 = true;
 												}
 											}
 										}
@@ -16072,8 +16150,8 @@ function validate28(
 							}
 						}
 					} else if (tag0 === 'runWpInstallationWizard') {
-						const _errs331 = errors;
-						if (errors === _errs331) {
+						const _errs335 = errors;
+						if (errors === _errs335) {
 							if (
 								data &&
 								typeof data == 'object' &&
@@ -16102,13 +16180,13 @@ function validate28(
 									];
 									return false;
 								} else {
-									const _errs333 = errors;
-									for (const key44 in data) {
+									const _errs337 = errors;
+									for (const key45 in data) {
 										if (
 											!(
-												key44 === 'progress' ||
-												key44 === 'step' ||
-												key44 === 'options'
+												key45 === 'progress' ||
+												key45 === 'step' ||
+												key45 === 'options'
 											)
 										) {
 											validate28.errors = [
@@ -16120,7 +16198,7 @@ function validate28(
 														'additionalProperties',
 													params: {
 														additionalProperty:
-															key44,
+															key45,
 													},
 													message:
 														'must NOT have additional properties',
@@ -16130,24 +16208,24 @@ function validate28(
 											break;
 										}
 									}
-									if (_errs333 === errors) {
+									if (_errs337 === errors) {
 										if (data.progress !== undefined) {
-											let data121 = data.progress;
-											const _errs334 = errors;
-											if (errors === _errs334) {
+											let data123 = data.progress;
+											const _errs338 = errors;
+											if (errors === _errs338) {
 												if (
-													data121 &&
-													typeof data121 ==
+													data123 &&
+													typeof data123 ==
 														'object' &&
-													!Array.isArray(data121)
+													!Array.isArray(data123)
 												) {
-													const _errs336 = errors;
-													for (const key45 in data121) {
+													const _errs340 = errors;
+													for (const key46 in data123) {
 														if (
 															!(
-																key45 ===
+																key46 ===
 																	'weight' ||
-																key45 ===
+																key46 ===
 																	'caption'
 															)
 														) {
@@ -16163,7 +16241,7 @@ function validate28(
 																			'additionalProperties',
 																		params: {
 																			additionalProperty:
-																				key45,
+																				key46,
 																		},
 																		message:
 																			'must NOT have additional properties',
@@ -16173,21 +16251,21 @@ function validate28(
 															break;
 														}
 													}
-													if (_errs336 === errors) {
+													if (_errs340 === errors) {
 														if (
-															data121.weight !==
+															data123.weight !==
 															undefined
 														) {
-															let data122 =
-																data121.weight;
-															const _errs337 =
+															let data124 =
+																data123.weight;
+															const _errs341 =
 																errors;
 															if (
 																!(
-																	typeof data122 ==
+																	typeof data124 ==
 																		'number' &&
 																	isFinite(
-																		data122
+																		data124
 																	)
 																)
 															) {
@@ -16210,21 +16288,21 @@ function validate28(
 																	];
 																return false;
 															}
-															var valid72 =
-																_errs337 ===
+															var valid73 =
+																_errs341 ===
 																errors;
 														} else {
-															var valid72 = true;
+															var valid73 = true;
 														}
-														if (valid72) {
+														if (valid73) {
 															if (
-																data121.caption !==
+																data123.caption !==
 																undefined
 															) {
-																const _errs339 =
+																const _errs343 =
 																	errors;
 																if (
-																	typeof data121.caption !==
+																	typeof data123.caption !==
 																	'string'
 																) {
 																	validate28.errors =
@@ -16246,11 +16324,11 @@ function validate28(
 																		];
 																	return false;
 																}
-																var valid72 =
-																	_errs339 ===
+																var valid73 =
+																	_errs343 ===
 																	errors;
 															} else {
-																var valid72 = true;
+																var valid73 = true;
 															}
 														}
 													}
@@ -16273,16 +16351,16 @@ function validate28(
 													return false;
 												}
 											}
-											var valid71 = _errs334 === errors;
+											var valid72 = _errs338 === errors;
 										} else {
-											var valid71 = true;
+											var valid72 = true;
 										}
-										if (valid71) {
+										if (valid72) {
 											if (data.step !== undefined) {
-												let data124 = data.step;
-												const _errs341 = errors;
+												let data126 = data.step;
+												const _errs345 = errors;
 												if (
-													typeof data124 !== 'string'
+													typeof data126 !== 'string'
 												) {
 													validate28.errors = [
 														{
@@ -16303,7 +16381,7 @@ function validate28(
 												}
 												if (
 													'runWpInstallationWizard' !==
-													data124
+													data126
 												) {
 													validate28.errors = [
 														{
@@ -16323,35 +16401,35 @@ function validate28(
 													];
 													return false;
 												}
-												var valid71 =
-													_errs341 === errors;
+												var valid72 =
+													_errs345 === errors;
 											} else {
-												var valid71 = true;
+												var valid72 = true;
 											}
-											if (valid71) {
+											if (valid72) {
 												if (
 													data.options !== undefined
 												) {
-													let data125 = data.options;
-													const _errs343 = errors;
-													const _errs344 = errors;
-													if (errors === _errs344) {
+													let data127 = data.options;
+													const _errs347 = errors;
+													const _errs348 = errors;
+													if (errors === _errs348) {
 														if (
-															data125 &&
-															typeof data125 ==
+															data127 &&
+															typeof data127 ==
 																'object' &&
 															!Array.isArray(
-																data125
+																data127
 															)
 														) {
-															const _errs346 =
+															const _errs350 =
 																errors;
-															for (const key46 in data125) {
+															for (const key47 in data127) {
 																if (
 																	!(
-																		key46 ===
+																		key47 ===
 																			'adminUsername' ||
-																		key46 ===
+																		key47 ===
 																			'adminPassword'
 																	)
 																) {
@@ -16367,7 +16445,7 @@ function validate28(
 																					'additionalProperties',
 																				params: {
 																					additionalProperty:
-																						key46,
+																						key47,
 																				},
 																				message:
 																					'must NOT have additional properties',
@@ -16378,17 +16456,17 @@ function validate28(
 																}
 															}
 															if (
-																_errs346 ===
+																_errs350 ===
 																errors
 															) {
 																if (
-																	data125.adminUsername !==
+																	data127.adminUsername !==
 																	undefined
 																) {
-																	const _errs347 =
+																	const _errs351 =
 																		errors;
 																	if (
-																		typeof data125.adminUsername !==
+																		typeof data127.adminUsername !==
 																		'string'
 																	) {
 																		validate28.errors =
@@ -16410,21 +16488,21 @@ function validate28(
 																			];
 																		return false;
 																	}
-																	var valid74 =
-																		_errs347 ===
+																	var valid75 =
+																		_errs351 ===
 																		errors;
 																} else {
-																	var valid74 = true;
+																	var valid75 = true;
 																}
-																if (valid74) {
+																if (valid75) {
 																	if (
-																		data125.adminPassword !==
+																		data127.adminPassword !==
 																		undefined
 																	) {
-																		const _errs349 =
+																		const _errs353 =
 																			errors;
 																		if (
-																			typeof data125.adminPassword !==
+																			typeof data127.adminPassword !==
 																			'string'
 																		) {
 																			validate28.errors =
@@ -16446,11 +16524,11 @@ function validate28(
 																				];
 																			return false;
 																		}
-																		var valid74 =
-																			_errs349 ===
+																		var valid75 =
+																			_errs353 ===
 																			errors;
 																	} else {
-																		var valid74 = true;
+																		var valid75 = true;
 																	}
 																}
 															}
@@ -16475,10 +16553,10 @@ function validate28(
 															return false;
 														}
 													}
-													var valid71 =
-														_errs343 === errors;
+													var valid72 =
+														_errs347 === errors;
 												} else {
-													var valid71 = true;
+													var valid72 = true;
 												}
 											}
 										}
@@ -16498,8 +16576,8 @@ function validate28(
 							}
 						}
 					} else if (tag0 === 'runSql') {
-						const _errs351 = errors;
-						if (errors === _errs351) {
+						const _errs355 = errors;
+						if (errors === _errs355) {
 							if (
 								data &&
 								typeof data == 'object' &&
@@ -16528,13 +16606,13 @@ function validate28(
 									];
 									return false;
 								} else {
-									const _errs353 = errors;
-									for (const key47 in data) {
+									const _errs357 = errors;
+									for (const key48 in data) {
 										if (
 											!(
-												key47 === 'progress' ||
-												key47 === 'step' ||
-												key47 === 'sql'
+												key48 === 'progress' ||
+												key48 === 'step' ||
+												key48 === 'sql'
 											)
 										) {
 											validate28.errors = [
@@ -16546,7 +16624,7 @@ function validate28(
 														'additionalProperties',
 													params: {
 														additionalProperty:
-															key47,
+															key48,
 													},
 													message:
 														'must NOT have additional properties',
@@ -16556,24 +16634,24 @@ function validate28(
 											break;
 										}
 									}
-									if (_errs353 === errors) {
+									if (_errs357 === errors) {
 										if (data.progress !== undefined) {
-											let data128 = data.progress;
-											const _errs354 = errors;
-											if (errors === _errs354) {
+											let data130 = data.progress;
+											const _errs358 = errors;
+											if (errors === _errs358) {
 												if (
-													data128 &&
-													typeof data128 ==
+													data130 &&
+													typeof data130 ==
 														'object' &&
-													!Array.isArray(data128)
+													!Array.isArray(data130)
 												) {
-													const _errs356 = errors;
-													for (const key48 in data128) {
+													const _errs360 = errors;
+													for (const key49 in data130) {
 														if (
 															!(
-																key48 ===
+																key49 ===
 																	'weight' ||
-																key48 ===
+																key49 ===
 																	'caption'
 															)
 														) {
@@ -16589,7 +16667,7 @@ function validate28(
 																			'additionalProperties',
 																		params: {
 																			additionalProperty:
-																				key48,
+																				key49,
 																		},
 																		message:
 																			'must NOT have additional properties',
@@ -16599,21 +16677,21 @@ function validate28(
 															break;
 														}
 													}
-													if (_errs356 === errors) {
+													if (_errs360 === errors) {
 														if (
-															data128.weight !==
+															data130.weight !==
 															undefined
 														) {
-															let data129 =
-																data128.weight;
-															const _errs357 =
+															let data131 =
+																data130.weight;
+															const _errs361 =
 																errors;
 															if (
 																!(
-																	typeof data129 ==
+																	typeof data131 ==
 																		'number' &&
 																	isFinite(
-																		data129
+																		data131
 																	)
 																)
 															) {
@@ -16636,21 +16714,21 @@ function validate28(
 																	];
 																return false;
 															}
-															var valid77 =
-																_errs357 ===
+															var valid78 =
+																_errs361 ===
 																errors;
 														} else {
-															var valid77 = true;
+															var valid78 = true;
 														}
-														if (valid77) {
+														if (valid78) {
 															if (
-																data128.caption !==
+																data130.caption !==
 																undefined
 															) {
-																const _errs359 =
+																const _errs363 =
 																	errors;
 																if (
-																	typeof data128.caption !==
+																	typeof data130.caption !==
 																	'string'
 																) {
 																	validate28.errors =
@@ -16672,11 +16750,11 @@ function validate28(
 																		];
 																	return false;
 																}
-																var valid77 =
-																	_errs359 ===
+																var valid78 =
+																	_errs363 ===
 																	errors;
 															} else {
-																var valid77 = true;
+																var valid78 = true;
 															}
 														}
 													}
@@ -16699,16 +16777,16 @@ function validate28(
 													return false;
 												}
 											}
-											var valid76 = _errs354 === errors;
+											var valid77 = _errs358 === errors;
 										} else {
-											var valid76 = true;
+											var valid77 = true;
 										}
-										if (valid76) {
+										if (valid77) {
 											if (data.step !== undefined) {
-												let data131 = data.step;
-												const _errs361 = errors;
+												let data133 = data.step;
+												const _errs365 = errors;
 												if (
-													typeof data131 !== 'string'
+													typeof data133 !== 'string'
 												) {
 													validate28.errors = [
 														{
@@ -16727,7 +16805,7 @@ function validate28(
 													];
 													return false;
 												}
-												if ('runSql' !== data131) {
+												if ('runSql' !== data133) {
 													validate28.errors = [
 														{
 															instancePath:
@@ -16746,14 +16824,14 @@ function validate28(
 													];
 													return false;
 												}
-												var valid76 =
-													_errs361 === errors;
+												var valid77 =
+													_errs365 === errors;
 											} else {
-												var valid76 = true;
+												var valid77 = true;
 											}
-											if (valid76) {
+											if (valid77) {
 												if (data.sql !== undefined) {
-													const _errs363 = errors;
+													const _errs367 = errors;
 													if (
 														!validate16(data.sql, {
 															instancePath:
@@ -16773,10 +16851,10 @@ function validate28(
 																	);
 														errors = vErrors.length;
 													}
-													var valid76 =
-														_errs363 === errors;
+													var valid77 =
+														_errs367 === errors;
 												} else {
-													var valid76 = true;
+													var valid77 = true;
 												}
 											}
 										}
@@ -16796,8 +16874,8 @@ function validate28(
 							}
 						}
 					} else if (tag0 === 'setSiteOptions') {
-						const _errs364 = errors;
-						if (errors === _errs364) {
+						const _errs368 = errors;
+						if (errors === _errs368) {
 							if (
 								data &&
 								typeof data == 'object' &&
@@ -16826,13 +16904,13 @@ function validate28(
 									];
 									return false;
 								} else {
-									const _errs366 = errors;
-									for (const key49 in data) {
+									const _errs370 = errors;
+									for (const key50 in data) {
 										if (
 											!(
-												key49 === 'progress' ||
-												key49 === 'step' ||
-												key49 === 'options'
+												key50 === 'progress' ||
+												key50 === 'step' ||
+												key50 === 'options'
 											)
 										) {
 											validate28.errors = [
@@ -16844,7 +16922,7 @@ function validate28(
 														'additionalProperties',
 													params: {
 														additionalProperty:
-															key49,
+															key50,
 													},
 													message:
 														'must NOT have additional properties',
@@ -16854,24 +16932,24 @@ function validate28(
 											break;
 										}
 									}
-									if (_errs366 === errors) {
+									if (_errs370 === errors) {
 										if (data.progress !== undefined) {
-											let data133 = data.progress;
-											const _errs367 = errors;
-											if (errors === _errs367) {
+											let data135 = data.progress;
+											const _errs371 = errors;
+											if (errors === _errs371) {
 												if (
-													data133 &&
-													typeof data133 ==
+													data135 &&
+													typeof data135 ==
 														'object' &&
-													!Array.isArray(data133)
+													!Array.isArray(data135)
 												) {
-													const _errs369 = errors;
-													for (const key50 in data133) {
+													const _errs373 = errors;
+													for (const key51 in data135) {
 														if (
 															!(
-																key50 ===
+																key51 ===
 																	'weight' ||
-																key50 ===
+																key51 ===
 																	'caption'
 															)
 														) {
@@ -16887,7 +16965,7 @@ function validate28(
 																			'additionalProperties',
 																		params: {
 																			additionalProperty:
-																				key50,
+																				key51,
 																		},
 																		message:
 																			'must NOT have additional properties',
@@ -16897,21 +16975,21 @@ function validate28(
 															break;
 														}
 													}
-													if (_errs369 === errors) {
+													if (_errs373 === errors) {
 														if (
-															data133.weight !==
+															data135.weight !==
 															undefined
 														) {
-															let data134 =
-																data133.weight;
-															const _errs370 =
+															let data136 =
+																data135.weight;
+															const _errs374 =
 																errors;
 															if (
 																!(
-																	typeof data134 ==
+																	typeof data136 ==
 																		'number' &&
 																	isFinite(
-																		data134
+																		data136
 																	)
 																)
 															) {
@@ -16934,21 +17012,21 @@ function validate28(
 																	];
 																return false;
 															}
-															var valid80 =
-																_errs370 ===
+															var valid81 =
+																_errs374 ===
 																errors;
 														} else {
-															var valid80 = true;
+															var valid81 = true;
 														}
-														if (valid80) {
+														if (valid81) {
 															if (
-																data133.caption !==
+																data135.caption !==
 																undefined
 															) {
-																const _errs372 =
+																const _errs376 =
 																	errors;
 																if (
-																	typeof data133.caption !==
+																	typeof data135.caption !==
 																	'string'
 																) {
 																	validate28.errors =
@@ -16970,11 +17048,11 @@ function validate28(
 																		];
 																	return false;
 																}
-																var valid80 =
-																	_errs372 ===
+																var valid81 =
+																	_errs376 ===
 																	errors;
 															} else {
-																var valid80 = true;
+																var valid81 = true;
 															}
 														}
 													}
@@ -16997,16 +17075,16 @@ function validate28(
 													return false;
 												}
 											}
-											var valid79 = _errs367 === errors;
+											var valid80 = _errs371 === errors;
 										} else {
-											var valid79 = true;
+											var valid80 = true;
 										}
-										if (valid79) {
+										if (valid80) {
 											if (data.step !== undefined) {
-												let data136 = data.step;
-												const _errs374 = errors;
+												let data138 = data.step;
+												const _errs378 = errors;
 												if (
-													typeof data136 !== 'string'
+													typeof data138 !== 'string'
 												) {
 													validate28.errors = [
 														{
@@ -17026,7 +17104,7 @@ function validate28(
 													return false;
 												}
 												if (
-													'setSiteOptions' !== data136
+													'setSiteOptions' !== data138
 												) {
 													validate28.errors = [
 														{
@@ -17046,33 +17124,33 @@ function validate28(
 													];
 													return false;
 												}
-												var valid79 =
-													_errs374 === errors;
+												var valid80 =
+													_errs378 === errors;
 											} else {
-												var valid79 = true;
+												var valid80 = true;
 											}
-											if (valid79) {
+											if (valid80) {
 												if (
 													data.options !== undefined
 												) {
-													let data137 = data.options;
-													const _errs376 = errors;
-													if (errors === _errs376) {
+													let data139 = data.options;
+													const _errs380 = errors;
+													if (errors === _errs380) {
 														if (
-															data137 &&
-															typeof data137 ==
+															data139 &&
+															typeof data139 ==
 																'object' &&
 															!Array.isArray(
-																data137
+																data139
 															)
 														) {
-															for (const key51 in data137) {
-																const _errs379 =
+															for (const key52 in data139) {
+																const _errs383 =
 																	errors;
-																var valid81 =
-																	_errs379 ===
+																var valid82 =
+																	_errs383 ===
 																	errors;
-																if (!valid81) {
+																if (!valid82) {
 																	break;
 																}
 															}
@@ -17097,10 +17175,10 @@ function validate28(
 															return false;
 														}
 													}
-													var valid79 =
-														_errs376 === errors;
+													var valid80 =
+														_errs380 === errors;
 												} else {
-													var valid79 = true;
+													var valid80 = true;
 												}
 											}
 										}
@@ -17120,8 +17198,8 @@ function validate28(
 							}
 						}
 					} else if (tag0 === 'unzip') {
-						const _errs380 = errors;
-						if (errors === _errs380) {
+						const _errs384 = errors;
+						if (errors === _errs384) {
 							if (
 								data &&
 								typeof data == 'object' &&
@@ -17150,15 +17228,15 @@ function validate28(
 									];
 									return false;
 								} else {
-									const _errs382 = errors;
-									for (const key52 in data) {
+									const _errs386 = errors;
+									for (const key53 in data) {
 										if (
 											!(
-												key52 === 'progress' ||
-												key52 === 'step' ||
-												key52 === 'zipFile' ||
-												key52 === 'zipPath' ||
-												key52 === 'extractToPath'
+												key53 === 'progress' ||
+												key53 === 'step' ||
+												key53 === 'zipFile' ||
+												key53 === 'zipPath' ||
+												key53 === 'extractToPath'
 											)
 										) {
 											validate28.errors = [
@@ -17170,7 +17248,7 @@ function validate28(
 														'additionalProperties',
 													params: {
 														additionalProperty:
-															key52,
+															key53,
 													},
 													message:
 														'must NOT have additional properties',
@@ -17180,24 +17258,24 @@ function validate28(
 											break;
 										}
 									}
-									if (_errs382 === errors) {
+									if (_errs386 === errors) {
 										if (data.progress !== undefined) {
-											let data139 = data.progress;
-											const _errs383 = errors;
-											if (errors === _errs383) {
+											let data141 = data.progress;
+											const _errs387 = errors;
+											if (errors === _errs387) {
 												if (
-													data139 &&
-													typeof data139 ==
+													data141 &&
+													typeof data141 ==
 														'object' &&
-													!Array.isArray(data139)
+													!Array.isArray(data141)
 												) {
-													const _errs385 = errors;
-													for (const key53 in data139) {
+													const _errs389 = errors;
+													for (const key54 in data141) {
 														if (
 															!(
-																key53 ===
+																key54 ===
 																	'weight' ||
-																key53 ===
+																key54 ===
 																	'caption'
 															)
 														) {
@@ -17213,7 +17291,7 @@ function validate28(
 																			'additionalProperties',
 																		params: {
 																			additionalProperty:
-																				key53,
+																				key54,
 																		},
 																		message:
 																			'must NOT have additional properties',
@@ -17223,21 +17301,21 @@ function validate28(
 															break;
 														}
 													}
-													if (_errs385 === errors) {
+													if (_errs389 === errors) {
 														if (
-															data139.weight !==
+															data141.weight !==
 															undefined
 														) {
-															let data140 =
-																data139.weight;
-															const _errs386 =
+															let data142 =
+																data141.weight;
+															const _errs390 =
 																errors;
 															if (
 																!(
-																	typeof data140 ==
+																	typeof data142 ==
 																		'number' &&
 																	isFinite(
-																		data140
+																		data142
 																	)
 																)
 															) {
@@ -17260,21 +17338,21 @@ function validate28(
 																	];
 																return false;
 															}
-															var valid84 =
-																_errs386 ===
+															var valid85 =
+																_errs390 ===
 																errors;
 														} else {
-															var valid84 = true;
+															var valid85 = true;
 														}
-														if (valid84) {
+														if (valid85) {
 															if (
-																data139.caption !==
+																data141.caption !==
 																undefined
 															) {
-																const _errs388 =
+																const _errs392 =
 																	errors;
 																if (
-																	typeof data139.caption !==
+																	typeof data141.caption !==
 																	'string'
 																) {
 																	validate28.errors =
@@ -17296,11 +17374,11 @@ function validate28(
 																		];
 																	return false;
 																}
-																var valid84 =
-																	_errs388 ===
+																var valid85 =
+																	_errs392 ===
 																	errors;
 															} else {
-																var valid84 = true;
+																var valid85 = true;
 															}
 														}
 													}
@@ -17323,16 +17401,16 @@ function validate28(
 													return false;
 												}
 											}
-											var valid83 = _errs383 === errors;
+											var valid84 = _errs387 === errors;
 										} else {
-											var valid83 = true;
+											var valid84 = true;
 										}
-										if (valid83) {
+										if (valid84) {
 											if (data.step !== undefined) {
-												let data142 = data.step;
-												const _errs390 = errors;
+												let data144 = data.step;
+												const _errs394 = errors;
 												if (
-													typeof data142 !== 'string'
+													typeof data144 !== 'string'
 												) {
 													validate28.errors = [
 														{
@@ -17351,7 +17429,7 @@ function validate28(
 													];
 													return false;
 												}
-												if ('unzip' !== data142) {
+												if ('unzip' !== data144) {
 													validate28.errors = [
 														{
 															instancePath:
@@ -17370,16 +17448,16 @@ function validate28(
 													];
 													return false;
 												}
-												var valid83 =
-													_errs390 === errors;
+												var valid84 =
+													_errs394 === errors;
 											} else {
-												var valid83 = true;
+												var valid84 = true;
 											}
-											if (valid83) {
+											if (valid84) {
 												if (
 													data.zipFile !== undefined
 												) {
-													const _errs392 = errors;
+													const _errs396 = errors;
 													if (
 														!validate16(
 															data.zipFile,
@@ -17403,17 +17481,17 @@ function validate28(
 																	);
 														errors = vErrors.length;
 													}
-													var valid83 =
-														_errs392 === errors;
+													var valid84 =
+														_errs396 === errors;
 												} else {
-													var valid83 = true;
+													var valid84 = true;
 												}
-												if (valid83) {
+												if (valid84) {
 													if (
 														data.zipPath !==
 														undefined
 													) {
-														const _errs393 = errors;
+														const _errs397 = errors;
 														if (
 															typeof data.zipPath !==
 															'string'
@@ -17437,17 +17515,17 @@ function validate28(
 																];
 															return false;
 														}
-														var valid83 =
-															_errs393 === errors;
+														var valid84 =
+															_errs397 === errors;
 													} else {
-														var valid83 = true;
+														var valid84 = true;
 													}
-													if (valid83) {
+													if (valid84) {
 														if (
 															data.extractToPath !==
 															undefined
 														) {
-															const _errs395 =
+															const _errs399 =
 																errors;
 															if (
 																typeof data.extractToPath !==
@@ -17472,11 +17550,11 @@ function validate28(
 																	];
 																return false;
 															}
-															var valid83 =
-																_errs395 ===
+															var valid84 =
+																_errs399 ===
 																errors;
 														} else {
-															var valid83 = true;
+															var valid84 = true;
 														}
 													}
 												}
@@ -17498,8 +17576,8 @@ function validate28(
 							}
 						}
 					} else if (tag0 === 'updateUserMeta') {
-						const _errs397 = errors;
-						if (errors === _errs397) {
+						const _errs401 = errors;
+						if (errors === _errs401) {
 							if (
 								data &&
 								typeof data == 'object' &&
@@ -17530,14 +17608,14 @@ function validate28(
 									];
 									return false;
 								} else {
-									const _errs399 = errors;
-									for (const key54 in data) {
+									const _errs403 = errors;
+									for (const key55 in data) {
 										if (
 											!(
-												key54 === 'progress' ||
-												key54 === 'step' ||
-												key54 === 'meta' ||
-												key54 === 'userId'
+												key55 === 'progress' ||
+												key55 === 'step' ||
+												key55 === 'meta' ||
+												key55 === 'userId'
 											)
 										) {
 											validate28.errors = [
@@ -17549,7 +17627,7 @@ function validate28(
 														'additionalProperties',
 													params: {
 														additionalProperty:
-															key54,
+															key55,
 													},
 													message:
 														'must NOT have additional properties',
@@ -17559,24 +17637,24 @@ function validate28(
 											break;
 										}
 									}
-									if (_errs399 === errors) {
+									if (_errs403 === errors) {
 										if (data.progress !== undefined) {
-											let data146 = data.progress;
-											const _errs400 = errors;
-											if (errors === _errs400) {
+											let data148 = data.progress;
+											const _errs404 = errors;
+											if (errors === _errs404) {
 												if (
-													data146 &&
-													typeof data146 ==
+													data148 &&
+													typeof data148 ==
 														'object' &&
-													!Array.isArray(data146)
+													!Array.isArray(data148)
 												) {
-													const _errs402 = errors;
-													for (const key55 in data146) {
+													const _errs406 = errors;
+													for (const key56 in data148) {
 														if (
 															!(
-																key55 ===
+																key56 ===
 																	'weight' ||
-																key55 ===
+																key56 ===
 																	'caption'
 															)
 														) {
@@ -17592,7 +17670,7 @@ function validate28(
 																			'additionalProperties',
 																		params: {
 																			additionalProperty:
-																				key55,
+																				key56,
 																		},
 																		message:
 																			'must NOT have additional properties',
@@ -17602,21 +17680,21 @@ function validate28(
 															break;
 														}
 													}
-													if (_errs402 === errors) {
+													if (_errs406 === errors) {
 														if (
-															data146.weight !==
+															data148.weight !==
 															undefined
 														) {
-															let data147 =
-																data146.weight;
-															const _errs403 =
+															let data149 =
+																data148.weight;
+															const _errs407 =
 																errors;
 															if (
 																!(
-																	typeof data147 ==
+																	typeof data149 ==
 																		'number' &&
 																	isFinite(
-																		data147
+																		data149
 																	)
 																)
 															) {
@@ -17639,21 +17717,21 @@ function validate28(
 																	];
 																return false;
 															}
-															var valid87 =
-																_errs403 ===
+															var valid88 =
+																_errs407 ===
 																errors;
 														} else {
-															var valid87 = true;
+															var valid88 = true;
 														}
-														if (valid87) {
+														if (valid88) {
 															if (
-																data146.caption !==
+																data148.caption !==
 																undefined
 															) {
-																const _errs405 =
+																const _errs409 =
 																	errors;
 																if (
-																	typeof data146.caption !==
+																	typeof data148.caption !==
 																	'string'
 																) {
 																	validate28.errors =
@@ -17675,11 +17753,11 @@ function validate28(
 																		];
 																	return false;
 																}
-																var valid87 =
-																	_errs405 ===
+																var valid88 =
+																	_errs409 ===
 																	errors;
 															} else {
-																var valid87 = true;
+																var valid88 = true;
 															}
 														}
 													}
@@ -17702,16 +17780,16 @@ function validate28(
 													return false;
 												}
 											}
-											var valid86 = _errs400 === errors;
+											var valid87 = _errs404 === errors;
 										} else {
-											var valid86 = true;
+											var valid87 = true;
 										}
-										if (valid86) {
+										if (valid87) {
 											if (data.step !== undefined) {
-												let data149 = data.step;
-												const _errs407 = errors;
+												let data151 = data.step;
+												const _errs411 = errors;
 												if (
-													typeof data149 !== 'string'
+													typeof data151 !== 'string'
 												) {
 													validate28.errors = [
 														{
@@ -17731,7 +17809,7 @@ function validate28(
 													return false;
 												}
 												if (
-													'updateUserMeta' !== data149
+													'updateUserMeta' !== data151
 												) {
 													validate28.errors = [
 														{
@@ -17751,31 +17829,31 @@ function validate28(
 													];
 													return false;
 												}
-												var valid86 =
-													_errs407 === errors;
+												var valid87 =
+													_errs411 === errors;
 											} else {
-												var valid86 = true;
+												var valid87 = true;
 											}
-											if (valid86) {
+											if (valid87) {
 												if (data.meta !== undefined) {
-													let data150 = data.meta;
-													const _errs409 = errors;
-													if (errors === _errs409) {
+													let data152 = data.meta;
+													const _errs413 = errors;
+													if (errors === _errs413) {
 														if (
-															data150 &&
-															typeof data150 ==
+															data152 &&
+															typeof data152 ==
 																'object' &&
 															!Array.isArray(
-																data150
+																data152
 															)
 														) {
-															for (const key56 in data150) {
-																const _errs412 =
+															for (const key57 in data152) {
+																const _errs416 =
 																	errors;
-																var valid88 =
-																	_errs412 ===
+																var valid89 =
+																	_errs416 ===
 																	errors;
-																if (!valid88) {
+																if (!valid89) {
 																	break;
 																}
 															}
@@ -17800,25 +17878,25 @@ function validate28(
 															return false;
 														}
 													}
-													var valid86 =
-														_errs409 === errors;
+													var valid87 =
+														_errs413 === errors;
 												} else {
-													var valid86 = true;
+													var valid87 = true;
 												}
-												if (valid86) {
+												if (valid87) {
 													if (
 														data.userId !==
 														undefined
 													) {
-														let data152 =
+														let data154 =
 															data.userId;
-														const _errs413 = errors;
+														const _errs417 = errors;
 														if (
 															!(
-																typeof data152 ==
+																typeof data154 ==
 																	'number' &&
 																isFinite(
-																	data152
+																	data154
 																)
 															)
 														) {
@@ -17841,10 +17919,10 @@ function validate28(
 																];
 															return false;
 														}
-														var valid86 =
-															_errs413 === errors;
+														var valid87 =
+															_errs417 === errors;
 													} else {
-														var valid86 = true;
+														var valid87 = true;
 													}
 												}
 											}
@@ -17865,8 +17943,8 @@ function validate28(
 							}
 						}
 					} else if (tag0 === 'writeFile') {
-						const _errs415 = errors;
-						if (errors === _errs415) {
+						const _errs419 = errors;
+						if (errors === _errs419) {
 							if (
 								data &&
 								typeof data == 'object' &&
@@ -17897,14 +17975,14 @@ function validate28(
 									];
 									return false;
 								} else {
-									const _errs417 = errors;
-									for (const key57 in data) {
+									const _errs421 = errors;
+									for (const key58 in data) {
 										if (
 											!(
-												key57 === 'progress' ||
-												key57 === 'step' ||
-												key57 === 'path' ||
-												key57 === 'data'
+												key58 === 'progress' ||
+												key58 === 'step' ||
+												key58 === 'path' ||
+												key58 === 'data'
 											)
 										) {
 											validate28.errors = [
@@ -17916,7 +17994,7 @@ function validate28(
 														'additionalProperties',
 													params: {
 														additionalProperty:
-															key57,
+															key58,
 													},
 													message:
 														'must NOT have additional properties',
@@ -17926,24 +18004,24 @@ function validate28(
 											break;
 										}
 									}
-									if (_errs417 === errors) {
+									if (_errs421 === errors) {
 										if (data.progress !== undefined) {
-											let data153 = data.progress;
-											const _errs418 = errors;
-											if (errors === _errs418) {
+											let data155 = data.progress;
+											const _errs422 = errors;
+											if (errors === _errs422) {
 												if (
-													data153 &&
-													typeof data153 ==
+													data155 &&
+													typeof data155 ==
 														'object' &&
-													!Array.isArray(data153)
+													!Array.isArray(data155)
 												) {
-													const _errs420 = errors;
-													for (const key58 in data153) {
+													const _errs424 = errors;
+													for (const key59 in data155) {
 														if (
 															!(
-																key58 ===
+																key59 ===
 																	'weight' ||
-																key58 ===
+																key59 ===
 																	'caption'
 															)
 														) {
@@ -17959,7 +18037,7 @@ function validate28(
 																			'additionalProperties',
 																		params: {
 																			additionalProperty:
-																				key58,
+																				key59,
 																		},
 																		message:
 																			'must NOT have additional properties',
@@ -17969,21 +18047,21 @@ function validate28(
 															break;
 														}
 													}
-													if (_errs420 === errors) {
+													if (_errs424 === errors) {
 														if (
-															data153.weight !==
+															data155.weight !==
 															undefined
 														) {
-															let data154 =
-																data153.weight;
-															const _errs421 =
+															let data156 =
+																data155.weight;
+															const _errs425 =
 																errors;
 															if (
 																!(
-																	typeof data154 ==
+																	typeof data156 ==
 																		'number' &&
 																	isFinite(
-																		data154
+																		data156
 																	)
 																)
 															) {
@@ -18006,21 +18084,21 @@ function validate28(
 																	];
 																return false;
 															}
-															var valid91 =
-																_errs421 ===
+															var valid92 =
+																_errs425 ===
 																errors;
 														} else {
-															var valid91 = true;
+															var valid92 = true;
 														}
-														if (valid91) {
+														if (valid92) {
 															if (
-																data153.caption !==
+																data155.caption !==
 																undefined
 															) {
-																const _errs423 =
+																const _errs427 =
 																	errors;
 																if (
-																	typeof data153.caption !==
+																	typeof data155.caption !==
 																	'string'
 																) {
 																	validate28.errors =
@@ -18042,11 +18120,11 @@ function validate28(
 																		];
 																	return false;
 																}
-																var valid91 =
-																	_errs423 ===
+																var valid92 =
+																	_errs427 ===
 																	errors;
 															} else {
-																var valid91 = true;
+																var valid92 = true;
 															}
 														}
 													}
@@ -18069,16 +18147,16 @@ function validate28(
 													return false;
 												}
 											}
-											var valid90 = _errs418 === errors;
+											var valid91 = _errs422 === errors;
 										} else {
-											var valid90 = true;
+											var valid91 = true;
 										}
-										if (valid90) {
+										if (valid91) {
 											if (data.step !== undefined) {
-												let data156 = data.step;
-												const _errs425 = errors;
+												let data158 = data.step;
+												const _errs429 = errors;
 												if (
-													typeof data156 !== 'string'
+													typeof data158 !== 'string'
 												) {
 													validate28.errors = [
 														{
@@ -18097,7 +18175,7 @@ function validate28(
 													];
 													return false;
 												}
-												if ('writeFile' !== data156) {
+												if ('writeFile' !== data158) {
 													validate28.errors = [
 														{
 															instancePath:
@@ -18116,14 +18194,14 @@ function validate28(
 													];
 													return false;
 												}
-												var valid90 =
-													_errs425 === errors;
+												var valid91 =
+													_errs429 === errors;
 											} else {
-												var valid90 = true;
+												var valid91 = true;
 											}
-											if (valid90) {
+											if (valid91) {
 												if (data.path !== undefined) {
-													const _errs427 = errors;
+													const _errs431 = errors;
 													if (
 														typeof data.path !==
 														'string'
@@ -18145,23 +18223,23 @@ function validate28(
 														];
 														return false;
 													}
-													var valid90 =
-														_errs427 === errors;
+													var valid91 =
+														_errs431 === errors;
 												} else {
-													var valid90 = true;
+													var valid91 = true;
 												}
-												if (valid90) {
+												if (valid91) {
 													if (
 														data.data !== undefined
 													) {
-														let data158 = data.data;
-														const _errs429 = errors;
-														const _errs430 = errors;
-														let valid92 = false;
-														const _errs431 = errors;
+														let data160 = data.data;
+														const _errs433 = errors;
+														const _errs434 = errors;
+														let valid93 = false;
+														const _errs435 = errors;
 														if (
 															!validate16(
-																data158,
+																data160,
 																{
 																	instancePath:
 																		instancePath +
@@ -18184,14 +18262,14 @@ function validate28(
 																vErrors.length;
 														}
 														var _valid3 =
-															_errs431 === errors;
-														valid92 =
-															valid92 || _valid3;
-														if (!valid92) {
-															const _errs432 =
+															_errs435 === errors;
+														valid93 =
+															valid93 || _valid3;
+														if (!valid93) {
+															const _errs436 =
 																errors;
 															if (
-																typeof data158 !==
+																typeof data160 !==
 																'string'
 															) {
 																const err9 = {
@@ -18223,45 +18301,45 @@ function validate28(
 																errors++;
 															}
 															var _valid3 =
-																_errs432 ===
+																_errs436 ===
 																errors;
-															valid92 =
-																valid92 ||
+															valid93 =
+																valid93 ||
 																_valid3;
-															if (!valid92) {
-																const _errs434 =
+															if (!valid93) {
+																const _errs438 =
 																	errors;
 																if (
 																	errors ===
-																	_errs434
+																	_errs438
 																) {
 																	if (
-																		data158 &&
-																		typeof data158 ==
+																		data160 &&
+																		typeof data160 ==
 																			'object' &&
 																		!Array.isArray(
-																			data158
+																			data160
 																		)
 																	) {
 																		let missing28;
 																		if (
-																			(data158.BYTES_PER_ELEMENT ===
+																			(data160.BYTES_PER_ELEMENT ===
 																				undefined &&
 																				(missing28 =
 																					'BYTES_PER_ELEMENT')) ||
-																			(data158.buffer ===
+																			(data160.buffer ===
 																				undefined &&
 																				(missing28 =
 																					'buffer')) ||
-																			(data158.byteLength ===
+																			(data160.byteLength ===
 																				undefined &&
 																				(missing28 =
 																					'byteLength')) ||
-																			(data158.byteOffset ===
+																			(data160.byteOffset ===
 																				undefined &&
 																				(missing28 =
 																					'byteOffset')) ||
-																			(data158.length ===
+																			(data160.length ===
 																				undefined &&
 																				(missing28 =
 																					'length'))
@@ -18299,35 +18377,35 @@ function validate28(
 																			}
 																			errors++;
 																		} else {
-																			const _errs436 =
+																			const _errs440 =
 																				errors;
-																			for (const key59 in data158) {
+																			for (const key60 in data160) {
 																				if (
 																					!(
-																						key59 ===
+																						key60 ===
 																							'BYTES_PER_ELEMENT' ||
-																						key59 ===
+																						key60 ===
 																							'buffer' ||
-																						key59 ===
+																						key60 ===
 																							'byteLength' ||
-																						key59 ===
+																						key60 ===
 																							'byteOffset' ||
-																						key59 ===
+																						key60 ===
 																							'length'
 																					)
 																				) {
-																					let data159 =
-																						data158[
-																							key59
+																					let data161 =
+																						data160[
+																							key60
 																						];
-																					const _errs437 =
+																					const _errs441 =
 																						errors;
 																					if (
 																						!(
-																							typeof data159 ==
+																							typeof data161 ==
 																								'number' &&
 																							isFinite(
-																								data159
+																								data161
 																							)
 																						)
 																					) {
@@ -18336,7 +18414,7 @@ function validate28(
 																								instancePath:
 																									instancePath +
 																									'/data/' +
-																									key59
+																									key60
 																										.replace(
 																											/~/g,
 																											'~0'
@@ -18370,34 +18448,34 @@ function validate28(
 																						}
 																						errors++;
 																					}
-																					var valid93 =
-																						_errs437 ===
+																					var valid94 =
+																						_errs441 ===
 																						errors;
 																					if (
-																						!valid93
+																						!valid94
 																					) {
 																						break;
 																					}
 																				}
 																			}
 																			if (
-																				_errs436 ===
+																				_errs440 ===
 																				errors
 																			) {
 																				if (
-																					data158.BYTES_PER_ELEMENT !==
+																					data160.BYTES_PER_ELEMENT !==
 																					undefined
 																				) {
-																					let data160 =
-																						data158.BYTES_PER_ELEMENT;
-																					const _errs439 =
+																					let data162 =
+																						data160.BYTES_PER_ELEMENT;
+																					const _errs443 =
 																						errors;
 																					if (
 																						!(
-																							typeof data160 ==
+																							typeof data162 ==
 																								'number' &&
 																							isFinite(
-																								data160
+																								data162
 																							)
 																						)
 																					) {
@@ -18431,38 +18509,38 @@ function validate28(
 																						}
 																						errors++;
 																					}
-																					var valid94 =
-																						_errs439 ===
+																					var valid95 =
+																						_errs443 ===
 																						errors;
 																				} else {
-																					var valid94 = true;
+																					var valid95 = true;
 																				}
 																				if (
-																					valid94
+																					valid95
 																				) {
 																					if (
-																						data158.buffer !==
+																						data160.buffer !==
 																						undefined
 																					) {
-																						let data161 =
-																							data158.buffer;
-																						const _errs441 =
+																						let data163 =
+																							data160.buffer;
+																						const _errs445 =
 																							errors;
 																						if (
 																							errors ===
-																							_errs441
+																							_errs445
 																						) {
 																							if (
-																								data161 &&
-																								typeof data161 ==
+																								data163 &&
+																								typeof data163 ==
 																									'object' &&
 																								!Array.isArray(
-																									data161
+																									data163
 																								)
 																							) {
 																								let missing29;
 																								if (
-																									data161.byteLength ===
+																									data163.byteLength ===
 																										undefined &&
 																									(missing29 =
 																										'byteLength')
@@ -18500,12 +18578,12 @@ function validate28(
 																									}
 																									errors++;
 																								} else {
-																									const _errs443 =
+																									const _errs447 =
 																										errors;
-																									for (const key60 in data161) {
+																									for (const key61 in data163) {
 																										if (
 																											!(
-																												key60 ===
+																												key61 ===
 																												'byteLength'
 																											)
 																										) {
@@ -18520,7 +18598,7 @@ function validate28(
 																														'additionalProperties',
 																													params: {
 																														additionalProperty:
-																															key60,
+																															key61,
 																													},
 																													message:
 																														'must NOT have additional properties',
@@ -18543,21 +18621,21 @@ function validate28(
 																										}
 																									}
 																									if (
-																										_errs443 ===
+																										_errs447 ===
 																										errors
 																									) {
 																										if (
-																											data161.byteLength !==
+																											data163.byteLength !==
 																											undefined
 																										) {
-																											let data162 =
-																												data161.byteLength;
+																											let data164 =
+																												data163.byteLength;
 																											if (
 																												!(
-																													typeof data162 ==
+																													typeof data164 ==
 																														'number' &&
 																													isFinite(
-																														data162
+																														data164
 																													)
 																												)
 																											) {
@@ -18626,29 +18704,29 @@ function validate28(
 																								errors++;
 																							}
 																						}
-																						var valid94 =
-																							_errs441 ===
+																						var valid95 =
+																							_errs445 ===
 																							errors;
 																					} else {
-																						var valid94 = true;
+																						var valid95 = true;
 																					}
 																					if (
-																						valid94
+																						valid95
 																					) {
 																						if (
-																							data158.byteLength !==
+																							data160.byteLength !==
 																							undefined
 																						) {
-																							let data163 =
-																								data158.byteLength;
-																							const _errs446 =
+																							let data165 =
+																								data160.byteLength;
+																							const _errs450 =
 																								errors;
 																							if (
 																								!(
-																									typeof data163 ==
+																									typeof data165 ==
 																										'number' &&
 																									isFinite(
-																										data163
+																										data165
 																									)
 																								)
 																							) {
@@ -18682,29 +18760,29 @@ function validate28(
 																								}
 																								errors++;
 																							}
-																							var valid94 =
-																								_errs446 ===
+																							var valid95 =
+																								_errs450 ===
 																								errors;
 																						} else {
-																							var valid94 = true;
+																							var valid95 = true;
 																						}
 																						if (
-																							valid94
+																							valid95
 																						) {
 																							if (
-																								data158.byteOffset !==
+																								data160.byteOffset !==
 																								undefined
 																							) {
-																								let data164 =
-																									data158.byteOffset;
-																								const _errs448 =
+																								let data166 =
+																									data160.byteOffset;
+																								const _errs452 =
 																									errors;
 																								if (
 																									!(
-																										typeof data164 ==
+																										typeof data166 ==
 																											'number' &&
 																										isFinite(
-																											data164
+																											data166
 																										)
 																									)
 																								) {
@@ -18738,29 +18816,29 @@ function validate28(
 																									}
 																									errors++;
 																								}
-																								var valid94 =
-																									_errs448 ===
+																								var valid95 =
+																									_errs452 ===
 																									errors;
 																							} else {
-																								var valid94 = true;
+																								var valid95 = true;
 																							}
 																							if (
-																								valid94
+																								valid95
 																							) {
 																								if (
-																									data158.length !==
+																									data160.length !==
 																									undefined
 																								) {
-																									let data165 =
-																										data158.length;
-																									const _errs450 =
+																									let data167 =
+																										data160.length;
+																									const _errs454 =
 																										errors;
 																									if (
 																										!(
-																											typeof data165 ==
+																											typeof data167 ==
 																												'number' &&
 																											isFinite(
-																												data165
+																												data167
 																											)
 																										)
 																									) {
@@ -18794,11 +18872,11 @@ function validate28(
 																										}
 																										errors++;
 																									}
-																									var valid94 =
-																										_errs450 ===
+																									var valid95 =
+																										_errs454 ===
 																										errors;
 																								} else {
-																									var valid94 = true;
+																									var valid95 = true;
 																								}
 																							}
 																						}
@@ -18839,14 +18917,14 @@ function validate28(
 																	}
 																}
 																var _valid3 =
-																	_errs434 ===
+																	_errs438 ===
 																	errors;
-																valid92 =
-																	valid92 ||
+																valid93 =
+																	valid93 ||
 																	_valid3;
 															}
 														}
-														if (!valid92) {
+														if (!valid93) {
 															const err21 = {
 																instancePath:
 																	instancePath +
@@ -18875,23 +18953,23 @@ function validate28(
 																vErrors;
 															return false;
 														} else {
-															errors = _errs430;
+															errors = _errs434;
 															if (
 																vErrors !== null
 															) {
-																if (_errs430) {
+																if (_errs434) {
 																	vErrors.length =
-																		_errs430;
+																		_errs434;
 																} else {
 																	vErrors =
 																		null;
 																}
 															}
 														}
-														var valid90 =
-															_errs429 === errors;
+														var valid91 =
+															_errs433 === errors;
 													} else {
-														var valid90 = true;
+														var valid91 = true;
 													}
 												}
 											}
@@ -18912,8 +18990,8 @@ function validate28(
 							}
 						}
 					} else if (tag0 === 'writeFiles') {
-						const _errs452 = errors;
-						if (errors === _errs452) {
+						const _errs456 = errors;
+						if (errors === _errs456) {
 							if (
 								data &&
 								typeof data == 'object' &&
@@ -18944,14 +19022,14 @@ function validate28(
 									];
 									return false;
 								} else {
-									const _errs454 = errors;
-									for (const key61 in data) {
+									const _errs458 = errors;
+									for (const key62 in data) {
 										if (
 											!(
-												key61 === 'progress' ||
-												key61 === 'step' ||
-												key61 === 'writeToPath' ||
-												key61 === 'filesTree'
+												key62 === 'progress' ||
+												key62 === 'step' ||
+												key62 === 'writeToPath' ||
+												key62 === 'filesTree'
 											)
 										) {
 											validate28.errors = [
@@ -18963,7 +19041,7 @@ function validate28(
 														'additionalProperties',
 													params: {
 														additionalProperty:
-															key61,
+															key62,
 													},
 													message:
 														'must NOT have additional properties',
@@ -18973,24 +19051,24 @@ function validate28(
 											break;
 										}
 									}
-									if (_errs454 === errors) {
+									if (_errs458 === errors) {
 										if (data.progress !== undefined) {
-											let data166 = data.progress;
-											const _errs455 = errors;
-											if (errors === _errs455) {
+											let data168 = data.progress;
+											const _errs459 = errors;
+											if (errors === _errs459) {
 												if (
-													data166 &&
-													typeof data166 ==
+													data168 &&
+													typeof data168 ==
 														'object' &&
-													!Array.isArray(data166)
+													!Array.isArray(data168)
 												) {
-													const _errs457 = errors;
-													for (const key62 in data166) {
+													const _errs461 = errors;
+													for (const key63 in data168) {
 														if (
 															!(
-																key62 ===
+																key63 ===
 																	'weight' ||
-																key62 ===
+																key63 ===
 																	'caption'
 															)
 														) {
@@ -19006,7 +19084,7 @@ function validate28(
 																			'additionalProperties',
 																		params: {
 																			additionalProperty:
-																				key62,
+																				key63,
 																		},
 																		message:
 																			'must NOT have additional properties',
@@ -19016,21 +19094,21 @@ function validate28(
 															break;
 														}
 													}
-													if (_errs457 === errors) {
+													if (_errs461 === errors) {
 														if (
-															data166.weight !==
+															data168.weight !==
 															undefined
 														) {
-															let data167 =
-																data166.weight;
-															const _errs458 =
+															let data169 =
+																data168.weight;
+															const _errs462 =
 																errors;
 															if (
 																!(
-																	typeof data167 ==
+																	typeof data169 ==
 																		'number' &&
 																	isFinite(
-																		data167
+																		data169
 																	)
 																)
 															) {
@@ -19053,21 +19131,21 @@ function validate28(
 																	];
 																return false;
 															}
-															var valid98 =
-																_errs458 ===
+															var valid99 =
+																_errs462 ===
 																errors;
 														} else {
-															var valid98 = true;
+															var valid99 = true;
 														}
-														if (valid98) {
+														if (valid99) {
 															if (
-																data166.caption !==
+																data168.caption !==
 																undefined
 															) {
-																const _errs460 =
+																const _errs464 =
 																	errors;
 																if (
-																	typeof data166.caption !==
+																	typeof data168.caption !==
 																	'string'
 																) {
 																	validate28.errors =
@@ -19089,11 +19167,11 @@ function validate28(
 																		];
 																	return false;
 																}
-																var valid98 =
-																	_errs460 ===
+																var valid99 =
+																	_errs464 ===
 																	errors;
 															} else {
-																var valid98 = true;
+																var valid99 = true;
 															}
 														}
 													}
@@ -19116,16 +19194,16 @@ function validate28(
 													return false;
 												}
 											}
-											var valid97 = _errs455 === errors;
+											var valid98 = _errs459 === errors;
 										} else {
-											var valid97 = true;
+											var valid98 = true;
 										}
-										if (valid97) {
+										if (valid98) {
 											if (data.step !== undefined) {
-												let data169 = data.step;
-												const _errs462 = errors;
+												let data171 = data.step;
+												const _errs466 = errors;
 												if (
-													typeof data169 !== 'string'
+													typeof data171 !== 'string'
 												) {
 													validate28.errors = [
 														{
@@ -19144,7 +19222,7 @@ function validate28(
 													];
 													return false;
 												}
-												if ('writeFiles' !== data169) {
+												if ('writeFiles' !== data171) {
 													validate28.errors = [
 														{
 															instancePath:
@@ -19163,17 +19241,17 @@ function validate28(
 													];
 													return false;
 												}
-												var valid97 =
-													_errs462 === errors;
+												var valid98 =
+													_errs466 === errors;
 											} else {
-												var valid97 = true;
+												var valid98 = true;
 											}
-											if (valid97) {
+											if (valid98) {
 												if (
 													data.writeToPath !==
 													undefined
 												) {
-													const _errs464 = errors;
+													const _errs468 = errors;
 													if (
 														typeof data.writeToPath !==
 														'string'
@@ -19195,17 +19273,17 @@ function validate28(
 														];
 														return false;
 													}
-													var valid97 =
-														_errs464 === errors;
+													var valid98 =
+														_errs468 === errors;
 												} else {
-													var valid97 = true;
+													var valid98 = true;
 												}
-												if (valid97) {
+												if (valid98) {
 													if (
 														data.filesTree !==
 														undefined
 													) {
-														const _errs466 = errors;
+														const _errs470 = errors;
 														if (
 															!validate18(
 																data.filesTree,
@@ -19230,10 +19308,10 @@ function validate28(
 															errors =
 																vErrors.length;
 														}
-														var valid97 =
-															_errs466 === errors;
+														var valid98 =
+															_errs470 === errors;
 													} else {
-														var valid97 = true;
+														var valid98 = true;
 													}
 												}
 											}
@@ -19254,8 +19332,8 @@ function validate28(
 							}
 						}
 					} else if (tag0 === 'wp-cli') {
-						const _errs467 = errors;
-						if (errors === _errs467) {
+						const _errs471 = errors;
+						if (errors === _errs471) {
 							if (
 								data &&
 								typeof data == 'object' &&
@@ -19284,14 +19362,14 @@ function validate28(
 									];
 									return false;
 								} else {
-									const _errs469 = errors;
-									for (const key63 in data) {
+									const _errs473 = errors;
+									for (const key64 in data) {
 										if (
 											!(
-												key63 === 'progress' ||
-												key63 === 'step' ||
-												key63 === 'command' ||
-												key63 === 'wpCliPath'
+												key64 === 'progress' ||
+												key64 === 'step' ||
+												key64 === 'command' ||
+												key64 === 'wpCliPath'
 											)
 										) {
 											validate28.errors = [
@@ -19303,7 +19381,7 @@ function validate28(
 														'additionalProperties',
 													params: {
 														additionalProperty:
-															key63,
+															key64,
 													},
 													message:
 														'must NOT have additional properties',
@@ -19313,24 +19391,24 @@ function validate28(
 											break;
 										}
 									}
-									if (_errs469 === errors) {
+									if (_errs473 === errors) {
 										if (data.progress !== undefined) {
-											let data172 = data.progress;
-											const _errs470 = errors;
-											if (errors === _errs470) {
+											let data174 = data.progress;
+											const _errs474 = errors;
+											if (errors === _errs474) {
 												if (
-													data172 &&
-													typeof data172 ==
+													data174 &&
+													typeof data174 ==
 														'object' &&
-													!Array.isArray(data172)
+													!Array.isArray(data174)
 												) {
-													const _errs472 = errors;
-													for (const key64 in data172) {
+													const _errs476 = errors;
+													for (const key65 in data174) {
 														if (
 															!(
-																key64 ===
+																key65 ===
 																	'weight' ||
-																key64 ===
+																key65 ===
 																	'caption'
 															)
 														) {
@@ -19346,7 +19424,7 @@ function validate28(
 																			'additionalProperties',
 																		params: {
 																			additionalProperty:
-																				key64,
+																				key65,
 																		},
 																		message:
 																			'must NOT have additional properties',
@@ -19356,21 +19434,21 @@ function validate28(
 															break;
 														}
 													}
-													if (_errs472 === errors) {
+													if (_errs476 === errors) {
 														if (
-															data172.weight !==
+															data174.weight !==
 															undefined
 														) {
-															let data173 =
-																data172.weight;
-															const _errs473 =
+															let data175 =
+																data174.weight;
+															const _errs477 =
 																errors;
 															if (
 																!(
-																	typeof data173 ==
+																	typeof data175 ==
 																		'number' &&
 																	isFinite(
-																		data173
+																		data175
 																	)
 																)
 															) {
@@ -19393,21 +19471,21 @@ function validate28(
 																	];
 																return false;
 															}
-															var valid101 =
-																_errs473 ===
+															var valid102 =
+																_errs477 ===
 																errors;
 														} else {
-															var valid101 = true;
+															var valid102 = true;
 														}
-														if (valid101) {
+														if (valid102) {
 															if (
-																data172.caption !==
+																data174.caption !==
 																undefined
 															) {
-																const _errs475 =
+																const _errs479 =
 																	errors;
 																if (
-																	typeof data172.caption !==
+																	typeof data174.caption !==
 																	'string'
 																) {
 																	validate28.errors =
@@ -19429,11 +19507,11 @@ function validate28(
 																		];
 																	return false;
 																}
-																var valid101 =
-																	_errs475 ===
+																var valid102 =
+																	_errs479 ===
 																	errors;
 															} else {
-																var valid101 = true;
+																var valid102 = true;
 															}
 														}
 													}
@@ -19456,16 +19534,16 @@ function validate28(
 													return false;
 												}
 											}
-											var valid100 = _errs470 === errors;
+											var valid101 = _errs474 === errors;
 										} else {
-											var valid100 = true;
+											var valid101 = true;
 										}
-										if (valid100) {
+										if (valid101) {
 											if (data.step !== undefined) {
-												let data175 = data.step;
-												const _errs477 = errors;
+												let data177 = data.step;
+												const _errs481 = errors;
 												if (
-													typeof data175 !== 'string'
+													typeof data177 !== 'string'
 												) {
 													validate28.errors = [
 														{
@@ -19484,7 +19562,7 @@ function validate28(
 													];
 													return false;
 												}
-												if ('wp-cli' !== data175) {
+												if ('wp-cli' !== data177) {
 													validate28.errors = [
 														{
 															instancePath:
@@ -19503,22 +19581,22 @@ function validate28(
 													];
 													return false;
 												}
-												var valid100 =
-													_errs477 === errors;
+												var valid101 =
+													_errs481 === errors;
 											} else {
-												var valid100 = true;
+												var valid101 = true;
 											}
-											if (valid100) {
+											if (valid101) {
 												if (
 													data.command !== undefined
 												) {
-													let data176 = data.command;
-													const _errs479 = errors;
-													const _errs480 = errors;
-													let valid102 = false;
-													const _errs481 = errors;
+													let data178 = data.command;
+													const _errs483 = errors;
+													const _errs484 = errors;
+													let valid103 = false;
+													const _errs485 = errors;
 													if (
-														typeof data176 !==
+														typeof data178 !==
 														'string'
 													) {
 														const err22 = {
@@ -19542,31 +19620,31 @@ function validate28(
 														errors++;
 													}
 													var _valid4 =
-														_errs481 === errors;
-													valid102 =
-														valid102 || _valid4;
-													if (!valid102) {
-														const _errs483 = errors;
+														_errs485 === errors;
+													valid103 =
+														valid103 || _valid4;
+													if (!valid103) {
+														const _errs487 = errors;
 														if (
-															errors === _errs483
+															errors === _errs487
 														) {
 															if (
 																Array.isArray(
-																	data176
+																	data178
 																)
 															) {
-																var valid103 = true;
+																var valid104 = true;
 																const len0 =
-																	data176.length;
+																	data178.length;
 																for (
 																	let i0 = 0;
 																	i0 < len0;
 																	i0++
 																) {
-																	const _errs485 =
+																	const _errs489 =
 																		errors;
 																	if (
-																		typeof data176[
+																		typeof data178[
 																			i0
 																		] !==
 																		'string'
@@ -19602,11 +19680,11 @@ function validate28(
 																		}
 																		errors++;
 																	}
-																	var valid103 =
-																		_errs485 ===
+																	var valid104 =
+																		_errs489 ===
 																		errors;
 																	if (
-																		!valid103
+																		!valid104
 																	) {
 																		break;
 																	}
@@ -19642,11 +19720,11 @@ function validate28(
 															}
 														}
 														var _valid4 =
-															_errs483 === errors;
-														valid102 =
-															valid102 || _valid4;
+															_errs487 === errors;
+														valid103 =
+															valid103 || _valid4;
 													}
-													if (!valid102) {
+													if (!valid103) {
 														const err25 = {
 															instancePath:
 																instancePath +
@@ -19668,27 +19746,27 @@ function validate28(
 															vErrors;
 														return false;
 													} else {
-														errors = _errs480;
+														errors = _errs484;
 														if (vErrors !== null) {
-															if (_errs480) {
+															if (_errs484) {
 																vErrors.length =
-																	_errs480;
+																	_errs484;
 															} else {
 																vErrors = null;
 															}
 														}
 													}
-													var valid100 =
-														_errs479 === errors;
+													var valid101 =
+														_errs483 === errors;
 												} else {
-													var valid100 = true;
+													var valid101 = true;
 												}
-												if (valid100) {
+												if (valid101) {
 													if (
 														data.wpCliPath !==
 														undefined
 													) {
-														const _errs487 = errors;
+														const _errs491 = errors;
 														if (
 															typeof data.wpCliPath !==
 															'string'
@@ -19712,10 +19790,10 @@ function validate28(
 																];
 															return false;
 														}
-														var valid100 =
-															_errs487 === errors;
+														var valid101 =
+															_errs491 === errors;
 													} else {
-														var valid100 = true;
+														var valid101 = true;
 													}
 												}
 											}
@@ -19736,8 +19814,8 @@ function validate28(
 							}
 						}
 					} else if (tag0 === 'setSiteLanguage') {
-						const _errs489 = errors;
-						if (errors === _errs489) {
+						const _errs493 = errors;
+						if (errors === _errs493) {
 							if (
 								data &&
 								typeof data == 'object' &&
@@ -19766,13 +19844,13 @@ function validate28(
 									];
 									return false;
 								} else {
-									const _errs491 = errors;
-									for (const key65 in data) {
+									const _errs495 = errors;
+									for (const key66 in data) {
 										if (
 											!(
-												key65 === 'progress' ||
-												key65 === 'step' ||
-												key65 === 'language'
+												key66 === 'progress' ||
+												key66 === 'step' ||
+												key66 === 'language'
 											)
 										) {
 											validate28.errors = [
@@ -19784,7 +19862,7 @@ function validate28(
 														'additionalProperties',
 													params: {
 														additionalProperty:
-															key65,
+															key66,
 													},
 													message:
 														'must NOT have additional properties',
@@ -19794,24 +19872,24 @@ function validate28(
 											break;
 										}
 									}
-									if (_errs491 === errors) {
+									if (_errs495 === errors) {
 										if (data.progress !== undefined) {
-											let data179 = data.progress;
-											const _errs492 = errors;
-											if (errors === _errs492) {
+											let data181 = data.progress;
+											const _errs496 = errors;
+											if (errors === _errs496) {
 												if (
-													data179 &&
-													typeof data179 ==
+													data181 &&
+													typeof data181 ==
 														'object' &&
-													!Array.isArray(data179)
+													!Array.isArray(data181)
 												) {
-													const _errs494 = errors;
-													for (const key66 in data179) {
+													const _errs498 = errors;
+													for (const key67 in data181) {
 														if (
 															!(
-																key66 ===
+																key67 ===
 																	'weight' ||
-																key66 ===
+																key67 ===
 																	'caption'
 															)
 														) {
@@ -19827,7 +19905,7 @@ function validate28(
 																			'additionalProperties',
 																		params: {
 																			additionalProperty:
-																				key66,
+																				key67,
 																		},
 																		message:
 																			'must NOT have additional properties',
@@ -19837,21 +19915,21 @@ function validate28(
 															break;
 														}
 													}
-													if (_errs494 === errors) {
+													if (_errs498 === errors) {
 														if (
-															data179.weight !==
+															data181.weight !==
 															undefined
 														) {
-															let data180 =
-																data179.weight;
-															const _errs495 =
+															let data182 =
+																data181.weight;
+															const _errs499 =
 																errors;
 															if (
 																!(
-																	typeof data180 ==
+																	typeof data182 ==
 																		'number' &&
 																	isFinite(
-																		data180
+																		data182
 																	)
 																)
 															) {
@@ -19874,21 +19952,21 @@ function validate28(
 																	];
 																return false;
 															}
-															var valid106 =
-																_errs495 ===
+															var valid107 =
+																_errs499 ===
 																errors;
 														} else {
-															var valid106 = true;
+															var valid107 = true;
 														}
-														if (valid106) {
+														if (valid107) {
 															if (
-																data179.caption !==
+																data181.caption !==
 																undefined
 															) {
-																const _errs497 =
+																const _errs501 =
 																	errors;
 																if (
-																	typeof data179.caption !==
+																	typeof data181.caption !==
 																	'string'
 																) {
 																	validate28.errors =
@@ -19910,11 +19988,11 @@ function validate28(
 																		];
 																	return false;
 																}
-																var valid106 =
-																	_errs497 ===
+																var valid107 =
+																	_errs501 ===
 																	errors;
 															} else {
-																var valid106 = true;
+																var valid107 = true;
 															}
 														}
 													}
@@ -19937,16 +20015,16 @@ function validate28(
 													return false;
 												}
 											}
-											var valid105 = _errs492 === errors;
+											var valid106 = _errs496 === errors;
 										} else {
-											var valid105 = true;
+											var valid106 = true;
 										}
-										if (valid105) {
+										if (valid106) {
 											if (data.step !== undefined) {
-												let data182 = data.step;
-												const _errs499 = errors;
+												let data184 = data.step;
+												const _errs503 = errors;
 												if (
-													typeof data182 !== 'string'
+													typeof data184 !== 'string'
 												) {
 													validate28.errors = [
 														{
@@ -19967,7 +20045,7 @@ function validate28(
 												}
 												if (
 													'setSiteLanguage' !==
-													data182
+													data184
 												) {
 													validate28.errors = [
 														{
@@ -19987,16 +20065,16 @@ function validate28(
 													];
 													return false;
 												}
-												var valid105 =
-													_errs499 === errors;
+												var valid106 =
+													_errs503 === errors;
 											} else {
-												var valid105 = true;
+												var valid106 = true;
 											}
-											if (valid105) {
+											if (valid106) {
 												if (
 													data.language !== undefined
 												) {
-													const _errs501 = errors;
+													const _errs505 = errors;
 													if (
 														typeof data.language !==
 														'string'
@@ -20018,10 +20096,10 @@ function validate28(
 														];
 														return false;
 													}
-													var valid105 =
-														_errs501 === errors;
+													var valid106 =
+														_errs505 === errors;
 												} else {
-													var valid105 = true;
+													var valid106 = true;
 												}
 											}
 										}

--- a/packages/playground/blueprints/public/blueprint-schema.json
+++ b/packages/playground/blueprints/public/blueprint-schema.json
@@ -1486,6 +1486,11 @@
 					"type": "boolean",
 					"description": "Whether to activate the plugin after installing it."
 				},
+				"activationOptions": {
+					"type": "object",
+					"additionalProperties": {},
+					"description": "Parameters to expose to the plugin during its activation hook."
+				},
 				"targetFolderName": {
 					"type": "string",
 					"description": "The name of the folder to install the plugin to. Defaults to guessing from pluginData"

--- a/packages/playground/blueprints/src/lib/steps/install-plugin.ts
+++ b/packages/playground/blueprints/src/lib/steps/install-plugin.ts
@@ -6,8 +6,10 @@ import { writeFile } from './write-file';
 import { zipNameToHumanName } from '../utils/zip-name-to-human-name';
 import type { Directory } from '../v1/resources';
 import { joinPaths } from '@php-wasm/util';
-import { writeFiles } from '@php-wasm/universal';
+import { writeFiles, type UniversalPHP } from '@php-wasm/universal';
 import { logger } from '@php-wasm/logger';
+
+const ACTIVATION_OPTIONS_PAYLOAD_PREFIX = 'PLAYGROUND_ACTIVATION_OPTIONS:';
 
 /**
  * @inheritDoc installPlugin
@@ -46,8 +48,10 @@ import { logger } from '@php-wasm/logger';
  * }
  * </code>
  */
-export interface InstallPluginStep<FileResource, DirectoryResource>
-	extends Pick<InstallAssetOptions, 'ifAlreadyInstalled'> {
+export interface InstallPluginStep<
+	FileResource,
+	DirectoryResource,
+> extends Pick<InstallAssetOptions, 'ifAlreadyInstalled'> {
 	/**
 	 * The step identifier.
 	 */
@@ -74,6 +78,10 @@ export interface InstallPluginOptions {
 	 * Whether to activate the plugin after installing it.
 	 */
 	activate?: boolean;
+	/**
+	 * Parameters to expose to the plugin during its activation hook.
+	 */
+	activationOptions?: Record<string, unknown>;
 	/**
 	 * The name of the folder to install the plugin to. Defaults to guessing from pluginData
 	 */
@@ -180,13 +188,168 @@ export const installPlugin: StepHandler<
 	const activate = 'activate' in options ? options.activate : true;
 
 	if (activate) {
-		await activatePlugin(
-			playground,
-			{
-				pluginPath: assetFolderPath,
-				pluginName: assetNiceName,
-			},
-			progress
-		);
+		let activationOptionName: string | undefined;
+		if (options.activationOptions !== undefined) {
+			activationOptionName = await setPluginActivationOptions(
+				playground,
+				assetFolderPath,
+				options.activationOptions
+			);
+		}
+		try {
+			await activatePlugin(
+				playground,
+				{
+					pluginPath: assetFolderPath,
+					pluginName: assetNiceName,
+				},
+				progress
+			);
+		} finally {
+			if (activationOptionName) {
+				await deletePluginActivationOptions(
+					playground,
+					activationOptionName
+				);
+			}
+		}
 	}
 };
+
+/**
+ * Stages activation options for a plugin before its activation hook runs.
+ *
+ * Blueprint v2 defines these as values exposed through the
+ * `blueprint_activation_` + `plugin_basename(__FILE__)` option during
+ * activation. A runtime-only global/env value would be cleaner, but activation
+ * currently happens behind `activatePlugin()`, across a separate PHP request
+ * boundary from this staging call. The temporary option survives that boundary
+ * and is deleted in `finally` after activation.
+ */
+async function setPluginActivationOptions(
+	playground: UniversalPHP,
+	pluginPath: string,
+	activationOptions: Record<string, unknown>
+) {
+	const docroot = await playground.documentRoot;
+	const result = await playground.run({
+		code: `<?php
+ob_start();
+define('WP_ADMIN', true);
+require_once getenv('DOCROOT') . "/wp-load.php";
+require_once getenv('DOCROOT') . "/wp-admin/includes/plugin.php";
+
+$payload_prefix = getenv('ACTIVATION_OPTIONS_PAYLOAD_PREFIX');
+$plugin_path = getenv('PLUGIN_PATH');
+$plugin_file = '';
+if (is_dir($plugin_path)) {
+	foreach ((glob(rtrim($plugin_path, '/') . '/*.php') ?: array()) as $file) {
+		$info = get_plugin_data($file, false, false);
+		if (!empty($info['Name'])) {
+			$plugin_file = $file;
+			break;
+		}
+	}
+} else {
+	$plugin_dir = rtrim(WP_PLUGIN_DIR, '/');
+	$plugin_file = $plugin_path;
+	if (strpos($plugin_file, $plugin_dir . '/') !== 0 && file_exists($plugin_dir . '/' . $plugin_file)) {
+		$plugin_file = $plugin_dir . '/' . $plugin_file;
+	}
+}
+
+if (!$plugin_file || !file_exists($plugin_file)) {
+	ob_end_clean();
+	// Prefix the JSON payload so JS can find it even if plugin bootstrap
+	// code prints notices or other output during this request.
+	echo $payload_prefix . json_encode(array('error' => 'Could not find plugin file for activation options.'));
+	exit;
+}
+
+$options_json = getenv('ACTIVATION_OPTIONS_JSON');
+$options = json_decode($options_json ?: '', true);
+if (!is_array($options)) {
+	ob_end_clean();
+	// Prefix the JSON payload so JS can find it even if plugin bootstrap
+	// code prints notices or other output during this request.
+	echo $payload_prefix . json_encode(array('error' => 'Could not decode plugin activation options.'));
+	exit;
+}
+$option_name = 'blueprint_activation_' . plugin_basename($plugin_file);
+update_option($option_name, $options);
+ob_end_clean();
+// Prefix the JSON payload so JS can find it even if plugin bootstrap
+// code prints notices or other output during this request.
+echo $payload_prefix . json_encode(array('optionName' => $option_name));
+`,
+		env: {
+			DOCROOT: docroot,
+			PLUGIN_PATH: pluginPath,
+			ACTIVATION_OPTIONS_JSON: JSON.stringify(activationOptions),
+			ACTIVATION_OPTIONS_PAYLOAD_PREFIX:
+				ACTIVATION_OPTIONS_PAYLOAD_PREFIX,
+		},
+	});
+	const payload = parseActivationOptionsPayload(result.text);
+	if (payload?.['error']) {
+		throw new Error(String(payload['error']));
+	}
+	if (!payload?.['optionName'] || typeof payload['optionName'] !== 'string') {
+		throw new Error('Could not determine plugin activation options name.');
+	}
+	return payload['optionName'];
+}
+
+async function deletePluginActivationOptions(
+	playground: UniversalPHP,
+	optionName: string
+) {
+	await playground.run({
+		code: `<?php
+require_once getenv('DOCROOT') . "/wp-load.php";
+delete_option(getenv('OPTION_NAME'));
+`,
+		env: {
+			DOCROOT: await playground.documentRoot,
+			OPTION_NAME: optionName,
+		},
+	});
+}
+
+/**
+ * Extracts the staging helper's JSON payload from noisy PHP output.
+ *
+ * `playground.run()` returns everything printed during the request. A plugin
+ * file loaded by WordPress may echo warnings, notices, or regular output while
+ * the helper is locating the plugin file. The helper therefore prefixes its
+ * machine-readable JSON with `ACTIVATION_OPTIONS_PAYLOAD_PREFIX`, and this
+ * parser reads only the first line after the last prefix occurrence.
+ */
+function parseActivationOptionsPayload(text: string | undefined) {
+	const output = text || '';
+
+	// Plugin bootstrap code may write arbitrary output before or after our
+	// helper runs, so read the last sentinel occurrence instead of assuming
+	// the response body is only JSON.
+	const payloadIndex = output.lastIndexOf(ACTIVATION_OPTIONS_PAYLOAD_PREFIX);
+	if (payloadIndex === -1) {
+		return undefined;
+	}
+
+	// The helper emits exactly one JSON object after the sentinel. Keep only
+	// the first line so later plugin output cannot become part of the JSON
+	// parse.
+	const payload = output
+		.slice(payloadIndex + ACTIVATION_OPTIONS_PAYLOAD_PREFIX.length)
+		.trimStart()
+		.split(/\r?\n/, 1)[0]
+		.trim();
+	if (!payload) {
+		return undefined;
+	}
+	try {
+		return JSON.parse(payload) as Record<string, unknown>;
+	} catch {
+		throw new Error('Could not parse plugin activation options payload.');
+	}
+}

--- a/packages/playground/blueprints/src/tests/steps/install-plugin.spec.ts
+++ b/packages/playground/blueprints/src/tests/steps/install-plugin.spec.ts
@@ -4,6 +4,11 @@ import { installPlugin } from '../../lib/steps/install-plugin';
 import { phpVar } from '@php-wasm/util';
 import { PHPRequestHandler } from '@php-wasm/universal';
 import { loadNodeRuntime } from '@php-wasm/node';
+import {
+	getSqliteDriverModule,
+	getWordPressModule,
+} from '@wp-playground/wordpress-builds';
+import { bootWordPressAndRequestHandler } from '@wp-playground/wordpress';
 
 async function zipFiles(
 	php: PHP,
@@ -118,6 +123,99 @@ describe('Blueprint step installPlugin', () => {
 		const pluginFilePath = `${pluginsPath}/test-plugin.php`;
 		expect(php.fileExists(pluginFilePath)).toBe(true);
 		expect(php.readFileAsText(pluginFilePath)).toBe(rawPluginContent);
+	});
+
+	it('should expose activationOptions during plugin activation', async () => {
+		const handler = await bootWordPressAndRequestHandler({
+			createPhpRuntime: async () =>
+				await loadNodeRuntime(RecommendedPHPVersion),
+			siteUrl: 'http://playground-domain/',
+			wordPressZip: await getWordPressModule(),
+			sqliteIntegrationPluginZip: await getSqliteDriverModule(),
+		});
+		const wpPhp = await handler.getPrimaryPhp();
+
+		try {
+			await installPlugin(wpPhp, {
+				pluginData: await zipFiles(wpPhp, zipFileName, {
+					[`${pluginName}/index.php`]: `<?php
+/**
+ * Plugin Name: Test Plugin
+ */
+register_activation_hook(__FILE__, function() {
+	update_option(
+		'blueprint_activation_seen',
+		get_option('blueprint_activation_' . plugin_basename(__FILE__))
+	);
+});
+`,
+				}),
+				ifAlreadyInstalled: 'overwrite',
+				options: {
+					activate: true,
+					activationOptions: {
+						storeCity: 'Wroclaw',
+						enabled: true,
+					},
+				},
+			});
+
+			const response = await wpPhp.run({
+				code: `<?php
+require '/wordpress/wp-load.php';
+echo json_encode(array(
+	'seen' => get_option('blueprint_activation_seen'),
+	'cleanup' => get_option('blueprint_activation_test-plugin/index.php', 'missing'),
+));
+`,
+			});
+
+			expect(JSON.parse(response.text)).toEqual({
+				seen: {
+					storeCity: 'Wroclaw',
+					enabled: true,
+				},
+				cleanup: 'missing',
+			});
+		} finally {
+			wpPhp.exit();
+			await handler[Symbol.asyncDispose]();
+		}
+	});
+
+	it('should report missing plugin files when setting activationOptions', async () => {
+		const handler = await bootWordPressAndRequestHandler({
+			createPhpRuntime: async () =>
+				await loadNodeRuntime(RecommendedPHPVersion),
+			siteUrl: 'http://playground-domain/',
+			wordPressZip: await getWordPressModule(),
+			sqliteIntegrationPluginZip: await getSqliteDriverModule(),
+		});
+		const wpPhp = await handler.getPrimaryPhp();
+
+		try {
+			await expect(
+				installPlugin(wpPhp, {
+					pluginData: {
+						name: 'plugin-without-php-file',
+						files: {
+							'readme.txt': 'Not a plugin file.',
+						},
+					},
+					options: {
+						activate: true,
+						activationOptions: {
+							enabled: true,
+						},
+					},
+				})
+			).rejects.toThrow(
+				'Could not find plugin file for activation options.'
+			);
+		} finally {
+			wpPhp.exit();
+			await handler[Symbol.asyncDispose]();
+		}
 	});
 
 	it('should install a plugin using the deprecated pluginZipFile option', async () => {


### PR DESCRIPTION
## What it does

Adds `activationOptions` to the `installPlugin` Blueprint step.

```json
{
  "step": "installPlugin",
  "pluginData": { "resource": "wordpress.org/plugins", "slug": "my-plugin" },
  "options": {
    "activate": true,
    "activationOptions": {
      "storeCity": "Wroclaw",
      "enabled": true
    }
  }
}
```

When activation options are provided, `installPlugin` stores them in a temporary WordPress option before running the plugin activation hook. The option name is based on `plugin_basename(__FILE__)`, so plugin code can read:

```php
get_option('blueprint_activation_' . plugin_basename(__FILE__))
```

The temporary option is deleted after activation, even if activation fails.

## Rationale

Some plugins need setup values during activation, not after activation. A later Blueprint step can update options or run PHP, but it cannot affect code that already ran inside `register_activation_hook()`.

The Blueprint v2 schema already describes `activationOptions` as data exposed through a WordPress option named `blueprint_activation_` plus `plugin_basename(__FILE__)`, and removed after activation. This PR brings the v1 `installPlugin` step in line with that contract so the behavior can be reviewed independently before #3725 depends on it.

This does not change plugin installation, plugin path validation, overwrite behavior, or `onError` handling.

## Implementation

`installPlugin` now wraps the activation call:

1. Locate the plugin PHP file that will receive activation options.
2. Store `options.activationOptions` in `blueprint_activation_<plugin_basename>`.
3. Run `activatePlugin()` as before.
4. Delete the temporary option in `finally`.

The PHP staging helper prints a sentinel-prefixed JSON payload because plugin bootstrap code may write to stdout before the helper reports the option name.

## Testing instructions

```bash
npm exec nx run playground-blueprints:test:vite -- --testFiles=packages/playground/blueprints/src/tests/steps/install-plugin.spec.ts
npm exec nx run playground-blueprints:typecheck
npm exec nx run playground-blueprints:lint
git diff --check
```

The new tests cover:

- a plugin activation hook reading `activationOptions`
- cleanup of the temporary activation option after activation
- a clear error when `activationOptions` is requested but no plugin PHP file can be found