### PR TITLE
[Blueprints][installTheme step] Honor ifAlreadyInstalled for directory themes

### DIFF
--- a/packages/playground/blueprints/src/lib/steps/install-theme.ts
+++ b/packages/playground/blueprints/src/lib/steps/install-theme.ts
@@ -132,9 +132,36 @@ export const installTheme: StepHandler<
 				'themes',
 				assetFolderName
 			);
-			await writeFiles(playground, themeDirectoryPath, themeData.files, {
-				rmRoot: true,
-			});
+			let shouldWriteThemeFiles = true;
+			/**
+			 * Directory themes are written directly instead of going through
+			 * `installAsset()`, so apply the same `ifAlreadyInstalled` rule here.
+			 */
+			if (await playground.fileExists(themeDirectoryPath)) {
+				if (!(await playground.isDir(themeDirectoryPath))) {
+					throw new Error(
+						`Cannot install theme ${assetFolderName} to ${themeDirectoryPath} because a file with the same name already exists. Note it's a file, not a directory! Is this by mistake?`
+					);
+				}
+				if ((ifAlreadyInstalled ?? 'overwrite') === 'skip') {
+					shouldWriteThemeFiles = false;
+				} else if (ifAlreadyInstalled === 'error') {
+					throw new Error(
+						`Cannot install theme ${assetFolderName} to ${themeDirectoryPath} because it already exists and ` +
+							`the ifAlreadyInstalled option was set to ${ifAlreadyInstalled}`
+					);
+				}
+			}
+			if (shouldWriteThemeFiles) {
+				await writeFiles(
+					playground,
+					themeDirectoryPath,
+					themeData.files,
+					{
+						rmRoot: true,
+					}
+				);
+			}
 		}
 
 		const activate = 'activate' in options ? options.activate : true;

--- a/packages/playground/blueprints/src/tests/steps/install-theme.spec.ts
+++ b/packages/playground/blueprints/src/tests/steps/install-theme.spec.ts
@@ -227,6 +227,68 @@ describe('Blueprint step installTheme', () => {
 				})
 			).rejects.toThrow();
 		});
+
+		it('should apply ifAlreadyInstalled to directory theme resources', async () => {
+			await installTheme(php, {
+				themeData: {
+					name: 'test-theme',
+					files: {
+						'index.php': `/**\n * Theme Name: Existing Directory Theme`,
+					},
+				},
+				ifAlreadyInstalled: 'overwrite',
+				options: {
+					activate: false,
+				},
+			});
+
+			await installTheme(php, {
+				themeData: {
+					name: 'test-theme',
+					files: {
+						'index.php': `/**\n * Theme Name: Skipped Theme`,
+					},
+				},
+				ifAlreadyInstalled: 'skip',
+				options: {
+					activate: false,
+				},
+			});
+			expect(php.readFileAsText(expectedThemeIndexPhpPath)).toContain(
+				'Theme Name: Existing Directory Theme'
+			);
+
+			await installTheme(php, {
+				themeData: {
+					name: 'test-theme',
+					files: {
+						'index.php': `/**\n * Theme Name: Overwritten Theme`,
+					},
+				},
+				ifAlreadyInstalled: 'overwrite',
+				options: {
+					activate: false,
+				},
+			});
+			expect(php.readFileAsText(expectedThemeIndexPhpPath)).toContain(
+				'Theme Name: Overwritten Theme'
+			);
+
+			await expect(
+				installTheme(php, {
+					themeData: {
+						name: 'test-theme',
+						files: {
+							'index.php': `/**\n * Theme Name: Error Theme`,
+						},
+					},
+					ifAlreadyInstalled: 'error',
+					options: {
+						activate: false,
+					},
+				})
+			).rejects.toThrow(/already exists/);
+		});
 	});
 
 	describe('targetFolderName option', () => {


### PR DESCRIPTION
## What it does

Makes directory-based `installTheme` resources honor the existing `ifAlreadyInstalled` option.

| `ifAlreadyInstalled` | Directory theme behavior |
| --- | --- |
| `overwrite` | Replace the existing theme directory. |
| `skip` | Keep the existing theme directory and continue. |
| `error` | Throw before writing files. |

## Rationale

Zip-based theme installs already respect `ifAlreadyInstalled`, but directory resources always rewrote the target directory through `writeFiles(..., { rmRoot: true })`.

Blueprint v2 lowering uses directory resources, so it needs the same collision semantics as zip resources before the runner can rely on this step consistently.

## Implementation

Before writing directory-resource theme files, `installTheme()` now checks whether the target directory already exists and applies the same `ifAlreadyInstalled` rule used by zip installs.

This PR intentionally does not add path validation or symlink hardening. Those are separate behaviors and should stay reviewable on their own.

## Testing instructions

Validated locally:

```bash
npm run format:uncommitted
npm exec nx run playground-blueprints:test:vite -- --testFiles=packages/playground/blueprints/src/tests/steps/install-theme.spec.ts
npm exec nx run playground-blueprints:lint
npm exec nx run playground-blueprints:typecheck
git diff --check
```