### PR TITLE
[Blueprints] Keep directory theme writes inside the target folder

### DIFF
--- a/packages/php-wasm/node/src/test/write-files.spec.ts
+++ b/packages/php-wasm/node/src/test/write-files.spec.ts
@@ -64,6 +64,16 @@ describe('writeFiles', () => {
 		]);
 	});
 
+	it('rejects file paths outside the target directory', async () => {
+		await expect(
+			writeFiles(php, '/test', {
+				'../escape.txt': 'file',
+			})
+		).rejects.toThrow('File paths must stay inside the target directory.');
+
+		expect(php.fileExists('/escape.txt')).toBe(false);
+	});
+
 	it('removes any pre-existing when ran with rmRoot: true', async () => {
 		php.writeFile('/test/file.txt', 'file');
 		php.mkdir('/test/subdirectory1');

--- a/packages/php-wasm/universal/src/lib/write-files.ts
+++ b/packages/php-wasm/universal/src/lib/write-files.ts
@@ -1,9 +1,11 @@
-import { dirname, joinPaths } from '@php-wasm/util';
+import { dirname, isParentOf, joinPaths } from '@php-wasm/util';
 import type { UniversalPHP } from './universal-php';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export interface FileTree
-	extends Record<string, Uint8Array | string | FileTree> {}
+export interface FileTree extends Record<
+	string,
+	Uint8Array | string | FileTree
+> {}
 
 export interface WriteFilesOptions {
 	/**
@@ -43,6 +45,11 @@ export async function writeFiles(
 	}
 	for (const [relativePath, content] of Object.entries(newFiles)) {
 		const filePath = joinPaths(root, relativePath);
+		if (!isParentOf(root, filePath)) {
+			throw new Error(
+				'File paths must stay inside the target directory.'
+			);
+		}
 		if (!(await php.fileExists(dirname(filePath)))) {
 			await php.mkdir(dirname(filePath));
 		}

--- a/packages/playground/blueprints/src/lib/steps/install-theme.ts
+++ b/packages/playground/blueprints/src/lib/steps/install-theme.ts
@@ -6,7 +6,7 @@ import type { Directory } from '../v1/resources';
 import { importThemeStarterContent } from './import-theme-starter-content';
 import { zipNameToHumanName } from '../utils/zip-name-to-human-name';
 import { writeFiles } from '@php-wasm/universal';
-import { joinPaths } from '@php-wasm/util';
+import { basename, joinPaths } from '@php-wasm/util';
 import { logger } from '@php-wasm/logger';
 
 /**
@@ -122,6 +122,14 @@ export const installTheme: StepHandler<
 		} else {
 			assetNiceName = themeData.name;
 			assetFolderName = targetFolderName || assetNiceName;
+			if (
+				!assetFolderName ||
+				basename(assetFolderName) !== assetFolderName
+			) {
+				throw new Error(
+					'Theme folder name must be a single directory name.'
+				);
+			}
 
 			progress?.tracker.setCaption(
 				`Installing the ${progressName()} theme`

--- a/packages/playground/blueprints/src/tests/steps/install-theme.spec.ts
+++ b/packages/playground/blueprints/src/tests/steps/install-theme.spec.ts
@@ -101,6 +101,67 @@ describe('Blueprint step installTheme', () => {
 		expect(php.fileExists(expectedThemeIndexPhpPath)).toBe(true);
 	});
 
+	it('should reject directory theme names outside the themes directory', async () => {
+		await expect(
+			installTheme(php, {
+				themeData: {
+					name: '../escape',
+					files: {
+						'index.php': `/**\n * Theme Name: Test Theme`,
+					},
+				},
+				options: {
+					activate: false,
+				},
+			})
+		).rejects.toThrow(
+			'Theme folder name must be a single directory name.'
+		);
+
+		expect(php.fileExists('/wordpress/wp-content/escape')).toBe(false);
+	});
+
+	it('should reject directory theme targetFolderName values with subdirectories', async () => {
+		await expect(
+			installTheme(php, {
+				themeData: {
+					name: 'test-theme',
+					files: {
+						'index.php': `/**\n * Theme Name: Test Theme`,
+					},
+				},
+				options: {
+					activate: false,
+					targetFolderName: 'nested/theme',
+				},
+			})
+		).rejects.toThrow(
+			'Theme folder name must be a single directory name.'
+		);
+
+		expect(php.fileExists('/wordpress/wp-content/themes/nested')).toBe(
+			false
+		);
+	});
+
+	it('should reject directory theme file paths outside the theme directory', async () => {
+		await expect(
+			installTheme(php, {
+				themeData: {
+					name: 'test-theme',
+					files: {
+						'../escape.php': `/**\n * Theme Name: Test Theme`,
+					},
+				},
+				options: {
+					activate: false,
+				},
+			})
+		).rejects.toThrow('File paths must stay inside the target directory.');
+
+		expect(php.fileExists('/wordpress/wp-content/escape.php')).toBe(false);
+	});
+
 	it('should skip installation errors when onError is skip-theme', async () => {
 		const loggerWarnSpy = vi
 			.spyOn(logger, 'warn')


### PR DESCRIPTION
## What it does

Prevents directory-based theme installs from writing outside the intended theme folder.

Rejected examples:

```json
{ "themeData": { "name": "../escape" } }
{ "options": { "targetFolderName": "nested/theme" } }
{ "themeData": { "files": { "../escape.php": "..." } } }
```

## Rationale

Zip-based theme installs go through `installAsset()`, which moves one resolved asset folder into `wp-content/themes`.

Directory resources skip `installAsset()` and pass caller-provided names and file keys directly to `writeFiles()`. Without an explicit boundary check, `../` segments can resolve outside the theme directory before the files are written.

Blueprint v2 lowering emits directory resources, so this needs to be enforced before the v2 runner depends on that path.

## Implementation

Uses the existing POSIX path utilities instead of local string parsing:

- `installTheme()` requires the resolved directory theme target to be a single directory name by checking `basename(assetFolderName) === assetFolderName`.
- `writeFiles()` computes each destination with `joinPaths(root, relativePath)` and rejects it unless `isParentOf(root, filePath)` is true.

The `writeFiles()` guard is intentionally shared: any `FileTree` write now stays inside the root passed by the caller.

This does not add symlink hardening or change zip install behavior.

## Testing instructions

```bash
npm run format:uncommitted
npm exec nx run playground-blueprints:test:vite -- --testFiles=packages/playground/blueprints/src/tests/steps/install-theme.spec.ts
npm exec nx run php-wasm-node:test-group-5-asyncify -- --testFiles=write-files.spec.ts
npm exec nx run php-wasm-universal:typecheck
npm exec nx run playground-blueprints:typecheck
npm exec nx run php-wasm-node:typecheck
npm exec nx run playground-blueprints:lint
npm exec nx run php-wasm-universal:lint
npm exec nx run php-wasm-node:lint
git diff --check
```