### PR TITLE
[Blueprints] Share Git repository URL detection logic

### DIFF
--- a/packages/playground/blueprints/src/lib/is-git-repo-url.ts
+++ b/packages/playground/blueprints/src/lib/is-git-repo-url.ts
@@ -1,0 +1,25 @@
+/**
+ * Heuristically indicates whether a URL looks like a Git repository.
+ *
+ * Blueprint compilers use this to distinguish plugin/theme repository URLs
+ * from downloadable ZIP URLs. This is intentionally a small allowlist of URL
+ * shapes Playground can clone, not a general Git remote detector.
+ */
+export function seemsLikeGitRepoUrl(url: string): boolean {
+	const normalizedUrl = url.trim().replace(/\/+$/, '');
+
+	// Explicit Git clone URLs can point to any HTTPS host.
+	if (/^https:\/\/.+\.git$/.test(normalizedUrl)) {
+		return true;
+	}
+
+	// GitHub shorthand: exactly /owner/repo.
+	if (/^https:\/\/github\.com\/[^/]+\/[^/]+$/.test(normalizedUrl)) {
+		return true;
+	}
+
+	// GitLab shorthand: /group[/subgroup...]/project.
+	return /^https:\/\/gitlab\.com\/[^/]+\/[^/]+(\/[^/]+)*$/.test(
+		normalizedUrl
+	);
+}

--- a/packages/playground/blueprints/src/lib/v1/compile.ts
+++ b/packages/playground/blueprints/src/lib/v1/compile.ts
@@ -39,6 +39,7 @@ const keyedStepHandlers = {
 import blueprintValidator from '../../../public/blueprint-schema-validator';
 import { defaultWpCliPath, defaultWpCliResource } from '../steps/wp-cli';
 import type { ErrorObject } from 'ajv';
+import { seemsLikeGitRepoUrl } from '../is-git-repo-url';
 
 export class InvalidBlueprintError extends Error {
 	public readonly validationErrors?: unknown;
@@ -259,7 +260,7 @@ function compileBlueprintJson(
 		const steps = blueprint.plugins
 			.map((value) => {
 				if (typeof value === 'string') {
-					if (isGitRepoUrl(value)) {
+					if (seemsLikeGitRepoUrl(value)) {
 						return {
 							resource: 'zip',
 							inner: {
@@ -842,22 +843,4 @@ function assertNoWordPressFeatures(blueprint: BlueprintV1Declaration) {
 			[]
 		);
 	}
-}
-
-function isGitRepoUrl(url: string): boolean {
-	const normalizedUrl = url.trim().replace(/\/+$/, '');
-	if (/^https:\/\/.+\.git$/.test(normalizedUrl)) {
-		return true;
-	}
-	// GitHub: exactly /owner/repo
-	if (/^https:\/\/github\.com\/[^/]+\/[^/]+$/.test(normalizedUrl)) {
-		return true;
-	}
-	// GitLab: /group[/subgroup...]/project (2+ path segments)
-	if (
-		/^https:\/\/gitlab\.com\/[^/]+\/[^/]+(\/[^/]+)*$/.test(normalizedUrl)
-	) {
-		return true;
-	}
-	return false;
 }

--- a/packages/playground/blueprints/src/tests/is-git-repo-url.spec.ts
+++ b/packages/playground/blueprints/src/tests/is-git-repo-url.spec.ts
@@ -1,0 +1,35 @@
+import { seemsLikeGitRepoUrl } from '../lib/is-git-repo-url';
+
+describe('seemsLikeGitRepoUrl', () => {
+	it('accepts cloneable HTTPS repository URLs', () => {
+		expect(seemsLikeGitRepoUrl('https://example.com/project.git')).toBe(
+			true
+		);
+		expect(seemsLikeGitRepoUrl('https://github.com/owner/repo')).toBe(true);
+		expect(
+			seemsLikeGitRepoUrl('https://gitlab.com/group/subgroup/project')
+		).toBe(true);
+	});
+
+	it('trims surrounding whitespace and trailing slashes', () => {
+		expect(seemsLikeGitRepoUrl(' https://github.com/owner/repo/ ')).toBe(
+			true
+		);
+		expect(seemsLikeGitRepoUrl('https://example.com/project.git/')).toBe(
+			true
+		);
+		expect(
+			seemsLikeGitRepoUrl('https://gitlab.com/group/subgroup/project/')
+		).toBe(true);
+	});
+
+	it('rejects URLs that should be handled as downloads or slugs', () => {
+		expect(
+			seemsLikeGitRepoUrl(
+				'https://github.com/owner/repo/archive/main.zip'
+			)
+		).toBe(false);
+		expect(seemsLikeGitRepoUrl('http://github.com/owner/repo')).toBe(false);
+		expect(seemsLikeGitRepoUrl('classic-editor')).toBe(false);
+	});
+});


### PR DESCRIPTION
## What it does

Moves the Blueprint v1 plugin URL heuristic into a shared internal helper: `seemsLikeGitRepoUrl()`.

The v1 compiler still treats these as Git repositories:

```text
https://example.com/project.git
https://github.com/owner/repo
https://gitlab.com/group/subgroup/project
```

## Rationale

Blueprint v2 compilation also needs to distinguish Git repository URLs from direct download URLs and WordPress.org slugs.

Keeping the heuristic inside `v1/compile.ts` would force the v2 compiler to duplicate it or reach into v1 internals. This PR makes the logic reusable without changing v1 behavior.

## Implementation

Adds `src/lib/is-git-repo-url.ts` and updates `v1/compile.ts` to call `seemsLikeGitRepoUrl()`.

The helper intentionally keeps the existing allowlist-style behavior. It is not a general Git remote parser.

## Testing instructions

```bash
npm run format:uncommitted
npm exec nx run playground-blueprints:test:vite -- --testFiles=packages/playground/blueprints/src/tests/is-git-repo-url.spec.ts
npm exec nx run playground-blueprints:lint
npm exec nx run playground-blueprints:typecheck
git diff --check
```

Part of #2592.