### PR TITLE
[Blueprints] Fix package typecheck target

### DIFF
--- a/packages/playground/blueprints/project.json
+++ b/packages/playground/blueprints/project.json
@@ -103,8 +103,8 @@
 			"executor": "nx:run-commands",
 			"options": {
 				"commands": [
-					"tsc -p packages/playground/remote/tsconfig.spec.json --noEmit",
-					"tsc -p packages/playground/remote/tsconfig.lib.json --noEmit"
+					"tsc -p packages/playground/blueprints/tsconfig.spec.json --noEmit",
+					"tsc -p packages/playground/blueprints/tsconfig.lib.json --noEmit"
 				]
 			}
 		}

--- a/packages/playground/blueprints/src/tests/steps/install-plugin.spec.ts
+++ b/packages/playground/blueprints/src/tests/steps/install-plugin.spec.ts
@@ -371,6 +371,7 @@ echo json_encode(array(
 
 	describe('targetFolderName option', () => {
 		it('should install a plugin to expected path', async () => {
+			// @ts-expect-error pluginZipFile is deprecated but still supported at runtime.
 			await installPlugin(php, {
 				pluginZipFile: await zipFiles(php, zipFileName, {
 					[`unexpected-path/index.php`]: `/**\n * Plugin Name: Test Plugin`,

--- a/packages/playground/blueprints/src/tests/steps/install-theme.spec.ts
+++ b/packages/playground/blueprints/src/tests/steps/install-theme.spec.ts
@@ -114,9 +114,7 @@ describe('Blueprint step installTheme', () => {
 					activate: false,
 				},
 			})
-		).rejects.toThrow(
-			'Theme folder name must be a single directory name.'
-		);
+		).rejects.toThrow('Theme folder name must be a single directory name.');
 
 		expect(php.fileExists('/wordpress/wp-content/escape')).toBe(false);
 	});
@@ -135,9 +133,7 @@ describe('Blueprint step installTheme', () => {
 					targetFolderName: 'nested/theme',
 				},
 			})
-		).rejects.toThrow(
-			'Theme folder name must be a single directory name.'
-		);
+		).rejects.toThrow('Theme folder name must be a single directory name.');
 
 		expect(php.fileExists('/wordpress/wp-content/themes/nested')).toBe(
 			false
@@ -366,6 +362,7 @@ describe('Blueprint step installTheme', () => {
 			const zip = await php.readFileAsBuffer(unexpectedZipFilePath);
 			php.unlink(unexpectedZipFilePath);
 
+			// @ts-expect-error themeZipFile is deprecated but still supported at runtime.
 			await installTheme(php, {
 				themeZipFile: new File([zip], unexpectedZipFileName),
 				ifAlreadyInstalled: 'overwrite',


### PR DESCRIPTION
## What it does

Makes `playground-blueprints:typecheck` typecheck the Blueprints package instead of `packages/playground/remote`.

## Rationale

The target currently runs:

```bash
tsc -p packages/playground/remote/tsconfig.spec.json --noEmit
tsc -p packages/playground/remote/tsconfig.lib.json --noEmit
```

That means Blueprints changes can pass `playground-blueprints:typecheck` without checking Blueprints sources or specs.

## Implementation

Points the target at:

```bash
tsc -p packages/playground/blueprints/tsconfig.spec.json --noEmit
tsc -p packages/playground/blueprints/tsconfig.lib.json --noEmit
```

The corrected spec typecheck exposed two deprecated-input tests that intentionally omit `pluginData` / `themeData`. Those tests now use `@ts-expect-error` because they verify runtime support for deprecated `pluginZipFile` and `themeZipFile`.

## Testing instructions

```bash
npm run format:uncommitted
npm exec nx run playground-blueprints:typecheck
npm exec nx run playground-blueprints:lint
npm exec nx run playground-blueprints:test:vite -- --testFiles=packages/playground/blueprints/src/tests/steps/install-plugin.spec.ts
npm exec nx run playground-blueprints:test:vite -- --testFiles=packages/playground/blueprints/src/tests/steps/install-theme.spec.ts
git diff --check
```