### PR TITLE
[Blueprints] Restrict Blueprint v2 file references

### DIFF
--- a/packages/playground/blueprints/src/lib/v2/wep-1-blueprint-v2-schema/appendix-A-blueprint-v2-schema.ts
+++ b/packages/playground/blueprints/src/lib/v2/wep-1-blueprint-v2-schema/appendix-A-blueprint-v2-schema.ts
@@ -449,13 +449,15 @@ export namespace V2Schema {
 	type ContentDefinition =
 		| ({
 				type: 'mysql-dump';
-				source: DataSources.DataReference | DataSources.DataReference[];
+				source:
+					| DataSources.FileDataReference
+					| DataSources.FileDataReference[];
 		  } & URLMappingConfig)
 		| ({
 				type: 'posts';
 				source:
-					| DataSources.DataReference
-					| DataSources.DataReference[]
+					| DataSources.FileDataReference
+					| DataSources.FileDataReference[]
 					| WordPressPost
 					| WordPressPost[];
 		  } & URLMappingConfig)
@@ -483,7 +485,7 @@ export namespace V2Schema {
 		 */
 		| ({
 				type: 'wxr';
-				source: DataSources.DataReference;
+				source: DataSources.FileDataReference;
 
 				/**
 				 * Static assets handling.
@@ -552,9 +554,9 @@ export namespace V2Schema {
 		  } & URLMappingConfig);
 
 	type MediaDefinition =
-		| DataSources.DataReference
+		| DataSources.FileDataReference
 		| {
-				source: DataSources.DataReference;
+				source: DataSources.FileDataReference;
 				title?: string;
 				description?: string;
 				alt?: string;
@@ -1523,7 +1525,7 @@ export namespace V2Schema {
 		/**
 		 * The PHP file to execute.
 		 */
-		code: DataSources.DataReference;
+		code: DataSources.FileDataReference;
 		/**
 		 * Environment variables to set for this run.
 		 */
@@ -1532,7 +1534,7 @@ export namespace V2Schema {
 
 	type RunSQLStep = {
 		step: 'runSQL';
-		source: DataSources.DataReference;
+		source: DataSources.FileDataReference;
 	};
 
 	/**
@@ -1564,7 +1566,7 @@ export namespace V2Schema {
 		/**
 		 * The zip file resource to extract.
 		 */
-		zipFile: DataSources.DataReference;
+		zipFile: DataSources.FileDataReference;
 		/**
 		 * The path to extract the zip file to inside the virtual filesystem.
 		 */

--- a/packages/playground/blueprints/src/lib/v2/wep-1-blueprint-v2-schema/appendix-B-data-sources.ts
+++ b/packages/playground/blueprints/src/lib/v2/wep-1-blueprint-v2-schema/appendix-B-data-sources.ts
@@ -112,6 +112,14 @@ export namespace DataSources {
 		| GitPath;
 
 	/**
+	 * A data reference that must resolve to a single file.
+	 */
+	export type FileDataReference =
+		| URLReference
+		| ExecutionContextPath
+		| InlineFile;
+
+	/**
 	 * }}}
 	 */
 

--- a/packages/playground/blueprints/src/tests/v2/blueprint-v2-declaration.spec.ts
+++ b/packages/playground/blueprints/src/tests/v2/blueprint-v2-declaration.spec.ts
@@ -1,0 +1,90 @@
+import type { BlueprintV2Declaration } from '../../lib/v2/blueprint-v2-declaration';
+
+describe('Blueprint v2 declaration types', () => {
+	it('accepts file data references for file-only fields', () => {
+		const blueprint = {
+			version: 2,
+			content: [
+				{
+					type: 'mysql-dump',
+					source: './dump.sql',
+				},
+				{
+					type: 'posts',
+					source: {
+						filename: 'posts.json',
+						content: '[]',
+					},
+				},
+				{
+					type: 'wxr',
+					source: './content.wxr',
+				},
+			],
+			media: [
+				'./image.jpg',
+				{
+					source: {
+						filename: 'image.jpg',
+						content: 'image',
+					},
+					title: 'Image',
+				},
+			],
+			additionalStepsAfterExecution: [
+				{
+					step: 'runPHP',
+					code: {
+						filename: 'script.php',
+						content: '<?php echo "Hello";',
+					},
+				},
+				{
+					step: 'runSQL',
+					source: './dump.sql',
+				},
+				{
+					step: 'unzip',
+					zipFile: './archive.zip',
+					extractToPath: '/tmp/archive',
+				},
+			],
+		} satisfies BlueprintV2Declaration;
+
+		expect(blueprint.version).toBe(2);
+	});
+});
+
+const blueprintWithDirectoryAsRunPHPCode = {
+	version: 2,
+	additionalStepsAfterExecution: [
+		{
+			step: 'runPHP',
+			code: {
+				// @ts-expect-error runPHP code must resolve to a single file.
+				directoryName: 'scripts',
+				files: {
+					'index.php': '<?php echo "Hello";',
+				},
+			},
+		},
+	],
+} satisfies BlueprintV2Declaration;
+
+const blueprintWithDirectoryAsMediaSource = {
+	version: 2,
+	media: [
+		{
+			source: {
+				// @ts-expect-error media source must resolve to a single file.
+				directoryName: 'images',
+				files: {
+					'image.jpg': 'image',
+				},
+			},
+		},
+	],
+} satisfies BlueprintV2Declaration;
+
+void blueprintWithDirectoryAsRunPHPCode;
+void blueprintWithDirectoryAsMediaSource;


### PR DESCRIPTION
## What?

Tightens the Blueprint v2 declaration types so fields that consume a single file no longer accept directory-like data references.

This adds `DataSources.FileDataReference` and uses it for:

- `content[].source` for `mysql-dump`, `posts`, and `wxr` imports
- `media` sources
- `runPHP.code`
- `runSQL.source`
- `unzip.zipFile`

It also adds a type-level spec that accepts file references for those fields and rejects inline directories where a single file is required.

## Why?

`DataReference` can point to URLs, execution-context paths, inline files, inline directories, or git paths. That is too broad for fields that are executed or imported as a single file. For example, `runPHP.code` cannot sensibly execute an inline directory, and `unzip.zipFile` needs a zip file, not a directory tree.

This does not add runtime behavior. It makes the public Blueprint v2 TypeScript contract match the shape those consumers already require.

## Who benefits?

- TypeScript users authoring Blueprint v2 objects get earlier feedback for invalid declarations.
- Playground APIs that accept `BlueprintV2Declaration` avoid advertising impossible input shapes.
- Future schema/runner work gets a smaller, clearer distinction between "any data reference" and "one file".

## Testing

- `npm exec nx run playground-blueprints:typecheck`
- `npm exec nx run playground-blueprints:lint`
- `npm exec nx run playground-blueprints:test:vite -- --testFiles=packages/playground/blueprints/src/tests/v2/blueprint-v2-declaration.spec.ts`
- `git diff --check`

Part of #2592.