### PR TITLE
[Blueprints] Type nested Blueprint v2 inline directories

### DIFF
--- a/packages/playground/blueprints/src/lib/v2/wep-1-blueprint-v2-schema/appendix-B-data-sources.ts
+++ b/packages/playground/blueprints/src/lib/v2/wep-1-blueprint-v2-schema/appendix-B-data-sources.ts
@@ -74,7 +74,16 @@ export namespace DataSources {
 	 */
 	export type InlineDirectory = {
 		directoryName: string;
-		files: Record<string, InlineFileContent | InlineDirectory>;
+		files: Record<string, InlineFileContent | NestedInlineDirectory>;
+	};
+
+	/**
+	 * A child directory inside an inline directory.
+	 *
+	 * Its directory name comes from the parent `files` record key.
+	 */
+	export type NestedInlineDirectory = {
+		files: Record<string, InlineFileContent | NestedInlineDirectory>;
 	};
 
 	/**

--- a/packages/playground/blueprints/src/tests/v2/blueprint-v2-declaration.spec.ts
+++ b/packages/playground/blueprints/src/tests/v2/blueprint-v2-declaration.spec.ts
@@ -53,6 +53,35 @@ describe('Blueprint v2 declaration types', () => {
 
 		expect(blueprint.version).toBe(2);
 	});
+
+	it('accepts inline directories with nested child directories', () => {
+		const blueprint = {
+			version: 2,
+			additionalStepsAfterExecution: [
+				{
+					step: 'writeFiles',
+					files: {
+						'/wordpress/wp-content/uploads': {
+							directoryName: 'uploads',
+							files: {
+								'2026': {
+									files: {
+										'07': {
+											files: {
+												'image.txt': 'image',
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			],
+		} satisfies BlueprintV2Declaration;
+
+		expect(blueprint.version).toBe(2);
+	});
 });
 
 const blueprintWithDirectoryAsRunPHPCode = {
@@ -86,5 +115,29 @@ const blueprintWithDirectoryAsMediaSource = {
 	],
 } satisfies BlueprintV2Declaration;
 
+const blueprintWithNestedDirectoryName = {
+	version: 2,
+	additionalStepsAfterExecution: [
+		{
+			step: 'writeFiles',
+			files: {
+				'/wordpress/wp-content/uploads': {
+					directoryName: 'uploads',
+					files: {
+						'2026': {
+							// @ts-expect-error nested directory names come from the parent key.
+							directoryName: '2026',
+							files: {
+								'image.txt': 'image',
+							},
+						},
+					},
+				},
+			},
+		},
+	],
+} satisfies BlueprintV2Declaration;
+
 void blueprintWithDirectoryAsRunPHPCode;
 void blueprintWithDirectoryAsMediaSource;
+void blueprintWithNestedDirectoryName;


### PR DESCRIPTION
## What?

Updates the Blueprint v2 inline directory types so only the top-level inline directory needs `directoryName`.

Nested directories now use a new `NestedInlineDirectory` type whose name comes from the parent `files` record key:

```ts
{
  directoryName: 'uploads',
  files: {
    '2026': {
      files: {
        'image.txt': 'image'
      }
    }
  }
}
```

## Why?

The existing type required nested directories to repeat `directoryName`, even though the inline-directory example already models child directory names as object keys. This makes the TypeScript declaration match the documented shape.

This is type-only. It does not change runtime behavior.

## Testing

- `npm exec nx run playground-blueprints:typecheck`
- `npm exec nx run playground-blueprints:lint`
- `npm exec nx run playground-blueprints:test:vite -- --testFiles=packages/playground/blueprints/src/tests/v2/blueprint-v2-declaration.spec.ts`
- `git diff --check`

Part of #2592.