### PR TITLE
[Blueprints] Type Blueprint v2 WXR author maps

### DIFF
--- a/packages/playground/blueprints/src/lib/v2/wep-1-blueprint-v2-schema/appendix-A-blueprint-v2-schema.ts
+++ b/packages/playground/blueprints/src/lib/v2/wep-1-blueprint-v2-schema/appendix-A-blueprint-v2-schema.ts
@@ -714,8 +714,8 @@ export namespace V2Schema {
 		humanReadableName?: string;
 	};
 
-	type RemoteUsername = 'string';
-	type LocalUsername = 'string';
+	type RemoteUsername = string;
+	type LocalUsername = string;
 
 	/**
 	 * WordPress register_post_type() arguments representation. {{{

--- a/packages/playground/blueprints/src/tests/v2/blueprint-v2-declaration.spec.ts
+++ b/packages/playground/blueprints/src/tests/v2/blueprint-v2-declaration.spec.ts
@@ -82,6 +82,25 @@ describe('Blueprint v2 declaration types', () => {
 
 		expect(blueprint.version).toBe(2);
 	});
+
+	it('accepts arbitrary WXR author-map usernames', () => {
+		const blueprint = {
+			version: 2,
+			content: [
+				{
+					type: 'wxr',
+					source: './content.wxr',
+					authorsMode: 'map',
+					authorsMap: {
+						alice: 'admin',
+						'bob@example.com': 'editor',
+					},
+				},
+			],
+		} satisfies BlueprintV2Declaration;
+
+		expect(blueprint.version).toBe(2);
+	});
 });
 
 const blueprintWithDirectoryAsRunPHPCode = {


### PR DESCRIPTION
## What?

Fixes the Blueprint v2 WXR author-map declaration types.

`RemoteUsername` and `LocalUsername` were typed as the literal value `'string'`, which made `authorsMap` only accept that exact value. This changes both aliases to `string` so real usernames can be mapped.

## Why?

Blueprint v2 WXR imports can map remote authors to local users. TypeScript consumers should be able to write real mappings such as:

```ts
authorsMap: {
  alice: 'admin',
  'bob@example.com': 'editor',
}
```

This is type-only. It does not change runtime behavior.

## Testing

- `npm exec nx run playground-blueprints:typecheck`
- `npm exec nx run playground-blueprints:lint`
- `npm exec nx run playground-blueprints:test:vite -- --testFiles=packages/playground/blueprints/src/tests/v2/blueprint-v2-declaration.spec.ts`
- `git diff --check`

Part of #2592.