### PR TITLE
[Blueprints] Type Blueprint v2 runtime version labels

### DIFF
--- a/packages/playground/blueprints/src/lib/v2/wep-1-blueprint-v2-schema/appendix-B-data-sources.ts
+++ b/packages/playground/blueprints/src/lib/v2/wep-1-blueprint-v2-schema/appendix-B-data-sources.ts
@@ -195,7 +195,8 @@ export namespace DataSources {
 		| `${Slug}@${SimpleVersionExpression}`;
 
 	/**
-	 * WordPress version, e.g. "6.4", "6.4.3", "6.8-RC1", or "6.7-beta2".
+	 * WordPress version, e.g. "latest", "beta", "trunk", "6.4",
+	 * "6.4.3", "6.8-RC1", or "6.7-beta2".
 	 *
 	 * These refer to slugs of specific WordPress releases as listed in
 	 * the first table column on https://wordpress.org/download/releases/.
@@ -204,18 +205,23 @@ export namespace DataSources {
 	 * `wordpressVersion` property.
 	 */
 	export type WordPressVersion =
+		| 'beta'
+		| 'trunk'
+		| 'nightly'
 		| SimpleVersionExpression
 		| `${SimpleVersionExpression}-${WordPressVersionSuffix}`;
 
 	/**
-	 * PHP version, e.g. "8.1" or "8.1.3".
+	 * PHP version, e.g. "8.1", "8.1.3", or "next".
 	 *
 	 * These refer to PHP versions as listed in https://www.php.net/releases/.
+	 * `next` previews the php-src development branch and is currently
+	 * supported by the web runtime only.
 	 *
 	 * The PHPVersion type is only meaningful in the top-level
 	 * `phpVersion` property.
 	 */
-	export type PHPVersion = SimpleVersionExpression;
+	export type PHPVersion = SimpleVersionExpression | 'next';
 
 	/**
 	 * A path within the built WordPress site, relative to the WordPress root

--- a/packages/playground/blueprints/src/tests/v2/blueprint-v2-declaration.spec.ts
+++ b/packages/playground/blueprints/src/tests/v2/blueprint-v2-declaration.spec.ts
@@ -101,6 +101,26 @@ describe('Blueprint v2 declaration types', () => {
 
 		expect(blueprint.version).toBe(2);
 	});
+
+	it('accepts Blueprint v2 runtime version labels', () => {
+		const blueprints = [
+			{
+				version: 2,
+				wordpressVersion: 'beta',
+				phpVersion: 'next',
+			},
+			{
+				version: 2,
+				wordpressVersion: 'trunk',
+			},
+			{
+				version: 2,
+				wordpressVersion: 'nightly',
+			},
+		] satisfies BlueprintV2Declaration[];
+
+		expect(blueprints).toHaveLength(3);
+	});
 });
 
 const blueprintWithDirectoryAsRunPHPCode = {


### PR DESCRIPTION
## What changed?

This updates the Blueprint v2 declaration types to accept runtime labels that are already meaningful to v2 runner work:

| Field | Added accepted values |
| --- | --- |
| `wordpressVersion` | `beta`, `trunk`, `nightly` |
| `phpVersion` | `next` |

It also adds a focused declaration-type test covering those labels.

## Why?

The previous type only accepted release-like versions, so TypeScript Blueprint authors could not write declarations that target these v2 runtime labels without casts.

This PR intentionally does not change constraint object semantics like `wordpressVersion.min` or `phpVersion.max`. If we need stricter constraint-bound typing, that can be a separate PR with its own rationale.

## Consumers

| Consumer | Benefit |
| --- | --- |
| Blueprint v2 runner work | Can type declarations that target non-release runtime channels. |
| TypeScript Blueprint authors | Can use WordPress `beta`/`trunk`/`nightly` and PHP `next` directly. |
| Existing Blueprint v1 consumers | No runtime behavior change; this only affects v2 declaration types. |

## Testing

- `npm run format:uncommitted`
- `npm exec nx run playground-blueprints:typecheck`
- `npm exec nx run playground-blueprints:lint`
- `npm exec nx run playground-blueprints:test:vite -- --testFiles=packages/playground/blueprints/src/tests/v2/blueprint-v2-declaration.spec.ts`
- `git diff --check`

Part of #2592.