### PR TITLE
[Blueprints] Type Blueprint v2 plugin collision handling

### DIFF
--- a/packages/playground/blueprints/src/lib/v2/wep-1-blueprint-v2-schema/appendix-A-blueprint-v2-schema.ts
+++ b/packages/playground/blueprints/src/lib/v2/wep-1-blueprint-v2-schema/appendix-A-blueprint-v2-schema.ts
@@ -654,6 +654,13 @@ export namespace V2Schema {
 		onError?: 'skip-plugin' | 'throw';
 
 		/**
+		 * How to handle a plugin that is already installed.
+		 *
+		 * @default "overwrite"
+		 */
+		ifAlreadyInstalled?: 'overwrite' | 'skip' | 'error';
+
+		/**
 		 * Human-readable name of the plugin for the progress bar.
 		 *
 		 * For example, with the following Blueprint:

--- a/packages/playground/blueprints/src/tests/v2/blueprint-v2-declaration.spec.ts
+++ b/packages/playground/blueprints/src/tests/v2/blueprint-v2-declaration.spec.ts
@@ -121,6 +121,24 @@ describe('Blueprint v2 declaration types', () => {
 
 		expect(blueprints).toHaveLength(3);
 	});
+
+	it('accepts plugin install collision handling', () => {
+		const blueprint = {
+			version: 2,
+			plugins: [
+				{
+					source: 'akismet',
+					ifAlreadyInstalled: 'skip',
+				},
+				{
+					source: 'jetpack',
+					ifAlreadyInstalled: 'error',
+				},
+			],
+		} satisfies BlueprintV2Declaration;
+
+		expect(blueprint.version).toBe(2);
+	});
 });
 
 const blueprintWithDirectoryAsRunPHPCode = {
@@ -177,6 +195,18 @@ const blueprintWithNestedDirectoryName = {
 	],
 } satisfies BlueprintV2Declaration;
 
+const blueprintWithInvalidPluginCollisionHandling = {
+	version: 2,
+	plugins: [
+		{
+			source: 'akismet',
+			// @ts-expect-error Plugin collision handling must be a known policy.
+			ifAlreadyInstalled: 'replace',
+		},
+	],
+} satisfies BlueprintV2Declaration;
+
 void blueprintWithDirectoryAsRunPHPCode;
 void blueprintWithDirectoryAsMediaSource;
 void blueprintWithNestedDirectoryName;
+void blueprintWithInvalidPluginCollisionHandling;


### PR DESCRIPTION
## What changed?

This types `ifAlreadyInstalled` on Blueprint v2 plugin object declarations:

| Field | Accepted values |
| --- | --- |
| `plugins[].ifAlreadyInstalled` | `overwrite`, `skip`, `error` |

It adds declaration tests for accepted values and rejects an unknown value with `@ts-expect-error`.

## Why?

The plugin install step already has this collision policy. Blueprint v2 plugin objects need to expose the same option at the declaration layer so TypeScript authors can express install collision behavior without casts.

This PR only updates v2 declaration types. It does not wire the option into the v2 runner; that should remain a separate, focused PR if needed.

## Consumers

| Consumer | Benefit |
| --- | --- |
| Blueprint v2 runner work | Gets a typed declaration field for plugin install collision policy. |
| TypeScript Blueprint authors | Can write `ifAlreadyInstalled: "skip"` or `"error"` on plugin objects directly. |
| Existing Blueprint v1 consumers | No runtime behavior change; this only affects v2 declaration types. |

## Testing

- `npm run format:uncommitted`
- `npm exec nx run playground-blueprints:typecheck`
- `npm exec nx run playground-blueprints:lint`
- `npm exec nx run playground-blueprints:test:vite -- --testFiles=packages/playground/blueprints/src/tests/v2/blueprint-v2-declaration.spec.ts`
- `git diff --check`

Part of #2592.