### PR TITLE
[Blueprints] Type Blueprint v2 theme install failures

### DIFF
--- a/packages/playground/blueprints/src/lib/v2/wep-1-blueprint-v2-schema/appendix-A-blueprint-v2-schema.ts
+++ b/packages/playground/blueprints/src/lib/v2/wep-1-blueprint-v2-schema/appendix-A-blueprint-v2-schema.ts
@@ -700,6 +700,12 @@ export namespace V2Schema {
 		 */
 		targetDirectoryName?: string;
 		/**
+		 * Sometimes it's fine when a theme fails to install.
+		 *
+		 * @default "throw"
+		 */
+		onError?: 'skip-theme' | 'throw';
+		/**
 		 * Human-readable name of the theme for the progress bar.
 		 *
 		 * For example, with the following Blueprint:

--- a/packages/playground/blueprints/src/tests/v2/blueprint-v2-declaration.spec.ts
+++ b/packages/playground/blueprints/src/tests/v2/blueprint-v2-declaration.spec.ts
@@ -139,6 +139,20 @@ describe('Blueprint v2 declaration types', () => {
 
 		expect(blueprint.version).toBe(2);
 	});
+
+	it('accepts theme install failure handling', () => {
+		const blueprint = {
+			version: 2,
+			themes: [
+				{
+					source: 'twentytwentyfour',
+					onError: 'skip-theme',
+				},
+			],
+		} satisfies BlueprintV2Declaration;
+
+		expect(blueprint.version).toBe(2);
+	});
 });
 
 const blueprintWithDirectoryAsRunPHPCode = {
@@ -206,7 +220,19 @@ const blueprintWithInvalidPluginCollisionHandling = {
 	],
 } satisfies BlueprintV2Declaration;
 
+const blueprintWithInvalidThemeInstallFailureHandling = {
+	version: 2,
+	themes: [
+		{
+			source: 'twentytwentyfour',
+			// @ts-expect-error Theme install failure handling must be theme-specific.
+			onError: 'skip-plugin',
+		},
+	],
+} satisfies BlueprintV2Declaration;
+
 void blueprintWithDirectoryAsRunPHPCode;
 void blueprintWithDirectoryAsMediaSource;
 void blueprintWithNestedDirectoryName;
 void blueprintWithInvalidPluginCollisionHandling;
+void blueprintWithInvalidThemeInstallFailureHandling;


### PR DESCRIPTION
## What?

Types the Blueprint v2 theme `onError` policy as `skip-theme | throw`.

## Why?

The v2 schema already has the plugin install failure policy typed. Themes need the same declaration-level coverage so TypeScript consumers can express optional theme installs and reject plugin-only policies like `skip-plugin`.

## Scope

This is type-only. It does not change the Blueprint v2 runner or theme install behavior.

## Testing

- `npm run format:uncommitted`
- `git diff --check`
- `npm exec nx run playground-blueprints:typecheck`
- `npm exec nx run playground-blueprints:lint`
- `npm exec nx run playground-blueprints:test:vite -- --testFiles=packages/playground/blueprints/src/tests/v2/blueprint-v2-declaration.spec.ts`

Part of #2592.