### PR TITLE
[Blueprints] Type Blueprint v2 theme collision handling

### DIFF
--- a/packages/playground/blueprints/src/lib/v2/wep-1-blueprint-v2-schema/appendix-A-blueprint-v2-schema.ts
+++ b/packages/playground/blueprints/src/lib/v2/wep-1-blueprint-v2-schema/appendix-A-blueprint-v2-schema.ts
@@ -706,6 +706,12 @@ export namespace V2Schema {
 		 */
 		onError?: 'skip-theme' | 'throw';
 		/**
+		 * How to handle a theme that is already installed.
+		 *
+		 * @default "overwrite"
+		 */
+		ifAlreadyInstalled?: 'overwrite' | 'skip' | 'error';
+		/**
 		 * Human-readable name of the theme for the progress bar.
 		 *
 		 * For example, with the following Blueprint:

--- a/packages/playground/blueprints/src/tests/v2/blueprint-v2-declaration.spec.ts
+++ b/packages/playground/blueprints/src/tests/v2/blueprint-v2-declaration.spec.ts
@@ -153,6 +153,24 @@ describe('Blueprint v2 declaration types', () => {
 
 		expect(blueprint.version).toBe(2);
 	});
+
+	it('accepts theme install collision handling', () => {
+		const blueprint = {
+			version: 2,
+			activeTheme: {
+				source: 'twentytwentyfour',
+				ifAlreadyInstalled: 'skip',
+			},
+			themes: [
+				{
+					source: 'twentytwentythree',
+					ifAlreadyInstalled: 'error',
+				},
+			],
+		} satisfies BlueprintV2Declaration;
+
+		expect(blueprint.version).toBe(2);
+	});
 });
 
 const blueprintWithDirectoryAsRunPHPCode = {
@@ -231,8 +249,20 @@ const blueprintWithInvalidThemeInstallFailureHandling = {
 	],
 } satisfies BlueprintV2Declaration;
 
+const blueprintWithInvalidThemeCollisionHandling = {
+	version: 2,
+	themes: [
+		{
+			source: 'twentytwentyfour',
+			// @ts-expect-error Theme collision handling must be a known policy.
+			ifAlreadyInstalled: 'replace',
+		},
+	],
+} satisfies BlueprintV2Declaration;
+
 void blueprintWithDirectoryAsRunPHPCode;
 void blueprintWithDirectoryAsMediaSource;
 void blueprintWithNestedDirectoryName;
 void blueprintWithInvalidPluginCollisionHandling;
 void blueprintWithInvalidThemeInstallFailureHandling;
+void blueprintWithInvalidThemeCollisionHandling;


### PR DESCRIPTION
## What?

Types the Blueprint v2 theme `ifAlreadyInstalled` policy as `overwrite | skip | error`.

## Why?

Plugin installs already expose the collision policy in the v2 declaration type. Theme installs use the same policy shape, and typing it lets TypeScript consumers catch invalid values before a Blueprint reaches a runner.

## Scope

This is type-only. It does not change the Blueprint v2 runner or theme install behavior.

## Stack

Base: #3866

## Testing

- `npm run format:uncommitted`
- `git diff --check`
- `npm exec nx run playground-blueprints:typecheck`
- `npm exec nx run playground-blueprints:lint`
- `npm exec nx run playground-blueprints:test:vite -- --testFiles=packages/playground/blueprints/src/tests/v2/blueprint-v2-declaration.spec.ts`

Part of #2592.