### PR TITLE
[Blueprints] Type Blueprint v2 WXR source lists

### DIFF
--- a/packages/playground/blueprints/src/lib/v2/wep-1-blueprint-v2-schema/appendix-A-blueprint-v2-schema.ts
+++ b/packages/playground/blueprints/src/lib/v2/wep-1-blueprint-v2-schema/appendix-A-blueprint-v2-schema.ts
@@ -485,7 +485,9 @@ export namespace V2Schema {
 		 */
 		| ({
 				type: 'wxr';
-				source: DataSources.FileDataReference;
+				source:
+					| DataSources.FileDataReference
+					| DataSources.FileDataReference[];
 
 				/**
 				 * Static assets handling.

--- a/packages/playground/blueprints/src/tests/v2/blueprint-v2-declaration.spec.ts
+++ b/packages/playground/blueprints/src/tests/v2/blueprint-v2-declaration.spec.ts
@@ -102,6 +102,26 @@ describe('Blueprint v2 declaration types', () => {
 		expect(blueprint.version).toBe(2);
 	});
 
+	it('accepts WXR source lists', () => {
+		const blueprint = {
+			version: 2,
+			content: [
+				{
+					type: 'wxr',
+					source: [
+						'./products.wxr',
+						{
+							filename: 'pages.wxr',
+							content: '<rss version="2.0"></rss>',
+						},
+					],
+				},
+			],
+		} satisfies BlueprintV2Declaration;
+
+		expect(blueprint.version).toBe(2);
+	});
+
 	it('accepts Blueprint v2 runtime version labels', () => {
 		const blueprints = [
 			{


### PR DESCRIPTION
## What?

Allows Blueprint v2 WXR content definitions to type `source` as either one file reference or a list of file references.

## Why?

Other content import types already accept source lists. WXR imports can also be split across multiple files, and TypeScript consumers should be able to declare that without falling out of the v2 declaration type.

## Scope

This is type-only. It does not change import execution, author mapping, URL rewriting, or runner behavior.

## Stack

Base: #3867

## Testing

- `npm run format:uncommitted`
- `git diff --check`
- `npm exec nx run playground-blueprints:typecheck`
- `npm exec nx run playground-blueprints:lint`
- `npm exec nx run playground-blueprints:test:vite -- --testFiles=packages/playground/blueprints/src/tests/v2/blueprint-v2-declaration.spec.ts`

Part of #2592.