### PR TITLE
[Blueprints] Require WXR author maps in Blueprint v2 types

### DIFF
--- a/packages/playground/blueprints/src/lib/v2/wep-1-blueprint-v2-schema/appendix-A-blueprint-v2-schema.ts
+++ b/packages/playground/blueprints/src/lib/v2/wep-1-blueprint-v2-schema/appendix-A-blueprint-v2-schema.ts
@@ -483,77 +483,77 @@ export namespace V2Schema {
 		 * ]
 		 * ```
 		 */
-		| ({
-				type: 'wxr';
-				source:
-					| DataSources.FileDataReference
-					| DataSources.FileDataReference[];
+		| WXRContentDefinition;
 
-				/**
-				 * Static assets handling.
-				 *
-				 * Possible values:
-				 *
-				 * * "fetch" – Fetch the static assets and save them to the local filesystem.
-				 * * "hotlink" – Hotlink the static assets from the remote site.
-				 *
-				 * @default "fetch".
-				 */
-				staticAssets?: 'fetch' | 'hotlink';
+	type WXRContentDefinition = WXRContentBase &
+		(
+			| {
+					/**
+					 * Map remote authors to existing local authors.
+					 */
+					authorsMode: 'map';
+					authorsMap: Record<RemoteUsername, LocalUsername>;
+			  }
+			| {
+					/**
+					 * How to handle authors that don't exist on the current site.
+					 *
+					 * Possible values:
+					 *
+					 * * "create" – Create a new author.
+					 * * "default-author" – Use the default author.
+					 *
+					 * @default "create".
+					 */
+					authorsMode?: 'create' | 'default-author';
+					authorsMap?: Record<RemoteUsername, LocalUsername>;
+			  }
+		);
 
-				/**
-				 * How to handle authors that don't exist on the current site.
-				 *
-				 * Possible values:
-				 *
-				 * * "create" – Create a new author.
-				 * * "default-author" – Use the default author.
-				 * * "map" – Map the author to an existing author on the current site.
-				 *
-				 * @default "create".
-				 */
-				authorsMode?: 'create' | 'default-author' | 'map';
+	type WXRContentBase = {
+		type: 'wxr';
+		source: DataSources.FileDataReference | DataSources.FileDataReference[];
 
-				/**
-				 * The default author to use when `mode` is "default-author".
-				 *
-				 * @default "admin".
-				 */
-				defaultAuthorUsername?: string;
+		/**
+		 * Static assets handling.
+		 *
+		 * Possible values:
+		 *
+		 * * "fetch" – Fetch the static assets and save them to the local filesystem.
+		 * * "hotlink" – Hotlink the static assets from the remote site.
+		 *
+		 * @default "fetch".
+		 */
+		staticAssets?: 'fetch' | 'hotlink';
 
-				/**
-				 * Map post authors from the remote site to the current site.
-				 *
-				 * When not provided, the importer will attempt to match the authors by
-				 * username, email, or name.
-				 *
-				 * Required when `authorsMode` is "map".
-				 *
-				 * @default undefined.
-				 */
-				authorsMap?: Record<RemoteUsername, LocalUsername>;
+		/**
+		 * The default author to use when `mode` is "default-author".
+		 *
+		 * @default "admin".
+		 */
+		defaultAuthorUsername?: string;
 
-				/**
-				 * Whether to import users from the remote site.
-				 *
-				 * @default false.
-				 */
-				importUsers?: boolean;
+		/**
+		 * Whether to import users from the remote site.
+		 *
+		 * @default false.
+		 */
+		importUsers?: boolean;
 
-				/**
-				 * Whether to import comments from the remote site.
-				 *
-				 * @default false.
-				 */
-				importComments?: boolean;
+		/**
+		 * Whether to import comments from the remote site.
+		 *
+		 * @default false.
+		 */
+		importComments?: boolean;
 
-				/**
-				 * Whether to import site settings from the remote site.
-				 *
-				 * @default false.
-				 */
-				importSiteOptions?: boolean;
-		  } & URLMappingConfig);
+		/**
+		 * Whether to import site settings from the remote site.
+		 *
+		 * @default false.
+		 */
+		importSiteOptions?: boolean;
+	} & URLMappingConfig;
 
 	type MediaDefinition =
 		| DataSources.FileDataReference

--- a/packages/playground/blueprints/src/tests/v2/blueprint-v2-declaration.spec.ts
+++ b/packages/playground/blueprints/src/tests/v2/blueprint-v2-declaration.spec.ts
@@ -280,9 +280,22 @@ const blueprintWithInvalidThemeCollisionHandling = {
 	],
 } satisfies BlueprintV2Declaration;
 
+const blueprintWithMissingWxrAuthorsMap = {
+	version: 2,
+	content: [
+		// @ts-expect-error WXR author mapping must declare the author map.
+		{
+			type: 'wxr',
+			source: './content.wxr',
+			authorsMode: 'map',
+		},
+	],
+} satisfies BlueprintV2Declaration;
+
 void blueprintWithDirectoryAsRunPHPCode;
 void blueprintWithDirectoryAsMediaSource;
 void blueprintWithNestedDirectoryName;
 void blueprintWithInvalidPluginCollisionHandling;
 void blueprintWithInvalidThemeInstallFailureHandling;
 void blueprintWithInvalidThemeCollisionHandling;
+void blueprintWithMissingWxrAuthorsMap;


### PR DESCRIPTION
## What?

Updates the Blueprint v2 declaration type so WXR content with `authorsMode: "map"` must also provide `authorsMap`.

## Why?

The schema docs already say `authorsMap` is required when WXR author mode is `map`. Encoding that in the TypeScript declaration catches incomplete Blueprints before they reach a runner.

## Scope

This is type-only. It does not change WXR import execution, URL rewriting, or author matching behavior.

## Testing

- `npm run format:uncommitted`
- `git diff --check`
- `npm exec nx run playground-blueprints:typecheck`
- `npm exec nx run playground-blueprints:lint`
- `npm exec nx run playground-blueprints:test:vite -- --testFiles=packages/playground/blueprints/src/tests/v2/blueprint-v2-declaration.spec.ts`

Part of #2592.