### PR TITLE
[Blueprints] Type Blueprint v2 version constraints

### DIFF
--- a/packages/playground/blueprints/src/lib/v2/wep-1-blueprint-v2-schema/appendix-A-blueprint-v2-schema.ts
+++ b/packages/playground/blueprints/src/lib/v2/wep-1-blueprint-v2-schema/appendix-A-blueprint-v2-schema.ts
@@ -180,12 +180,12 @@ export namespace V2Schema {
 			| DataSources.WordPressVersion
 			| DataSources.DataReference
 			| {
-					min: DataSources.WordPressVersion;
-					max?: DataSources.WordPressVersion;
+					min: DataSources.WordPressVersionConstraintVersion;
+					max?: DataSources.WordPressVersionConstraintVersion;
 					/**
 					 * @default "latest"
 					 */
-					preferred?: DataSources.WordPressVersion;
+					preferred?: DataSources.WordPressVersionPreferredVersion;
 			  };
 
 		/**
@@ -204,9 +204,9 @@ export namespace V2Schema {
 		phpVersion?:
 			| DataSources.PHPVersion
 			| {
-					min?: DataSources.PHPVersion;
-					recommended?: DataSources.PHPVersion;
-					max?: DataSources.PHPVersion;
+					min?: DataSources.PHPVersionConstraintVersion;
+					recommended?: DataSources.PHPVersionConstraintVersion;
+					max?: DataSources.PHPVersionConstraintVersion;
 			  };
 
 		/**

--- a/packages/playground/blueprints/src/lib/v2/wep-1-blueprint-v2-schema/appendix-B-data-sources.ts
+++ b/packages/playground/blueprints/src/lib/v2/wep-1-blueprint-v2-schema/appendix-B-data-sources.ts
@@ -157,7 +157,20 @@ export namespace DataSources {
 		| 'latest'
 		| `${number}.${number}`
 		| `${number}.${number}.${number}`;
-	export type WordPressVersionSuffix = `beta${number}` | `rc${number}`;
+	export type VersionNumberComponent = `${bigint}`;
+	export type ComparableVersionExpression =
+		| `${VersionNumberComponent}.${VersionNumberComponent}`
+		| `${VersionNumberComponent}.${VersionNumberComponent}.${VersionNumberComponent}`;
+	export type WordPressVersionSuffix =
+		| `beta${VersionNumberComponent}`
+		| `rc${VersionNumberComponent}`;
+	export type WordPressVersionConstraintVersion =
+		| ComparableVersionExpression
+		| `${ComparableVersionExpression}-${WordPressVersionSuffix}`;
+	export type WordPressVersionPreferredVersion =
+		| 'latest'
+		| WordPressVersionConstraintVersion;
+	export type PHPVersionConstraintVersion = SimpleVersionExpression;
 	/** }}} Helper types */
 
 	/**

--- a/packages/playground/blueprints/src/tests/v2/blueprint-v2-declaration.spec.ts
+++ b/packages/playground/blueprints/src/tests/v2/blueprint-v2-declaration.spec.ts
@@ -142,6 +142,24 @@ describe('Blueprint v2 declaration types', () => {
 		expect(blueprints).toHaveLength(3);
 	});
 
+	it('accepts Blueprint v2 version constraints', () => {
+		const blueprint = {
+			version: 2,
+			wordpressVersion: {
+				min: '6.8-rc1',
+				max: '6.9',
+				preferred: 'latest',
+			},
+			phpVersion: {
+				min: '8.0',
+				recommended: '8.3',
+				max: '8.4',
+			},
+		} satisfies BlueprintV2Declaration;
+
+		expect(blueprint.version).toBe(2);
+	});
+
 	it('accepts plugin install collision handling', () => {
 		const blueprint = {
 			version: 2,
@@ -292,6 +310,39 @@ const blueprintWithMissingWxrAuthorsMap = {
 	],
 } satisfies BlueprintV2Declaration;
 
+const blueprintWithNonComparableWordPressVersionMinimum = {
+	version: 2,
+	wordpressVersion: {
+		// @ts-expect-error Version constraint minimums must be comparable versions.
+		min: 'latest',
+	},
+} satisfies BlueprintV2Declaration;
+
+const blueprintWithExtraWordPressVersionComponent = {
+	version: 2,
+	wordpressVersion: {
+		// @ts-expect-error Version constraints must have two or three components.
+		min: '6.8.1.2',
+	},
+} satisfies BlueprintV2Declaration;
+
+const blueprintWithUnsupportedWordPressVersionRecommendation = {
+	version: 2,
+	wordpressVersion: {
+		min: '6.8',
+		// @ts-expect-error WordPress version constraints use preferred, not recommended.
+		recommended: '6.8.1',
+	},
+} satisfies BlueprintV2Declaration;
+
+const blueprintWithNonComparablePHPVersionRecommendation = {
+	version: 2,
+	phpVersion: {
+		// @ts-expect-error Runtime labels are only valid as top-level PHP versions.
+		recommended: 'next',
+	},
+} satisfies BlueprintV2Declaration;
+
 void blueprintWithDirectoryAsRunPHPCode;
 void blueprintWithDirectoryAsMediaSource;
 void blueprintWithNestedDirectoryName;
@@ -299,3 +350,7 @@ void blueprintWithInvalidPluginCollisionHandling;
 void blueprintWithInvalidThemeInstallFailureHandling;
 void blueprintWithInvalidThemeCollisionHandling;
 void blueprintWithMissingWxrAuthorsMap;
+void blueprintWithNonComparableWordPressVersionMinimum;
+void blueprintWithExtraWordPressVersionComponent;
+void blueprintWithUnsupportedWordPressVersionRecommendation;
+void blueprintWithNonComparablePHPVersionRecommendation;


### PR DESCRIPTION
## What?

Tightens the Blueprint v2 declaration types for `wordpressVersion` and `phpVersion` object constraints.

## Why?

Top-level runtime labels like `beta`, `trunk`, `nightly`, and `next` are valid as direct version values, but constraint objects need comparable versions for `min` and `max`. This makes that distinction visible to TypeScript consumers.

## Scope

Type-only. No runner behavior changes.

## Testing

- `npm run format:uncommitted`
- `git diff --check`
- `npm exec nx run playground-blueprints:typecheck`
- `npm exec nx run playground-blueprints:lint`
- `npm exec nx run playground-blueprints:test:vite -- --testFiles=packages/playground/blueprints/src/tests/v2/blueprint-v2-declaration.spec.ts`

Part of #2592.