### PR TITLE
[Blueprints] Type Blueprint v2 plugin data references

### DIFF
--- a/packages/playground/blueprints/src/lib/v2/wep-1-blueprint-v2-schema/appendix-A-blueprint-v2-schema.ts
+++ b/packages/playground/blueprints/src/lib/v2/wep-1-blueprint-v2-schema/appendix-A-blueprint-v2-schema.ts
@@ -566,14 +566,14 @@ export namespace V2Schema {
 		  };
 
 	type PluginDefinition =
-		| DataSources.DataReference
+		| DataSources.PluginDataReference
 		| DataSources.PluginDirectoryReference
 		| PluginObjectDefinition;
 
 	// Separated from PluginDefinition to avoid duplicate step entries in the generated JSON schema
 	type PluginObjectDefinition = {
 		source:
-			| DataSources.DataReference
+			| DataSources.PluginDataReference
 			| DataSources.PluginDirectoryReference;
 
 		/**

--- a/packages/playground/blueprints/src/lib/v2/wep-1-blueprint-v2-schema/appendix-B-data-sources.ts
+++ b/packages/playground/blueprints/src/lib/v2/wep-1-blueprint-v2-schema/appendix-B-data-sources.ts
@@ -129,6 +129,19 @@ export namespace DataSources {
 		| InlineFile;
 
 	/**
+	 * A data reference that must resolve to an installable plugin.
+	 *
+	 * File references must point to a .zip archive or a single .php plugin
+	 * file. Directory and git references are installed as plugin directories.
+	 */
+	export type PluginDataReference =
+		| URLReference
+		| ExecutionContextPath
+		| InlineFile
+		| InlineDirectory
+		| GitPath;
+
+	/**
 	 * }}}
 	 */
 


### PR DESCRIPTION
## What?

Adds a `PluginDataReference` alias and uses it for Blueprint v2 plugin sources.

## Why?

Plugin install sources have a specific contract: files must resolve to installable plugin files or zips, while directories and git paths install as plugin directories. Naming that contract separately makes the schema easier to evolve without changing unrelated data references.

## Scope

Type-only. This does not change plugin install behavior.

## Stack

Base: #3870

## Testing

- `npm run format:uncommitted`
- `git diff --check`
- `npm exec nx run playground-blueprints:typecheck`
- `npm exec nx run playground-blueprints:lint`
- `npm exec nx run playground-blueprints:test:vite -- --testFiles=packages/playground/blueprints/src/tests/v2/blueprint-v2-declaration.spec.ts`