### PR TITLE
[Blueprints] Type Blueprint v2 SQL dump content without URL mapping

### DIFF
--- a/packages/playground/blueprints/src/lib/v2/wep-1-blueprint-v2-schema/appendix-A-blueprint-v2-schema.ts
+++ b/packages/playground/blueprints/src/lib/v2/wep-1-blueprint-v2-schema/appendix-A-blueprint-v2-schema.ts
@@ -447,12 +447,12 @@ export namespace V2Schema {
 	};
 
 	type ContentDefinition =
-		| ({
+		| {
 				type: 'mysql-dump';
 				source:
 					| DataSources.FileDataReference
 					| DataSources.FileDataReference[];
-		  } & URLMappingConfig)
+		  }
 		| ({
 				type: 'posts';
 				source:

--- a/packages/playground/blueprints/src/tests/v2/blueprint-v2-declaration.spec.ts
+++ b/packages/playground/blueprints/src/tests/v2/blueprint-v2-declaration.spec.ts
@@ -343,6 +343,18 @@ const blueprintWithNonComparablePHPVersionRecommendation = {
 	},
 } satisfies BlueprintV2Declaration;
 
+const blueprintWithUrlMappingForMysqlDump = {
+	version: 2,
+	content: [
+		{
+			type: 'mysql-dump',
+			source: './dump.sql',
+			// @ts-expect-error URL mapping does not apply to SQL dump imports.
+			urlsMode: 'rewrite',
+		},
+	],
+} satisfies BlueprintV2Declaration;
+
 void blueprintWithDirectoryAsRunPHPCode;
 void blueprintWithDirectoryAsMediaSource;
 void blueprintWithNestedDirectoryName;
@@ -354,3 +366,4 @@ void blueprintWithNonComparableWordPressVersionMinimum;
 void blueprintWithExtraWordPressVersionComponent;
 void blueprintWithUnsupportedWordPressVersionRecommendation;
 void blueprintWithNonComparablePHPVersionRecommendation;
+void blueprintWithUrlMappingForMysqlDump;


### PR DESCRIPTION
## What?

Removes URL mapping options from the Blueprint v2 `mysql-dump` content declaration.

## Why?

URL rewriting applies to imported content such as posts and WXR files. SQL dump imports are raw database imports, so accepting URL mapping options there advertises behavior the content type does not provide.

## Scope

Type-only. This does not change SQL dump import execution.

## Stack

Base: #3871

## Testing

- `npm run format:uncommitted`
- `git diff --check`
- `npm exec nx run playground-blueprints:typecheck`
- `npm exec nx run playground-blueprints:lint`
- `npm exec nx run playground-blueprints:test:vite -- --testFiles=packages/playground/blueprints/src/tests/v2/blueprint-v2-declaration.spec.ts`