### PR TITLE
[Blueprints] Document valid Blueprint v2 schema examples

### DIFF
--- a/packages/playground/blueprints/src/lib/v2/wep-1-blueprint-v2-schema/appendix-A-blueprint-v2-schema.ts
+++ b/packages/playground/blueprints/src/lib/v2/wep-1-blueprint-v2-schema/appendix-A-blueprint-v2-schema.ts
@@ -221,9 +221,13 @@ export namespace V2Schema {
 		 * @example `"activeTheme": "adventurer@4.6.0"`
 		 * @example
 		 * ```json
-		 * "activeTheme": {
-		 *     "source": "https://github.com/richtabor/kanso/archive/refs/heads/main.zip",
-		 *     "id": "kanso"
+		 * {
+		 *     "version": 2,
+		 *     "activeTheme": {
+		 *         "source": "https://github.com/richtabor/kanso/archive/refs/heads/main.zip",
+		 *         "targetDirectoryName": "kanso",
+		 *         "importStarterContent": true
+		 *     }
 		 * }
 		 * ```
 		 */
@@ -235,14 +239,17 @@ export namespace V2Schema {
 		 * Example:
 		 *
 		 * ```json
-		 * themes: [
-		 *     "stylish-press-theme",
-		 *     "adventurer@4.6.0",
-		 *     {
-		 *         "source": "https://github.com/richtabor/kanso/archive/refs/heads/main.zip",
-		 *         "id": "kanso"
-		 *     }
-		 * ]
+		 * {
+		 *     "version": 2,
+		 *     "themes": [
+		 *         "stylish-press-theme",
+		 *         "adventurer@4.6.0",
+		 *         {
+		 *             "source": "https://github.com/richtabor/kanso/archive/refs/heads/main.zip",
+		 *             "targetDirectoryName": "kanso"
+		 *         }
+		 *     ]
+		 * }
 		 * ```
 		 */
 		themes?: ThemeDefinition[];
@@ -253,16 +260,20 @@ export namespace V2Schema {
 		 * Example:
 		 *
 		 * ```json
-		 * plugins: [
-		 *     "jetpack",
-		 *     "akismet@6.4.3",
-		 *     "./query-monitor.php",
-		 *     "./code-block.zip",
-		 *     {
-		 *         "source": "https://github.com/woocommerce/woocommerce/archive/refs/heads/6.4.3.zip",
-		 *         "active": false
-		 *     }
-		 * ]
+		 * {
+		 *     "version": 2,
+		 *     "plugins": [
+		 *         "jetpack",
+		 *         "akismet@6.4.3",
+		 *         "./query-monitor.php",
+		 *         "./code-block.zip",
+		 *         {
+		 *             "source": "https://github.com/woocommerce/woocommerce/archive/refs/heads/6.4.3.zip",
+		 *             "active": false
+		 *         }
+		 *     ]
+		 * }
+		 * ```
 		 */
 		plugins?: PluginDefinition[];
 
@@ -272,14 +283,15 @@ export namespace V2Schema {
 		 * Example:
 		 *
 		 * ```json
-		 * muPlugins: [
-		 *     {
-		 *         "file": {
+		 * {
+		 *     "version": 2,
+		 *     "muPlugins": [
+		 *         {
 		 *             "filename": "addFilter-0.php",
 		 *             "content": "<?php add_action( 'requests-requests.before_request', function( &$url ) {\n$url = 'https://playground.wordpress.net/cors-proxy.php?' . $url;\n} );"
 		 *         }
-		 *     }
-		 * ]
+		 *     ]
+		 * }
 		 * ```
 		 */
 		muPlugins?: Array<DataSources.DataReference>;
@@ -467,20 +479,23 @@ export namespace V2Schema {
 		 * Example:
 		 *
 		 * ```json
-		 * content: [
-		 *     {
-		 *         "type": "wxr",
-		 *         "https://raw.githubusercontent.com/wordpress/blueprints/trunk/blueprints/stylish-press/woo-products.wxr"
-		 *     },
-		 *     {
-		 *         "type": "wxr",
-		 *         "url": "https://raw.githubusercontent.com/wordpress/blueprints/trunk/blueprints/stylish-press/site-content.wxr",
-		 *         "rewriteUrls": true,
-		 *         "fetchStaticAssets": false,
-		 *         "users": false,
-		 *         "comments": false,
-		 *     }
-		 * ]
+		 * {
+		 *     "version": 2,
+		 *     "content": [
+		 *         {
+		 *             "type": "wxr",
+		 *             "source": "https://raw.githubusercontent.com/wordpress/blueprints/trunk/blueprints/stylish-press/woo-products.wxr"
+		 *         },
+		 *         {
+		 *             "type": "wxr",
+		 *             "source": "https://raw.githubusercontent.com/wordpress/blueprints/trunk/blueprints/stylish-press/site-content.wxr",
+		 *             "urlsMode": "rewrite",
+		 *             "staticAssets": "hotlink",
+		 *             "importUsers": false,
+		 *             "importComments": false
+		 *         }
+		 *     ]
+		 * }
 		 * ```
 		 */
 		| WXRContentDefinition;


### PR DESCRIPTION
## What?

Updates Blueprint v2 schema comments so examples are complete, valid Blueprint v2 JSON.

## Why?

Several examples were fragments or used old property names such as `id`, `url`, `rewriteUrls`, and `fetchStaticAssets`. These examples are copied into generated schema/docs surfaces, so they should match the current declaration shape.

## Scope

Documentation/comments only. No type or runtime behavior changes.

## Stack

Base: #3872

## Testing

- `npm run format:uncommitted`
- `git diff --check`
- `npm exec nx run playground-blueprints:typecheck`
- `npm exec nx run playground-blueprints:lint`
- `npm exec nx run playground-blueprints:test:vite -- --testFiles=packages/playground/blueprints/src/tests/v2/blueprint-v2-declaration.spec.ts`

Part of #2592.