### PR TITLE
[Website] Keep git:directory installs on browser isomorphic-git

### DIFF
--- a/packages/playground/storage/vite.config.ts
+++ b/packages/playground/storage/vite.config.ts
@@ -13,6 +13,11 @@ import { getExternalModules } from '../../vite-extensions/vite-external-modules'
 // eslint-disable-next-line @nx/enforce-module-boundaries
 import viteGlobalExtensions from '../../vite-extensions/vite-global-extensions';
 
+const isomorphicGitEsmEntry = join(
+	__dirname,
+	'../../../node_modules/isomorphic-git/index.js'
+);
+
 export default defineConfig({
 	root: __dirname,
 	base: '/',
@@ -39,6 +44,15 @@ export default defineConfig({
 		}),
 		...viteGlobalExtensions,
 	],
+
+	resolve: {
+		alias: [
+			{
+				find: /^isomorphic-git$/,
+				replacement: isomorphicGitEsmEntry,
+			},
+		],
+	},
 
 	// Configuration for building your library.
 	// See: https://vitejs.dev/guide/build.html#library-mode

--- a/packages/playground/website-extras/vite.config.ts
+++ b/packages/playground/website-extras/vite.config.ts
@@ -19,6 +19,10 @@ import virtualModule from '../../vite-extensions/vite-virtual-module';
 // eslint-disable-next-line @nx/enforce-module-boundaries
 import viteGlobalExtensions from '../../vite-extensions/vite-global-extensions';
 
+const isomorphicGitEsmEntry = fileURLToPath(
+	new URL('../../../node_modules/isomorphic-git/index.js', import.meta.url)
+);
+
 export default defineConfig(({ mode }) => {
 	const corsProxyUrl =
 		'CORS_PROXY_URL' in process.env
@@ -35,6 +39,15 @@ export default defineConfig(({ mode }) => {
 
 		cacheDir:
 			'../../../node_modules/.vite/packages-playground-website-extras',
+
+		resolve: {
+			alias: [
+				{
+					find: /^isomorphic-git$/,
+					replacement: isomorphicGitEsmEntry,
+				},
+			],
+		},
 
 		css: {
 			modules: {

--- a/packages/playground/website/playwright/e2e/blueprints.spec.ts
+++ b/packages/playground/website/playwright/e2e/blueprints.spec.ts
@@ -22,6 +22,40 @@ test('Base64-encoded Blueprints should work', async ({
 	await expect(wordpress.locator('body')).toContainText('Dashboard');
 });
 
+test('installPlugin should install a plugin from a git:directory resource', async ({
+	website,
+	wordpress,
+}) => {
+	const blueprint: Blueprint = {
+		landingPage: '/wp-admin/plugins.php',
+		steps: [
+			{ step: 'login' },
+			{
+				step: 'installPlugin',
+				pluginData: {
+					resource: 'git:directory',
+					url: 'https://github.com/WordPress/wordpress-playground.git',
+					ref: 'b27a0e69ce12f7ad9503bc5dba96c01ee1bfdcda',
+					refType: 'commit',
+					path: 'packages/playground/cli/tests/mount-examples/plugin',
+				},
+				options: {
+					activate: true,
+				},
+			},
+		],
+	};
+
+	const encodedBlueprint = encodeStringAsBase64(JSON.stringify(blueprint));
+	await website.goto(`./?storage=temp#${encodedBlueprint}`);
+	await expect(wordpress.locator('body')).toContainText('Sample Plugin', {
+		timeout: 120000,
+	});
+	await expect(wordpress.getByLabel('Deactivate Sample Plugin')).toHaveText(
+		'Deactivate'
+	);
+});
+
 test('spawning less should work', async ({ website, wordpress }) => {
 	const blueprint: Blueprint = {
 		landingPage: '/less.php',

--- a/packages/playground/website/vite.config.ts
+++ b/packages/playground/website/vite.config.ts
@@ -33,6 +33,10 @@ import viteGlobalExtensions from '../../vite-extensions/vite-global-extensions';
 import { analyticsInjectionPlugin } from './vite-analytics-plugin';
 
 const exec = promisify(execCb);
+const isomorphicGitEsmEntry = join(
+	__dirname,
+	'../../../node_modules/isomorphic-git/index.js'
+);
 
 // Determine if we are running in a devcontainer.
 const isDevcontainer = process.env.VITE_DEVCONTAINER === 'true';
@@ -83,6 +87,15 @@ export default defineConfig(({ command, mode }) => {
 		assetsInclude: ['**/*.so', '**/*.dat'],
 
 		cacheDir: '../../../node_modules/.vite/packages-playground-website',
+
+		resolve: {
+			alias: [
+				{
+					find: /^isomorphic-git$/,
+					replacement: isomorphicGitEsmEntry,
+				},
+			],
+		},
 
 		css: {
 			modules: {


### PR DESCRIPTION
## Why

#3841 introduced a bug: `isomorphic-git`'s package exports resolve to the CommonJS/Node build in the browser build of the `website` package. That path calls Node's `crypto.createHash`, which is externalized by Vite and fails in Playground with `createHash is not a function` when a `git:directory` resource is installed.

This PR aliases the `isomorphic-git` package to the browser version and adds a regressino test.

Fixes #3875.

## Testing

* CI 
* Run a Blueprint with a `git:directory` resource and confirm it runs