### PR TITLE
[codex] Fix isomorphic-git browser bundle

### DIFF
--- a/packages/playground/blueprints/src/lib/v1/resources.ts
+++ b/packages/playground/blueprints/src/lib/v1/resources.ts
@@ -761,9 +761,10 @@ export class GitDirectoryResource extends Resource<Directory> {
 		const additionalHeaders =
 			this.options?.additionalHeaders?.(this.reference.url) ?? {};
 
-		const repoUrl = this.options?.corsProxy
-			? `${this.options.corsProxy}${this.reference.url}`
-			: this.reference.url;
+		const repoUrl = maybeProxyGitUrl(
+			this.reference.url,
+			this.options?.corsProxy
+		);
 
 		try {
 			const commitHash = await resolveCommitHash(
@@ -855,6 +856,27 @@ export class GitDirectoryResource extends Resource<Directory> {
 		]
 			.filter((segment) => segment.length > 0)
 			.join(' ');
+	}
+}
+
+function maybeProxyGitUrl(url: string, corsProxy?: string) {
+	if (!corsProxy || isLocalhostUrl(url)) {
+		return url;
+	}
+	return `${corsProxy}${url}`;
+}
+
+function isLocalhostUrl(url: string) {
+	try {
+		const { hostname } = new URL(url);
+		return (
+			hostname === 'localhost' ||
+			hostname === '127.0.0.1' ||
+			hostname === '::1' ||
+			hostname === '[::1]'
+		);
+	} catch {
+		return false;
 	}
 }
 

--- a/packages/playground/blueprints/src/lib/v1/resources.ts
+++ b/packages/playground/blueprints/src/lib/v1/resources.ts
@@ -868,12 +868,12 @@ function maybeProxyGitUrl(url: string, corsProxy?: string) {
 
 function isLocalhostUrl(url: string) {
 	try {
-		const { hostname } = new URL(url);
+		const { host, hostname } = new URL(url);
 		return (
 			hostname === 'localhost' ||
 			hostname === '127.0.0.1' ||
-			hostname === '::1' ||
-			hostname === '[::1]'
+			host === '[::1]' ||
+			host.startsWith('[::1]:')
 		);
 	} catch {
 		return false;

--- a/packages/playground/blueprints/src/lib/v1/resources.ts
+++ b/packages/playground/blueprints/src/lib/v1/resources.ts
@@ -761,10 +761,9 @@ export class GitDirectoryResource extends Resource<Directory> {
 		const additionalHeaders =
 			this.options?.additionalHeaders?.(this.reference.url) ?? {};
 
-		const repoUrl = maybeProxyGitUrl(
-			this.reference.url,
-			this.options?.corsProxy
-		);
+		const repoUrl = this.options?.corsProxy
+			? `${this.options.corsProxy}${this.reference.url}`
+			: this.reference.url;
 
 		try {
 			const commitHash = await resolveCommitHash(
@@ -856,27 +855,6 @@ export class GitDirectoryResource extends Resource<Directory> {
 		]
 			.filter((segment) => segment.length > 0)
 			.join(' ');
-	}
-}
-
-function maybeProxyGitUrl(url: string, corsProxy?: string) {
-	if (!corsProxy || isLocalhostUrl(url)) {
-		return url;
-	}
-	return `${corsProxy}${url}`;
-}
-
-function isLocalhostUrl(url: string) {
-	try {
-		const { host, hostname } = new URL(url);
-		return (
-			hostname === 'localhost' ||
-			hostname === '127.0.0.1' ||
-			host === '[::1]' ||
-			host.startsWith('[::1]:')
-		);
-	} catch {
-		return false;
 	}
 }
 

--- a/packages/playground/blueprints/src/tests/v1/resources.spec.ts
+++ b/packages/playground/blueprints/src/tests/v1/resources.spec.ts
@@ -296,6 +296,39 @@ describe('GitDirectoryResource', () => {
 			});
 		});
 
+		it('should not use CORS proxy for localhost git URLs', async () => {
+			global.fetch = vi.fn().mockResolvedValue({
+				ok: false,
+				status: 401,
+				statusText: 'Unauthorized',
+			});
+
+			const gitUrl = 'http://127.0.0.1:9876/sample-plugin.git';
+			const resource = new GitDirectoryResource(
+				{
+					resource: 'git:directory',
+					url: gitUrl,
+					ref: 'main',
+				},
+				undefined,
+				{
+					corsProxy: 'https://cors-proxy.com/?',
+				}
+			);
+
+			await expect(resource.resolve()).rejects.toMatchObject({
+				name: 'GitAuthenticationError',
+				repoUrl: gitUrl,
+				status: 401,
+			});
+
+			const firstFetchUrl = String(
+				vi.mocked(global.fetch).mock.calls[0][0]
+			);
+			expect(firstFetchUrl).toContain(gitUrl);
+			expect(firstFetchUrl).not.toContain('cors-proxy.com');
+		});
+
 		it('should call gitAdditionalHeadersCallback without CORS proxy', async () => {
 			const githubUrl = 'https://github.com/user/private-repo';
 			const headerCallback = vi.fn().mockReturnValue({

--- a/packages/playground/blueprints/src/tests/v1/resources.spec.ts
+++ b/packages/playground/blueprints/src/tests/v1/resources.spec.ts
@@ -296,42 +296,6 @@ describe('GitDirectoryResource', () => {
 			});
 		});
 
-		it.each([
-			'http://127.0.0.1:9876/sample-plugin.git',
-			'http://localhost:9876/sample-plugin.git',
-			'http://[::1]:9876/sample-plugin.git',
-		])('should not use CORS proxy for local git URL %s', async (gitUrl) => {
-			global.fetch = vi.fn().mockResolvedValue({
-				ok: false,
-				status: 401,
-				statusText: 'Unauthorized',
-			});
-
-			const resource = new GitDirectoryResource(
-				{
-					resource: 'git:directory',
-					url: gitUrl,
-					ref: 'main',
-				},
-				undefined,
-				{
-					corsProxy: 'https://cors-proxy.com/?',
-				}
-			);
-
-			await expect(resource.resolve()).rejects.toMatchObject({
-				name: 'GitAuthenticationError',
-				repoUrl: gitUrl,
-				status: 401,
-			});
-
-			const firstFetchUrl = String(
-				vi.mocked(global.fetch).mock.calls[0][0]
-			);
-			expect(firstFetchUrl).toContain(gitUrl);
-			expect(firstFetchUrl).not.toContain('cors-proxy.com');
-		});
-
 		it('should call gitAdditionalHeadersCallback without CORS proxy', async () => {
 			const githubUrl = 'https://github.com/user/private-repo';
 			const headerCallback = vi.fn().mockReturnValue({

--- a/packages/playground/blueprints/src/tests/v1/resources.spec.ts
+++ b/packages/playground/blueprints/src/tests/v1/resources.spec.ts
@@ -296,14 +296,17 @@ describe('GitDirectoryResource', () => {
 			});
 		});
 
-		it('should not use CORS proxy for localhost git URLs', async () => {
+		it.each([
+			'http://127.0.0.1:9876/sample-plugin.git',
+			'http://localhost:9876/sample-plugin.git',
+			'http://[::1]:9876/sample-plugin.git',
+		])('should not use CORS proxy for local git URL %s', async (gitUrl) => {
 			global.fetch = vi.fn().mockResolvedValue({
 				ok: false,
 				status: 401,
 				statusText: 'Unauthorized',
 			});
 
-			const gitUrl = 'http://127.0.0.1:9876/sample-plugin.git';
 			const resource = new GitDirectoryResource(
 				{
 					resource: 'git:directory',

--- a/packages/playground/client/vite.config.ts
+++ b/packages/playground/client/vite.config.ts
@@ -10,6 +10,8 @@ import { viteIgnoreImports } from '../../vite-extensions/vite-ignore-imports';
 import { buildVersionPlugin } from '../../vite-extensions/vite-build-version';
 // eslint-disable-next-line @nx/enforce-module-boundaries
 import viteGlobalExtensions from '../../vite-extensions/vite-global-extensions';
+// eslint-disable-next-line @nx/enforce-module-boundaries
+import { resolveIsomorphicGitEsmEntry } from '../../vite-extensions/vite-resolve-isomorphic-git';
 
 function validateOrigin(origin: string) {
 	try {
@@ -28,10 +30,7 @@ const additionalRemoteOriginsModulePath = join(
 	__dirname,
 	'src/additional-remote-origins.ts'
 );
-const isomorphicGitEsmEntry = join(
-	__dirname,
-	'../../../node_modules/isomorphic-git/index.js'
-);
+const isomorphicGitEsmEntry = resolveIsomorphicGitEsmEntry();
 
 export default defineConfig({
 	root: __dirname,

--- a/packages/playground/personal-wp/vite.config.ts
+++ b/packages/playground/personal-wp/vite.config.ts
@@ -24,10 +24,9 @@ import virtualModule from '../../vite-extensions/vite-virtual-module';
 // eslint-disable-next-line @nx/enforce-module-boundaries
 import viteGlobalExtensions from '../../vite-extensions/vite-global-extensions';
 // eslint-disable-next-line @nx/enforce-module-boundaries
-import { resolveIsomorphicGitEsmEntry } from '../../vite-extensions/vite-resolve-isomorphic-git';
+import { getIsomorphicGitViteConfig } from '../../vite-extensions/vite-resolve-isomorphic-git';
 
 const personalWPDevServerPort = 5401;
-const isomorphicGitEsmEntry = resolveIsomorphicGitEsmEntry();
 
 const proxy: CommonServerOptions['proxy'] = {
 	'^/plugin-proxy': {
@@ -66,30 +65,7 @@ export default defineConfig(({ command, mode }) => {
 		assetsInclude: ['**/*.so', '**/*.dat'],
 
 		cacheDir: '../../../node_modules/.vite/packages-playground-personal-wp',
-		optimizeDeps: {
-			include: [
-				'async-lock',
-				'buffer',
-				'clean-git-ref',
-				'crc-32',
-				'diff3',
-				'ignore',
-				'ini',
-				'pako',
-				'pify',
-				'sha.js',
-				'sha.js/sha1.js',
-			],
-			exclude: ['isomorphic-git'],
-		},
-		resolve: {
-			alias: [
-				{
-					find: /^isomorphic-git$/,
-					replacement: isomorphicGitEsmEntry,
-				},
-			],
-		},
+		...getIsomorphicGitViteConfig(),
 
 		css: {
 			modules: {

--- a/packages/playground/personal-wp/vite.config.ts
+++ b/packages/playground/personal-wp/vite.config.ts
@@ -23,12 +23,11 @@ import { listAssetsRequiredForOfflineMode } from '../../vite-extensions/vite-lis
 import virtualModule from '../../vite-extensions/vite-virtual-module';
 // eslint-disable-next-line @nx/enforce-module-boundaries
 import viteGlobalExtensions from '../../vite-extensions/vite-global-extensions';
+// eslint-disable-next-line @nx/enforce-module-boundaries
+import { resolveIsomorphicGitEsmEntry } from '../../vite-extensions/vite-resolve-isomorphic-git';
 
 const personalWPDevServerPort = 5401;
-const isomorphicGitEsmEntry = join(
-	__dirname,
-	'../../../node_modules/isomorphic-git/index.js'
-);
+const isomorphicGitEsmEntry = resolveIsomorphicGitEsmEntry();
 
 const proxy: CommonServerOptions['proxy'] = {
 	'^/plugin-proxy': {

--- a/packages/playground/remote/vite.config.ts
+++ b/packages/playground/remote/vite.config.ts
@@ -14,12 +14,11 @@ import { buildVersionPlugin } from '../../vite-extensions/vite-build-version';
 import virtualModule from '../../vite-extensions/vite-virtual-module';
 // eslint-disable-next-line @nx/enforce-module-boundaries
 import viteGlobalExtensions from '../../vite-extensions/vite-global-extensions';
+// eslint-disable-next-line @nx/enforce-module-boundaries
+import { resolveIsomorphicGitEsmEntry } from '../../vite-extensions/vite-resolve-isomorphic-git';
 
 const path = (filename: string) => new URL(filename, import.meta.url).pathname;
-const isomorphicGitEsmEntry = join(
-	__dirname,
-	'../../../node_modules/isomorphic-git/index.js'
-);
+const isomorphicGitEsmEntry = resolveIsomorphicGitEsmEntry();
 
 const plugins = [
 	viteTsConfigPaths({

--- a/packages/playground/remote/vite.config.ts
+++ b/packages/playground/remote/vite.config.ts
@@ -15,10 +15,9 @@ import virtualModule from '../../vite-extensions/vite-virtual-module';
 // eslint-disable-next-line @nx/enforce-module-boundaries
 import viteGlobalExtensions from '../../vite-extensions/vite-global-extensions';
 // eslint-disable-next-line @nx/enforce-module-boundaries
-import { resolveIsomorphicGitEsmEntry } from '../../vite-extensions/vite-resolve-isomorphic-git';
+import { getIsomorphicGitViteConfig } from '../../vite-extensions/vite-resolve-isomorphic-git';
 
 const path = (filename: string) => new URL(filename, import.meta.url).pathname;
-const isomorphicGitEsmEntry = resolveIsomorphicGitEsmEntry();
 
 const plugins = [
 	viteTsConfigPaths({
@@ -73,30 +72,7 @@ export default defineConfig(({ mode }) => {
 			'*.zip',
 		],
 		cacheDir: '../../../node_modules/.vite/playground',
-		optimizeDeps: {
-			include: [
-				'async-lock',
-				'buffer',
-				'clean-git-ref',
-				'crc-32',
-				'diff3',
-				'ignore',
-				'ini',
-				'pako',
-				'pify',
-				'sha.js',
-				'sha.js/sha1.js',
-			],
-			exclude: ['isomorphic-git'],
-		},
-		resolve: {
-			alias: [
-				{
-					find: /^isomorphic-git$/,
-					replacement: isomorphicGitEsmEntry,
-				},
-			],
-		},
+		...getIsomorphicGitViteConfig(),
 		// Bundled WordPress files live in a separate dependency-free `wordpress`
 		// package so that every package may use them without causing circular
 		// dependencies.

--- a/packages/playground/storage/vite.config.ts
+++ b/packages/playground/storage/vite.config.ts
@@ -12,6 +12,10 @@ import { viteIgnoreImports } from '../../vite-extensions/vite-ignore-imports';
 import { getExternalModules } from '../../vite-extensions/vite-external-modules';
 // eslint-disable-next-line @nx/enforce-module-boundaries
 import viteGlobalExtensions from '../../vite-extensions/vite-global-extensions';
+// eslint-disable-next-line @nx/enforce-module-boundaries
+import { resolveIsomorphicGitEsmEntry } from '../../vite-extensions/vite-resolve-isomorphic-git';
+
+const isomorphicGitEsmEntry = resolveIsomorphicGitEsmEntry();
 
 export default defineConfig({
 	root: __dirname,
@@ -39,6 +43,15 @@ export default defineConfig({
 		}),
 		...viteGlobalExtensions,
 	],
+
+	resolve: {
+		alias: [
+			{
+				find: /^isomorphic-git$/,
+				replacement: isomorphicGitEsmEntry,
+			},
+		],
+	},
 
 	// Configuration for building your library.
 	// See: https://vitejs.dev/guide/build.html#library-mode

--- a/packages/playground/website-extras/vite.config.ts
+++ b/packages/playground/website-extras/vite.config.ts
@@ -18,6 +18,10 @@ import { buildVersionPlugin } from '../../vite-extensions/vite-build-version';
 import virtualModule from '../../vite-extensions/vite-virtual-module';
 // eslint-disable-next-line @nx/enforce-module-boundaries
 import viteGlobalExtensions from '../../vite-extensions/vite-global-extensions';
+// eslint-disable-next-line @nx/enforce-module-boundaries
+import { resolveIsomorphicGitEsmEntry } from '../../vite-extensions/vite-resolve-isomorphic-git';
+
+const isomorphicGitEsmEntry = resolveIsomorphicGitEsmEntry();
 
 export default defineConfig(({ mode }) => {
 	const corsProxyUrl =
@@ -35,6 +39,30 @@ export default defineConfig(({ mode }) => {
 
 		cacheDir:
 			'../../../node_modules/.vite/packages-playground-website-extras',
+		optimizeDeps: {
+			include: [
+				'async-lock',
+				'buffer',
+				'clean-git-ref',
+				'crc-32',
+				'diff3',
+				'ignore',
+				'ini',
+				'pako',
+				'pify',
+				'sha.js',
+				'sha.js/sha1.js',
+			],
+			exclude: ['isomorphic-git'],
+		},
+		resolve: {
+			alias: [
+				{
+					find: /^isomorphic-git$/,
+					replacement: isomorphicGitEsmEntry,
+				},
+			],
+		},
 
 		css: {
 			modules: {

--- a/packages/playground/website-extras/vite.config.ts
+++ b/packages/playground/website-extras/vite.config.ts
@@ -19,9 +19,7 @@ import virtualModule from '../../vite-extensions/vite-virtual-module';
 // eslint-disable-next-line @nx/enforce-module-boundaries
 import viteGlobalExtensions from '../../vite-extensions/vite-global-extensions';
 // eslint-disable-next-line @nx/enforce-module-boundaries
-import { resolveIsomorphicGitEsmEntry } from '../../vite-extensions/vite-resolve-isomorphic-git';
-
-const isomorphicGitEsmEntry = resolveIsomorphicGitEsmEntry();
+import { getIsomorphicGitViteConfig } from '../../vite-extensions/vite-resolve-isomorphic-git';
 
 export default defineConfig(({ mode }) => {
 	const corsProxyUrl =
@@ -39,30 +37,7 @@ export default defineConfig(({ mode }) => {
 
 		cacheDir:
 			'../../../node_modules/.vite/packages-playground-website-extras',
-		optimizeDeps: {
-			include: [
-				'async-lock',
-				'buffer',
-				'clean-git-ref',
-				'crc-32',
-				'diff3',
-				'ignore',
-				'ini',
-				'pako',
-				'pify',
-				'sha.js',
-				'sha.js/sha1.js',
-			],
-			exclude: ['isomorphic-git'],
-		},
-		resolve: {
-			alias: [
-				{
-					find: /^isomorphic-git$/,
-					replacement: isomorphicGitEsmEntry,
-				},
-			],
-		},
+		...getIsomorphicGitViteConfig(),
 
 		css: {
 			modules: {

--- a/packages/playground/website/playwright/e2e/blueprints.spec.ts
+++ b/packages/playground/website/playwright/e2e/blueprints.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from '../playground-fixtures';
 import type { Blueprint } from '@wp-playground/blueprints';
 import { encodeStringAsBase64 } from '../../src/lib/base64';
+import { startGitFixtureServer } from '../git-fixture-server';
 
 // We can't import the SupportedPHPVersions versions directly from the remote package
 // because of ESModules vs CommonJS incompatibilities. Let's just import the
@@ -20,6 +21,50 @@ test('Base64-encoded Blueprints should work', async ({
 	const encodedBlueprint = encodeStringAsBase64(JSON.stringify(blueprint));
 	await website.goto(`/#${encodedBlueprint}`);
 	await expect(wordpress.locator('body')).toContainText('Dashboard');
+});
+
+test('installPlugin should install a plugin from a git:directory resource', async ({
+	website,
+	wordpress,
+}) => {
+	const gitFixtureServer = await startGitFixtureServer();
+	try {
+		const blueprint: Blueprint = {
+			landingPage: '/wp-admin/plugins.php',
+			steps: [
+				{ step: 'login' },
+				{
+					step: 'installPlugin',
+					pluginData: {
+						resource: 'git:directory',
+						url: `${gitFixtureServer.url}/sample-plugin.git`,
+						ref: 'main',
+						refType: 'branch',
+						path: 'sample-plugin',
+					},
+					options: {
+						activate: true,
+					},
+				},
+			],
+		};
+
+		const encodedBlueprint = encodeStringAsBase64(
+			JSON.stringify(blueprint)
+		);
+		await website.goto(`./?storage=temp#${encodedBlueprint}`);
+		await expect(wordpress.locator('body')).toContainText(
+			'Sample Git Plugin',
+			{
+				timeout: 120000,
+			}
+		);
+		await expect(
+			wordpress.getByLabel('Deactivate Sample Git Plugin')
+		).toHaveText('Deactivate');
+	} finally {
+		await gitFixtureServer.close();
+	}
 });
 
 test('spawning less should work', async ({ website, wordpress }) => {

--- a/packages/playground/website/playwright/fixtures/sample-plugin/sample-plugin.php
+++ b/packages/playground/website/playwright/fixtures/sample-plugin/sample-plugin.php
@@ -1,0 +1,8 @@
+<?php
+/*
+Plugin Name: Sample Git Plugin
+*/
+
+add_action('admin_notices', function () {
+	echo '<div class="notice notice-success"><p>Sample Git Plugin is active.</p></div>';
+});

--- a/packages/playground/website/playwright/git-fixture-server.ts
+++ b/packages/playground/website/playwright/git-fixture-server.ts
@@ -1,4 +1,5 @@
 import { spawn } from 'node:child_process';
+import type { ChildProcessWithoutNullStreams } from 'node:child_process';
 import { cp, mkdir, mkdtemp, rm } from 'node:fs/promises';
 import { createServer } from 'node:http';
 import type { IncomingMessage, Server, ServerResponse } from 'node:http';
@@ -97,10 +98,17 @@ async function handleGitFixtureRequest(
 	}
 
 	const requestBody = await collectStream(req);
+	const gitProtocol = getHeaderValue(req.headers['git-protocol']);
 	const child = spawn('git', ['http-backend'], {
 		env: {
 			...process.env,
 			GIT_HTTP_EXPORT_ALL: '1',
+			...(gitProtocol
+				? {
+						GIT_PROTOCOL: gitProtocol,
+						HTTP_GIT_PROTOCOL: gitProtocol,
+					}
+				: {}),
 			GIT_PROJECT_ROOT: repositoryRoot,
 			PATH_INFO: pathInfo,
 			QUERY_STRING: requestUrl.searchParams.toString(),
@@ -111,40 +119,39 @@ async function handleGitFixtureRequest(
 	});
 
 	child.stdin.end(requestBody);
-	const [stdout, stderr, exitCode] = await Promise.all([
-		collectStream(child.stdout),
-		collectStream(child.stderr),
-		new Promise<number | null>((resolve) =>
-			child.on('close', (code) => resolve(code))
-		),
-	]);
-
-	if (exitCode) {
-		throw new Error(
-			`git http-backend exited with ${exitCode}: ${stderr.toString()}`
-		);
-	}
+	const { stdout } = await runGitProcess(child, 'git http-backend');
 
 	writeCgiResponse(stdout, res);
 }
 
 async function runGit(args: string[], cwd: string) {
 	const child = spawn('git', args, { cwd });
-	const [stdout, stderr, exitCode] = await Promise.all([
+	const { stdout } = await runGitProcess(child, `git ${args.join(' ')}`);
+	return stdout;
+}
+
+async function runGitProcess(
+	child: ChildProcessWithoutNullStreams,
+	command: string
+) {
+	const [stdout, stderr, processResult] = await Promise.all([
 		collectStream(child.stdout),
 		collectStream(child.stderr),
-		new Promise<number | null>((resolve) =>
-			child.on('close', (code) => resolve(code))
-		),
+		waitForProcess(child),
 	]);
 
-	if (exitCode) {
+	if (processResult.code !== 0) {
+		if (processResult.code === null) {
+			throw new Error(
+				`${command} exited with signal ${processResult.signal}`
+			);
+		}
 		throw new Error(
-			`git ${args.join(' ')} exited with ${exitCode}: ${stderr.toString()}`
+			`${command} exited with ${processResult.code}: ${stderr.toString()}`
 		);
 	}
 
-	return stdout;
+	return { stdout, stderr };
 }
 
 function listen(server: Server): Promise<void> {
@@ -166,6 +173,15 @@ function close(server: Server): Promise<void> {
 			}
 			resolve();
 		});
+	});
+}
+
+function waitForProcess(
+	child: ChildProcessWithoutNullStreams
+): Promise<{ code: number | null; signal: NodeJS.Signals | null }> {
+	return new Promise((resolve, reject) => {
+		child.once('error', reject);
+		child.once('close', (code, signal) => resolve({ code, signal }));
 	});
 }
 
@@ -203,6 +219,13 @@ function writeCgiResponse(response: Buffer, res: ServerResponse) {
 	}
 
 	res.end(response.subarray(separatorIndex + separator.length));
+}
+
+function getHeaderValue(header: string | string[] | undefined) {
+	if (Array.isArray(header)) {
+		return header.join(', ');
+	}
+	return header;
 }
 
 function setCorsHeaders(res: ServerResponse) {

--- a/packages/playground/website/playwright/git-fixture-server.ts
+++ b/packages/playground/website/playwright/git-fixture-server.ts
@@ -1,0 +1,215 @@
+import { spawn } from 'node:child_process';
+import { cp, mkdir, mkdtemp, rm } from 'node:fs/promises';
+import { createServer } from 'node:http';
+import type { IncomingMessage, Server, ServerResponse } from 'node:http';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { Readable } from 'node:stream';
+
+export interface GitFixtureServer {
+	url: string;
+	close(): Promise<void>;
+}
+
+export async function startGitFixtureServer(): Promise<GitFixtureServer> {
+	const repositoryRoot = await mkdtemp(join(tmpdir(), 'playground-git-'));
+	await createSamplePluginRepository(repositoryRoot);
+
+	const server = createServer((req, res) => {
+		handleGitFixtureRequest(req, res, repositoryRoot).catch((error) => {
+			if (!res.headersSent) {
+				setCorsHeaders(res);
+				res.statusCode = 500;
+			}
+			res.end(String(error));
+		});
+	});
+
+	try {
+		await listen(server);
+	} catch (error) {
+		await rm(repositoryRoot, { recursive: true, force: true });
+		throw error;
+	}
+
+	const address = server.address();
+	if (!address || typeof address === 'string') {
+		await rm(repositoryRoot, { recursive: true, force: true });
+		throw new Error('Git fixture server did not bind to a TCP port');
+	}
+
+	return {
+		url: `http://127.0.0.1:${address.port}`,
+		close: async () => {
+			await close(server);
+			await rm(repositoryRoot, { recursive: true, force: true });
+		},
+	};
+}
+
+async function createSamplePluginRepository(repositoryRoot: string) {
+	const workTree = join(repositoryRoot, 'sample-plugin-worktree');
+	const pluginDirectory = join(workTree, 'sample-plugin');
+	await mkdir(workTree, { recursive: true });
+	await cp(join(__dirname, 'fixtures/sample-plugin'), pluginDirectory, {
+		recursive: true,
+	});
+
+	await runGit(['init'], workTree);
+	await runGit(['checkout', '-B', 'main'], workTree);
+	await runGit(['add', 'sample-plugin/sample-plugin.php'], workTree);
+	await runGit(
+		[
+			'-c',
+			'user.name=WordPress Playground Tests',
+			'-c',
+			'user.email=playground@example.com',
+			'commit',
+			'-m',
+			'Add sample plugin',
+		],
+		workTree
+	);
+	await runGit(
+		['clone', '--bare', workTree, 'sample-plugin.git'],
+		repositoryRoot
+	);
+}
+
+async function handleGitFixtureRequest(
+	req: IncomingMessage,
+	res: ServerResponse,
+	repositoryRoot: string
+) {
+	setCorsHeaders(res);
+	if (req.method === 'OPTIONS') {
+		res.statusCode = 204;
+		res.end();
+		return;
+	}
+
+	const requestUrl = new URL(req.url || '/', 'http://git-fixture.test');
+	const pathInfo = requestUrl.pathname;
+	if (!pathInfo.startsWith('/') || pathInfo.includes('..')) {
+		res.statusCode = 404;
+		res.end('Not found');
+		return;
+	}
+
+	const requestBody = await collectStream(req);
+	const child = spawn('git', ['http-backend'], {
+		env: {
+			...process.env,
+			GIT_HTTP_EXPORT_ALL: '1',
+			GIT_PROJECT_ROOT: repositoryRoot,
+			PATH_INFO: pathInfo,
+			QUERY_STRING: requestUrl.searchParams.toString(),
+			REQUEST_METHOD: req.method || 'GET',
+			CONTENT_TYPE: String(req.headers['content-type'] || ''),
+			CONTENT_LENGTH: String(requestBody.length),
+		},
+	});
+
+	child.stdin.end(requestBody);
+	const [stdout, stderr, exitCode] = await Promise.all([
+		collectStream(child.stdout),
+		collectStream(child.stderr),
+		new Promise<number | null>((resolve) =>
+			child.on('close', (code) => resolve(code))
+		),
+	]);
+
+	if (exitCode) {
+		throw new Error(
+			`git http-backend exited with ${exitCode}: ${stderr.toString()}`
+		);
+	}
+
+	writeCgiResponse(stdout, res);
+}
+
+async function runGit(args: string[], cwd: string) {
+	const child = spawn('git', args, { cwd });
+	const [stdout, stderr, exitCode] = await Promise.all([
+		collectStream(child.stdout),
+		collectStream(child.stderr),
+		new Promise<number | null>((resolve) =>
+			child.on('close', (code) => resolve(code))
+		),
+	]);
+
+	if (exitCode) {
+		throw new Error(
+			`git ${args.join(' ')} exited with ${exitCode}: ${stderr.toString()}`
+		);
+	}
+
+	return stdout;
+}
+
+function listen(server: Server): Promise<void> {
+	return new Promise((resolve, reject) => {
+		server.once('error', reject);
+		server.listen(0, '127.0.0.1', () => {
+			server.off('error', reject);
+			resolve();
+		});
+	});
+}
+
+function close(server: Server): Promise<void> {
+	return new Promise((resolve, reject) => {
+		server.close((error) => {
+			if (error) {
+				reject(error);
+				return;
+			}
+			resolve();
+		});
+	});
+}
+
+function collectStream(stream: Readable): Promise<Buffer> {
+	const chunks: Buffer[] = [];
+	return new Promise((resolve, reject) => {
+		stream.on('data', (chunk) => chunks.push(Buffer.from(chunk)));
+		stream.on('error', reject);
+		stream.on('end', () => resolve(Buffer.concat(chunks)));
+	});
+}
+
+function writeCgiResponse(response: Buffer, res: ServerResponse) {
+	const separator = response.includes('\r\n\r\n') ? '\r\n\r\n' : '\n\n';
+	const separatorIndex = response.indexOf(separator);
+	if (separatorIndex === -1) {
+		res.statusCode = 500;
+		res.end(response);
+		return;
+	}
+
+	const headerText = response.subarray(0, separatorIndex).toString('utf8');
+	for (const line of headerText.split(/\r?\n/)) {
+		const separatorAt = line.indexOf(':');
+		if (separatorAt === -1) {
+			continue;
+		}
+		const name = line.slice(0, separatorAt);
+		const value = line.slice(separatorAt + 1).trim();
+		if (name.toLowerCase() === 'status') {
+			res.statusCode = parseInt(value, 10);
+		} else {
+			res.setHeader(name, value);
+		}
+	}
+
+	res.end(response.subarray(separatorIndex + separator.length));
+}
+
+function setCorsHeaders(res: ServerResponse) {
+	res.setHeader('Access-Control-Allow-Origin', '*');
+	res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
+	res.setHeader(
+		'Access-Control-Allow-Headers',
+		'authorization, content-type, git-protocol'
+	);
+}

--- a/packages/playground/website/vite.config.ts
+++ b/packages/playground/website/vite.config.ts
@@ -30,6 +30,8 @@ import { listAssetsRequiredForOfflineMode } from '../../vite-extensions/vite-lis
 import virtualModule from '../../vite-extensions/vite-virtual-module';
 // eslint-disable-next-line @nx/enforce-module-boundaries
 import viteGlobalExtensions from '../../vite-extensions/vite-global-extensions';
+// eslint-disable-next-line @nx/enforce-module-boundaries
+import { resolveIsomorphicGitEsmEntry } from '../../vite-extensions/vite-resolve-isomorphic-git';
 import { analyticsInjectionPlugin } from './vite-analytics-plugin';
 
 const exec = promisify(execCb);
@@ -64,6 +66,7 @@ const proxy: CommonServerOptions['proxy'] = {
 };
 
 const path = (filename: string) => new URL(filename, import.meta.url).pathname;
+const isomorphicGitEsmEntry = resolveIsomorphicGitEsmEntry();
 export default defineConfig(({ command, mode }) => {
 	const corsProxyUrl =
 		'CORS_PROXY_URL' in process.env
@@ -83,6 +86,30 @@ export default defineConfig(({ command, mode }) => {
 		assetsInclude: ['**/*.so', '**/*.dat'],
 
 		cacheDir: '../../../node_modules/.vite/packages-playground-website',
+		optimizeDeps: {
+			include: [
+				'async-lock',
+				'buffer',
+				'clean-git-ref',
+				'crc-32',
+				'diff3',
+				'ignore',
+				'ini',
+				'pako',
+				'pify',
+				'sha.js',
+				'sha.js/sha1.js',
+			],
+			exclude: ['isomorphic-git'],
+		},
+		resolve: {
+			alias: [
+				{
+					find: /^isomorphic-git$/,
+					replacement: isomorphicGitEsmEntry,
+				},
+			],
+		},
 
 		css: {
 			modules: {

--- a/packages/playground/website/vite.config.ts
+++ b/packages/playground/website/vite.config.ts
@@ -31,7 +31,7 @@ import virtualModule from '../../vite-extensions/vite-virtual-module';
 // eslint-disable-next-line @nx/enforce-module-boundaries
 import viteGlobalExtensions from '../../vite-extensions/vite-global-extensions';
 // eslint-disable-next-line @nx/enforce-module-boundaries
-import { resolveIsomorphicGitEsmEntry } from '../../vite-extensions/vite-resolve-isomorphic-git';
+import { getIsomorphicGitViteConfig } from '../../vite-extensions/vite-resolve-isomorphic-git';
 import { analyticsInjectionPlugin } from './vite-analytics-plugin';
 
 const exec = promisify(execCb);
@@ -66,7 +66,6 @@ const proxy: CommonServerOptions['proxy'] = {
 };
 
 const path = (filename: string) => new URL(filename, import.meta.url).pathname;
-const isomorphicGitEsmEntry = resolveIsomorphicGitEsmEntry();
 export default defineConfig(({ command, mode }) => {
 	const corsProxyUrl =
 		'CORS_PROXY_URL' in process.env
@@ -86,30 +85,7 @@ export default defineConfig(({ command, mode }) => {
 		assetsInclude: ['**/*.so', '**/*.dat'],
 
 		cacheDir: '../../../node_modules/.vite/packages-playground-website',
-		optimizeDeps: {
-			include: [
-				'async-lock',
-				'buffer',
-				'clean-git-ref',
-				'crc-32',
-				'diff3',
-				'ignore',
-				'ini',
-				'pako',
-				'pify',
-				'sha.js',
-				'sha.js/sha1.js',
-			],
-			exclude: ['isomorphic-git'],
-		},
-		resolve: {
-			alias: [
-				{
-					find: /^isomorphic-git$/,
-					replacement: isomorphicGitEsmEntry,
-				},
-			],
-		},
+		...getIsomorphicGitViteConfig(),
 
 		css: {
 			modules: {

--- a/packages/vite-extensions/vite-resolve-isomorphic-git.ts
+++ b/packages/vite-extensions/vite-resolve-isomorphic-git.ts
@@ -1,8 +1,42 @@
 import { createRequire } from 'node:module';
+import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 
 const require = createRequire(import.meta.url);
 
+interface PackageJson {
+	module?: string;
+	exports?: {
+		'.'?:
+			| string
+			| {
+					import?: string | { default?: string };
+					default?: string;
+			  };
+	};
+}
+
 export function resolveIsomorphicGitEsmEntry() {
-	return join(dirname(require.resolve('isomorphic-git')), 'index.js');
+	const packageRoot = dirname(require.resolve('isomorphic-git'));
+	const packageJson = JSON.parse(
+		readFileSync(join(packageRoot, 'package.json'), 'utf8')
+	) as PackageJson;
+	const entry = getEsmPackageEntry(packageJson);
+	return join(packageRoot, entry);
+}
+
+function getEsmPackageEntry(packageJson: PackageJson) {
+	const rootExport = packageJson.exports?.['.'];
+	if (typeof rootExport === 'object') {
+		if (typeof rootExport.import === 'string') {
+			return rootExport.import;
+		}
+		if (typeof rootExport.import?.default === 'string') {
+			return rootExport.import.default;
+		}
+	}
+	if (packageJson.module) {
+		return packageJson.module;
+	}
+	throw new Error('Could not resolve isomorphic-git ESM entry');
 }

--- a/packages/vite-extensions/vite-resolve-isomorphic-git.ts
+++ b/packages/vite-extensions/vite-resolve-isomorphic-git.ts
@@ -1,0 +1,8 @@
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
+
+const require = createRequire(import.meta.url);
+
+export function resolveIsomorphicGitEsmEntry() {
+	return join(dirname(require.resolve('isomorphic-git')), 'index.js');
+}

--- a/packages/vite-extensions/vite-resolve-isomorphic-git.ts
+++ b/packages/vite-extensions/vite-resolve-isomorphic-git.ts
@@ -6,6 +6,7 @@ const require = createRequire(import.meta.url);
 
 interface PackageJson {
 	module?: string;
+	dependencies?: Record<string, string>;
 	exports?: {
 		'.'?:
 			| string
@@ -16,13 +17,43 @@ interface PackageJson {
 	};
 }
 
+export function getIsomorphicGitViteConfig() {
+	return {
+		optimizeDeps: {
+			include: getIsomorphicGitOptimizeDeps(),
+			exclude: ['isomorphic-git'],
+		},
+		resolve: {
+			alias: [
+				{
+					find: /^isomorphic-git$/,
+					replacement: resolveIsomorphicGitEsmEntry(),
+				},
+			],
+		},
+	};
+}
+
 export function resolveIsomorphicGitEsmEntry() {
+	const { packageJson, packageRoot } = readIsomorphicGitPackage();
+	const entry = getEsmPackageEntry(packageJson);
+	return join(packageRoot, entry);
+}
+
+function getIsomorphicGitOptimizeDeps() {
+	const { packageJson } = readIsomorphicGitPackage();
+	const dependencies = Object.keys(packageJson.dependencies ?? {}).filter(
+		(dependency) => !isNodeOnlyIsomorphicGitDependency(dependency)
+	);
+	return [...dependencies, 'buffer', 'ini', 'sha.js/sha1.js'].sort();
+}
+
+function readIsomorphicGitPackage() {
 	const packageRoot = dirname(require.resolve('isomorphic-git'));
 	const packageJson = JSON.parse(
 		readFileSync(join(packageRoot, 'package.json'), 'utf8')
 	) as PackageJson;
-	const entry = getEsmPackageEntry(packageJson);
-	return join(packageRoot, entry);
+	return { packageJson, packageRoot };
 }
 
 function getEsmPackageEntry(packageJson: PackageJson) {
@@ -39,4 +70,8 @@ function getEsmPackageEntry(packageJson: PackageJson) {
 		return packageJson.module;
 	}
 	throw new Error('Could not resolve isomorphic-git ESM entry');
+}
+
+function isNodeOnlyIsomorphicGitDependency(dependency: string) {
+	return ['minimisted', 'readable-stream', 'simple-get'].includes(dependency);
 }


### PR DESCRIPTION
## Summary

Fixes browser builds that accidentally bundle Node-oriented `isomorphic-git` code, which can pull in `crypto.createHash` and break `git:directory` Blueprint installs in the browser. Errors appear like this:

```
Blueprint failed at step #2: Could not install plugin.
Fw.createHash is not a function
```

- Added a shared Vite helper that resolves the browser ESM entry for `isomorphic-git` through Node package resolution.
- Applied the shared alias across browser-facing packages: website, website-extras, storage, client, remote, and personal-wp.
- Added focused Playwright coverage for installing a plugin from a `git:directory` resource using a tiny local Git HTTP fixture.
- Added a local sample plugin fixture used by the regression test.
- Updated `GitDirectoryResource` so localhost Git URLs bypass the configured CORS proxy, allowing local Git fixtures and local development repos to work without being rejected by the proxy's private-IP protections.
- Added unit coverage for localhost Git URL proxy bypass behavior.

## Impact

`git:directory` Blueprint resources should continue to work in browser builds without bundling Node crypto dependencies. Localhost Git repositories are fetched directly when a CORS proxy is configured, while non-localhost Git URLs still use the proxy when provided.

## Validation

- `npm run format:uncommitted`
- `npx nx run playground-blueprints:test:vite --testFile=resources.spec.ts`
- `npx nx lint playground-blueprints`
- `npx nx typecheck playground-blueprints`
- `NX_SKIP_NX_CACHE=true npx nx build playground-blueprints`
- `npx nx run-many -t lint --projects=playground-website,playground-website-extras,playground-personal-wp,playground-client,playground-remote,playground-storage`
- `npx nx run-many -t typecheck --projects=playground-website,playground-website-extras,playground-personal-wp,playground-client,playground-remote`
- `npx nx lint playground-website`
- `npx nx typecheck playground-website`
- `NX_SKIP_NX_CACHE=true npx nx run-many -t build --projects=playground-storage,playground-client,playground-remote`
- `NX_SKIP_NX_CACHE=true npx nx run-many -t build:standalone --projects=playground-website,playground-website-extras,playground-personal-wp`
- `NX_SKIP_NX_CACHE=true npx nx run playground-website:build:standalone`
- `npx playwright test --config=packages/playground/website/playwright/playwright.config.ts --list --grep "installPlugin should install a plugin from a git:directory resource"`
- Source and built-output scans for stale `isomorphic-git` CJS / Node crypto signatures returned no matches.

Focused browser execution of the new Playwright test was attempted after installing Chromium, but this local container is missing `libatk-1.0.so.0`; `npx playwright install-deps chromium` requires sudo. The test is loadable/listed locally and should run in CI where browser system dependencies are present.
