### PR TITLE
[Blueprints] Remove WXR site options from Blueprint v2 schema

### DIFF
--- a/packages/playground/blueprints/src/lib/v2/wep-1-blueprint-v2-schema/appendix-A-blueprint-v2-schema.ts
+++ b/packages/playground/blueprints/src/lib/v2/wep-1-blueprint-v2-schema/appendix-A-blueprint-v2-schema.ts
@@ -562,12 +562,6 @@ export namespace V2Schema {
 		 */
 		importComments?: boolean;
 
-		/**
-		 * Whether to import site settings from the remote site.
-		 *
-		 * @default false.
-		 */
-		importSiteOptions?: boolean;
 	} & URLMappingConfig;
 
 	type MediaDefinition =


### PR DESCRIPTION
## What

Removes `importSiteOptions` from the local Blueprint v2 WXR content definition. The WordPress-importer plugin doesn't support that so Blueprints don't need to either.

## Testing

| Check | Result |
| --- | --- |
| `npm exec nx run playground-blueprints:typecheck` | Passed |
| `npm exec nx run playground-blueprints:test:vite -- --testFiles=packages/playground/blueprints/src/tests/v2/blueprint-v2-declaration.spec.ts` | Passed |
| `git diff --check` | Passed |

Part of #2592.