### PR TITLE
[Website] Resolve isomorphic-git browser entry without dependency lists

### DIFF
--- a/packages/playground/client/vite.config.ts
+++ b/packages/playground/client/vite.config.ts
@@ -10,6 +10,8 @@ import { viteIgnoreImports } from '../../vite-extensions/vite-ignore-imports';
 import { buildVersionPlugin } from '../../vite-extensions/vite-build-version';
 // eslint-disable-next-line @nx/enforce-module-boundaries
 import viteGlobalExtensions from '../../vite-extensions/vite-global-extensions';
+// eslint-disable-next-line @nx/enforce-module-boundaries
+import { isomorphicGitBrowserAlias } from '../../vite-extensions/vite-resolve-isomorphic-git';
 
 function validateOrigin(origin: string) {
 	try {
@@ -27,10 +29,6 @@ function validateOrigin(origin: string) {
 const additionalRemoteOriginsModulePath = join(
 	__dirname,
 	'src/additional-remote-origins.ts'
-);
-const isomorphicGitEsmEntry = join(
-	__dirname,
-	'../../../node_modules/isomorphic-git/index.js'
 );
 
 export default defineConfig({
@@ -83,12 +81,7 @@ export default defineConfig({
 		},
 	],
 	resolve: {
-		alias: [
-			{
-				find: /^isomorphic-git$/,
-				replacement: isomorphicGitEsmEntry,
-			},
-		],
+		alias: [isomorphicGitBrowserAlias()],
 	},
 
 	// Configuration for building your library.

--- a/packages/playground/personal-wp/vite.config.ts
+++ b/packages/playground/personal-wp/vite.config.ts
@@ -23,12 +23,10 @@ import { listAssetsRequiredForOfflineMode } from '../../vite-extensions/vite-lis
 import virtualModule from '../../vite-extensions/vite-virtual-module';
 // eslint-disable-next-line @nx/enforce-module-boundaries
 import viteGlobalExtensions from '../../vite-extensions/vite-global-extensions';
+// eslint-disable-next-line @nx/enforce-module-boundaries
+import { isomorphicGitBrowserAlias } from '../../vite-extensions/vite-resolve-isomorphic-git';
 
 const personalWPDevServerPort = 5401;
-const isomorphicGitEsmEntry = join(
-	__dirname,
-	'../../../node_modules/isomorphic-git/index.js'
-);
 
 const proxy: CommonServerOptions['proxy'] = {
 	'^/plugin-proxy': {
@@ -67,29 +65,8 @@ export default defineConfig(({ command, mode }) => {
 		assetsInclude: ['**/*.so', '**/*.dat'],
 
 		cacheDir: '../../../node_modules/.vite/packages-playground-personal-wp',
-		optimizeDeps: {
-			include: [
-				'async-lock',
-				'buffer',
-				'clean-git-ref',
-				'crc-32',
-				'diff3',
-				'ignore',
-				'ini',
-				'pako',
-				'pify',
-				'sha.js',
-				'sha.js/sha1.js',
-			],
-			exclude: ['isomorphic-git'],
-		},
 		resolve: {
-			alias: [
-				{
-					find: /^isomorphic-git$/,
-					replacement: isomorphicGitEsmEntry,
-				},
-			],
+			alias: [isomorphicGitBrowserAlias()],
 		},
 
 		css: {

--- a/packages/playground/remote/vite.config.ts
+++ b/packages/playground/remote/vite.config.ts
@@ -14,12 +14,10 @@ import { buildVersionPlugin } from '../../vite-extensions/vite-build-version';
 import virtualModule from '../../vite-extensions/vite-virtual-module';
 // eslint-disable-next-line @nx/enforce-module-boundaries
 import viteGlobalExtensions from '../../vite-extensions/vite-global-extensions';
+// eslint-disable-next-line @nx/enforce-module-boundaries
+import { isomorphicGitBrowserAlias } from '../../vite-extensions/vite-resolve-isomorphic-git';
 
 const path = (filename: string) => new URL(filename, import.meta.url).pathname;
-const isomorphicGitEsmEntry = join(
-	__dirname,
-	'../../../node_modules/isomorphic-git/index.js'
-);
 
 const plugins = [
 	viteTsConfigPaths({
@@ -74,29 +72,8 @@ export default defineConfig(({ mode }) => {
 			'*.zip',
 		],
 		cacheDir: '../../../node_modules/.vite/playground',
-		optimizeDeps: {
-			include: [
-				'async-lock',
-				'buffer',
-				'clean-git-ref',
-				'crc-32',
-				'diff3',
-				'ignore',
-				'ini',
-				'pako',
-				'pify',
-				'sha.js',
-				'sha.js/sha1.js',
-			],
-			exclude: ['isomorphic-git'],
-		},
 		resolve: {
-			alias: [
-				{
-					find: /^isomorphic-git$/,
-					replacement: isomorphicGitEsmEntry,
-				},
-			],
+			alias: [isomorphicGitBrowserAlias()],
 		},
 		// Bundled WordPress files live in a separate dependency-free `wordpress`
 		// package so that every package may use them without causing circular

--- a/packages/playground/storage/vite.config.ts
+++ b/packages/playground/storage/vite.config.ts
@@ -12,12 +12,18 @@ import { viteIgnoreImports } from '../../vite-extensions/vite-ignore-imports';
 import { getExternalModules } from '../../vite-extensions/vite-external-modules';
 // eslint-disable-next-line @nx/enforce-module-boundaries
 import viteGlobalExtensions from '../../vite-extensions/vite-global-extensions';
+// eslint-disable-next-line @nx/enforce-module-boundaries
+import { isomorphicGitBrowserAlias } from '../../vite-extensions/vite-resolve-isomorphic-git';
 
 export default defineConfig({
 	root: __dirname,
 	base: '/',
 
 	cacheDir: '../../../node_modules/.vite/packages-playground-storage',
+
+	resolve: {
+		alias: [isomorphicGitBrowserAlias()],
+	},
 
 	css: {
 		modules: {

--- a/packages/playground/website-extras/vite.config.ts
+++ b/packages/playground/website-extras/vite.config.ts
@@ -18,6 +18,8 @@ import { buildVersionPlugin } from '../../vite-extensions/vite-build-version';
 import virtualModule from '../../vite-extensions/vite-virtual-module';
 // eslint-disable-next-line @nx/enforce-module-boundaries
 import viteGlobalExtensions from '../../vite-extensions/vite-global-extensions';
+// eslint-disable-next-line @nx/enforce-module-boundaries
+import { isomorphicGitBrowserAlias } from '../../vite-extensions/vite-resolve-isomorphic-git';
 
 export default defineConfig(({ mode }) => {
 	const corsProxyUrl =
@@ -35,6 +37,9 @@ export default defineConfig(({ mode }) => {
 
 		cacheDir:
 			'../../../node_modules/.vite/packages-playground-website-extras',
+		resolve: {
+			alias: [isomorphicGitBrowserAlias()],
+		},
 
 		css: {
 			modules: {

--- a/packages/playground/website/playwright/e2e/isomorphic-git-bundle.spec.ts
+++ b/packages/playground/website/playwright/e2e/isomorphic-git-bundle.spec.ts
@@ -1,0 +1,80 @@
+import { test, expect, type Page } from '@playwright/test';
+
+test('browser bundle should not include the isomorphic-git Node crypto path', async ({
+	page,
+}) => {
+	await page.goto('./');
+
+	const bundle = await fetchIsomorphicGitBundle(page);
+
+	expect(bundle.source).not.toContain('createHash');
+	expect(bundle.source).not.toContain('__vite-browser-external');
+
+	if (bundle.sourceMap) {
+		expect(bundle.sourceMap).not.toContain(
+			'node_modules/isomorphic-git/index.cjs'
+		);
+		expect(bundle.sourceMap).not.toContain('browser-external:crypto');
+	}
+});
+
+async function fetchIsomorphicGitBundle(page: Page) {
+	const productionBundle = await fetchProductionIsomorphicGitBundle(page);
+	if (productionBundle) {
+		return productionBundle;
+	}
+	return await fetchDevIsomorphicGitBundle(page);
+}
+
+async function fetchProductionIsomorphicGitBundle(page: Page) {
+	const assetsResponse = await page.request.get(
+		new URL('assets-required-for-offline-mode.json', page.url()).href
+	);
+	if (!assetsResponse.ok()) {
+		return undefined;
+	}
+
+	const assetsText = await assetsResponse.text();
+	if (!assetsText.trim().startsWith('[')) {
+		return undefined;
+	}
+
+	const assets = JSON.parse(assetsText) as string[];
+	const bundlePath = assets.find(
+		(asset) =>
+			asset.startsWith('/assets/isomorphic-git-internals-') &&
+			asset.endsWith('.js')
+	);
+	expect(bundlePath).toBeTruthy();
+
+	const bundleUrl = new URL(bundlePath!.replace(/^\//, ''), page.url()).href;
+	return {
+		source: await fetchText(page, bundleUrl),
+		sourceMap: await fetchOptionalText(page, `${bundleUrl}.map`),
+	};
+}
+
+async function fetchDevIsomorphicGitBundle(page: Page) {
+	const bundleUrl = new URL(
+		'node_modules/.vite/packages-playground-website/deps/isomorphic-git.js',
+		page.url()
+	).href;
+	return {
+		source: await fetchText(page, bundleUrl),
+		sourceMap: await fetchOptionalText(page, `${bundleUrl}.map`),
+	};
+}
+
+async function fetchText(page: Page, url: string) {
+	const response = await page.request.get(url);
+	expect(response.ok()).toBeTruthy();
+	return await response.text();
+}
+
+async function fetchOptionalText(page: Page, url: string) {
+	const response = await page.request.get(url);
+	if (!response.ok()) {
+		return undefined;
+	}
+	return await response.text();
+}

--- a/packages/playground/website/vite.config.ts
+++ b/packages/playground/website/vite.config.ts
@@ -30,6 +30,8 @@ import { listAssetsRequiredForOfflineMode } from '../../vite-extensions/vite-lis
 import virtualModule from '../../vite-extensions/vite-virtual-module';
 // eslint-disable-next-line @nx/enforce-module-boundaries
 import viteGlobalExtensions from '../../vite-extensions/vite-global-extensions';
+// eslint-disable-next-line @nx/enforce-module-boundaries
+import { isomorphicGitBrowserAlias } from '../../vite-extensions/vite-resolve-isomorphic-git';
 import { analyticsInjectionPlugin } from './vite-analytics-plugin';
 
 const exec = promisify(execCb);
@@ -83,6 +85,9 @@ export default defineConfig(({ command, mode }) => {
 		assetsInclude: ['**/*.so', '**/*.dat'],
 
 		cacheDir: '../../../node_modules/.vite/packages-playground-website',
+		resolve: {
+			alias: [isomorphicGitBrowserAlias()],
+		},
 
 		css: {
 			modules: {

--- a/packages/vite-extensions/vite-resolve-isomorphic-git.ts
+++ b/packages/vite-extensions/vite-resolve-isomorphic-git.ts
@@ -21,6 +21,14 @@ type PackageExport =
 			default?: PackageExport;
 	  };
 
+/**
+ * Forces Vite to use the browser ESM entry of isomorphic-git.
+ *
+ * Without this alias, Vite may optimize the package from its Node/CJS entry,
+ * which pulls in Node crypto and breaks browser bundles. Resolve the entry
+ * from package metadata instead of hardcoding the current transitive package
+ * graph.
+ */
 export function isomorphicGitBrowserAlias() {
 	return {
 		find: /^isomorphic-git$/,

--- a/packages/vite-extensions/vite-resolve-isomorphic-git.ts
+++ b/packages/vite-extensions/vite-resolve-isomorphic-git.ts
@@ -22,12 +22,18 @@ type PackageExport =
 	  };
 
 /**
- * Forces Vite to use the browser ESM entry of isomorphic-git.
+ * Forces bare `isomorphic-git` imports to start from the browser ESM entry.
  *
- * Without this alias, Vite may optimize the package from its Node/CJS entry,
- * which pulls in Node crypto and breaks browser bundles. Resolve the entry
- * from package metadata instead of hardcoding the current transitive package
- * graph.
+ * Vite's dependency optimizer may otherwise resolve the package through
+ * `exports["."].default`, which is currently `index.cjs`. That CJS entry
+ * imports Node `crypto`, so browser builds can end up with Vite's
+ * `browser-external:crypto` stub.
+ *
+ * Keep the workaround at the package boundary instead of listing
+ * `isomorphic-git`'s current dependencies in every consumer. Dependencies
+ * such as `crc-32`, `pako`, or `sha.js` are still resolved normally from
+ * `isomorphic-git`'s ESM imports, and any other package that imports those
+ * dependencies gets Vite's normal resolution/optimization behavior.
  */
 export function isomorphicGitBrowserAlias() {
 	return {
@@ -37,6 +43,12 @@ export function isomorphicGitBrowserAlias() {
 }
 
 function resolveIsomorphicGitBrowserEsmEntry() {
+	/**
+	 * `isomorphic-git/package.json` is not exported, and bare
+	 * `require.resolve('isomorphic-git')` intentionally follows the package's
+	 * default CJS entry. Use that resolved file only as an anchor to find the
+	 * package root, then choose the browser ESM entry from package metadata.
+	 */
 	const packageRoot = findPackageRoot(
 		require.resolve('isomorphic-git'),
 		'isomorphic-git'
@@ -93,6 +105,10 @@ function resolvePackageExport(
 		return packageExport;
 	}
 
+	/**
+	 * Do not fall back to `default`: in the current `isomorphic-git` package,
+	 * that is the Node/CJS entry this alias is meant to avoid.
+	 */
 	return (
 		resolvePackageExport(packageExport.browser) ||
 		resolvePackageExport(packageExport.import)

--- a/packages/vite-extensions/vite-resolve-isomorphic-git.ts
+++ b/packages/vite-extensions/vite-resolve-isomorphic-git.ts
@@ -1,6 +1,6 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
-import { dirname, join } from 'node:path';
+import { dirname, isAbsolute, join } from 'node:path';
 
 const require = createRequire(import.meta.url);
 
@@ -55,7 +55,7 @@ function resolveIsomorphicGitBrowserEsmEntry() {
 	);
 	const packageJson = readPackageJson(packageRoot);
 	const entry = getBrowserEsmPackageEntry(packageJson);
-	return join(packageRoot, entry);
+	return resolvePackageEntryPath(packageRoot, entry);
 }
 
 function findPackageRoot(resolvedPath: string, packageName: string) {
@@ -82,11 +82,9 @@ function readPackageJson(packageRoot: string) {
 }
 
 function getBrowserEsmPackageEntry(packageJson: PackageJson): string {
-	if (typeof packageJson.browser === 'string') {
-		return packageJson.browser;
-	}
-
-	const exportEntry = resolvePackageExport(packageJson.exports?.['.']);
+	const exportEntry = resolveBrowserImportPackageExport(
+		packageJson.exports?.['.']
+	);
 	if (exportEntry) {
 		return exportEntry;
 	}
@@ -95,22 +93,56 @@ function getBrowserEsmPackageEntry(packageJson: PackageJson): string {
 		return packageJson.module;
 	}
 
-	throw new Error('Could not resolve isomorphic-git browser ESM entry');
+	if (typeof packageJson.browser === 'string') {
+		return packageJson.browser;
+	}
+
+	throw new Error(
+		'Could not resolve isomorphic-git browser ESM entry from ' +
+			'exports["."].browser, exports["."].import, module, or browser'
+	);
 }
 
-function resolvePackageExport(
+function resolvePackageEntryPath(packageRoot: string, entry: string) {
+	if (isAbsolute(entry)) {
+		throw new Error(
+			`Resolved isomorphic-git browser ESM entry must be relative: ${entry}`
+		);
+	}
+
+	const resolvedEntry = join(packageRoot, entry);
+	if (!existsSync(resolvedEntry)) {
+		throw new Error(
+			`Resolved isomorphic-git browser ESM entry does not exist: ` +
+				`${entry} (${resolvedEntry})`
+		);
+	}
+
+	return resolvedEntry;
+}
+
+function resolveBrowserImportPackageExport(
 	packageExport: PackageExport | undefined
 ): string | undefined {
 	if (!packageExport || typeof packageExport === 'string') {
 		return packageExport;
 	}
 
+	const browserOrImport =
+		resolveBrowserImportPackageExport(packageExport.browser) ||
+		resolveBrowserImportPackageExport(packageExport.import);
+	if (browserOrImport) {
+		return browserOrImport;
+	}
+
 	/**
-	 * Do not fall back to `default`: in the current `isomorphic-git` package,
-	 * that is the Node/CJS entry this alias is meant to avoid.
+	 * The current `isomorphic-git` package uses `default` for its Node/CJS entry.
+	 * Only inspect nested condition objects there; do not accept a string default
+	 * as the browser ESM entry.
 	 */
-	return (
-		resolvePackageExport(packageExport.browser) ||
-		resolvePackageExport(packageExport.import)
-	);
+	if (packageExport.default && typeof packageExport.default !== 'string') {
+		return resolveBrowserImportPackageExport(packageExport.default);
+	}
+
+	return undefined;
 }

--- a/packages/vite-extensions/vite-resolve-isomorphic-git.ts
+++ b/packages/vite-extensions/vite-resolve-isomorphic-git.ts
@@ -1,0 +1,92 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
+
+const require = createRequire(import.meta.url);
+
+interface PackageJson {
+	name?: string;
+	browser?: string | Record<string, string | false>;
+	module?: string;
+	exports?: {
+		'.'?: PackageExport;
+	};
+}
+
+type PackageExport =
+	| string
+	| {
+			browser?: PackageExport;
+			import?: PackageExport;
+			default?: PackageExport;
+	  };
+
+export function isomorphicGitBrowserAlias() {
+	return {
+		find: /^isomorphic-git$/,
+		replacement: resolveIsomorphicGitBrowserEsmEntry(),
+	};
+}
+
+function resolveIsomorphicGitBrowserEsmEntry() {
+	const packageRoot = findPackageRoot(
+		require.resolve('isomorphic-git'),
+		'isomorphic-git'
+	);
+	const packageJson = readPackageJson(packageRoot);
+	const entry = getBrowserEsmPackageEntry(packageJson);
+	return join(packageRoot, entry);
+}
+
+function findPackageRoot(resolvedPath: string, packageName: string) {
+	let directory = dirname(resolvedPath);
+
+	while (directory !== dirname(directory)) {
+		const packageJsonPath = join(directory, 'package.json');
+		if (existsSync(packageJsonPath)) {
+			const packageJson = readPackageJson(directory);
+			if (packageJson.name === packageName) {
+				return directory;
+			}
+		}
+		directory = dirname(directory);
+	}
+
+	throw new Error(`Could not find ${packageName} package root`);
+}
+
+function readPackageJson(packageRoot: string) {
+	return JSON.parse(
+		readFileSync(join(packageRoot, 'package.json'), 'utf8')
+	) as PackageJson;
+}
+
+function getBrowserEsmPackageEntry(packageJson: PackageJson): string {
+	if (typeof packageJson.browser === 'string') {
+		return packageJson.browser;
+	}
+
+	const exportEntry = resolvePackageExport(packageJson.exports?.['.']);
+	if (exportEntry) {
+		return exportEntry;
+	}
+
+	if (packageJson.module) {
+		return packageJson.module;
+	}
+
+	throw new Error('Could not resolve isomorphic-git browser ESM entry');
+}
+
+function resolvePackageExport(
+	packageExport: PackageExport | undefined
+): string | undefined {
+	if (!packageExport || typeof packageExport === 'string') {
+		return packageExport;
+	}
+
+	return (
+		resolvePackageExport(packageExport.browser) ||
+		resolvePackageExport(packageExport.import)
+	);
+}


### PR DESCRIPTION
## What it does

Makes browser-facing Vite configs resolve `isomorphic-git` through its browser ESM entry instead of maintaining a hand-written list of bundled transitive packages.

The PR keeps the existing workaround for Vite's dependency optimizer, but changes the source of truth from this kind of list:

```ts
optimizeDeps: {
	include: ['isomorphic-git > clean-git-ref', 'isomorphic-git > crc-32', ...]
}
```

to one shared alias helper:

```ts
resolve: {
	alias: [isomorphicGitBrowserAlias()],
}
```

## Rationale

The hardcoded package list can drift whenever `isomorphic-git` changes its dependency graph. The actual invariant is narrower: browser bundles must not resolve `isomorphic-git` through the Node/CJS entry that pulls in Node `crypto`.

Resolving the browser ESM entry from `isomorphic-git` package metadata keeps that invariant tied to the installed package instead of duplicating its current internals in Vite configs.

## Testing instructions

* CI. 
* This PR is merged now so confirm this URL doesn't crash:  https://playground.wordpress.net/#%7B%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22git%3Adirectory%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2Fwptrainingteam%2Fdevblog-dataviews-plugin%22%2C%22ref%22%3A%22HEAD%22%2C%22refType%22%3A%22refname%22%7D%7D%5D%7D 