### PR TITLE
[Blueprints] Test Blueprint v2 runtime defaults

### DIFF
--- a/packages/playground/blueprints/src/tests/v2/resolve-runtime-configuration.spec.ts
+++ b/packages/playground/blueprints/src/tests/v2/resolve-runtime-configuration.spec.ts
@@ -1,3 +1,4 @@
+import { StreamedFile } from '@php-wasm/stream-compression';
 import { RecommendedPHPVersion } from '@wp-playground/common';
 import { resolveRuntimeConfiguration } from '../../lib/resolve-runtime-configuration';
 import type { BlueprintBundle } from '../../lib/types';
@@ -36,13 +37,14 @@ describe('Blueprint v2 runtime configuration', () => {
 
 function createBundle(blueprint: BlueprintV2Declaration): BlueprintBundle {
 	return {
-		read(path: string) {
+		async read(path: string) {
 			if (path !== 'blueprint.json') {
 				throw new Error(`Unexpected bundle read: ${path}`);
 			}
-			return Promise.resolve(
-				new File([JSON.stringify(blueprint)], 'blueprint.json')
+			return StreamedFile.fromArrayBuffer(
+				new TextEncoder().encode(JSON.stringify(blueprint)),
+				'blueprint.json'
 			);
 		},
-	} as BlueprintBundle;
+	} satisfies BlueprintBundle;
 }

--- a/packages/playground/blueprints/src/tests/v2/resolve-runtime-configuration.spec.ts
+++ b/packages/playground/blueprints/src/tests/v2/resolve-runtime-configuration.spec.ts
@@ -1,0 +1,48 @@
+import { RecommendedPHPVersion } from '@wp-playground/common';
+import { resolveRuntimeConfiguration } from '../../lib/resolve-runtime-configuration';
+import type { BlueprintBundle } from '../../lib/types';
+import type { BlueprintV2Declaration } from '../../lib/v2/blueprint-v2-declaration';
+
+describe('Blueprint v2 runtime configuration', () => {
+	const expectedDefaults = {
+		phpVersion: RecommendedPHPVersion,
+		wpVersion: 'latest',
+		intl: false,
+		networking: true,
+		constants: {},
+		extraLibraries: [],
+	};
+
+	it('resolves default runtime configuration from a declaration', async () => {
+		const blueprint = {
+			version: 2,
+		} satisfies BlueprintV2Declaration;
+
+		await expect(resolveRuntimeConfiguration(blueprint)).resolves.toEqual(
+			expectedDefaults
+		);
+	});
+
+	it('resolves default runtime configuration from a bundle declaration', async () => {
+		const blueprint = createBundle({
+			version: 2,
+		});
+
+		await expect(resolveRuntimeConfiguration(blueprint)).resolves.toEqual(
+			expectedDefaults
+		);
+	});
+});
+
+function createBundle(blueprint: BlueprintV2Declaration): BlueprintBundle {
+	return {
+		read(path: string) {
+			if (path !== 'blueprint.json') {
+				throw new Error(`Unexpected bundle read: ${path}`);
+			}
+			return Promise.resolve(
+				new File([JSON.stringify(blueprint)], 'blueprint.json')
+			);
+		},
+	} as BlueprintBundle;
+}


### PR DESCRIPTION
## What?
Adds focused tests for the runtime configuration currently returned by `resolveRuntimeConfiguration()` for Blueprint v2 declarations.

The tests cover both direct Blueprint v2 declaration objects and bundled `blueprint.json` declarations.

## Why?
The next stack entries start resolving concrete Blueprint v2 runtime fields. This PR locks in the current default behavior first so follow-up PRs can show one behavior change at a time.

## Testing

- `npm run format:uncommitted`
- `npm exec nx run playground-blueprints:test:vite -- --testFiles=packages/playground/blueprints/src/tests/v2/resolve-runtime-configuration.spec.ts`
- `npm exec nx run playground-blueprints:typecheck`
- `npm exec nx run playground-blueprints:lint`
- `git diff --check`

Part of #2592.