### PR TITLE
[Blueprints] Resolve Blueprint v2 network runtime option

### DIFF
--- a/packages/playground/blueprints/src/lib/resolve-runtime-configuration.ts
+++ b/packages/playground/blueprints/src/lib/resolve-runtime-configuration.ts
@@ -3,6 +3,7 @@ import { BlueprintReflection } from './reflection';
 import type { Blueprint, RuntimeConfiguration } from './types';
 import { compileBlueprintV1 } from './v1/compile';
 import type { BlueprintV1 } from './v1/types';
+import type { BlueprintV2Declaration } from './v2/blueprint-v2-declaration';
 
 export async function resolveRuntimeConfiguration(
 	blueprint: Blueprint
@@ -31,12 +32,17 @@ export async function resolveRuntimeConfiguration(
 			constants: {},
 		};
 	} else {
+		const declaration =
+			reflection.getDeclaration() as BlueprintV2Declaration;
+		const playgroundOptions =
+			declaration.applicationOptions?.['wordpress-playground'];
+
 		// @TODO: actually compute the runtime configuration based on the resolved Blueprint v2
 		return {
 			phpVersion: RecommendedPHPVersion,
 			wpVersion: 'latest',
 			intl: false,
-			networking: true,
+			networking: playgroundOptions?.networkAccess ?? true,
 			constants: {},
 			extraLibraries: [],
 		};

--- a/packages/playground/blueprints/src/lib/resolve-runtime-configuration.ts
+++ b/packages/playground/blueprints/src/lib/resolve-runtime-configuration.ts
@@ -1,6 +1,10 @@
 import { RecommendedPHPVersion } from '@wp-playground/common';
 import { BlueprintReflection } from './reflection';
-import type { Blueprint, RuntimeConfiguration } from './types';
+import type {
+	Blueprint,
+	BlueprintDeclaration,
+	RuntimeConfiguration,
+} from './types';
 import { compileBlueprintV1 } from './v1/compile';
 import type { BlueprintV1 } from './v1/types';
 import type { BlueprintV2Declaration } from './v2/blueprint-v2-declaration';
@@ -32,8 +36,10 @@ export async function resolveRuntimeConfiguration(
 			constants: {},
 		};
 	} else {
-		const declaration =
-			reflection.getDeclaration() as BlueprintV2Declaration;
+		const declaration = reflection.getDeclaration();
+		if (!isBlueprintV2Declaration(declaration)) {
+			throw new Error('Expected a Blueprint v2 declaration.');
+		}
 		const playgroundOptions =
 			declaration.applicationOptions?.['wordpress-playground'];
 
@@ -47,4 +53,10 @@ export async function resolveRuntimeConfiguration(
 			extraLibraries: [],
 		};
 	}
+}
+
+function isBlueprintV2Declaration(
+	declaration: BlueprintDeclaration
+): declaration is BlueprintV2Declaration {
+	return (declaration as { version?: unknown }).version === 2;
 }

--- a/packages/playground/blueprints/src/tests/v2/resolve-runtime-configuration.spec.ts
+++ b/packages/playground/blueprints/src/tests/v2/resolve-runtime-configuration.spec.ts
@@ -33,6 +33,34 @@ describe('Blueprint v2 runtime configuration', () => {
 			expectedDefaults
 		);
 	});
+
+	it('resolves networking from Playground application options', async () => {
+		await expect(
+			resolveRuntimeConfiguration({
+				version: 2,
+				applicationOptions: {
+					'wordpress-playground': {
+						networkAccess: false,
+					},
+				},
+			})
+		).resolves.toMatchObject({
+			networking: false,
+		});
+
+		await expect(
+			resolveRuntimeConfiguration({
+				version: 2,
+				applicationOptions: {
+					'wordpress-playground': {
+						networkAccess: true,
+					},
+				},
+			})
+		).resolves.toMatchObject({
+			networking: true,
+		});
+	});
 });
 
 function createBundle(blueprint: BlueprintV2Declaration): BlueprintBundle {

--- a/packages/playground/blueprints/src/tests/v2/resolve-runtime-configuration.spec.ts
+++ b/packages/playground/blueprints/src/tests/v2/resolve-runtime-configuration.spec.ts
@@ -61,6 +61,19 @@ describe('Blueprint v2 runtime configuration', () => {
 			networking: true,
 		});
 	});
+
+	it('uses the default networking value when network access is omitted', async () => {
+		await expect(
+			resolveRuntimeConfiguration({
+				version: 2,
+				applicationOptions: {
+					'wordpress-playground': {},
+				},
+			})
+		).resolves.toMatchObject({
+			networking: true,
+		});
+	});
 });
 
 function createBundle(blueprint: BlueprintV2Declaration): BlueprintBundle {


### PR DESCRIPTION
## What?
Resolves Blueprint v2 `applicationOptions['wordpress-playground'].networkAccess` into `RuntimeConfiguration.networking`.

When the option is omitted, this preserves the current v2 runtime default.

## Why?
This is the first small piece of connecting Blueprint v2 declarations to existing Playground boot/runtime data flows.

## Testing

- `npm run format:uncommitted`
- `npm exec nx run playground-blueprints:test:vite -- --testFiles=packages/playground/blueprints/src/tests/v2/resolve-runtime-configuration.spec.ts`
- `npm exec nx run playground-blueprints:typecheck`
- `npm exec nx run playground-blueprints:lint`
- `git diff --check`

Part of #2592.