### PR TITLE
[Blueprints] Resolve exact Blueprint v2 PHP versions

### DIFF
--- a/packages/playground/blueprints/src/lib/resolve-runtime-configuration.ts
+++ b/packages/playground/blueprints/src/lib/resolve-runtime-configuration.ts
@@ -1,3 +1,4 @@
+import { AllPHPVersions, type AllPHPVersion } from '@php-wasm/universal';
 import { RecommendedPHPVersion } from '@wp-playground/common';
 import { BlueprintReflection } from './reflection';
 import type {
@@ -45,7 +46,7 @@ export async function resolveRuntimeConfiguration(
 
 		// @TODO: actually compute the runtime configuration based on the resolved Blueprint v2
 		return {
-			phpVersion: RecommendedPHPVersion,
+			phpVersion: resolveV2PHPVersion(declaration),
 			wpVersion: 'latest',
 			intl: false,
 			networking: playgroundOptions?.networkAccess ?? true,
@@ -59,4 +60,23 @@ function isBlueprintV2Declaration(
 	declaration: BlueprintDeclaration
 ): declaration is BlueprintV2Declaration {
 	return (declaration as { version?: unknown }).version === 2;
+}
+
+function resolveV2PHPVersion(
+	declaration: BlueprintV2Declaration
+): AllPHPVersion {
+	if (typeof declaration.phpVersion !== 'string') {
+		return RecommendedPHPVersion;
+	}
+
+	if (
+		(AllPHPVersions as readonly string[]).includes(declaration.phpVersion)
+	) {
+		return declaration.phpVersion as AllPHPVersion;
+	}
+
+	throw new Error(
+		`Unsupported Blueprint v2 PHP version "${declaration.phpVersion}". ` +
+			`Supported versions: ${AllPHPVersions.join(', ')}.`
+	);
 }

--- a/packages/playground/blueprints/src/tests/v2/resolve-runtime-configuration.spec.ts
+++ b/packages/playground/blueprints/src/tests/v2/resolve-runtime-configuration.spec.ts
@@ -74,6 +74,52 @@ describe('Blueprint v2 runtime configuration', () => {
 			networking: true,
 		});
 	});
+
+	it('resolves exact PHP version strings', async () => {
+		await expect(
+			resolveRuntimeConfiguration({
+				version: 2,
+				phpVersion: '8.2',
+			})
+		).resolves.toMatchObject({
+			phpVersion: '8.2',
+		});
+
+		await expect(
+			resolveRuntimeConfiguration({
+				version: 2,
+				phpVersion: 'next',
+			})
+		).resolves.toMatchObject({
+			phpVersion: 'next',
+		});
+	});
+
+	it('uses the default PHP version for constraint objects', async () => {
+		await expect(
+			resolveRuntimeConfiguration({
+				version: 2,
+				phpVersion: {
+					min: '8.1',
+					recommended: '8.2',
+					max: '8.4',
+				},
+			})
+		).resolves.toMatchObject({
+			phpVersion: RecommendedPHPVersion,
+		});
+	});
+
+	it('rejects unsupported PHP version strings', async () => {
+		await expect(
+			resolveRuntimeConfiguration({
+				version: 2,
+				phpVersion: '8.9',
+			} as BlueprintV2Declaration)
+		).rejects.toThrow(
+			'Unsupported Blueprint v2 PHP version "8.9". Supported versions:'
+		);
+	});
 });
 
 function createBundle(blueprint: BlueprintV2Declaration): BlueprintBundle {


### PR DESCRIPTION
## What?
Resolves exact Blueprint v2 `phpVersion` strings into `RuntimeConfiguration.phpVersion`.

Supported examples include concrete bundled versions like `8.2` and the `next` pseudo-version. Constraint-object handling remains unchanged and is left for a later PR.

## Why?
This lets Playground choose the requested PHP runtime for the simple, already-supported Blueprint v2 schema shape without pulling in version-constraint resolution yet.

## Testing

- `npm run format:uncommitted`
- `npm exec nx run playground-blueprints:test:vite -- --testFiles=packages/playground/blueprints/src/tests/v2/resolve-runtime-configuration.spec.ts`
- `npm exec nx run playground-blueprints:typecheck`
- `npm exec nx run playground-blueprints:lint`
- `git diff --check`

Part of #2592.