### PR TITLE
[Blueprints] Resolve simple Blueprint v2 WordPress versions

### DIFF
--- a/packages/playground/blueprints/src/lib/resolve-runtime-configuration.ts
+++ b/packages/playground/blueprints/src/lib/resolve-runtime-configuration.ts
@@ -10,6 +10,10 @@ import { compileBlueprintV1 } from './v1/compile';
 import type { BlueprintV1 } from './v1/types';
 import type { BlueprintV2Declaration } from './v2/blueprint-v2-declaration';
 
+const V2_WORDPRESS_VERSION_LABELS = ['latest', 'beta', 'trunk', 'nightly'];
+const V2_WORDPRESS_VERSION_PATTERN =
+	/^\d+\.\d+(?:\.\d+)?(?:-(?:beta|rc)\d+)?$/i;
+
 export async function resolveRuntimeConfiguration(
 	blueprint: Blueprint
 ): Promise<RuntimeConfiguration> {
@@ -47,7 +51,7 @@ export async function resolveRuntimeConfiguration(
 		// @TODO: actually compute the runtime configuration based on the resolved Blueprint v2
 		return {
 			phpVersion: resolveV2PHPVersion(declaration),
-			wpVersion: 'latest',
+			wpVersion: resolveV2WordPressVersion(declaration),
 			intl: false,
 			networking: playgroundOptions?.networkAccess ?? true,
 			constants: {},
@@ -78,5 +82,25 @@ function resolveV2PHPVersion(
 	throw new Error(
 		`Unsupported Blueprint v2 PHP version "${declaration.phpVersion}". ` +
 			`Supported versions: ${AllPHPVersions.join(', ')}.`
+	);
+}
+
+function resolveV2WordPressVersion(
+	declaration: BlueprintV2Declaration
+): string {
+	if (typeof declaration.wordpressVersion !== 'string') {
+		return 'latest';
+	}
+
+	if (
+		V2_WORDPRESS_VERSION_LABELS.includes(declaration.wordpressVersion) ||
+		V2_WORDPRESS_VERSION_PATTERN.test(declaration.wordpressVersion)
+	) {
+		return declaration.wordpressVersion;
+	}
+
+	throw new Error(
+		`Unsupported Blueprint v2 WordPress version "${declaration.wordpressVersion}". ` +
+			'Use latest, beta, trunk, nightly, or a version like 6.8, 6.8.1, or 6.8-rc1.'
 	);
 }

--- a/packages/playground/blueprints/src/tests/v2/resolve-runtime-configuration.spec.ts
+++ b/packages/playground/blueprints/src/tests/v2/resolve-runtime-configuration.spec.ts
@@ -120,6 +120,52 @@ describe('Blueprint v2 runtime configuration', () => {
 			'Unsupported Blueprint v2 PHP version "8.9". Supported versions:'
 		);
 	});
+
+	it('resolves simple WordPress version strings', async () => {
+		for (const wordpressVersion of [
+			'latest',
+			'6.8',
+			'6.8.1',
+			'6.8-rc1',
+			'beta',
+			'trunk',
+			'nightly',
+		]) {
+			await expect(
+				resolveRuntimeConfiguration({
+					version: 2,
+					wordpressVersion,
+				} as BlueprintV2Declaration)
+			).resolves.toMatchObject({
+				wpVersion: wordpressVersion,
+			});
+		}
+	});
+
+	it('uses the default WordPress version for constraint objects', async () => {
+		await expect(
+			resolveRuntimeConfiguration({
+				version: 2,
+				wordpressVersion: {
+					min: '6.8',
+					preferred: '6.8',
+				},
+			})
+		).resolves.toMatchObject({
+			wpVersion: 'latest',
+		});
+	});
+
+	it('rejects unsupported WordPress version strings', async () => {
+		await expect(
+			resolveRuntimeConfiguration({
+				version: 2,
+				wordpressVersion: 'not-a-version',
+			} as unknown as BlueprintV2Declaration)
+		).rejects.toThrow(
+			'Unsupported Blueprint v2 WordPress version "not-a-version".'
+		);
+	});
 });
 
 function createBundle(blueprint: BlueprintV2Declaration): BlueprintBundle {


### PR DESCRIPTION
## What?
Resolves simple Blueprint v2 `wordpressVersion` strings into `RuntimeConfiguration.wpVersion`.

This covers concrete versions and labels such as `beta`, `trunk`, and `nightly`. Constraint-object handling remains unchanged and stays on the default `latest` behavior for now.

## Why?
This connects another simple Blueprint v2 runtime field to the existing Playground boot data flow while keeping version constraint resolution separate.

## Testing

- `npm run format:uncommitted`
- `npm exec nx run playground-blueprints:test:vite -- --testFiles=packages/playground/blueprints/src/tests/v2/resolve-runtime-configuration.spec.ts`
- `npm exec nx run playground-blueprints:typecheck`
- `npm exec nx run playground-blueprints:lint`
- `git diff --check`

Part of #2592.