### PR TITLE
[Blueprints] Resolve Blueprint v2 runtime constants

### DIFF
--- a/packages/playground/blueprints/src/lib/resolve-runtime-configuration.ts
+++ b/packages/playground/blueprints/src/lib/resolve-runtime-configuration.ts
@@ -54,7 +54,7 @@ export async function resolveRuntimeConfiguration(
 			wpVersion: resolveV2WordPressVersion(declaration),
 			intl: false,
 			networking: playgroundOptions?.networkAccess ?? true,
-			constants: {},
+			constants: declaration.constants ?? {},
 			extraLibraries: [],
 		};
 	}

--- a/packages/playground/blueprints/src/tests/v2/resolve-runtime-configuration.spec.ts
+++ b/packages/playground/blueprints/src/tests/v2/resolve-runtime-configuration.spec.ts
@@ -75,6 +75,23 @@ describe('Blueprint v2 runtime configuration', () => {
 		});
 	});
 
+	it('resolves constants from the declaration', async () => {
+		const constants = {
+			WP_DEBUG: true,
+			WP_ENVIRONMENT_TYPE: 'local',
+			AUTOSAVE_INTERVAL: 120,
+		};
+
+		await expect(
+			resolveRuntimeConfiguration({
+				version: 2,
+				constants,
+			})
+		).resolves.toMatchObject({
+			constants,
+		});
+	});
+
 	it('resolves exact PHP version strings', async () => {
 		await expect(
 			resolveRuntimeConfiguration({


### PR DESCRIPTION
## What

Carries top-level Blueprint v2 `constants` into `resolveRuntimeConfiguration()`.

## Why

Consumers resolve runtime configuration before booting WordPress. If a Blueprint v2 declaration defines constants, stored-site flows need those constants preserved in the runtime configuration instead of silently defaulting to an empty object.

## Testing

- `npm run format:uncommitted`
- `npm exec nx run playground-blueprints:test:vite -- --testFiles=packages/playground/blueprints/src/tests/v2/resolve-runtime-configuration.spec.ts`
- `npm exec nx run playground-blueprints:typecheck`
- `npm exec nx run playground-blueprints:lint`
- `git diff --check`

Part of #2592.