### PR TITLE
[Blueprints] Resolve preferred Blueprint v2 WordPress versions

### DIFF
--- a/packages/playground/blueprints/src/lib/resolve-runtime-configuration.ts
+++ b/packages/playground/blueprints/src/lib/resolve-runtime-configuration.ts
@@ -88,19 +88,47 @@ function resolveV2PHPVersion(
 function resolveV2WordPressVersion(
 	declaration: BlueprintV2Declaration
 ): string {
-	if (typeof declaration.wordpressVersion !== 'string') {
-		return 'latest';
+	const wordpressVersion = declaration.wordpressVersion;
+	if (typeof wordpressVersion === 'string') {
+		return resolveV2WordPressVersionString(wordpressVersion);
 	}
 
+	const preferredVersion =
+		getV2WordPressConstraintPreferredVersion(wordpressVersion);
+	if (preferredVersion) {
+		return resolveV2WordPressVersionString(preferredVersion);
+	}
+
+	return 'latest';
+}
+
+function resolveV2WordPressVersionString(wordpressVersion: string): string {
 	if (
-		V2_WORDPRESS_VERSION_LABELS.includes(declaration.wordpressVersion) ||
-		V2_WORDPRESS_VERSION_PATTERN.test(declaration.wordpressVersion)
+		V2_WORDPRESS_VERSION_LABELS.includes(wordpressVersion) ||
+		V2_WORDPRESS_VERSION_PATTERN.test(wordpressVersion)
 	) {
-		return declaration.wordpressVersion;
+		return wordpressVersion;
 	}
 
 	throw new Error(
-		`Unsupported Blueprint v2 WordPress version "${declaration.wordpressVersion}". ` +
+		`Unsupported Blueprint v2 WordPress version "${wordpressVersion}". ` +
 			'Use latest, beta, trunk, nightly, or a version like 6.8, 6.8.1, or 6.8-rc1.'
 	);
+}
+
+function getV2WordPressConstraintPreferredVersion(
+	wordpressVersion: BlueprintV2Declaration['wordpressVersion']
+): string | undefined {
+	if (!wordpressVersion || typeof wordpressVersion !== 'object') {
+		return undefined;
+	}
+	if (!('min' in wordpressVersion)) {
+		return undefined;
+	}
+	if (!('preferred' in wordpressVersion)) {
+		return undefined;
+	}
+	return typeof wordpressVersion.preferred === 'string'
+		? wordpressVersion.preferred
+		: undefined;
 }

--- a/packages/playground/blueprints/src/tests/v2/resolve-runtime-configuration.spec.ts
+++ b/packages/playground/blueprints/src/tests/v2/resolve-runtime-configuration.spec.ts
@@ -159,13 +159,26 @@ describe('Blueprint v2 runtime configuration', () => {
 		}
 	});
 
-	it('uses the default WordPress version for constraint objects', async () => {
+	it('resolves preferred WordPress versions from constraint objects', async () => {
 		await expect(
 			resolveRuntimeConfiguration({
 				version: 2,
 				wordpressVersion: {
 					min: '6.8',
 					preferred: '6.8',
+				},
+			})
+		).resolves.toMatchObject({
+			wpVersion: '6.8',
+		});
+	});
+
+	it('uses the default WordPress version for constraints without a preferred version', async () => {
+		await expect(
+			resolveRuntimeConfiguration({
+				version: 2,
+				wordpressVersion: {
+					min: '6.8',
 				},
 			})
 		).resolves.toMatchObject({


### PR DESCRIPTION
## What

Uses `wordpressVersion.preferred` from Blueprint v2 constraint objects when resolving runtime configuration. Constraints without a preferred version keep the current `latest` fallback.

## Why

This is a small step toward honoring Blueprint v2 version constraints without adding full constraint solving yet. It lets consumers that already provide an explicit preferred WordPress version get the matching runtime instead of silently booting `latest`.

## Testing

- `npm run format:uncommitted`
- `npm exec nx run playground-blueprints:test:vite -- --testFiles=packages/playground/blueprints/src/tests/v2/resolve-runtime-configuration.spec.ts`
- `npm exec nx run playground-blueprints:typecheck`
- `npm exec nx run playground-blueprints:lint`
- `git diff --check`

Part of #2592.