### PR TITLE
[Blueprints] Resolve recommended Blueprint v2 PHP versions

### DIFF
--- a/packages/playground/blueprints/src/lib/resolve-runtime-configuration.ts
+++ b/packages/playground/blueprints/src/lib/resolve-runtime-configuration.ts
@@ -69,20 +69,41 @@ function isBlueprintV2Declaration(
 function resolveV2PHPVersion(
 	declaration: BlueprintV2Declaration
 ): AllPHPVersion {
-	if (typeof declaration.phpVersion !== 'string') {
-		return RecommendedPHPVersion;
+	const phpVersion = declaration.phpVersion;
+	if (typeof phpVersion === 'string') {
+		return resolveV2PHPVersionString(phpVersion);
 	}
 
-	if (
-		(AllPHPVersions as readonly string[]).includes(declaration.phpVersion)
-	) {
-		return declaration.phpVersion as AllPHPVersion;
+	const recommendedVersion = getV2PHPConstraintRecommendedVersion(phpVersion);
+	if (recommendedVersion) {
+		return resolveV2PHPVersionString(recommendedVersion);
 	}
 
+	return RecommendedPHPVersion;
+}
+
+function resolveV2PHPVersionString(phpVersion: string): AllPHPVersion {
+	if ((AllPHPVersions as readonly string[]).includes(phpVersion)) {
+		return phpVersion as AllPHPVersion;
+	}
 	throw new Error(
-		`Unsupported Blueprint v2 PHP version "${declaration.phpVersion}". ` +
+		`Unsupported Blueprint v2 PHP version "${phpVersion}". ` +
 			`Supported versions: ${AllPHPVersions.join(', ')}.`
 	);
+}
+
+function getV2PHPConstraintRecommendedVersion(
+	phpVersion: BlueprintV2Declaration['phpVersion']
+): string | undefined {
+	if (!phpVersion || typeof phpVersion !== 'object') {
+		return undefined;
+	}
+	if (!('recommended' in phpVersion)) {
+		return undefined;
+	}
+	return typeof phpVersion.recommended === 'string'
+		? phpVersion.recommended
+		: undefined;
 }
 
 function resolveV2WordPressVersion(

--- a/packages/playground/blueprints/src/tests/v2/resolve-runtime-configuration.spec.ts
+++ b/packages/playground/blueprints/src/tests/v2/resolve-runtime-configuration.spec.ts
@@ -112,13 +112,27 @@ describe('Blueprint v2 runtime configuration', () => {
 		});
 	});
 
-	it('uses the default PHP version for constraint objects', async () => {
+	it('resolves recommended PHP versions from constraint objects', async () => {
 		await expect(
 			resolveRuntimeConfiguration({
 				version: 2,
 				phpVersion: {
 					min: '8.1',
 					recommended: '8.2',
+					max: '8.4',
+				},
+			})
+		).resolves.toMatchObject({
+			phpVersion: '8.2',
+		});
+	});
+
+	it('uses the default PHP version for constraints without a recommended version', async () => {
+		await expect(
+			resolveRuntimeConfiguration({
+				version: 2,
+				phpVersion: {
+					min: '8.1',
 					max: '8.4',
 				},
 			})


### PR DESCRIPTION
## What

Uses `phpVersion.recommended` from Blueprint v2 PHP constraint objects when resolving `RuntimeConfiguration.phpVersion`. Constraints without a recommended version keep the current default behavior.

## Why

Blueprint v2 already lets callers express a preferred PHP version inside a constraint object. This lets Playground honor that explicit runtime choice without adding full constraint solving yet.

## Testing

- `npm run format:uncommitted`
- `npm exec nx run playground-blueprints:test:vite -- --testFiles=packages/playground/blueprints/src/tests/v2/resolve-runtime-configuration.spec.ts`
- `npm exec nx run playground-blueprints:typecheck`
- `npm exec nx run playground-blueprints:lint`
- `git diff --check`

Part of #2592.