### PR TITLE
[Blueprints] Resolve latest Blueprint v2 PHP label

### DIFF
--- a/packages/playground/blueprints/src/lib/resolve-runtime-configuration.ts
+++ b/packages/playground/blueprints/src/lib/resolve-runtime-configuration.ts
@@ -1,4 +1,8 @@
-import { AllPHPVersions, type AllPHPVersion } from '@php-wasm/universal';
+import {
+	AllPHPVersions,
+	LatestSupportedPHPVersion,
+	type AllPHPVersion,
+} from '@php-wasm/universal';
 import { RecommendedPHPVersion } from '@wp-playground/common';
 import { BlueprintReflection } from './reflection';
 import type {
@@ -83,6 +87,9 @@ function resolveV2PHPVersion(
 }
 
 function resolveV2PHPVersionString(phpVersion: string): AllPHPVersion {
+	if (phpVersion === 'latest') {
+		return LatestSupportedPHPVersion;
+	}
 	if ((AllPHPVersions as readonly string[]).includes(phpVersion)) {
 		return phpVersion as AllPHPVersion;
 	}

--- a/packages/playground/blueprints/src/tests/v2/resolve-runtime-configuration.spec.ts
+++ b/packages/playground/blueprints/src/tests/v2/resolve-runtime-configuration.spec.ts
@@ -1,4 +1,5 @@
 import { StreamedFile } from '@php-wasm/stream-compression';
+import { LatestSupportedPHPVersion } from '@php-wasm/universal';
 import { RecommendedPHPVersion } from '@wp-playground/common';
 import { resolveRuntimeConfiguration } from '../../lib/resolve-runtime-configuration';
 import type { BlueprintBundle } from '../../lib/types';
@@ -109,6 +110,17 @@ describe('Blueprint v2 runtime configuration', () => {
 			})
 		).resolves.toMatchObject({
 			phpVersion: 'next',
+		});
+	});
+
+	it('resolves the latest PHP version label', async () => {
+		await expect(
+			resolveRuntimeConfiguration({
+				version: 2,
+				phpVersion: 'latest',
+			})
+		).resolves.toMatchObject({
+			phpVersion: LatestSupportedPHPVersion,
 		});
 	});
 


### PR DESCRIPTION
## What

Maps Blueprint v2 `phpVersion: "latest"` to `LatestSupportedPHPVersion` when resolving runtime configuration.

## Why

The Blueprint v2 schema allows the `latest` PHP label, but Playground runtime configuration needs a concrete PHP wasm build id. This keeps the schema-supported label usable without passing `latest` through as an unsupported runtime version.

## Testing

- `npm run format:uncommitted`
- `npm exec nx run playground-blueprints:test:vite -- --testFiles=packages/playground/blueprints/src/tests/v2/resolve-runtime-configuration.spec.ts`
- `npm exec nx run playground-blueprints:typecheck`
- `npm exec nx run playground-blueprints:lint`
- `git diff --check`

Part of #2592.