### PR TITLE
[Blueprints] Resolve Blueprint v2 PHP version constraints

### DIFF
--- a/packages/playground/blueprints/src/lib/resolve-runtime-configuration.ts
+++ b/packages/playground/blueprints/src/lib/resolve-runtime-configuration.ts
@@ -17,6 +17,9 @@ import type { BlueprintV2Declaration } from './v2/blueprint-v2-declaration';
 const V2_WORDPRESS_VERSION_LABELS = ['latest', 'beta', 'trunk', 'nightly'];
 const V2_WORDPRESS_VERSION_PATTERN =
 	/^\d+\.\d+(?:\.\d+)?(?:-(?:beta|rc)\d+)?$/i;
+const V2_PHP_CONSTRAINT_CANDIDATES = AllPHPVersions.filter(
+	(phpVersion) => phpVersion !== 'next'
+) as AllPHPVersion[];
 
 export async function resolveRuntimeConfiguration(
 	blueprint: Blueprint
@@ -83,6 +86,11 @@ function resolveV2PHPVersion(
 		return resolveV2PHPVersionString(recommendedVersion);
 	}
 
+	const constrainedVersion = resolveV2PHPConstraintVersion(phpVersion);
+	if (constrainedVersion) {
+		return constrainedVersion;
+	}
+
 	return RecommendedPHPVersion;
 }
 
@@ -111,6 +119,66 @@ function getV2PHPConstraintRecommendedVersion(
 	return typeof phpVersion.recommended === 'string'
 		? phpVersion.recommended
 		: undefined;
+}
+
+function resolveV2PHPConstraintVersion(
+	phpVersion: BlueprintV2Declaration['phpVersion']
+): AllPHPVersion | undefined {
+	if (!phpVersion || typeof phpVersion !== 'object') {
+		return undefined;
+	}
+	if (isV2PHPVersionWithinConstraints(RecommendedPHPVersion, phpVersion)) {
+		return RecommendedPHPVersion;
+	}
+	return V2_PHP_CONSTRAINT_CANDIDATES.find((candidate) =>
+		isV2PHPVersionWithinConstraints(candidate, phpVersion)
+	);
+}
+
+function isV2PHPVersionWithinConstraints(
+	phpVersion: AllPHPVersion,
+	constraints: Exclude<BlueprintV2Declaration['phpVersion'], string>
+): boolean {
+	if (phpVersion === 'next') {
+		return false;
+	}
+	const minVersion = normalizeV2PHPConstraintVersion(constraints?.min);
+	if (minVersion && comparePHPVersions(phpVersion, minVersion) < 0) {
+		return false;
+	}
+	const maxVersion = normalizeV2PHPConstraintVersion(constraints?.max);
+	if (maxVersion && comparePHPVersions(phpVersion, maxVersion) > 0) {
+		return false;
+	}
+	return true;
+}
+
+function normalizeV2PHPConstraintVersion(
+	phpVersion: string | undefined
+): string | undefined {
+	if (phpVersion === 'latest') {
+		return LatestSupportedPHPVersion;
+	}
+	return phpVersion;
+}
+
+function comparePHPVersions(left: string, right: string): number {
+	const leftParts = parsePHPVersion(left);
+	const rightParts = parsePHPVersion(right);
+	for (let i = 0; i < 3; i++) {
+		const difference = leftParts[i] - rightParts[i];
+		if (difference !== 0) {
+			return difference;
+		}
+	}
+	return 0;
+}
+
+function parsePHPVersion(phpVersion: string): [number, number, number] {
+	const [major = 0, minor = 0, patch = 0] = phpVersion
+		.split('.')
+		.map((part) => Number(part));
+	return [major, minor, patch];
 }
 
 function resolveV2WordPressVersion(

--- a/packages/playground/blueprints/src/tests/v2/resolve-runtime-configuration.spec.ts
+++ b/packages/playground/blueprints/src/tests/v2/resolve-runtime-configuration.spec.ts
@@ -153,6 +153,32 @@ describe('Blueprint v2 runtime configuration', () => {
 		});
 	});
 
+	it('uses the highest supported PHP version matching version constraints', async () => {
+		await expect(
+			resolveRuntimeConfiguration({
+				version: 2,
+				phpVersion: {
+					min: LatestSupportedPHPVersion,
+				},
+			})
+		).resolves.toMatchObject({
+			phpVersion: LatestSupportedPHPVersion,
+		});
+	});
+
+	it('uses a lower supported PHP version when max excludes the default', async () => {
+		await expect(
+			resolveRuntimeConfiguration({
+				version: 2,
+				phpVersion: {
+					max: '8.2',
+				},
+			})
+		).resolves.toMatchObject({
+			phpVersion: '8.2',
+		});
+	});
+
 	it('rejects unsupported PHP version strings', async () => {
 		await expect(
 			resolveRuntimeConfiguration({


### PR DESCRIPTION
## What

When a Blueprint v2 PHP constraint object has no `recommended` version, resolves a concrete PHP runtime from `min`/`max` bounds:

- keeps `RecommendedPHPVersion` when it satisfies the bounds
- otherwise selects the highest concrete supported PHP version that satisfies them

## Why

This makes constraint objects meaningful even when they omit `recommended`, while still avoiding full validation/error behavior for unsatisfiable constraints in this slice.

## Testing

- `npm run format:uncommitted`
- `npm exec nx run playground-blueprints:test:vite -- --testFiles=packages/playground/blueprints/src/tests/v2/resolve-runtime-configuration.spec.ts`
- `npm exec nx run playground-blueprints:typecheck`
- `npm exec nx run playground-blueprints:lint`
- `git diff --check`

Part of #2592.