### PR TITLE
[Blueprints] Reject unsatisfied Blueprint v2 PHP constraints

### DIFF
--- a/packages/playground/blueprints/src/lib/resolve-runtime-configuration.ts
+++ b/packages/playground/blueprints/src/lib/resolve-runtime-configuration.ts
@@ -90,6 +90,13 @@ function resolveV2PHPVersion(
 	if (constrainedVersion) {
 		return constrainedVersion;
 	}
+	if (phpVersion && typeof phpVersion === 'object') {
+		throw new Error(
+			`Unsatisfiable Blueprint v2 PHP version constraints ` +
+				`${JSON.stringify(phpVersion)}. ` +
+				`Supported versions: ${AllPHPVersions.join(', ')}.`
+		);
+	}
 
 	return RecommendedPHPVersion;
 }

--- a/packages/playground/blueprints/src/tests/v2/resolve-runtime-configuration.spec.ts
+++ b/packages/playground/blueprints/src/tests/v2/resolve-runtime-configuration.spec.ts
@@ -190,6 +190,20 @@ describe('Blueprint v2 runtime configuration', () => {
 		);
 	});
 
+	it('rejects unsatisfied PHP version constraints', async () => {
+		await expect(
+			resolveRuntimeConfiguration({
+				version: 2,
+				phpVersion: {
+					min: '8.5',
+					max: '8.4',
+				},
+			})
+		).rejects.toThrow(
+			'Unsatisfiable Blueprint v2 PHP version constraints {"min":"8.5","max":"8.4"}. Supported versions:'
+		);
+	});
+
 	it('resolves simple WordPress version strings', async () => {
 		for (const wordpressVersion of [
 			'latest',


### PR DESCRIPTION
## What

Throws a clear error when a Blueprint v2 PHP constraint object cannot match any supported Playground PHP runtime.

## Why

After resolving `min`/`max` constraints, falling back to the default PHP version would hide invalid or unsatisfiable constraints. This keeps runtime resolution honest before booting WordPress.

## Testing

- `npm run format:uncommitted`
- `npm exec nx run playground-blueprints:test:vite -- --testFiles=packages/playground/blueprints/src/tests/v2/resolve-runtime-configuration.spec.ts`
- `npm exec nx run playground-blueprints:typecheck`
- `npm exec nx run playground-blueprints:lint`
- `git diff --check`

Part of #2592.