### PR TITLE
[Blueprints] Support bundled Blueprints in execution compile facade

### DIFF
--- a/packages/playground/blueprints/src/lib/compile.ts
+++ b/packages/playground/blueprints/src/lib/compile.ts
@@ -1,9 +1,10 @@
 import type { UniversalPHP } from '@php-wasm/universal';
-import type { BlueprintDeclaration } from './types';
+import type { BlueprintBundle, BlueprintDeclaration } from './types';
 import {
 	compileBlueprintV1,
 	type CompileBlueprintV1Options,
 	type CompiledBlueprintV1,
+	getBlueprintDeclaration,
 } from './v1/compile';
 import type { BlueprintV1Declaration } from './v1/types';
 
@@ -16,11 +17,10 @@ export type CompiledBlueprintForExecution = {
 	run: (playground: UniversalPHP) => Promise<void>;
 };
 
-export interface CompileBlueprintForExecutionOptions
-	extends Omit<
-		CompileBlueprintV1Options,
-		'onBlueprintValidated' | 'streamBundledFile'
-	> {
+export interface CompileBlueprintForExecutionOptions extends Omit<
+	CompileBlueprintV1Options,
+	'onBlueprintValidated' | 'streamBundledFile'
+> {
 	onBlueprintValidated?: (blueprint: BlueprintDeclaration) => void;
 }
 
@@ -32,10 +32,11 @@ export interface CompileBlueprintForExecutionOptions
  * newer callers can migrate to as Blueprint v2 support grows.
  */
 export async function compileBlueprintForExecution(
-	declaration: BlueprintV1Declaration,
+	input: BlueprintV1Declaration | BlueprintBundle,
 	options: CompileBlueprintForExecutionOptions = {}
 ): Promise<CompiledBlueprintForExecution> {
-	const compiled = await compileBlueprintV1(declaration, {
+	const declaration = await getBlueprintDeclaration(input);
+	const compiled = await compileBlueprintV1(input, {
 		...options,
 		onBlueprintValidated: options.onBlueprintValidated as
 			| CompileBlueprintV1Options['onBlueprintValidated']

--- a/packages/playground/blueprints/src/tests/compile.spec.ts
+++ b/packages/playground/blueprints/src/tests/compile.spec.ts
@@ -1,3 +1,5 @@
+import { InMemoryFilesystem } from '@wp-playground/storage';
+import { vi } from 'vitest';
 import { compileBlueprintForExecution } from '../lib/compile';
 import type { BlueprintV1Declaration } from '../lib/v1/types';
 
@@ -18,5 +20,49 @@ describe('compileBlueprintForExecution', () => {
 		expect(compiled.declaration).toBe(declaration);
 		expect(compiled.compiled).toHaveProperty('versions');
 		expect(compiled.run).toBe(compiled.compiled.run);
+	});
+
+	it('compiles Blueprint v1 bundles with bundled resources', async () => {
+		const bundle = new InMemoryFilesystem({
+			'message.txt': 'Hello from a bundled file.',
+			'blueprint.json': JSON.stringify({
+				steps: [
+					{
+						step: 'writeFile',
+						path: '/message.txt',
+						data: {
+							resource: 'bundled',
+							path: 'message.txt',
+						},
+					},
+				],
+			}),
+		});
+		const playground = {
+			writeFile: vi.fn(),
+		};
+
+		const compiled = await compileBlueprintForExecution(bundle);
+		await compiled.run(playground as any);
+
+		expect(compiled.version).toBe(1);
+		expect(compiled.declaration).toEqual({
+			steps: [
+				{
+					step: 'writeFile',
+					path: '/message.txt',
+					data: {
+						resource: 'bundled',
+						path: 'message.txt',
+					},
+				},
+			],
+		});
+		expect(playground.writeFile).toHaveBeenCalledTimes(1);
+		const [path, data] = playground.writeFile.mock.calls[0];
+		expect(path).toBe('/message.txt');
+		expect(await new File([data], 'message.txt').text()).toBe(
+			'Hello from a bundled file.'
+		);
 	});
 });


### PR DESCRIPTION
## What

Allows `compileBlueprintForExecution()` to accept Blueprint bundles, not just parsed v1 declarations.

## Why

Blueprint consumers may receive a full bundle with `blueprint.json` plus local resources. The new execution compile facade should preserve that input path so bundled resource steps continue to work before later Blueprint v2 routing is added.

## Testing

- `npm run format:uncommitted`
- `npm exec nx run playground-blueprints:test:vite -- --testFiles=packages/playground/blueprints/src/tests/compile.spec.ts`
- `npm exec nx run playground-blueprints:typecheck`
- `npm exec nx run playground-blueprints:lint`
- `git diff --check`

Part of #2592.