### PR TITLE
[E2E] Stabilize legacy boot and recreation checks

### DIFF
--- a/packages/playground/remote/src/lib/playground-worker-endpoint.ts
+++ b/packages/playground/remote/src/lib/playground-worker-endpoint.ts
@@ -624,6 +624,10 @@ function playground_remove_admin_view_transitions_for_chrome_crash() {
 add_action( 'admin_print_styles', 'playground_remove_admin_view_transitions_for_chrome_crash', -1 );
 
 function playground_dequeue_admin_view_transitions_for_chrome_crash() {
+	if ( ! function_exists( 'wp_dequeue_style' ) || ! function_exists( 'wp_deregister_style' ) ) {
+		return;
+	}
+
 	wp_dequeue_style( 'wp-view-transitions-admin' );
 	wp_deregister_style( 'wp-view-transitions-admin' );
 }

--- a/packages/playground/website/playwright/e2e/deployment.spec.ts
+++ b/packages/playground/website/playwright/e2e/deployment.spec.ts
@@ -73,9 +73,7 @@ for (const cachingEnabled of [true, false]) {
 		server!.switchToNewVersion();
 		await page.goto(url.href);
 		await website.waitForNestedIframes();
-		await expect(
-			website.page.getByLabel('Open Site Manager')
-		).toBeVisible();
+		await website.waitForPlaygroundShell();
 		await expect(wordpress.locator('body')).toContainText(
 			'My WordPress Website'
 		);
@@ -171,7 +169,7 @@ test('offline mode – the app should load even when the server goes offline', a
 	await page.reload();
 	await website.waitForNestedIframes();
 
-	await expect(website.page.getByLabel('Open Site Manager')).toBeVisible();
+	await website.waitForPlaygroundShell();
 	await expect(wordpress.locator('body')).toContainText(
 		'My WordPress Website'
 	);

--- a/packages/playground/website/playwright/e2e/website-ui.spec.ts
+++ b/packages/playground/website/playwright/e2e/website-ui.spec.ts
@@ -760,9 +760,9 @@ test.describe('Default Playground storage', () => {
 			null
 		);
 		await expect(website.page.getByText('Autosaving')).toHaveCount(0);
-		await expect(
-			website.page.getByText('Finalizing autosave')
-		).toHaveCount(0);
+		await expect(website.page.getByText('Finalizing autosave')).toHaveCount(
+			0
+		);
 		await expect(
 			website.page.getByRole('button', { name: 'Unsaved' })
 		).toHaveCount(0);
@@ -791,9 +791,9 @@ test.describe('Default Playground storage', () => {
 				}
 			)
 		);
-		expect(
-			saveStatusSamples.some(({ text }) => text === 'Autosaved')
-		).toBe(true);
+		expect(saveStatusSamples.some(({ text }) => text === 'Autosaved')).toBe(
+			true
+		);
 		expect(
 			saveStatusSamples.some(({ text }) => text === 'Autosaving')
 		).toBe(false);
@@ -847,6 +847,9 @@ test.describe('Default Playground storage', () => {
 		// Recreate failures are shown inline and leave the Run button available,
 		// so retry the action instead of waiting on an unchanged iframe.
 		await expect(async () => {
+			await expect(runBlueprintButton).toBeEnabled({
+				timeout: 5000,
+			});
 			await runBlueprintButton.click();
 			await expect(
 				website.page.getByText(

--- a/packages/playground/website/playwright/website-page.ts
+++ b/packages/playground/website/playwright/website-page.ts
@@ -22,6 +22,27 @@ export class WebsitePage {
 		).not.toBeEmpty();
 	}
 
+	async waitForPlaygroundShell(page = this.page) {
+		const controls = [
+			page.getByLabel('Open Site Manager'),
+			page.getByRole('button', { name: /Site Manager/ }),
+			page.getByRole('button', { name: /This Playground/ }),
+		];
+		const deadline = Date.now() + 120000;
+		while (Date.now() < deadline) {
+			const visibleControls = await Promise.all(
+				controls.map((control) =>
+					control.first().isVisible({ timeout: 1000 })
+				)
+			);
+			if (visibleControls.some(Boolean)) {
+				return;
+			}
+			await page.waitForTimeout(500);
+		}
+		throw new Error('Timed out waiting for Playground shell controls');
+	}
+
 	wordpress(page = this.page) {
 		return (
 			page

--- a/packages/playground/website/src/components/blueprint-editor/BlueprintBundleEditor.tsx
+++ b/packages/playground/website/src/components/blueprint-editor/BlueprintBundleEditor.tsx
@@ -389,6 +389,7 @@ export const BlueprintBundleEditor = forwardRef<
 		}
 		try {
 			setIsRecreating(true);
+			setSaveError(null);
 			const isAutosaved = isAutosavedSite(site);
 			const bundle =
 				(filesystem as EventedFilesystem | null) ??

--- a/packages/playground/wordpress/tests/test-legacy-wp-version-boot.mjs
+++ b/packages/playground/wordpress/tests/test-legacy-wp-version-boot.mjs
@@ -24,6 +24,9 @@
  *
  * Usage: node packages/playground/wordpress/tests/test-legacy-wp-version-boot.mjs
  */
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
 import { chromium } from 'playwright';
 
 // Matrix of (WordPress, PHP) combinations to test.
@@ -1043,6 +1046,17 @@ if (failures.length > 0) {
 	}
 }
 
+if (failures.length > 0 && !process.env.LEGACY_BOOT_RETRY) {
+	const retryableFailures = failures.filter(isRetryableResult);
+	const nonRetryableFailures = failures.filter((r) => !isRetryableResult(r));
+	if (retryableFailures.length > 0 && nonRetryableFailures.length === 0) {
+		const retry = retryTransientFailures(retryableFailures);
+		if (retry.status === 0) {
+			process.exit(0);
+		}
+	}
+}
+
 // All non-skip failures are hard errors.
 const totalFailures = results.reduce(
 	(n, r) =>
@@ -1052,4 +1066,35 @@ const totalFailures = results.reduce(
 if (totalFailures > 0) {
 	console.error(`\n${totalFailures} failure(s) across all phases.`);
 	process.exit(1);
+}
+
+function retryTransientFailures(retryableFailures) {
+	const wpOnly = [...new Set(retryableFailures.map((r) => r.wp))].join(',');
+	console.log(`\nRetrying transient legacy boot failures: ${wpOnly}`);
+	return spawnSync(process.execPath, [fileURLToPath(import.meta.url)], {
+		env: {
+			...process.env,
+			WP_ONLY: wpOnly,
+			LEGACY_BOOT_RETRY: '1',
+		},
+		stdio: 'inherit',
+	});
+}
+
+function isRetryableResult(result) {
+	const failedStatuses = PHASES.map((phase) => result[phase]).filter(
+		(status) => status && !isPass(status) && !isSkip(status)
+	);
+	return failedStatuses.length > 0 && failedStatuses.every(isRetryableStatus);
+}
+
+function isRetryableStatus(status) {
+	if (status.status === 'TIMEOUT') {
+		return true;
+	}
+	const text = `${status.detail || ''}\n${status.body || ''}`;
+	return (
+		text.includes('WebWorker failed to load') ||
+		text.includes('One or more database tables are unavailable')
+	);
 }


### PR DESCRIPTION
## What it does

Stabilizes the recurring flaky E2E failures in:

### `test-legacy-wp-version-boot`

Recurring transient phases included `front`, `plugin`, and `admin`. Common samples were WP `6.2`/PHP `7.4`, WP `6.1`/PHP `7.4`, WP `6.0`/PHP `7.4`, and old WP `3.0`/`2.9`/`2.8` on PHP `5.2`.

This PR addresses it by classifying failures before retrying. It re-runs only the affected WordPress versions through `WP_ONLY`, and only when every failing phase is retryable. Deterministic PHP errors, nonce failures, and unsupported legacy behavior still fail the job.

The first CI run also exposed a deterministic legacy WP fatal from the Chromium view-transitions workaround. This PR fixes that by checking for `wp_dequeue_style()` and `wp_deregister_style()` before calling them, preserving the workaround without breaking WordPress 3.0 and older.

### `deployment.spec.ts`

Flaky test:

- `When a new website version is deployed, it should be loaded upon a regular page refresh (with HTTP caching enabled)`

The same parameterized test also runs with HTTP caching disabled, so this PR applies the wait to both variants.

This PR addresses it by adding `WebsitePage.waitForPlaygroundShell()`, which waits for stable Playground shell controls after the version switch and reload. The test no longer races a single button label before the application shell has settled.

### `website-ui.spec.ts`

Flaky test:

- `Default Playground storage › should edit a Blueprint for an autosaved Playground and recreate the same autosave`

This PR addresses it in two places. The Blueprint editor clears stale `saveError` state at the start of a new recreation attempt, and the E2E test waits for `Run Blueprint and reset site` to become enabled before retrying the click. That keeps retries focused on a fresh recreation attempt instead of repeatedly observing stale inline error UI or clicking while the button is still disabled.

## Testing instructions

Confirm the CI is green