### PR TITLE
[Blueprints] Add Blueprint execution compile facade

### DIFF
--- a/packages/playground/blueprints/src/index.ts
+++ b/packages/playground/blueprints/src/index.ts
@@ -74,6 +74,12 @@ export {
 export type { ResolveRemoteBlueprintOptions } from './lib/resolve-remote-blueprint';
 export { wpContentFilesExcludedFromExport } from './lib/utils/wp-content-files-excluded-from-exports';
 export { resolveRuntimeConfiguration } from './lib/resolve-runtime-configuration';
+export { compileBlueprintForExecution } from './lib/compile';
+export type {
+	BlueprintExecutionPath,
+	CompiledBlueprintForExecution,
+	CompileBlueprintForExecutionOptions,
+} from './lib/compile';
 
 /**
  * @deprecated This function is a no-op. Playground no longer uses a proxy to download plugins and themes.

--- a/packages/playground/blueprints/src/lib/compile.ts
+++ b/packages/playground/blueprints/src/lib/compile.ts
@@ -1,0 +1,50 @@
+import type { UniversalPHP } from '@php-wasm/universal';
+import type { BlueprintDeclaration } from './types';
+import {
+	compileBlueprintV1,
+	type CompileBlueprintV1Options,
+	type CompiledBlueprintV1,
+} from './v1/compile';
+import type { BlueprintV1Declaration } from './v1/types';
+
+export type BlueprintExecutionPath = 'v1';
+
+export type CompiledBlueprintForExecution = {
+	version: 1;
+	declaration: BlueprintV1Declaration;
+	compiled: CompiledBlueprintV1;
+	run: (playground: UniversalPHP) => Promise<void>;
+};
+
+export interface CompileBlueprintForExecutionOptions
+	extends Omit<
+		CompileBlueprintV1Options,
+		'onBlueprintValidated' | 'streamBundledFile'
+	> {
+	onBlueprintValidated?: (blueprint: BlueprintDeclaration) => void;
+}
+
+/**
+ * Compiles a Blueprint into the shape consumers need before execution.
+ *
+ * The legacy `compileBlueprint()` export intentionally remains v1-only for
+ * backwards compatibility. This helper is the version-aware entrypoint that
+ * newer callers can migrate to as Blueprint v2 support grows.
+ */
+export async function compileBlueprintForExecution(
+	declaration: BlueprintV1Declaration,
+	options: CompileBlueprintForExecutionOptions = {}
+): Promise<CompiledBlueprintForExecution> {
+	const compiled = await compileBlueprintV1(declaration, {
+		...options,
+		onBlueprintValidated: options.onBlueprintValidated as
+			| CompileBlueprintV1Options['onBlueprintValidated']
+			| undefined,
+	});
+	return {
+		version: 1,
+		declaration,
+		compiled,
+		run: compiled.run,
+	};
+}

--- a/packages/playground/blueprints/src/tests/compile.spec.ts
+++ b/packages/playground/blueprints/src/tests/compile.spec.ts
@@ -1,0 +1,22 @@
+import { compileBlueprintForExecution } from '../lib/compile';
+import type { BlueprintV1Declaration } from '../lib/v1/types';
+
+describe('compileBlueprintForExecution', () => {
+	it('compiles Blueprint v1 declarations through the v1 compiler', async () => {
+		const declaration: BlueprintV1Declaration = {
+			steps: [
+				{
+					step: 'mkdir',
+					path: '/wordpress/cache',
+				},
+			],
+		};
+
+		const compiled = await compileBlueprintForExecution(declaration);
+
+		expect(compiled.version).toBe(1);
+		expect(compiled.declaration).toBe(declaration);
+		expect(compiled.compiled).toHaveProperty('versions');
+		expect(compiled.run).toBe(compiled.compiled.run);
+	});
+});


### PR DESCRIPTION
## What

Adds `compileBlueprintForExecution()` as a small v1-only facade that returns the compiled Blueprint together with the normalized declaration and `run` function.

## Why

Consumers that need to support multiple Blueprint execution paths need an entrypoint shaped around execution, not the legacy v1-only `compileBlueprint()` alias. This introduces the public shape without adding Blueprint v2 compiler behavior yet.

Replaces #3899, which was closed when the lower stacked base branch was deleted after #3898 merged.

## Testing

- `npm run format:uncommitted`
- `npm exec nx run playground-blueprints:test:vite -- --testFiles=packages/playground/blueprints/src/tests/compile.spec.ts`
- `npm exec nx run playground-blueprints:typecheck`
- `npm exec nx run playground-blueprints:lint`
- `git diff --check`

Part of #2592.