### PR TITLE
[Blueprints] Support raw JSON execution input

### DIFF
--- a/packages/playground/blueprints/src/lib/compile.ts
+++ b/packages/playground/blueprints/src/lib/compile.ts
@@ -16,6 +16,10 @@ export type CompiledBlueprintForExecution = {
 	compiled: CompiledBlueprintV1;
 	run: (playground: UniversalPHP) => Promise<void>;
 };
+type BlueprintExecutionInput =
+	| BlueprintV1Declaration
+	| BlueprintBundle
+	| string;
 
 export interface CompileBlueprintForExecutionOptions extends Omit<
 	CompileBlueprintV1Options,
@@ -32,20 +36,32 @@ export interface CompileBlueprintForExecutionOptions extends Omit<
  * newer callers can migrate to as Blueprint v2 support grows.
  */
 export async function compileBlueprintForExecution(
-	input: BlueprintV1Declaration | BlueprintBundle,
+	input: BlueprintExecutionInput,
 	options: CompileBlueprintForExecutionOptions = {}
 ): Promise<CompiledBlueprintForExecution> {
-	const declaration = await getBlueprintDeclaration(input);
-	const compiled = await compileBlueprintV1(input, {
-		...options,
-		onBlueprintValidated: options.onBlueprintValidated as
-			| CompileBlueprintV1Options['onBlueprintValidated']
-			| undefined,
-	});
+	const declaration = await getBlueprintV1Declaration(input);
+	const compiled = await compileBlueprintV1(
+		typeof input === 'string' ? declaration : input,
+		{
+			...options,
+			onBlueprintValidated: options.onBlueprintValidated as
+				| CompileBlueprintV1Options['onBlueprintValidated']
+				| undefined,
+		}
+	);
 	return {
 		version: 1,
 		declaration,
 		compiled,
 		run: compiled.run,
 	};
+}
+
+async function getBlueprintV1Declaration(
+	input: BlueprintExecutionInput
+): Promise<BlueprintV1Declaration> {
+	if (typeof input === 'string') {
+		return JSON.parse(input);
+	}
+	return getBlueprintDeclaration(input);
 }

--- a/packages/playground/blueprints/src/tests/compile.spec.ts
+++ b/packages/playground/blueprints/src/tests/compile.spec.ts
@@ -22,6 +22,31 @@ describe('compileBlueprintForExecution', () => {
 		expect(compiled.run).toBe(compiled.compiled.run);
 	});
 
+	it('compiles Blueprint v1 declarations from raw JSON', async () => {
+		const compiled = await compileBlueprintForExecution(
+			JSON.stringify({
+				steps: [
+					{
+						step: 'mkdir',
+						path: '/wordpress/cache',
+					},
+				],
+			})
+		);
+
+		expect(compiled.version).toBe(1);
+		expect(compiled.declaration).toEqual({
+			steps: [
+				{
+					step: 'mkdir',
+					path: '/wordpress/cache',
+				},
+			],
+		});
+		expect(compiled.compiled).toHaveProperty('versions');
+		expect(compiled.run).toBe(compiled.compiled.run);
+	});
+
 	it('compiles Blueprint v1 bundles with bundled resources', async () => {
 		const bundle = new InMemoryFilesystem({
 			'message.txt': 'Hello from a bundled file.',


### PR DESCRIPTION
## What

Allows `compileBlueprintForExecution()` to accept a raw Blueprint JSON string and compile it through the existing v1 declaration path.

## Why

Consumers often start with serialized Blueprint data from URLs, files, or API boundaries. Supporting raw JSON at the facade keeps parsing centralized before the next version-aware execution changes land.

## Testing

- `npm run format:uncommitted`
- `npm exec nx run playground-blueprints:test:vite -- --testFiles=packages/playground/blueprints/src/tests/compile.spec.ts`
- `npm exec nx run playground-blueprints:typecheck`
- `npm exec nx run playground-blueprints:lint`
- `git diff --check`