### PR TITLE
[Blueprints] Route Blueprint v2 execution facade to runner

### DIFF
--- a/packages/playground/blueprints/src/lib/compile.ts
+++ b/packages/playground/blueprints/src/lib/compile.ts
@@ -1,6 +1,12 @@
 import type { UniversalPHP } from '@php-wasm/universal';
-import type { Blueprint, BlueprintBundle, BlueprintDeclaration } from './types';
+import type {
+	Blueprint,
+	BlueprintBundle,
+	BlueprintDeclaration,
+	RuntimeConfiguration,
+} from './types';
 import { getBlueprintDeclaration } from './reflection';
+import { resolveRuntimeConfiguration } from './resolve-runtime-configuration';
 import {
 	compileBlueprintV1,
 	type CompileBlueprintV1Options,
@@ -9,15 +15,28 @@ import {
 } from './v1/compile';
 import type { BlueprintV1Declaration } from './v1/types';
 import type { BlueprintV2Declaration } from './v2/blueprint-v2-declaration';
+import { runBlueprintV2 } from './v2/run-blueprint-v2';
 
 export type BlueprintExecutionPath = 'v1' | 'v2';
 
-export type CompiledBlueprintForExecution = {
-	version: 1;
-	declaration: BlueprintV1Declaration;
-	compiled: CompiledBlueprintV1;
+type CompiledBlueprintV2 = {
+	runtime: RuntimeConfiguration;
 	run: (playground: UniversalPHP) => Promise<void>;
 };
+
+export type CompiledBlueprintForExecution =
+	| {
+			version: 1;
+			declaration: BlueprintV1Declaration;
+			compiled: CompiledBlueprintV1;
+			run: (playground: UniversalPHP) => Promise<void>;
+	  }
+	| {
+			version: 2;
+			declaration: BlueprintV2Declaration;
+			compiled: CompiledBlueprintV2;
+			run: (playground: UniversalPHP) => Promise<void>;
+	  };
 
 export interface CompileBlueprintForExecutionOptions extends Omit<
 	CompileBlueprintV1Options,
@@ -39,11 +58,36 @@ export async function compileBlueprintForExecution(
 ): Promise<CompiledBlueprintForExecution> {
 	const declaration = await getBlueprintDeclaration(input);
 	if (isBlueprintV2Declaration(declaration)) {
-		throw new Error(
-			'Blueprint v2 execution is not supported by compileBlueprintForExecution() yet.'
-		);
+		return compileBlueprintV2ForExecution(input, declaration);
 	}
 	return compileBlueprintV1ForExecution(input, declaration, options);
+}
+
+async function compileBlueprintV2ForExecution(
+	input: Blueprint | BlueprintBundle,
+	declaration: BlueprintV2Declaration
+): Promise<CompiledBlueprintForExecution> {
+	if (isBlueprintBundle(input)) {
+		throw new Error(
+			'Blueprint v2 bundles are not supported by compileBlueprintForExecution() yet.'
+		);
+	}
+	const runtime = await resolveRuntimeConfiguration(declaration);
+	const compiled = {
+		runtime,
+		run: async (playground: UniversalPHP) => {
+			await runBlueprintV2({
+				php: playground,
+				blueprint: declaration,
+			});
+		},
+	};
+	return {
+		version: 2,
+		declaration,
+		compiled,
+		run: compiled.run,
+	};
 }
 
 async function compileBlueprintV1ForExecution(
@@ -51,8 +95,7 @@ async function compileBlueprintV1ForExecution(
 	declaration: BlueprintV1Declaration,
 	options: CompileBlueprintForExecutionOptions
 ): Promise<CompiledBlueprintForExecution> {
-	const compileInput =
-		isBlueprintBundle(input) ? input : declaration;
+	const compileInput = isBlueprintBundle(input) ? input : declaration;
 	const compiled = await compileBlueprintV1(compileInput, {
 		...options,
 		onBlueprintValidated: options.onBlueprintValidated as

--- a/packages/playground/blueprints/src/tests/compile.spec.ts
+++ b/packages/playground/blueprints/src/tests/compile.spec.ts
@@ -2,8 +2,17 @@ import { InMemoryFilesystem } from '@wp-playground/storage';
 import { vi } from 'vitest';
 import { compileBlueprintForExecution } from '../lib/compile';
 import type { BlueprintV1Declaration } from '../lib/v1/types';
+import { runBlueprintV2 } from '../lib/v2/run-blueprint-v2';
+
+vi.mock('../lib/v2/run-blueprint-v2', () => ({
+	runBlueprintV2: vi.fn(),
+}));
 
 describe('compileBlueprintForExecution', () => {
+	beforeEach(() => {
+		vi.mocked(runBlueprintV2).mockReset();
+	});
+
 	it('compiles Blueprint v1 declarations through the v1 compiler', async () => {
 		const declaration: BlueprintV1Declaration = {
 			steps: [
@@ -66,13 +75,27 @@ describe('compileBlueprintForExecution', () => {
 		);
 	});
 
-	it('rejects Blueprint v2 declarations until the v2 execution path is wired', async () => {
-		await expect(
-			compileBlueprintForExecution({
-				version: 2,
-			})
-		).rejects.toThrow(
-			'Blueprint v2 execution is not supported by compileBlueprintForExecution() yet.'
-		);
+	it('compiles Blueprint v2 declarations through the v2 runner', async () => {
+		const declaration = {
+			version: 2,
+		} as const;
+		const playground = {};
+
+		const compiled = await compileBlueprintForExecution(declaration);
+		await compiled.run(playground as any);
+
+		expect(compiled.version).toBe(2);
+		if (compiled.version !== 2) {
+			throw new Error('Expected a compiled Blueprint v2 result.');
+		}
+		expect(compiled.declaration).toBe(declaration);
+		expect(compiled.compiled.runtime).toMatchObject({
+			wpVersion: 'latest',
+			networking: true,
+		});
+		expect(runBlueprintV2).toHaveBeenCalledWith({
+			php: playground,
+			blueprint: declaration,
+		});
 	});
 });


### PR DESCRIPTION
## What

Routes Blueprint v2 declarations passed to `compileBlueprintForExecution()` to the existing PHP `runBlueprintV2()` runner. The returned execution shape now supports `version: 2`, includes resolved runtime metadata, and exposes a `run()` callback that delegates to the v2 runner.

Blueprint v2 bundles remain out of scope here because `runBlueprintV2()` does not accept bundle streams yet.

## Why

This is the minimum runner hook needed before wiring consumers to the execution facade. It keeps the legacy `compileBlueprint()` export v1-only while giving newer callers a version-aware path.

## Testing

- `npm run format:uncommitted`
- `npm exec nx run playground-blueprints:test:vite -- --testFiles=packages/playground/blueprints/src/tests/compile.spec.ts`
- `npm exec nx run playground-blueprints:typecheck`
- `npm exec nx run playground-blueprints:lint`
- `git diff --check`