### PR TITLE
[Blueprints] Add TypeScript Blueprint v2 runner skeleton

### DIFF
--- a/packages/playground/blueprints/src/lib/compile.ts
+++ b/packages/playground/blueprints/src/lib/compile.ts
@@ -9,15 +9,23 @@ import {
 } from './v1/compile';
 import type { BlueprintV1Declaration } from './v1/types';
 import type { BlueprintV2Declaration } from './v2/blueprint-v2-declaration';
+import { compileBlueprintV2, type CompiledBlueprintV2 } from './v2/compile';
 
 export type BlueprintExecutionPath = 'v1' | 'v2';
 
-export type CompiledBlueprintForExecution = {
-	version: 1;
-	declaration: BlueprintV1Declaration;
-	compiled: CompiledBlueprintV1;
-	run: (playground: UniversalPHP) => Promise<void>;
-};
+export type CompiledBlueprintForExecution =
+	| {
+			version: 1;
+			declaration: BlueprintV1Declaration;
+			compiled: CompiledBlueprintV1;
+			run: (playground: UniversalPHP) => Promise<void>;
+	  }
+	| {
+			version: 2;
+			declaration: BlueprintV2Declaration;
+			compiled: CompiledBlueprintV2;
+			run: (playground: UniversalPHP) => Promise<void>;
+	  };
 
 export interface CompileBlueprintForExecutionOptions extends Omit<
 	CompileBlueprintV1Options,
@@ -39,11 +47,27 @@ export async function compileBlueprintForExecution(
 ): Promise<CompiledBlueprintForExecution> {
 	const declaration = await getBlueprintDeclaration(input);
 	if (isBlueprintV2Declaration(declaration)) {
-		throw new Error(
-			'Blueprint v2 execution is not supported by compileBlueprintForExecution() yet.'
-		);
+		return compileBlueprintV2ForExecution(input, declaration);
 	}
 	return compileBlueprintV1ForExecution(input, declaration, options);
+}
+
+async function compileBlueprintV2ForExecution(
+	input: Blueprint | BlueprintBundle,
+	declaration: BlueprintV2Declaration
+): Promise<CompiledBlueprintForExecution> {
+	if (isBlueprintBundle(input)) {
+		throw new Error(
+			'Blueprint v2 bundles are not supported by compileBlueprintForExecution() yet.'
+		);
+	}
+	const compiled = await compileBlueprintV2(declaration);
+	return {
+		version: 2,
+		declaration,
+		compiled,
+		run: compiled.run,
+	};
 }
 
 async function compileBlueprintV1ForExecution(
@@ -51,8 +75,7 @@ async function compileBlueprintV1ForExecution(
 	declaration: BlueprintV1Declaration,
 	options: CompileBlueprintForExecutionOptions
 ): Promise<CompiledBlueprintForExecution> {
-	const compileInput =
-		isBlueprintBundle(input) ? input : declaration;
+	const compileInput = isBlueprintBundle(input) ? input : declaration;
 	const compiled = await compileBlueprintV1(compileInput, {
 		...options,
 		onBlueprintValidated: options.onBlueprintValidated as

--- a/packages/playground/blueprints/src/lib/v2/compile.ts
+++ b/packages/playground/blueprints/src/lib/v2/compile.ts
@@ -1,0 +1,70 @@
+import type { UniversalPHP } from '@php-wasm/universal';
+import type { RuntimeConfiguration } from '../types';
+import { resolveRuntimeConfiguration } from '../resolve-runtime-configuration';
+import type { BlueprintV2Declaration } from './blueprint-v2-declaration';
+
+export class UnsupportedBlueprintV2FeatureError extends Error {
+	public readonly featurePath: string;
+
+	constructor(featurePath: string) {
+		super(
+			`${featurePath}: This Blueprint v2 feature is not supported by the TypeScript runner yet.`
+		);
+		this.name = 'UnsupportedBlueprintV2FeatureError';
+		this.featurePath = featurePath;
+	}
+}
+
+export type CompiledBlueprintV2 = {
+	runtime: RuntimeConfiguration;
+	run: (playground: UniversalPHP) => Promise<void>;
+};
+
+export async function compileBlueprintV2(
+	declaration: BlueprintV2Declaration
+): Promise<CompiledBlueprintV2> {
+	assertSupportedBlueprintV2Declaration(declaration);
+	const runtime = await resolveRuntimeConfiguration(declaration);
+	return {
+		runtime,
+		run: async () => {},
+	};
+}
+
+function assertSupportedBlueprintV2Declaration(
+	declaration: BlueprintV2Declaration
+) {
+	for (const property of UNSUPPORTED_EXECUTION_PROPERTIES) {
+		if (property in declaration) {
+			throw new UnsupportedBlueprintV2FeatureError(property);
+		}
+	}
+
+	const playgroundOptions =
+		declaration.applicationOptions?.['wordpress-playground'];
+	if (
+		playgroundOptions &&
+		('landingPage' in playgroundOptions || 'login' in playgroundOptions)
+	) {
+		throw new UnsupportedBlueprintV2FeatureError(
+			'applicationOptions.wordpress-playground'
+		);
+	}
+}
+
+const UNSUPPORTED_EXECUTION_PROPERTIES = [
+	'siteLanguage',
+	'siteOptions',
+	'constants',
+	'activeTheme',
+	'themes',
+	'plugins',
+	'muPlugins',
+	'postTypes',
+	'fonts',
+	'media',
+	'content',
+	'users',
+	'roles',
+	'additionalStepsAfterExecution',
+] as const;

--- a/packages/playground/blueprints/src/tests/compile.spec.ts
+++ b/packages/playground/blueprints/src/tests/compile.spec.ts
@@ -66,13 +66,37 @@ describe('compileBlueprintForExecution', () => {
 		);
 	});
 
-	it('rejects Blueprint v2 declarations until the v2 execution path is wired', async () => {
+	it('compiles minimal Blueprint v2 declarations through the TypeScript runner', async () => {
+		const declaration = {
+			version: 2,
+			phpVersion: '8.3',
+		} as const;
+		const playground = {};
+
+		const compiled = await compileBlueprintForExecution(declaration);
+		await compiled.run(playground as any);
+
+		expect(compiled.version).toBe(2);
+		if (compiled.version !== 2) {
+			throw new Error('Expected a compiled Blueprint v2 result.');
+		}
+		expect(compiled.declaration).toBe(declaration);
+		expect(compiled.compiled.runtime).toMatchObject({
+			phpVersion: '8.3',
+			wpVersion: 'latest',
+		});
+	});
+
+	it('rejects unsupported Blueprint v2 execution fields', async () => {
 		await expect(
 			compileBlueprintForExecution({
 				version: 2,
+				siteOptions: {
+					blogname: 'Unsupported for now',
+				},
 			})
 		).rejects.toThrow(
-			'Blueprint v2 execution is not supported by compileBlueprintForExecution() yet.'
+			'siteOptions: This Blueprint v2 feature is not supported by the TypeScript runner yet.'
 		);
 	});
 });


### PR DESCRIPTION
## What

Adds the first TypeScript Blueprint v2 runner path behind `compileBlueprintForExecution()`. Minimal v2 declarations now compile to a `version: 2` execution result with resolved runtime metadata and a no-op `run()` callback.

Side-effecting v2 fields intentionally throw `UnsupportedBlueprintV2FeatureError` until we implement them in TypeScript one by one. Blueprint v2 bundles also remain unsupported here.

## Why

This replaces the closed PHP-runner direction from #3905. The goal of this stack is to build the TypeScript runner, not route through the existing PHP `blueprints.phar` runner.

## Testing

- `npm run format:uncommitted`
- `npm exec nx run playground-blueprints:test:vite -- --testFiles=packages/playground/blueprints/src/tests/compile.spec.ts`
- `npm exec nx run playground-blueprints:typecheck`
- `npm exec nx run playground-blueprints:lint`
- `git diff --check`

Part of #2592.