### PR TITLE
[Blueprints] Compile Blueprint v2 declarations into an execution plan

### DIFF
--- a/packages/playground/blueprints/src/lib/v2/compile.ts
+++ b/packages/playground/blueprints/src/lib/v2/compile.ts
@@ -6,65 +6,260 @@ import type { BlueprintV2Declaration } from './blueprint-v2-declaration';
 export class UnsupportedBlueprintV2FeatureError extends Error {
 	public readonly featurePath: string;
 
-	constructor(featurePath: string) {
-		super(
-			`${featurePath}: This Blueprint v2 feature is not supported by the TypeScript runner yet.`
-		);
+	constructor(
+		featurePath: string,
+		message = 'This Blueprint v2 feature is not supported by the TypeScript runner yet.'
+	) {
+		super(`${featurePath}: ${message}`);
 		this.name = 'UnsupportedBlueprintV2FeatureError';
 		this.featurePath = featurePath;
 	}
 }
 
+type BlueprintV2ApplicationOptions =
+	BlueprintV2Declaration['applicationOptions'];
+type BlueprintV2Constants = NonNullable<BlueprintV2Declaration['constants']>;
+type BlueprintV2SiteOptions = NonNullable<
+	BlueprintV2Declaration['siteOptions']
+>;
+type BlueprintV2MuPlugin = NonNullable<
+	BlueprintV2Declaration['muPlugins']
+>[number];
+type BlueprintV2Theme = NonNullable<BlueprintV2Declaration['themes']>[number];
+type BlueprintV2ActiveTheme = NonNullable<
+	BlueprintV2Declaration['activeTheme']
+>;
+type BlueprintV2Plugin = NonNullable<BlueprintV2Declaration['plugins']>[number];
+type BlueprintV2Fonts = NonNullable<BlueprintV2Declaration['fonts']>;
+type BlueprintV2Media = NonNullable<BlueprintV2Declaration['media']>[number];
+type BlueprintV2Role = NonNullable<BlueprintV2Declaration['roles']>[number];
+type BlueprintV2User = NonNullable<BlueprintV2Declaration['users']>[number];
+type BlueprintV2PostTypes = NonNullable<BlueprintV2Declaration['postTypes']>;
+type BlueprintV2Content = NonNullable<
+	BlueprintV2Declaration['content']
+>[number];
+type BlueprintV2Step = NonNullable<
+	BlueprintV2Declaration['additionalStepsAfterExecution']
+>[number];
+
+export type BlueprintV2ExecutionPlan = BlueprintV2ExecutionPlanItem[];
+
+export type BlueprintV2ExecutionPlanItem =
+	| {
+			type: 'defineWpConfigConsts';
+			consts: BlueprintV2Constants;
+	  }
+	| {
+			type: 'setSiteOptions';
+			options: BlueprintV2SiteOptions;
+	  }
+	| {
+			type: 'installMuPlugin';
+			muPlugin: BlueprintV2MuPlugin;
+			sourcePath: string;
+	  }
+	| {
+			type: 'installTheme';
+			theme: BlueprintV2Theme;
+			active: false;
+			sourcePath: string;
+	  }
+	| {
+			type: 'installTheme';
+			theme: BlueprintV2ActiveTheme;
+			active: true;
+			sourcePath: string;
+	  }
+	| {
+			type: 'installPlugin';
+			plugin: BlueprintV2Plugin;
+			sourcePath: string;
+	  }
+	| {
+			type: 'installFonts';
+			fonts: BlueprintV2Fonts;
+	  }
+	| {
+			type: 'importMedia';
+			media: BlueprintV2Media;
+			sourcePath: string;
+	  }
+	| {
+			type: 'setSiteLanguage';
+			language: string;
+	  }
+	| {
+			type: 'defineRoles';
+			roles: BlueprintV2Role[];
+	  }
+	| {
+			type: 'defineUsers';
+			users: BlueprintV2User[];
+	  }
+	| {
+			type: 'definePostTypes';
+			postTypes: BlueprintV2PostTypes;
+	  }
+	| {
+			type: 'importContent';
+			content: BlueprintV2Content;
+			sourcePath: string;
+	  }
+	| {
+			type: 'runStep';
+			step: BlueprintV2Step;
+			sourcePath: string;
+	  };
+
 export type CompiledBlueprintV2 = {
 	runtime: RuntimeConfiguration;
+	applicationOptions?: BlueprintV2ApplicationOptions;
+	plan: BlueprintV2ExecutionPlan;
 	run: (playground: UniversalPHP) => Promise<void>;
 };
 
 export async function compileBlueprintV2(
 	declaration: BlueprintV2Declaration
 ): Promise<CompiledBlueprintV2> {
-	assertSupportedBlueprintV2Declaration(declaration);
 	const runtime = await resolveRuntimeConfiguration(declaration);
+	const plan = createBlueprintV2ExecutionPlan(declaration);
 	return {
 		runtime,
-		run: async () => {},
+		applicationOptions: declaration.applicationOptions,
+		plan,
+		run: async () => {
+			if (plan.length > 0) {
+				throw new UnsupportedBlueprintV2FeatureError(
+					'executionPlan',
+					'Blueprint v2 execution plans are not runnable by the TypeScript runner yet.'
+				);
+			}
+		},
 	};
 }
 
-function assertSupportedBlueprintV2Declaration(
+export function createBlueprintV2ExecutionPlan(
 	declaration: BlueprintV2Declaration
-) {
-	for (const property of UNSUPPORTED_EXECUTION_PROPERTIES) {
-		if (property in declaration) {
-			throw new UnsupportedBlueprintV2FeatureError(property);
-		}
-	}
+): BlueprintV2ExecutionPlan {
+	const plan: BlueprintV2ExecutionPlan = [];
 
-	const playgroundOptions =
-		declaration.applicationOptions?.['wordpress-playground'];
 	if (
-		playgroundOptions &&
-		('landingPage' in playgroundOptions || 'login' in playgroundOptions)
+		declaration.constants &&
+		Object.keys(declaration.constants).length > 0
 	) {
-		throw new UnsupportedBlueprintV2FeatureError(
-			'applicationOptions.wordpress-playground'
-		);
+		plan.push({
+			type: 'defineWpConfigConsts',
+			consts: declaration.constants,
+		});
 	}
-}
 
-const UNSUPPORTED_EXECUTION_PROPERTIES = [
-	'siteLanguage',
-	'siteOptions',
-	'constants',
-	'activeTheme',
-	'themes',
-	'plugins',
-	'muPlugins',
-	'postTypes',
-	'fonts',
-	'media',
-	'content',
-	'users',
-	'roles',
-	'additionalStepsAfterExecution',
-] as const;
+	if (
+		declaration.siteOptions &&
+		Object.keys(declaration.siteOptions).length > 0
+	) {
+		plan.push({
+			type: 'setSiteOptions',
+			options: declaration.siteOptions,
+		});
+	}
+
+	for (const [index, muPlugin] of (declaration.muPlugins ?? []).entries()) {
+		plan.push({
+			type: 'installMuPlugin',
+			muPlugin,
+			sourcePath: `/muPlugins/${index}`,
+		});
+	}
+
+	for (const [index, theme] of (declaration.themes ?? []).entries()) {
+		plan.push({
+			type: 'installTheme',
+			theme,
+			active: false,
+			sourcePath: `/themes/${index}`,
+		});
+	}
+
+	if (declaration.activeTheme !== undefined) {
+		plan.push({
+			type: 'installTheme',
+			theme: declaration.activeTheme,
+			active: true,
+			sourcePath: '/activeTheme',
+		});
+	}
+
+	for (const [index, plugin] of (declaration.plugins ?? []).entries()) {
+		plan.push({
+			type: 'installPlugin',
+			plugin,
+			sourcePath: `/plugins/${index}`,
+		});
+	}
+
+	if (declaration.fonts && Object.keys(declaration.fonts).length > 0) {
+		plan.push({
+			type: 'installFonts',
+			fonts: declaration.fonts,
+		});
+	}
+
+	for (const [index, media] of (declaration.media ?? []).entries()) {
+		plan.push({
+			type: 'importMedia',
+			media,
+			sourcePath: `/media/${index}`,
+		});
+	}
+
+	if (declaration.siteLanguage) {
+		plan.push({
+			type: 'setSiteLanguage',
+			language: declaration.siteLanguage,
+		});
+	}
+
+	if (declaration.roles?.length) {
+		plan.push({
+			type: 'defineRoles',
+			roles: declaration.roles,
+		});
+	}
+
+	if (declaration.users?.length) {
+		plan.push({
+			type: 'defineUsers',
+			users: declaration.users,
+		});
+	}
+
+	if (
+		declaration.postTypes &&
+		Object.keys(declaration.postTypes).length > 0
+	) {
+		plan.push({
+			type: 'definePostTypes',
+			postTypes: declaration.postTypes,
+		});
+	}
+
+	for (const [index, content] of (declaration.content ?? []).entries()) {
+		plan.push({
+			type: 'importContent',
+			content,
+			sourcePath: `/content/${index}`,
+		});
+	}
+
+	for (const [index, step] of (
+		declaration.additionalStepsAfterExecution ?? []
+	).entries()) {
+		plan.push({
+			type: 'runStep',
+			step,
+			sourcePath: `/additionalStepsAfterExecution/${index}`,
+		});
+	}
+
+	return plan;
+}

--- a/packages/playground/blueprints/src/tests/compile.spec.ts
+++ b/packages/playground/blueprints/src/tests/compile.spec.ts
@@ -2,6 +2,7 @@ import { InMemoryFilesystem } from '@wp-playground/storage';
 import { vi } from 'vitest';
 import { compileBlueprintForExecution } from '../lib/compile';
 import type { BlueprintV1Declaration } from '../lib/v1/types';
+import type { BlueprintV2Declaration } from '../lib/v2/blueprint-v2-declaration';
 
 describe('compileBlueprintForExecution', () => {
 	it('compiles Blueprint v1 declarations through the v1 compiler', async () => {
@@ -85,18 +86,165 @@ describe('compileBlueprintForExecution', () => {
 			phpVersion: '8.3',
 			wpVersion: 'latest',
 		});
+		expect(compiled.compiled.plan).toEqual([]);
 	});
 
-	it('rejects unsupported Blueprint v2 execution fields', async () => {
-		await expect(
-			compileBlueprintForExecution({
-				version: 2,
-				siteOptions: {
-					blogname: 'Unsupported for now',
+	it('compiles Blueprint v2 declarations into an ordered execution plan', async () => {
+		const declaration: BlueprintV2Declaration = {
+			version: 2,
+			applicationOptions: {
+				'wordpress-playground': {
+					landingPage: '/wp-admin/post-new.php',
+					login: true,
 				},
-			})
-		).rejects.toThrow(
-			'siteOptions: This Blueprint v2 feature is not supported by the TypeScript runner yet.'
+			},
+			constants: {
+				WP_DEBUG: true,
+			},
+			siteOptions: {
+				blogname: 'Compiled v2 plan',
+			},
+			muPlugins: [
+				{
+					filename: 'mu-plugin.php',
+					content: '<?php',
+				},
+			],
+			themes: ['twentytwentythree'],
+			activeTheme: {
+				source: 'twentytwentyfour',
+			},
+			plugins: [
+				{
+					source: 'akismet',
+					active: false,
+				},
+			],
+			fonts: {
+				inter: './fonts/inter.woff2',
+			},
+			media: ['./media/image.jpg'],
+			siteLanguage: 'pl_PL',
+			roles: [
+				{
+					name: 'movie_curator',
+					capabilities: {
+						read: 'true',
+					},
+				},
+			],
+			users: [
+				{
+					username: 'editor',
+					email: 'editor@example.com',
+					role: 'editor',
+					meta: {},
+				},
+			],
+			postTypes: {
+				movie: './post-types/movie.php',
+			},
+			content: [
+				{
+					type: 'mysql-dump',
+					source: './dump.sql',
+				},
+			],
+			additionalStepsAfterExecution: [
+				{
+					step: 'mkdir',
+					path: '/tmp/from-v2',
+				},
+			],
+		};
+
+		const compiled = await compileBlueprintForExecution(declaration);
+
+		expect(compiled.version).toBe(2);
+		if (compiled.version !== 2) {
+			throw new Error('Expected a compiled Blueprint v2 result.');
+		}
+		expect(compiled.compiled.applicationOptions).toEqual(
+			declaration.applicationOptions
+		);
+		expect(compiled.compiled.plan.map((item) => item.type)).toEqual([
+			'defineWpConfigConsts',
+			'setSiteOptions',
+			'installMuPlugin',
+			'installTheme',
+			'installTheme',
+			'installPlugin',
+			'installFonts',
+			'importMedia',
+			'setSiteLanguage',
+			'defineRoles',
+			'defineUsers',
+			'definePostTypes',
+			'importContent',
+			'runStep',
+		]);
+		expect(compiled.compiled.plan[0]).toEqual({
+			type: 'defineWpConfigConsts',
+			consts: declaration.constants,
+		});
+		expect(compiled.compiled.plan[1]).toEqual({
+			type: 'setSiteOptions',
+			options: declaration.siteOptions,
+		});
+		expect(compiled.compiled.plan[2]).toEqual({
+			type: 'installMuPlugin',
+			muPlugin: declaration.muPlugins?.[0],
+			sourcePath: '/muPlugins/0',
+		});
+		expect(compiled.compiled.plan[3]).toEqual({
+			type: 'installTheme',
+			theme: declaration.themes?.[0],
+			active: false,
+			sourcePath: '/themes/0',
+		});
+		expect(compiled.compiled.plan[4]).toEqual({
+			type: 'installTheme',
+			theme: declaration.activeTheme,
+			active: true,
+			sourcePath: '/activeTheme',
+		});
+		expect(compiled.compiled.plan[5]).toEqual({
+			type: 'installPlugin',
+			plugin: declaration.plugins?.[0],
+			sourcePath: '/plugins/0',
+		});
+		expect(compiled.compiled.plan[13]).toEqual({
+			type: 'runStep',
+			step: declaration.additionalStepsAfterExecution?.[0],
+			sourcePath: '/additionalStepsAfterExecution/0',
+		});
+	});
+
+	it('treats empty Blueprint v2 object fields as no-op plan inputs', async () => {
+		const compiled = await compileBlueprintForExecution({
+			version: 2,
+			constants: {},
+			siteOptions: {},
+		});
+
+		expect(compiled.version).toBe(2);
+		if (compiled.version !== 2) {
+			throw new Error('Expected a compiled Blueprint v2 result.');
+		}
+		expect(compiled.compiled.plan).toEqual([]);
+		await expect(compiled.run({} as any)).resolves.toBeUndefined();
+	});
+
+	it('rejects running Blueprint v2 plans until plan items are wired', async () => {
+		const compiled = await compileBlueprintForExecution({
+			version: 2,
+			siteOptions: {
+				blogname: 'Compiled but not runnable yet',
+			},
+		});
+
+		await expect(compiled.run({} as any)).rejects.toThrow(
+			'executionPlan: Blueprint v2 execution plans are not runnable by the TypeScript runner yet.'
 		);
 	});
 });


### PR DESCRIPTION
## What it does

Extracts the compile-only part of the native TypeScript Blueprint v2 runner work from #3725. `compileBlueprintV2()` now turns a parsed v2 declaration into a typed `BlueprintV2ExecutionPlan` while preserving runtime metadata and `applicationOptions`.

The plan records the ordered work implied by v2 fields such as `constants`, `siteOptions`, `muPlugins`, `themes`, `activeTheme`, `plugins`, `fonts`, `media`, `siteLanguage`, `roles`, `users`, `postTypes`, `content`, and `additionalStepsAfterExecution`.

## Rationale

This lets us review the v2 parser/compiler shape separately from execution. The current PR does **not** resolve resources, lower v2 data references into v1 resources, call v1 step handlers, or wire the plan into existing consumer data flows.

Non-empty v2 plans still fail at `run()` with an explicit `UnsupportedBlueprintV2FeatureError`, so callers cannot accidentally treat parsed-but-unwired v2 declarations as executed.

## Implementation

Adds `BlueprintV2ExecutionPlan` and `BlueprintV2ExecutionPlanItem` types in `lib/v2/compile.ts`. `createBlueprintV2ExecutionPlan()` mirrors the ordering from the broader TypeScript runner work while keeping each item in v2-shaped data:

```ts
{ type: 'defineWpConfigConsts', consts }
{ type: 'setSiteOptions', options }
{ type: 'installPlugin', plugin, sourcePath: '/plugins/0' }
{ type: 'runStep', step, sourcePath: '/additionalStepsAfterExecution/0' }
```

Minimal v2 declarations still compile and run as a no-op. Declarations with planned work compile successfully but reject on `run()` until follow-up PRs wire individual plan items.

## Testing instructions

```bash
npm run format:uncommitted
npm exec nx run playground-blueprints:test:vite -- --testFiles=packages/playground/blueprints/src/tests/compile.spec.ts
npm exec nx run playground-blueprints:typecheck
npm exec nx run playground-blueprints:lint
npm exec nx run playground-blueprints:build
npm exec nx run playground-blueprints:test:vite
git diff --check
```

Part of #2592.