### PR TITLE
[PHP] Default Playground SQLite journal mode to DELETE

### DIFF
--- a/packages/playground/wordpress/src/boot.ts
+++ b/packages/playground/wordpress/src/boot.ts
@@ -226,7 +226,6 @@ export async function bootWordPress(
 	if (isLegacyPHPVersion(options.phpVersion)) {
 		return bootLegacyWordPress(requestHandler, options);
 	}
-
 	const php = await requestHandler.getPrimaryPhp();
 	if (options.hooks?.beforeWordPressFiles) {
 		await options.hooks.beforeWordPressFiles(php);
@@ -367,6 +366,7 @@ async function assertValidDatabaseConnection(
 }
 
 export async function bootRequestHandler(options: BootRequestHandlerOptions) {
+	defaultSqliteJournalMode(options);
 	const createSpawnHandler =
 		options.spawnHandler ?? sandboxedSpawnHandlerFactory;
 	async function createPhp(
@@ -499,6 +499,21 @@ export async function bootRequestHandler(options: BootRequestHandlerOptions) {
 	});
 
 	return requestHandler;
+}
+
+function defaultSqliteJournalMode(options: BootRequestHandlerOptions) {
+	if ('SQLITE_JOURNAL_MODE' in (options.constants ?? {})) {
+		return;
+	}
+
+	/*
+	 * Blueprint constants are applied after SQLite may have opened the first
+	 * connection. Define Playground's default through auto-prepend first.
+	 */
+	options.constants = {
+		...options.constants,
+		SQLITE_JOURNAL_MODE: 'DELETE',
+	};
 }
 
 /**

--- a/packages/playground/wordpress/src/test/database.spec.ts
+++ b/packages/playground/wordpress/src/test/database.spec.ts
@@ -50,7 +50,7 @@ describe('Test database', () => {
 	});
 
 	it(
-		'should install WordPress when SQL data path specified, even without SQLite ZIP path or SQLite driver directory',
+		'should install WordPress in DELETE journal mode when SQL data path specified',
 		async () => {
 			await using handler = await bootWordPressAndRequestHandler({
 				createPhpRuntime: async () =>
@@ -67,6 +67,54 @@ describe('Test database', () => {
 			expect(Object.keys(MinifiedWordPressVersions)).toContain(
 				loadedWordPressVersion
 			);
+
+			const php = await handler.getPrimaryPhp();
+			const response = await php.run({
+				code: `<?php
+ob_start();
+require getenv('DOCUMENT_ROOT') . '/wp-load.php';
+ob_clean();
+echo $GLOBALS['@pdo']->query('PRAGMA journal_mode')->fetchColumn();
+`,
+				env: {
+					DOCUMENT_ROOT: '/wordpress',
+				},
+			});
+			expect(response.errors).toHaveLength(0);
+			expect(response.text).toBe('delete');
+		},
+		{ timeout: 30_000 }
+	);
+
+	it(
+		'should honor explicit WAL journal mode',
+		async () => {
+			await using handler = await bootWordPressAndRequestHandler({
+				createPhpRuntime: async () =>
+					await loadNodeRuntime(RecommendedPHPVersion),
+				siteUrl: 'http://playground-domain/',
+				wordPressZip: await getWordPressModule(),
+				sqliteIntegrationPluginZip: await getSqliteDriverModule(),
+				dataSqlPath: '/wordpress/wp-content/database/.ht.sqlite',
+				constants: {
+					SQLITE_JOURNAL_MODE: 'WAL',
+				},
+			});
+
+			const php = await handler.getPrimaryPhp();
+			const response = await php.run({
+				code: `<?php
+ob_start();
+require getenv('DOCUMENT_ROOT') . '/wp-load.php';
+ob_clean();
+echo $GLOBALS['@pdo']->query('PRAGMA journal_mode')->fetchColumn();
+`,
+				env: {
+					DOCUMENT_ROOT: '/wordpress',
+				},
+			});
+			expect(response.errors).toHaveLength(0);
+			expect(response.text).toBe('wal');
 		},
 		{ timeout: 30_000 }
 	);


### PR DESCRIPTION
## What it does

Defaults `SQLITE_JOURNAL_MODE` to `DELETE` before PHP instances run auto-prepended Playground code.

Explicit callers can still opt into WAL with:

```ts
constants: {
	SQLITE_JOURNAL_MODE: 'WAL',
}
```

## Rationale

Blueprint-defined constants are too late for this setting: the SQLite integration may already be loaded by the time Blueprint steps run. Defining `SQLITE_JOURNAL_MODE` through `bootRequestHandler()` feeds the PHP auto-prepend path early enough.

## Implementation

Adds a request-handler boot default that only runs when the caller has not already provided `SQLITE_JOURNAL_MODE`.

## Testing instructions

Run:

```bash
npm exec nx lint playground-wordpress
npm exec nx test playground-wordpress --testFile=database.spec.ts
```

Note: the database test requires the refreshed SQLite integration bundle that includes WordPress/sqlite-database-integration#447. Against the current pre-refresh bundle, the new DELETE-mode assertion still reports `wal`.
