### PR TITLE
[Blueprints] Lower Blueprint v2 plan items to step records

### DIFF
--- a/packages/playground/blueprints/src/lib/v2/compile.ts
+++ b/packages/playground/blueprints/src/lib/v2/compile.ts
@@ -3,7 +3,13 @@ import { joinPaths } from '@php-wasm/util';
 import type { RuntimeConfiguration } from '../types';
 import { resolveRuntimeConfiguration } from '../resolve-runtime-configuration';
 import { seemsLikeGitRepoUrl } from '../is-git-repo-url';
-import type { StepDefinition } from '../steps';
+import type {
+	InstallPluginOptions,
+	InstallPluginStep,
+	InstallThemeOptions,
+	InstallThemeStep,
+	StepDefinition,
+} from '../steps';
 import type { DirectoryReference, FileReference } from '../v1/resources';
 import type { BlueprintV2Declaration } from './blueprint-v2-declaration';
 
@@ -503,27 +509,46 @@ function lowerAdditionalBlueprintV2Step(
  */
 function createInstallPluginStep(plugin: BlueprintV2Plugin): StepDefinition {
 	const definition = normalizeAssetDefinition(plugin);
-
-	return {
+	const step: InstallPluginStep<FileReference, DirectoryReference> = {
 		step: 'installPlugin',
 		pluginData: convertV2DataReferenceToV1(definition.source, 'plugin'),
-		...(definition.ifAlreadyInstalled
-			? { ifAlreadyInstalled: definition.ifAlreadyInstalled }
-			: {}),
-		options: {
-			activate: definition.active ?? true,
-			...(definition.activationOptions
-				? { activationOptions: definition.activationOptions }
-				: {}),
-			...(definition.onError ? { onError: definition.onError } : {}),
-			...(definition.targetDirectoryName
-				? { targetFolderName: definition.targetDirectoryName }
-				: {}),
-			...(definition.humanReadableName
-				? { humanReadableName: definition.humanReadableName }
-				: {}),
-		},
-	} as StepDefinition;
+		options: createInstallPluginOptions(definition),
+	};
+
+	if (definition.ifAlreadyInstalled) {
+		step.ifAlreadyInstalled = definition.ifAlreadyInstalled;
+	}
+
+	return step;
+}
+
+/**
+ * Maps plugin-only v2 install options to the v1 `installPlugin` option names.
+ */
+function createInstallPluginOptions(
+	definition: BlueprintV2InstallAssetDefinition
+): InstallPluginOptions {
+	const options: InstallPluginOptions = {
+		activate: definition.active ?? true,
+	};
+
+	if (definition.activationOptions) {
+		options.activationOptions = definition.activationOptions;
+	}
+	if (
+		definition.onError === 'skip-plugin' ||
+		definition.onError === 'throw'
+	) {
+		options.onError = definition.onError;
+	}
+	if (definition.targetDirectoryName) {
+		options.targetFolderName = definition.targetDirectoryName;
+	}
+	if (definition.humanReadableName) {
+		options.humanReadableName = definition.humanReadableName;
+	}
+
+	return options;
 }
 
 /**
@@ -537,25 +562,42 @@ function createInstallThemeStep(
 	active: boolean
 ): StepDefinition {
 	const definition = normalizeAssetDefinition(theme);
-
-	return {
+	const step: InstallThemeStep<FileReference, DirectoryReference> = {
 		step: 'installTheme',
 		themeData: convertV2DataReferenceToV1(definition.source, 'theme'),
-		...(definition.ifAlreadyInstalled
-			? { ifAlreadyInstalled: definition.ifAlreadyInstalled }
-			: {}),
-		options: {
-			activate: active,
-			importStarterContent: definition.importStarterContent ?? false,
-			...(definition.targetDirectoryName
-				? { targetFolderName: definition.targetDirectoryName }
-				: {}),
-			...(definition.onError ? { onError: definition.onError } : {}),
-			...(definition.humanReadableName
-				? { humanReadableName: definition.humanReadableName }
-				: {}),
-		},
-	} as StepDefinition;
+		options: createInstallThemeOptions(definition, active),
+	};
+
+	if (definition.ifAlreadyInstalled) {
+		step.ifAlreadyInstalled = definition.ifAlreadyInstalled;
+	}
+
+	return step;
+}
+
+/**
+ * Maps theme-only v2 install options to the v1 `installTheme` option names.
+ */
+function createInstallThemeOptions(
+	definition: BlueprintV2InstallAssetDefinition,
+	active: boolean
+): InstallThemeOptions {
+	const options: InstallThemeOptions = {
+		activate: active,
+		importStarterContent: definition.importStarterContent ?? false,
+	};
+
+	if (definition.targetDirectoryName) {
+		options.targetFolderName = definition.targetDirectoryName;
+	}
+	if (definition.onError === 'skip-theme' || definition.onError === 'throw') {
+		options.onError = definition.onError;
+	}
+	if (definition.humanReadableName) {
+		options.humanReadableName = definition.humanReadableName;
+	}
+
+	return options;
 }
 
 /**

--- a/packages/playground/blueprints/src/lib/v2/compile.ts
+++ b/packages/playground/blueprints/src/lib/v2/compile.ts
@@ -158,6 +158,14 @@ export type CompiledBlueprintV2 = {
 	run: (playground: UniversalPHP) => Promise<void>;
 };
 
+/**
+ * Compiles a Blueprint v2 declaration into the pieces the TypeScript runner can
+ * understand today.
+ *
+ * This does not make v2 plans runnable yet. It resolves runtime options, creates
+ * an ordered v2 execution plan, and lowers the supported plan items into v1 step
+ * records so later PRs can wire those records into the existing runner.
+ */
 export async function compileBlueprintV2(
 	declaration: BlueprintV2Declaration
 ): Promise<CompiledBlueprintV2> {
@@ -181,6 +189,13 @@ export async function compileBlueprintV2(
 	};
 }
 
+/**
+ * Converts the top-level Blueprint v2 fields into a simple ordered plan.
+ *
+ * The plan keeps the original v2 data intact. It only decides execution order
+ * and records where each item came from, which makes unsupported items visible
+ * instead of silently dropping them during lowering.
+ */
 export function createBlueprintV2ExecutionPlan(
 	declaration: BlueprintV2Declaration
 ): BlueprintV2ExecutionPlan {
@@ -307,6 +322,13 @@ export function createBlueprintV2ExecutionPlan(
 	return plan;
 }
 
+/**
+ * Converts the supported v2 plan items into v1-compatible step records.
+ *
+ * The v1 step runner already knows how to install plugins, install themes, set
+ * options, and run several imperative steps. This function reuses those shapes
+ * while keeping unsupported v2-only work in `unsupportedPlan` for future PRs.
+ */
 export function lowerBlueprintV2ExecutionPlan(
 	plan: BlueprintV2ExecutionPlan
 ): BlueprintV2StepPlanLoweringResult {
@@ -325,6 +347,12 @@ export function lowerBlueprintV2ExecutionPlan(
 	return { steps, unsupportedPlan };
 }
 
+/**
+ * Lowers one v2 plan item when it has a direct v1 step equivalent.
+ *
+ * Returning `undefined` is intentional: it means "this plan item is valid v2,
+ * but this PR has not taught the TypeScript runner how to represent it yet."
+ */
 function lowerBlueprintV2ExecutionPlanItem(
 	planItem: BlueprintV2ExecutionPlanItem
 ): StepDefinition[] | undefined {
@@ -361,6 +389,10 @@ function lowerBlueprintV2ExecutionPlanItem(
 	}
 }
 
+/**
+ * Lowers v2's `additionalStepsAfterExecution` entries that already match v1
+ * steps closely enough to reuse their existing runner implementations.
+ */
 function lowerAdditionalBlueprintV2Step(
 	step: BlueprintV2Step
 ): StepDefinition[] | undefined {
@@ -462,6 +494,13 @@ function lowerAdditionalBlueprintV2Step(
 	}
 }
 
+/**
+ * Creates the v1 `installPlugin` step for a v2 plugin declaration.
+ *
+ * Blueprint v2 accepts either a bare data reference (`"akismet"`) or an object
+ * with a `source` plus install options. `normalizeAssetDefinition()` gives both
+ * forms one shape before this function maps the fields to v1 names.
+ */
 function createInstallPluginStep(plugin: BlueprintV2Plugin): StepDefinition {
 	const definition = normalizeAssetDefinition(plugin);
 
@@ -487,6 +526,12 @@ function createInstallPluginStep(plugin: BlueprintV2Plugin): StepDefinition {
 	} as StepDefinition;
 }
 
+/**
+ * Creates the v1 `installTheme` step for a v2 theme declaration.
+ *
+ * `active` comes from the surrounding v2 plan item because top-level themes and
+ * `activeTheme` use the same source shapes but different activation behavior.
+ */
 function createInstallThemeStep(
 	theme: BlueprintV2Theme | BlueprintV2ActiveTheme,
 	active: boolean
@@ -513,6 +558,13 @@ function createInstallThemeStep(
 	} as StepDefinition;
 }
 
+/**
+ * Turns the two accepted v2 asset forms into a single object shape.
+ *
+ * Objects with `source` are full install definitions. Inline files, inline
+ * directories, git references, and strings are data references and must be
+ * wrapped as `{ source }` before they can be lowered.
+ */
 function normalizeAssetDefinition(
 	asset: BlueprintV2Plugin | BlueprintV2Theme | BlueprintV2ActiveTheme
 ): BlueprintV2InstallAssetDefinition {
@@ -529,6 +581,13 @@ function normalizeAssetDefinition(
 	return { source: asset as BlueprintV2DataReference };
 }
 
+/**
+ * Maps a Blueprint v2 data reference to the equivalent v1 resource.
+ *
+ * V2 groups URLs, WordPress.org slugs, execution-context paths, inline data,
+ * and git repositories into one data-reference concept. V1 uses separate
+ * `resource` names, so each supported v2 form is identified here explicitly.
+ */
 function convertV2DataReferenceToV1(
 	reference: BlueprintV2DataReference,
 	context: 'plugin' | 'theme'
@@ -590,6 +649,14 @@ function convertV2DataReferenceToV1(
 	);
 }
 
+/**
+ * Converts a v2 target-site path into the absolute WordPress VFS path that v1
+ * file steps expect.
+ *
+ * V2 paths in imperative file steps are site-relative (`site:...`) or plain
+ * relative paths. Empty paths and parent-directory segments are rejected because
+ * they would make destructive steps like `rm` ambiguous or unsafe.
+ */
 function toPlaygroundPath(path: string): string {
 	if (typeof path !== 'string' || path.trim() === '') {
 		throw new UnsupportedBlueprintV2FeatureError(
@@ -612,6 +679,10 @@ function toPlaygroundPath(path: string): string {
 	return joinPaths('/wordpress', path);
 }
 
+/**
+ * Checks whether a string is an HTTP(S) URL rather than a WordPress.org slug or
+ * a Blueprint execution-context path.
+ */
 function isHttpUrl(value: string) {
 	try {
 		const url = new URL(value);
@@ -621,6 +692,9 @@ function isHttpUrl(value: string) {
 	}
 }
 
+/**
+ * Checks whether a string points at a file in the Blueprint Execution Context.
+ */
 function isExecutionContextPath(value: string) {
 	// The Blueprint v2 schema defines both "./" and "/" as paths in the
 	// Blueprint Execution Context. "/" is chrooted there, not in WordPress.
@@ -632,10 +706,18 @@ function isExecutionContextPath(value: string) {
 	);
 }
 
+/**
+ * Removes the execution-context marker so v1 bundled resources can resolve the
+ * path relative to the bundle root.
+ */
 function normalizeExecutionContextPath(path: string) {
 	return path.replace(/^\.?\//, '');
 }
 
+/**
+ * Rejects parent-directory traversal before a v2 path is converted to a v1 VFS
+ * or bundled-resource path.
+ */
 function pathContainsParentDirectorySegment(path: string) {
 	const vfsPath = path.startsWith('site:')
 		? path.slice('site:'.length)
@@ -643,6 +725,10 @@ function pathContainsParentDirectorySegment(path: string) {
 	return vfsPath.replace(/\\/g, '/').split('/').includes('..');
 }
 
+/**
+ * Converts a WordPress.org slug, optionally with `@version`, to the v1 resource
+ * shape that the existing plugin/theme installers already consume.
+ */
 function wordpressOrgResource(
 	reference: string,
 	type: 'plugins' | 'themes'
@@ -664,6 +750,9 @@ function wordpressOrgResource(
 	} as FileReference;
 }
 
+/**
+ * Detects v2 inline file references.
+ */
 function isInlineFile(
 	value: any
 ): value is { filename: string; content: string } {
@@ -675,6 +764,9 @@ function isInlineFile(
 	);
 }
 
+/**
+ * Detects v2 inline directory references.
+ */
 function isInlineDirectory(value: any): value is {
 	directoryName: string;
 	files: Record<string, string | BlueprintV2InlineDirectory>;
@@ -688,6 +780,9 @@ function isInlineDirectory(value: any): value is {
 	);
 }
 
+/**
+ * Detects v2 git directory references.
+ */
 function isGitPath(value: any): value is {
 	gitRepository: string;
 	ref?: string;
@@ -701,6 +796,14 @@ function isGitPath(value: any): value is {
 	);
 }
 
+/**
+ * Converts v2 inline directory contents to the recursive file-tree object used
+ * by v1 literal directory resources.
+ *
+ * File names come from user input, so `Object.defineProperty()` is used instead
+ * of normal assignment. That keeps names such as `__proto__` as file entries
+ * instead of letting JavaScript treat them as object-prototype operations.
+ */
 function inlineDirectoryFilesToFileTree(
 	files: Record<string, string | BlueprintV2InlineDirectory>
 ): FileTree {

--- a/packages/playground/blueprints/src/lib/v2/compile.ts
+++ b/packages/playground/blueprints/src/lib/v2/compile.ts
@@ -64,6 +64,16 @@ type BlueprintV2DataReference =
 type BlueprintV2InlineDirectory = {
 	files: Record<string, string | BlueprintV2InlineDirectory>;
 };
+type BlueprintV2InstallAssetDefinition = {
+	source: BlueprintV2DataReference;
+	active?: boolean;
+	activationOptions?: Record<string, unknown>;
+	ifAlreadyInstalled?: 'overwrite' | 'skip' | 'error';
+	importStarterContent?: boolean;
+	targetDirectoryName?: string;
+	onError?: 'skip-plugin' | 'skip-theme' | 'throw';
+	humanReadableName?: string;
+};
 
 export type BlueprintV2ExecutionPlan = BlueprintV2ExecutionPlanItem[];
 export type BlueprintV2StepPlan = StepDefinition[];
@@ -503,17 +513,20 @@ function createInstallThemeStep(
 	} as StepDefinition;
 }
 
-function normalizeAssetDefinition(asset: any) {
+function normalizeAssetDefinition(
+	asset: BlueprintV2Plugin | BlueprintV2Theme | BlueprintV2ActiveTheme
+): BlueprintV2InstallAssetDefinition {
 	if (
 		asset &&
 		typeof asset === 'object' &&
+		'source' in asset &&
 		!isInlineFile(asset) &&
 		!isInlineDirectory(asset) &&
 		!isGitPath(asset)
 	) {
-		return asset;
+		return asset as BlueprintV2InstallAssetDefinition;
 	}
-	return { source: asset };
+	return { source: asset as BlueprintV2DataReference };
 }
 
 function convertV2DataReferenceToV1(
@@ -578,8 +591,11 @@ function convertV2DataReferenceToV1(
 }
 
 function toPlaygroundPath(path: string): string {
-	if (typeof path !== 'string' || path.length === 0) {
-		return '/wordpress';
+	if (typeof path !== 'string' || path.trim() === '') {
+		throw new UnsupportedBlueprintV2FeatureError(
+			'path',
+			'Invalid Blueprint v2 path: must not be empty.'
+		);
 	}
 	if (pathContainsParentDirectorySegment(path)) {
 		throw new UnsupportedBlueprintV2FeatureError(
@@ -606,6 +622,8 @@ function isHttpUrl(value: string) {
 }
 
 function isExecutionContextPath(value: string) {
+	// The Blueprint v2 schema defines both "./" and "/" as paths in the
+	// Blueprint Execution Context. "/" is chrooted there, not in WordPress.
 	return (
 		(value.startsWith('./') || value.startsWith('/')) &&
 		!pathContainsParentDirectorySegment(
@@ -686,12 +704,18 @@ function isGitPath(value: any): value is {
 function inlineDirectoryFilesToFileTree(
 	files: Record<string, string | BlueprintV2InlineDirectory>
 ): FileTree {
-	return Object.fromEntries(
-		Object.entries(files).map(([path, content]) => {
-			if (typeof content === 'string') {
-				return [path, content];
-			}
-			return [path, inlineDirectoryFilesToFileTree(content.files)];
-		})
-	);
+	const fileTree: FileTree = {};
+	for (const [path, content] of Object.entries(files)) {
+		const value =
+			typeof content === 'string'
+				? content
+				: inlineDirectoryFilesToFileTree(content.files);
+		Object.defineProperty(fileTree, path, {
+			value,
+			enumerable: true,
+			configurable: true,
+			writable: true,
+		});
+	}
+	return fileTree;
 }

--- a/packages/playground/blueprints/src/lib/v2/compile.ts
+++ b/packages/playground/blueprints/src/lib/v2/compile.ts
@@ -1,6 +1,10 @@
-import type { UniversalPHP } from '@php-wasm/universal';
+import type { FileTree, UniversalPHP } from '@php-wasm/universal';
+import { joinPaths } from '@php-wasm/util';
 import type { RuntimeConfiguration } from '../types';
 import { resolveRuntimeConfiguration } from '../resolve-runtime-configuration';
+import { seemsLikeGitRepoUrl } from '../is-git-repo-url';
+import type { StepDefinition } from '../steps';
+import type { DirectoryReference, FileReference } from '../v1/resources';
 import type { BlueprintV2Declaration } from './blueprint-v2-declaration';
 
 export class UnsupportedBlueprintV2FeatureError extends Error {
@@ -41,8 +45,32 @@ type BlueprintV2Content = NonNullable<
 type BlueprintV2Step = NonNullable<
 	BlueprintV2Declaration['additionalStepsAfterExecution']
 >[number];
+type BlueprintV2DataReference =
+	| string
+	| {
+			filename: string;
+			content: string;
+	  }
+	| {
+			directoryName: string;
+			files: Record<string, string | BlueprintV2InlineDirectory>;
+	  }
+	| {
+			gitRepository: string;
+			ref?: string;
+			pathInRepository?: string;
+			path?: string;
+	  };
+type BlueprintV2InlineDirectory = {
+	files: Record<string, string | BlueprintV2InlineDirectory>;
+};
 
 export type BlueprintV2ExecutionPlan = BlueprintV2ExecutionPlanItem[];
+export type BlueprintV2StepPlan = StepDefinition[];
+export type BlueprintV2StepPlanLoweringResult = {
+	steps: BlueprintV2StepPlan;
+	unsupportedPlan: BlueprintV2ExecutionPlan;
+};
 
 export type BlueprintV2ExecutionPlanItem =
 	| {
@@ -115,6 +143,8 @@ export type CompiledBlueprintV2 = {
 	runtime: RuntimeConfiguration;
 	applicationOptions?: BlueprintV2ApplicationOptions;
 	plan: BlueprintV2ExecutionPlan;
+	steps: BlueprintV2StepPlan;
+	unsupportedPlan: BlueprintV2ExecutionPlan;
 	run: (playground: UniversalPHP) => Promise<void>;
 };
 
@@ -123,10 +153,13 @@ export async function compileBlueprintV2(
 ): Promise<CompiledBlueprintV2> {
 	const runtime = await resolveRuntimeConfiguration(declaration);
 	const plan = createBlueprintV2ExecutionPlan(declaration);
+	const { steps, unsupportedPlan } = lowerBlueprintV2ExecutionPlan(plan);
 	return {
 		runtime,
 		applicationOptions: declaration.applicationOptions,
 		plan,
+		steps,
+		unsupportedPlan,
 		run: async () => {
 			if (plan.length > 0) {
 				throw new UnsupportedBlueprintV2FeatureError(
@@ -262,4 +295,403 @@ export function createBlueprintV2ExecutionPlan(
 	}
 
 	return plan;
+}
+
+export function lowerBlueprintV2ExecutionPlan(
+	plan: BlueprintV2ExecutionPlan
+): BlueprintV2StepPlanLoweringResult {
+	const steps: StepDefinition[] = [];
+	const unsupportedPlan: BlueprintV2ExecutionPlan = [];
+
+	for (const planItem of plan) {
+		const loweredSteps = lowerBlueprintV2ExecutionPlanItem(planItem);
+		if (loweredSteps) {
+			steps.push(...loweredSteps);
+		} else {
+			unsupportedPlan.push(planItem);
+		}
+	}
+
+	return { steps, unsupportedPlan };
+}
+
+function lowerBlueprintV2ExecutionPlanItem(
+	planItem: BlueprintV2ExecutionPlanItem
+): StepDefinition[] | undefined {
+	switch (planItem.type) {
+		case 'defineWpConfigConsts':
+			return [
+				{
+					step: 'defineWpConfigConsts',
+					consts: planItem.consts,
+				},
+			];
+		case 'setSiteOptions':
+			return [
+				{
+					step: 'setSiteOptions',
+					options: planItem.options,
+				},
+			];
+		case 'installTheme':
+			return [createInstallThemeStep(planItem.theme, planItem.active)];
+		case 'installPlugin':
+			return [createInstallPluginStep(planItem.plugin)];
+		case 'setSiteLanguage':
+			return [
+				{
+					step: 'setSiteLanguage',
+					language: planItem.language,
+				},
+			];
+		case 'runStep':
+			return lowerAdditionalBlueprintV2Step(planItem.step);
+		default:
+			return undefined;
+	}
+}
+
+function lowerAdditionalBlueprintV2Step(
+	step: BlueprintV2Step
+): StepDefinition[] | undefined {
+	switch (step.step) {
+		case 'activatePlugin':
+			return [
+				{
+					step: 'activatePlugin',
+					pluginPath: step.pluginPath,
+					pluginName: step.humanReadableName,
+				},
+			];
+		case 'activateTheme':
+			return [
+				{
+					step: 'activateTheme',
+					themeFolderName: step.themeDirectoryName,
+				},
+			];
+		case 'cp':
+			return [
+				{
+					step: 'cp',
+					fromPath: toPlaygroundPath(step.fromPath),
+					toPath: toPlaygroundPath(step.toPath),
+				},
+			];
+		case 'defineConstants':
+			return [
+				{
+					step: 'defineWpConfigConsts',
+					consts: step.constants,
+				},
+			];
+		case 'importThemeStarterContent':
+			return [
+				{
+					step: 'importThemeStarterContent',
+					themeSlug: step.themeSlug,
+				},
+			];
+		case 'installPlugin':
+			return [createInstallPluginStep(step)];
+		case 'installTheme':
+			return [createInstallThemeStep(step, step.active ?? true)];
+		case 'mkdir':
+			return [
+				{
+					step: 'mkdir',
+					path: toPlaygroundPath(step.path),
+				},
+			];
+		case 'mv':
+			return [
+				{
+					step: 'mv',
+					fromPath: toPlaygroundPath(step.fromPath),
+					toPath: toPlaygroundPath(step.toPath),
+				},
+			];
+		case 'rm':
+			return [
+				{
+					step: 'rm',
+					path: toPlaygroundPath(step.path),
+				},
+			];
+		case 'rmdir':
+			return [
+				{
+					step: 'rmdir',
+					path: toPlaygroundPath(step.path),
+				},
+			];
+		case 'setSiteLanguage':
+			return [
+				{
+					step: 'setSiteLanguage',
+					language: step.language,
+				},
+			];
+		case 'setSiteOptions':
+			return [
+				{
+					step: 'setSiteOptions',
+					options: step.options,
+				},
+			];
+		case 'wp-cli':
+			return [
+				{
+					step: 'wp-cli',
+					command: step.command,
+					wpCliPath: step.wpCliPath,
+				},
+			];
+		default:
+			return undefined;
+	}
+}
+
+function createInstallPluginStep(plugin: BlueprintV2Plugin): StepDefinition {
+	const definition = normalizeAssetDefinition(plugin);
+
+	return {
+		step: 'installPlugin',
+		pluginData: convertV2DataReferenceToV1(definition.source, 'plugin'),
+		...(definition.ifAlreadyInstalled
+			? { ifAlreadyInstalled: definition.ifAlreadyInstalled }
+			: {}),
+		options: {
+			activate: definition.active ?? true,
+			...(definition.activationOptions
+				? { activationOptions: definition.activationOptions }
+				: {}),
+			...(definition.onError ? { onError: definition.onError } : {}),
+			...(definition.targetDirectoryName
+				? { targetFolderName: definition.targetDirectoryName }
+				: {}),
+			...(definition.humanReadableName
+				? { humanReadableName: definition.humanReadableName }
+				: {}),
+		},
+	} as StepDefinition;
+}
+
+function createInstallThemeStep(
+	theme: BlueprintV2Theme | BlueprintV2ActiveTheme,
+	active: boolean
+): StepDefinition {
+	const definition = normalizeAssetDefinition(theme);
+
+	return {
+		step: 'installTheme',
+		themeData: convertV2DataReferenceToV1(definition.source, 'theme'),
+		...(definition.ifAlreadyInstalled
+			? { ifAlreadyInstalled: definition.ifAlreadyInstalled }
+			: {}),
+		options: {
+			activate: active,
+			importStarterContent: definition.importStarterContent ?? false,
+			...(definition.targetDirectoryName
+				? { targetFolderName: definition.targetDirectoryName }
+				: {}),
+			...(definition.onError ? { onError: definition.onError } : {}),
+			...(definition.humanReadableName
+				? { humanReadableName: definition.humanReadableName }
+				: {}),
+		},
+	} as StepDefinition;
+}
+
+function normalizeAssetDefinition(asset: any) {
+	if (
+		asset &&
+		typeof asset === 'object' &&
+		!isInlineFile(asset) &&
+		!isInlineDirectory(asset) &&
+		!isGitPath(asset)
+	) {
+		return asset;
+	}
+	return { source: asset };
+}
+
+function convertV2DataReferenceToV1(
+	reference: BlueprintV2DataReference,
+	context: 'plugin' | 'theme'
+): FileReference | DirectoryReference {
+	if (typeof reference === 'string') {
+		if (seemsLikeGitRepoUrl(reference)) {
+			return {
+				resource: 'zip',
+				inner: {
+					resource: 'git:directory',
+					url: reference.trim().replace(/\/+$/, ''),
+					ref: 'HEAD',
+				},
+			};
+		}
+		if (isHttpUrl(reference)) {
+			return { resource: 'url', url: reference };
+		}
+		if (isExecutionContextPath(reference)) {
+			return {
+				resource: 'bundled',
+				path: normalizeExecutionContextPath(reference),
+			};
+		}
+		return wordpressOrgResource(
+			reference,
+			context === 'plugin' ? 'plugins' : 'themes'
+		);
+	}
+
+	if (isInlineFile(reference)) {
+		return {
+			resource: 'literal',
+			name: reference.filename,
+			contents: reference.content,
+		};
+	}
+
+	if (isInlineDirectory(reference)) {
+		return {
+			resource: 'literal:directory',
+			name: reference.directoryName,
+			files: inlineDirectoryFilesToFileTree(reference.files),
+		};
+	}
+
+	if (isGitPath(reference)) {
+		return {
+			resource: 'git:directory',
+			url: reference.gitRepository,
+			ref: reference.ref || 'HEAD',
+			path: reference.pathInRepository || reference.path || '',
+		};
+	}
+
+	throw new UnsupportedBlueprintV2FeatureError(
+		context,
+		'Unsupported Blueprint v2 data reference.'
+	);
+}
+
+function toPlaygroundPath(path: string): string {
+	if (typeof path !== 'string' || path.length === 0) {
+		return '/wordpress';
+	}
+	if (pathContainsParentDirectorySegment(path)) {
+		throw new UnsupportedBlueprintV2FeatureError(
+			'path',
+			`Invalid Blueprint v2 path "${path}": must not contain parent directory segments.`
+		);
+	}
+	if (path.startsWith('site:')) {
+		return joinPaths('/wordpress', path.slice('site:'.length));
+	}
+	if (path === '/wordpress' || path.startsWith('/wordpress/')) {
+		return path;
+	}
+	return joinPaths('/wordpress', path);
+}
+
+function isHttpUrl(value: string) {
+	try {
+		const url = new URL(value);
+		return url.protocol === 'http:' || url.protocol === 'https:';
+	} catch {
+		return false;
+	}
+}
+
+function isExecutionContextPath(value: string) {
+	return (
+		(value.startsWith('./') || value.startsWith('/')) &&
+		!pathContainsParentDirectorySegment(
+			normalizeExecutionContextPath(value)
+		)
+	);
+}
+
+function normalizeExecutionContextPath(path: string) {
+	return path.replace(/^\.?\//, '');
+}
+
+function pathContainsParentDirectorySegment(path: string) {
+	const vfsPath = path.startsWith('site:')
+		? path.slice('site:'.length)
+		: path;
+	return vfsPath.replace(/\\/g, '/').split('/').includes('..');
+}
+
+function wordpressOrgResource(
+	reference: string,
+	type: 'plugins' | 'themes'
+): FileReference {
+	const [slug, version] = reference.split('@');
+	if (version && version !== 'latest') {
+		const singular = type === 'plugins' ? 'plugin' : 'theme';
+		return {
+			resource: 'url',
+			url: `https://downloads.wordpress.org/${singular}/${slug}.${version}.zip`,
+		};
+	}
+	return {
+		resource:
+			type === 'plugins'
+				? 'wordpress.org/plugins'
+				: 'wordpress.org/themes',
+		slug,
+	} as FileReference;
+}
+
+function isInlineFile(
+	value: any
+): value is { filename: string; content: string } {
+	return (
+		value &&
+		typeof value === 'object' &&
+		typeof value.filename === 'string' &&
+		typeof value.content === 'string'
+	);
+}
+
+function isInlineDirectory(value: any): value is {
+	directoryName: string;
+	files: Record<string, string | BlueprintV2InlineDirectory>;
+} {
+	return (
+		value &&
+		typeof value === 'object' &&
+		typeof value.directoryName === 'string' &&
+		value.files &&
+		typeof value.files === 'object'
+	);
+}
+
+function isGitPath(value: any): value is {
+	gitRepository: string;
+	ref?: string;
+	pathInRepository?: string;
+	path?: string;
+} {
+	return (
+		value &&
+		typeof value === 'object' &&
+		typeof value.gitRepository === 'string'
+	);
+}
+
+function inlineDirectoryFilesToFileTree(
+	files: Record<string, string | BlueprintV2InlineDirectory>
+): FileTree {
+	return Object.fromEntries(
+		Object.entries(files).map(([path, content]) => {
+			if (typeof content === 'string') {
+				return [path, content];
+			}
+			return [path, inlineDirectoryFilesToFileTree(content.files)];
+		})
+	);
 }

--- a/packages/playground/blueprints/src/tests/compile.spec.ts
+++ b/packages/playground/blueprints/src/tests/compile.spec.ts
@@ -235,6 +235,200 @@ describe('compileBlueprintForExecution', () => {
 		await expect(compiled.run({} as any)).resolves.toBeUndefined();
 	});
 
+	it('lowers supported Blueprint v2 plan items to v1-compatible step records', async () => {
+		const declaration: BlueprintV2Declaration = {
+			version: 2,
+			constants: {
+				WP_DEBUG: true,
+			},
+			siteOptions: {
+				blogname: 'Lowered v2 plan',
+			},
+			themes: ['twentytwentythree'],
+			activeTheme: {
+				source: 'twentytwentyfour@1.2.3',
+				humanReadableName: 'Twenty Twenty-Four',
+			},
+			plugins: [
+				{
+					source: 'akismet',
+					active: false,
+					ifAlreadyInstalled: 'skip',
+					activationOptions: {
+						mode: 'test',
+					},
+				},
+			],
+			media: ['./media/image.jpg'],
+			siteLanguage: 'pl_PL',
+			additionalStepsAfterExecution: [
+				{
+					step: 'mkdir',
+					path: 'site:wp-content/uploads/from-v2',
+				},
+				{
+					step: 'defineConstants',
+					constants: {
+						SCRIPT_DEBUG: true,
+					},
+				},
+				{
+					step: 'setSiteOptions',
+					options: {
+						timezone_string: 'Europe/Warsaw',
+					},
+				},
+				{
+					step: 'installPlugin',
+					source: 'https://github.com/WordPress/wordpress-importer',
+					active: true,
+				},
+				{
+					step: 'installTheme',
+					source: {
+						directoryName: 'inline-theme',
+						files: {
+							'style.css': 'Theme Name: Inline',
+						},
+					},
+					active: false,
+				},
+				{
+					step: 'wp-cli',
+					command: 'plugin list',
+				},
+				{
+					step: 'runSQL',
+					source: './dump.sql',
+				},
+			],
+		};
+
+		const compiled = await compileBlueprintForExecution(declaration);
+
+		expect(compiled.version).toBe(2);
+		if (compiled.version !== 2) {
+			throw new Error('Expected a compiled Blueprint v2 result.');
+		}
+		expect(compiled.compiled.steps.map((step) => step.step)).toEqual([
+			'defineWpConfigConsts',
+			'setSiteOptions',
+			'installTheme',
+			'installTheme',
+			'installPlugin',
+			'setSiteLanguage',
+			'mkdir',
+			'defineWpConfigConsts',
+			'setSiteOptions',
+			'installPlugin',
+			'installTheme',
+			'wp-cli',
+		]);
+		expect(compiled.compiled.steps).toMatchObject([
+			{
+				step: 'defineWpConfigConsts',
+				consts: {
+					WP_DEBUG: true,
+				},
+			},
+			{
+				step: 'setSiteOptions',
+				options: {
+					blogname: 'Lowered v2 plan',
+				},
+			},
+			{
+				step: 'installTheme',
+				themeData: {
+					resource: 'wordpress.org/themes',
+					slug: 'twentytwentythree',
+				},
+				options: {
+					activate: false,
+				},
+			},
+			{
+				step: 'installTheme',
+				themeData: {
+					resource: 'url',
+					url: 'https://downloads.wordpress.org/theme/twentytwentyfour.1.2.3.zip',
+				},
+				options: {
+					activate: true,
+					humanReadableName: 'Twenty Twenty-Four',
+				},
+			},
+			{
+				step: 'installPlugin',
+				pluginData: {
+					resource: 'wordpress.org/plugins',
+					slug: 'akismet',
+				},
+				ifAlreadyInstalled: 'skip',
+				options: {
+					activate: false,
+					activationOptions: {
+						mode: 'test',
+					},
+				},
+			},
+			{
+				step: 'setSiteLanguage',
+				language: 'pl_PL',
+			},
+			{
+				step: 'mkdir',
+				path: '/wordpress/wp-content/uploads/from-v2',
+			},
+			{
+				step: 'defineWpConfigConsts',
+				consts: {
+					SCRIPT_DEBUG: true,
+				},
+			},
+			{
+				step: 'setSiteOptions',
+				options: {
+					timezone_string: 'Europe/Warsaw',
+				},
+			},
+			{
+				step: 'installPlugin',
+				pluginData: {
+					resource: 'zip',
+					inner: {
+						resource: 'git:directory',
+						url: 'https://github.com/WordPress/wordpress-importer',
+						ref: 'HEAD',
+					},
+				},
+				options: {
+					activate: true,
+				},
+			},
+			{
+				step: 'installTheme',
+				themeData: {
+					resource: 'literal:directory',
+					name: 'inline-theme',
+					files: {
+						'style.css': 'Theme Name: Inline',
+					},
+				},
+				options: {
+					activate: false,
+				},
+			},
+			{
+				step: 'wp-cli',
+				command: 'plugin list',
+			},
+		]);
+		expect(
+			compiled.compiled.unsupportedPlan.map((item) => item.type)
+		).toEqual(['importMedia', 'runStep']);
+	});
+
 	it('rejects running Blueprint v2 plans until plan items are wired', async () => {
 		const compiled = await compileBlueprintForExecution({
 			version: 2,

--- a/packages/playground/blueprints/src/tests/compile.spec.ts
+++ b/packages/playground/blueprints/src/tests/compile.spec.ts
@@ -429,6 +429,70 @@ describe('compileBlueprintForExecution', () => {
 		).toEqual(['importMedia', 'runStep']);
 	});
 
+	it('rejects empty Blueprint v2 target-site paths', async () => {
+		await expect(
+			compileBlueprintForExecution({
+				version: 2,
+				additionalStepsAfterExecution: [
+					{
+						step: 'rm',
+						path: '',
+					},
+				],
+			} as BlueprintV2Declaration)
+		).rejects.toThrow('Invalid Blueprint v2 path: must not be empty.');
+	});
+
+	it('treats absolute data paths as Blueprint execution-context paths', async () => {
+		const compiled = await compileBlueprintForExecution({
+			version: 2,
+			plugins: [
+				{
+					source: '/plugins/local-plugin.zip',
+				},
+			],
+		});
+
+		expect(compiled.version).toBe(2);
+		if (compiled.version !== 2) {
+			throw new Error('Expected a compiled Blueprint v2 result.');
+		}
+		expect(compiled.compiled.steps[0]).toMatchObject({
+			step: 'installPlugin',
+			pluginData: {
+				resource: 'bundled',
+				path: 'plugins/local-plugin.zip',
+			},
+		});
+	});
+
+	it('preserves special inline directory filenames as plain file entries', async () => {
+		const compiled = await compileBlueprintForExecution({
+			version: 2,
+			plugins: [
+				{
+					source: {
+						directoryName: 'inline-plugin',
+						files: {
+							['__proto__']: 'not a prototype',
+						},
+					},
+				},
+			],
+		});
+
+		expect(compiled.version).toBe(2);
+		if (compiled.version !== 2) {
+			throw new Error('Expected a compiled Blueprint v2 result.');
+		}
+		const pluginData = (compiled.compiled.steps[0] as any).pluginData;
+		expect(
+			Object.prototype.hasOwnProperty.call(pluginData.files, '__proto__')
+		).toBe(true);
+		expect(pluginData.files.__proto__).toBe('not a prototype');
+		expect(Object.getPrototypeOf(pluginData.files)).toBe(Object.prototype);
+	});
+
 	it('rejects running Blueprint v2 plans until plan items are wired', async () => {
 		const compiled = await compileBlueprintForExecution({
 			version: 2,


### PR DESCRIPTION
## What it does

Adds the next v2-local layer after #3908: `compileBlueprintV2()` now includes a lowered `steps` array and an `unsupportedPlan` array alongside the existing v2 `plan`.

In this PR, **lowering** means translating Blueprint v2 declarations into the older v1 step records that the current TypeScript runner already understands. For example, a v2 `plugins` declaration becomes an `installPlugin` step record, and a v2 `siteOptions` declaration becomes a `setSiteOptions` step record.

This PR does not execute those step records yet. It only converts the supported v2 plan items into a runner-friendly shape and keeps the rest visible as unsupported work.

The lowering covers many of the safe, already-understood v2 plan items:

- `constants` -> `defineWpConfigConsts`
- `siteOptions` -> `setSiteOptions`
- `siteLanguage` -> `setSiteLanguage`
- top-level `plugins` -> `installPlugin` step records
- top-level `themes` / `activeTheme` -> `installTheme` step records
- simple `additionalStepsAfterExecution` entries like `mkdir`, `cp`, `mv`, `rm`, `rmdir`, `defineConstants`, `setSiteOptions`, `setSiteLanguage`, `installPlugin`, `installTheme`, `activatePlugin`, `activateTheme`, `importThemeStarterContent`, and `wp-cli`

Unsupported v2-only areas such as media/content/font/user/role/post-type imports remain in `unsupportedPlan` instead of being silently dropped.

## Rationale

This keeps processing the larger TypeScript Blueprint v2 runner work from #3725 piece by piece. The previous PR made v2 declarations compile into an ordered v2 plan. This PR groups the v2-only translation work that does not need consumer wiring or actual runtime execution yet.

The benefit is that reviewers can inspect the v2-to-v1 mapping separately from the later execution work. If a v2 declaration maps cleanly to an existing v1 step shape, this PR makes that explicit. If it does not, the plan item stays in `unsupportedPlan` for a later focused PR.

It still does **not** execute the lowered steps, resolve resources at runtime, import content/media, or touch website/CLI/remote data flows. Non-empty v2 plans continue to reject at `run()` until a later PR wires execution.

## Implementation

Adds `lowerBlueprintV2ExecutionPlan()` in `lib/v2/compile.ts`. It returns:

```ts
{
  steps: StepDefinition[],
  unsupportedPlan: BlueprintV2ExecutionPlan
}
```

The lowering layer:

- walks the ordered v2 execution plan
- converts supported plan items to existing `StepDefinition` records
- keeps unsupported items in `unsupportedPlan`
- converts plugin/theme data references into existing v1 resource shapes
- normalizes target-site paths for simple file steps
- rejects empty paths and parent-directory traversal before producing v1 paths

Plugin/theme data references are lowered for WordPress.org slugs, versioned slugs, URLs, GitHub/GitLab repo URLs, execution-context paths, inline files, inline directories, and git directory objects.

## Testing instructions

```bash
npm run format:uncommitted
npm exec nx run playground-blueprints:test:vite -- --testFiles=packages/playground/blueprints/src/tests/compile.spec.ts
npm exec nx run playground-blueprints:typecheck
npm exec nx run playground-blueprints:lint
npm exec nx run playground-blueprints:build
git diff --check
```

Part of #2592.