### PR TITLE
[Blueprints] Run lowered Blueprint v2 steps

### DIFF
--- a/packages/playground/blueprints/src/lib/v2/compile.ts
+++ b/packages/playground/blueprints/src/lib/v2/compile.ts
@@ -3,6 +3,8 @@ import { joinPaths } from '@php-wasm/util';
 import type { RuntimeConfiguration } from '../types';
 import { resolveRuntimeConfiguration } from '../resolve-runtime-configuration';
 import { seemsLikeGitRepoUrl } from '../is-git-repo-url';
+import { compileBlueprintV1 } from '../v1/compile';
+import type { BlueprintV1Declaration } from '../v1/types';
 import type {
 	InstallPluginOptions,
 	InstallPluginStep,
@@ -178,21 +180,71 @@ export async function compileBlueprintV2(
 	const runtime = await resolveRuntimeConfiguration(declaration);
 	const plan = createBlueprintV2ExecutionPlan(declaration);
 	const { steps, unsupportedPlan } = lowerBlueprintV2ExecutionPlan(plan);
+	const v1Blueprint = createV1BlueprintForLoweredV2Steps(
+		declaration,
+		runtime,
+		steps
+	);
 	return {
 		runtime,
 		applicationOptions: declaration.applicationOptions,
 		plan,
 		steps,
 		unsupportedPlan,
-		run: async () => {
-			if (plan.length > 0) {
+		run: async (playground) => {
+			if (unsupportedPlan.length > 0) {
 				throw new UnsupportedBlueprintV2FeatureError(
 					'executionPlan',
-					'Blueprint v2 execution plans are not runnable by the TypeScript runner yet.'
+					getUnsupportedPlanMessage(unsupportedPlan)
 				);
 			}
+			const v1Runner = await compileBlueprintV1(v1Blueprint);
+			await v1Runner.run(playground);
 		},
 	};
+}
+
+/**
+ * Builds the smallest v1 declaration needed to run already-lowered v2 steps.
+ *
+ * Top-level v2 constants, site options, plugins, and themes are not copied into
+ * the v1 top-level fields because the v2 plan lowering already converted them
+ * into ordered steps. Copying them here would make the v1 compiler run them
+ * twice.
+ */
+function createV1BlueprintForLoweredV2Steps(
+	declaration: BlueprintV2Declaration,
+	runtime: RuntimeConfiguration,
+	steps: BlueprintV2StepPlan
+): BlueprintV1Declaration {
+	const applicationOptions =
+		declaration.applicationOptions?.['wordpress-playground'];
+
+	return {
+		preferredVersions: {
+			php: runtime.phpVersion,
+			wp: runtime.wpVersion,
+		},
+		features: {
+			intl: runtime.intl,
+			networking: runtime.networking,
+		},
+		extraLibraries: runtime.extraLibraries,
+		landingPage: applicationOptions?.landingPage,
+		login: applicationOptions?.login,
+		steps,
+	};
+}
+
+function getUnsupportedPlanMessage(unsupportedPlan: BlueprintV2ExecutionPlan) {
+	const unsupportedTypes = Array.from(
+		new Set(unsupportedPlan.map((item) => item.type))
+	).join(', ');
+
+	return (
+		`Blueprint v2 execution plan contains unsupported items: ` +
+		`${unsupportedTypes}.`
+	);
 }
 
 /**

--- a/packages/playground/blueprints/src/tests/compile.spec.ts
+++ b/packages/playground/blueprints/src/tests/compile.spec.ts
@@ -3,6 +3,7 @@ import { vi } from 'vitest';
 import { compileBlueprintForExecution } from '../lib/compile';
 import type { BlueprintV1Declaration } from '../lib/v1/types';
 import type { BlueprintV2Declaration } from '../lib/v2/blueprint-v2-declaration';
+import { UnsupportedBlueprintV2FeatureError } from '../lib/v2/compile';
 
 describe('compileBlueprintForExecution', () => {
 	it('compiles Blueprint v1 declarations through the v1 compiler', async () => {
@@ -493,16 +494,54 @@ describe('compileBlueprintForExecution', () => {
 		expect(Object.getPrototypeOf(pluginData.files)).toBe(Object.prototype);
 	});
 
-	it('rejects running Blueprint v2 plans until plan items are wired', async () => {
+	it('runs fully lowered Blueprint v2 plans through the v1 runner', async () => {
 		const compiled = await compileBlueprintForExecution({
 			version: 2,
-			siteOptions: {
-				blogname: 'Compiled but not runnable yet',
-			},
+			additionalStepsAfterExecution: [
+				{
+					step: 'mkdir',
+					path: 'site:wp-content/uploads/from-v2',
+				},
+			],
 		});
+		const playground = {
+			mkdir: vi.fn(),
+		};
 
-		await expect(compiled.run({} as any)).rejects.toThrow(
-			'executionPlan: Blueprint v2 execution plans are not runnable by the TypeScript runner yet.'
+		await compiled.run(playground as any);
+
+		expect(playground.mkdir).toHaveBeenCalledWith(
+			'/wordpress/wp-content/uploads/from-v2'
 		);
+	});
+
+	it('rejects unsupported Blueprint v2 plans before running lowered steps', async () => {
+		const compiled = await compileBlueprintForExecution({
+			version: 2,
+			media: ['./media/image.jpg'],
+			additionalStepsAfterExecution: [
+				{
+					step: 'mkdir',
+					path: 'site:wp-content/uploads/from-v2',
+				},
+			],
+		});
+		const playground = {
+			mkdir: vi.fn(),
+		};
+
+		let thrownError: unknown;
+		try {
+			await compiled.run(playground as any);
+		} catch (error) {
+			thrownError = error;
+		}
+
+		expect(thrownError).toBeInstanceOf(UnsupportedBlueprintV2FeatureError);
+		expect(thrownError).toMatchObject({
+			featurePath: 'executionPlan',
+			message: expect.stringContaining('importMedia'),
+		});
+		expect(playground.mkdir).not.toHaveBeenCalled();
 	});
 });


### PR DESCRIPTION
## What it does

Makes the TypeScript Blueprint v2 runner execute plans that are fully lowered to v1-compatible steps.

Unsupported v2 plan items still block execution. For example, a plan containing `media` plus a lowered `mkdir` step now fails before `mkdir` runs, instead of applying a partial Blueprint.

## Rationale

The previous PR made the compiler produce an ordered v2 plan and lower supported items into v1 step records, but `run()` still rejected every non-empty plan. This PR turns that lowered output into the first runnable slice without wiring Blueprint v2 into website, CLI, or bundle data flows.

## Implementation

`compileBlueprintV2()` now builds a minimal v1 declaration from the lowered steps and delegates execution to `compileBlueprintV1()`:

```ts
const v1Runner = await compileBlueprintV1(v1Blueprint);
await v1Runner.run(playground);
```

The v1 declaration intentionally does **not** copy v2 top-level `constants`, `siteOptions`, `plugins`, or `themes`; those fields have already been converted into ordered steps. Copying them into v1 top-level fields would run them twice.

The v1 runner is created lazily inside `run()` so plain v2 compilation can still inspect lowered bundled-resource steps without needing a bundle filesystem immediately.

## Testing instructions

```bash
npm exec nx run playground-blueprints:test:vite -- --testFiles=packages/playground/blueprints/src/tests/compile.spec.ts
npm exec nx run playground-blueprints:typecheck
npm exec nx run playground-blueprints:lint
npm exec nx run playground-blueprints:build
```

New coverage verifies:

- a fully lowered v2 `mkdir` step runs through the v1 runner
- unsupported v2 plan items reject before any lowered step runs

Part of #2592.