### PR TITLE
[Blueprints] Support bundled Blueprint v2 resources

### DIFF
--- a/packages/playground/blueprints/src/lib/compile.ts
+++ b/packages/playground/blueprints/src/lib/compile.ts
@@ -56,12 +56,12 @@ async function compileBlueprintV2ForExecution(
 	input: Blueprint | BlueprintBundle,
 	declaration: BlueprintV2Declaration
 ): Promise<CompiledBlueprintForExecution> {
-	if (isBlueprintBundle(input)) {
-		throw new Error(
-			'Blueprint v2 bundles are not supported by compileBlueprintForExecution() yet.'
-		);
-	}
-	const compiled = await compileBlueprintV2(declaration);
+	const compiled = await compileBlueprintV2(
+		declaration,
+		isBlueprintBundle(input)
+			? { streamBundledFile: (...args: [any]) => input.read(...args) }
+			: {}
+	);
 	return {
 		version: 2,
 		declaration,

--- a/packages/playground/blueprints/src/lib/v1/compile.ts
+++ b/packages/playground/blueprints/src/lib/v1/compile.ts
@@ -142,7 +142,7 @@ export interface CompileBlueprintV1Options {
 
 export async function compileBlueprintV1(
 	input: BlueprintV1Declaration | BlueprintBundle,
-	options: Omit<CompileBlueprintV1Options, 'streamBundledFile'> = {}
+	options: CompileBlueprintV1Options = {}
 ): Promise<CompiledBlueprintV1> {
 	const finalOptions: CompileBlueprintV1Options = {
 		...options,

--- a/packages/playground/blueprints/src/lib/v2/compile.ts
+++ b/packages/playground/blueprints/src/lib/v2/compile.ts
@@ -3,7 +3,10 @@ import { joinPaths } from '@php-wasm/util';
 import type { RuntimeConfiguration } from '../types';
 import { resolveRuntimeConfiguration } from '../resolve-runtime-configuration';
 import { seemsLikeGitRepoUrl } from '../is-git-repo-url';
-import { compileBlueprintV1 } from '../v1/compile';
+import {
+	compileBlueprintV1,
+	type CompileBlueprintV1Options,
+} from '../v1/compile';
 import type { BlueprintV1Declaration } from '../v1/types';
 import type {
 	InstallPluginOptions,
@@ -166,16 +169,23 @@ export type CompiledBlueprintV2 = {
 	run: (playground: UniversalPHP) => Promise<void>;
 };
 
+export type CompileBlueprintV2Options = Pick<
+	CompileBlueprintV1Options,
+	'streamBundledFile'
+>;
+
 /**
  * Compiles a Blueprint v2 declaration into the pieces the TypeScript runner can
  * understand today.
  *
- * This does not make v2 plans runnable yet. It resolves runtime options, creates
- * an ordered v2 execution plan, and lowers the supported plan items into v1 step
- * records so later PRs can wire those records into the existing runner.
+ * It resolves runtime options, creates an ordered v2 execution plan, and lowers
+ * supported plan items into v1 step records. Fully lowered plans run through the
+ * existing v1 runner; unsupported items stay visible and block execution before
+ * any partial work is applied.
  */
 export async function compileBlueprintV2(
-	declaration: BlueprintV2Declaration
+	declaration: BlueprintV2Declaration,
+	options: CompileBlueprintV2Options = {}
 ): Promise<CompiledBlueprintV2> {
 	const runtime = await resolveRuntimeConfiguration(declaration);
 	const plan = createBlueprintV2ExecutionPlan(declaration);
@@ -198,7 +208,7 @@ export async function compileBlueprintV2(
 					getUnsupportedPlanMessage(unsupportedPlan)
 				);
 			}
-			const v1Runner = await compileBlueprintV1(v1Blueprint);
+			const v1Runner = await compileBlueprintV1(v1Blueprint, options);
 			await v1Runner.run(playground);
 		},
 	};

--- a/packages/playground/blueprints/src/tests/compile.spec.ts
+++ b/packages/playground/blueprints/src/tests/compile.spec.ts
@@ -90,6 +90,34 @@ describe('compileBlueprintForExecution', () => {
 		expect(compiled.compiled.plan).toEqual([]);
 	});
 
+	it('runs Blueprint v2 bundles with bundled execution-context resources', async () => {
+		const bundle = new InMemoryFilesystem({
+			'plugin.php': '<?php /* Plugin Name: Bundled Plugin */',
+			'blueprint.json': JSON.stringify({
+				version: 2,
+				plugins: [
+					{
+						source: './plugin.php',
+						active: false,
+					},
+				],
+			}),
+		});
+		const playground = {
+			documentRoot: '/wordpress',
+			writeFile: vi.fn(),
+		};
+
+		const compiled = await compileBlueprintForExecution(bundle);
+		await compiled.run(playground as any);
+
+		expect(compiled.version).toBe(2);
+		expect(playground.writeFile).toHaveBeenCalledWith(
+			'/wordpress/wp-content/plugins/plugin.php',
+			expect.any(Uint8Array)
+		);
+	});
+
 	it('compiles Blueprint v2 declarations into an ordered execution plan', async () => {
 		const declaration: BlueprintV2Declaration = {
 			version: 2,


### PR DESCRIPTION
## What it does

Allows `compileBlueprintForExecution()` to run Blueprint v2 bundles whose lowered steps reference files from the Blueprint execution context, such as `./plugin.php`.

## Rationale

The v2 compiler already lowers execution-context paths to v1 `bundled` resources. After #3911, those lowered steps can run, but bundle inputs still lost their file reader before reaching the v1 resource layer. That meant a runnable v2 bundle could fail as if it were a standalone JSON file.

## Implementation

- Removes the v2 bundle rejection from `compileBlueprintForExecution()`.
- Passes the bundle reader into `compileBlueprintV2()` as `streamBundledFile`.
- Lets the v2 runner forward that reader to `compileBlueprintV1()` when it lazily builds the v1 runner.
- Widens `compileBlueprintV1()` options to accept the existing `streamBundledFile` option directly, which the internal options type already supported.

The test uses a bundled single-file plugin with `active: false`. That keeps the assertion focused on bundle-resource resolution and avoids pulling in plugin activation or WordPress runtime behavior.

## Testing instructions

```bash
npm exec nx run playground-blueprints:test:vite -- --testFiles=packages/playground/blueprints/src/tests/compile.spec.ts
npm exec nx run playground-blueprints:typecheck
npm exec nx run playground-blueprints:lint
npm exec nx run playground-blueprints:build
```

Part of #2592.