### PR TITLE
[Blueprints] Add native Blueprint v2 CLI flow

### DIFF
--- a/packages/playground/blueprints/src/index.ts
+++ b/packages/playground/blueprints/src/index.ts
@@ -66,6 +66,11 @@ export type {
 export { getV2Runner } from './lib/v2/get-v2-runner';
 export { runBlueprintV2 } from './lib/v2/run-blueprint-v2';
 export type { BlueprintMessage } from './lib/v2/run-blueprint-v2';
+export { compileBlueprintV2 } from './lib/v2/compile';
+export type {
+	CompiledBlueprintV2,
+	CompileBlueprintV2Options,
+} from './lib/v2/compile';
 
 export {
 	resolveRemoteBlueprint,

--- a/packages/playground/blueprints/src/lib/v2/compile.ts
+++ b/packages/playground/blueprints/src/lib/v2/compile.ts
@@ -171,7 +171,7 @@ export type CompiledBlueprintV2 = {
 
 export type CompileBlueprintV2Options = Pick<
 	CompileBlueprintV1Options,
-	'streamBundledFile'
+	'progress' | 'streamBundledFile'
 >;
 
 /**

--- a/packages/playground/cli/README.md
+++ b/packages/playground/cli/README.md
@@ -273,6 +273,13 @@ To use a Blueprint, create a file (e.g., my-blueprint.json) and run the followin
 npx @wp-playground/cli@latest server --blueprint=./my-blueprint.json
 ```
 
+Blueprint v2 declarations are routed to the native TypeScript v2 runner
+automatically.
+
+CLI runtime flags such as `--php`, `--wp`, and `--login` fill missing v2
+runtime fields. When the Blueprint declares `phpVersion`, `wordpressVersion`,
+or WordPress Playground login settings, the Blueprint value takes precedence.
+
 ## Programmatic Usage with JavaScript
 
 The Playground CLI can be controlled programmatically from your JavaScript code using the `runCLI` function. This allows you to integrate all CLI functionalities directly into your development workflow, for example, end-to-end testing.

--- a/packages/playground/cli/src/blueprints-v2/blueprints-v2-handler.ts
+++ b/packages/playground/cli/src/blueprints-v2/blueprints-v2-handler.ts
@@ -1,9 +1,30 @@
-import type { Pooled, SupportedPHPVersion } from '@php-wasm/universal';
-import { consumeAPI, type RemoteAPI } from '@php-wasm/universal';
+import { logger } from '@php-wasm/logger';
+import { EmscriptenDownloadMonitor, ProgressTracker } from '@php-wasm/progress';
+import {
+	consumeAPI,
+	isLegacyPHPVersion,
+	type Pooled,
+} from '@php-wasm/universal';
 import type {
-	PlaygroundCliBlueprintV2Worker,
-	SecondaryWorkerBootArgs,
-} from './worker-thread-v2';
+	BlueprintBundle,
+	BlueprintV2Declaration,
+} from '@wp-playground/blueprints';
+import {
+	BlueprintReflection,
+	compileBlueprintV2,
+	isBlueprintBundle,
+	resolveRuntimeConfiguration,
+} from '@wp-playground/blueprints';
+import { RecommendedPHPVersion } from '@wp-playground/common';
+import {
+	resolveWordPressRelease,
+	type WordPressInstallMode,
+} from '@wp-playground/wordpress';
+import {
+	cachedDownload,
+	fetchSqliteIntegration,
+} from '../blueprints-v1/download';
+import type { PlaygroundCliBlueprintV2Worker } from './worker-thread-v2';
 import type { MessagePort as NodeMessagePort } from 'worker_threads';
 import {
 	type PlaygroundCliWorker,
@@ -16,14 +37,10 @@ import type { CLIOutput } from '../cli-output';
 import { cliExtensionArgsToExtensionsArray } from '../php-extensions';
 
 /**
- * Boots Playground CLI workers using Blueprint version 2.
- *
- * Progress tracking, downloads, steps, and all other features are
- * implemented in PHP and orchestrated by the worker thread.
+ * Boots Playground CLI workers using the native TypeScript Blueprint v2
+ * compiler and step runtime.
  */
 export class BlueprintsV2Handler {
-	private phpVersion: SupportedPHPVersion;
-
 	private siteUrl: string;
 	private args: RunCLIArgs;
 	private cliOutput: CLIOutput;
@@ -37,7 +54,6 @@ export class BlueprintsV2Handler {
 	) {
 		this.args = args;
 		this.siteUrl = options.siteUrl;
-		this.phpVersion = args.php as SupportedPHPVersion;
 		this.cliOutput = options.cliOutput;
 	}
 
@@ -49,17 +65,91 @@ export class BlueprintsV2Handler {
 		playground: Pooled<PlaygroundCliWorker>,
 		workerPostInstallMountsPort: NodeMessagePort
 	) {
-		const workerBootArgs = {
-			command: this.args.command,
-			siteUrl: this.siteUrl,
-			blueprint: this.args.blueprint!,
-			workerPostInstallMountsPort,
-		};
+		let wordPressZip: any = undefined;
+		const v1PhpOnlyMode = await v1BlueprintRequestsPhpOnlyMode(
+			this.args.blueprint
+		);
+		const wordpressInstallMode = resolveV2WordPressInstallMode(
+			this.args,
+			v1PhpOnlyMode
+		);
+		const effectiveBlueprint = await this.getEffectiveBlueprint();
+		const runtimeConfiguration = await resolveRuntimeConfiguration(
+			effectiveBlueprint.declaration
+		);
+		assertCliSupportedPHPVersion(runtimeConfiguration.phpVersion);
+		if (wordpressInstallMode === 'download-and-install') {
+			const monitor = new EmscriptenDownloadMonitor();
+			let progressReached100 = false;
+			monitor.addEventListener('progress', ((
+				e: CustomEvent<ProgressEvent & { finished: boolean }>
+			) => {
+				if (progressReached100) {
+					return;
+				}
+				const { loaded, total } = e.detail;
+				const percentProgress = Math.floor(
+					Math.min(100, (100 * loaded) / total)
+				);
+				progressReached100 = percentProgress === 100;
+				this.cliOutput.updateProgress(
+					'Downloading WordPress',
+					percentProgress
+				);
+			}) as any);
 
-		// TODO: Fix this type issue that requires the cast to unknown
+			const wpDetails = await resolveWordPressRelease(
+				runtimeConfiguration.wpVersion
+			);
+			wordPressZip = await cachedDownload(
+				wpDetails.releaseUrl,
+				`${wpDetails.version}.zip`,
+				monitor
+			);
+			logger.debug(
+				`Resolved WordPress release URL: ${wpDetails?.releaseUrl}`
+			);
+		}
+
+		let sqliteIntegrationPluginZip;
+		if (
+			this.args.skipSqliteSetup ||
+			wordpressInstallMode === 'do-not-attempt-installing'
+		) {
+			logger.debug(`Skipping SQLite integration plugin setup...`);
+			sqliteIntegrationPluginZip = undefined;
+		} else {
+			this.cliOutput.updateProgress('Preparing SQLite database');
+			const isLegacyPhp = isLegacyPHPVersion(
+				runtimeConfiguration.phpVersion
+			);
+			const sqliteVersion = isLegacyPhp ? 'v3.0.0-rc.3-php52' : 'trunk';
+			sqliteIntegrationPluginZip =
+				await fetchSqliteIntegration(sqliteVersion);
+		}
+
+		this.cliOutput.updateProgress('Booting WordPress');
+
 		await (
 			playground as unknown as PlaygroundCliBlueprintV2Worker
-		).bootWordPress(workerBootArgs, workerPostInstallMountsPort);
+		).bootWordPress(
+			{
+				phpVersion: runtimeConfiguration.phpVersion,
+				siteUrl: this.siteUrl,
+				wordpressInstallMode,
+				networking: runtimeConfiguration.networking,
+				wordPressZip:
+					wordPressZip && (await wordPressZip.arrayBuffer()),
+				sqliteIntegrationPluginZip:
+					await sqliteIntegrationPluginZip?.arrayBuffer(),
+				constants: mergeDefinedConstantsForPHPVersion(
+					this.args,
+					runtimeConfiguration.phpVersion
+				),
+			},
+			workerPostInstallMountsPort
+		);
+
 		return playground;
 	}
 
@@ -72,26 +162,263 @@ export class BlueprintsV2Handler {
 		fileLockManagerPort: NodeMessagePort;
 		nativeInternalDirPath: string;
 	}) {
-		const playground: RemoteAPI<PlaygroundCliBlueprintV2Worker> =
-			consumeAPI(worker.phpPort);
+		const playground = consumeAPI<PlaygroundCliBlueprintV2Worker>(
+			worker.phpPort
+		);
 
+		await playground.isConnected();
+		const runtimeConfiguration = await resolveRuntimeConfiguration(
+			(await this.getEffectiveBlueprint()).declaration
+		);
+		assertCliSupportedPHPVersion(runtimeConfiguration.phpVersion);
 		await playground.useFileLockManager(fileLockManagerPort);
-
-		const workerBootArgs: SecondaryWorkerBootArgs = {
-			...this.args,
-			phpVersion: this.phpVersion,
+		await playground.bootRequestHandler({
+			phpVersion: runtimeConfiguration.phpVersion,
 			siteUrl: this.siteUrl,
-			processId: worker.processId,
-			trace: this.args.verbosity === 'debug',
-			extensions: cliExtensionArgsToExtensionsArray(this.args),
-			nativeInternalDirPath,
+			networking: runtimeConfiguration.networking,
 			mountsBeforeWpInstall: this.args['mount-before-install'] || [],
 			mountsAfterWpInstall: this.args.mount || [],
-			constants: mergeDefinedConstants(this.args),
-		};
-
-		await playground.bootWorker(workerBootArgs);
-
+			processId: worker.processId,
+			followSymlinks: this.args.followSymlinks === true,
+			trace: this.args.experimentalTrace === true,
+			extensions: cliExtensionArgsToExtensionsArray(
+				filterExtensionArgsForPHPVersion(
+					{
+						...this.args,
+						intl: runtimeConfiguration.intl,
+					},
+					runtimeConfiguration.phpVersion
+				)
+			),
+			nativeInternalDirPath,
+			pathAliases: this.args.pathAliases,
+		});
+		await playground.isReady();
 		return playground;
 	}
+
+	async compileInputBlueprint(additionalBlueprintSteps: any[]) {
+		const blueprint = await this.getEffectiveBlueprint(
+			additionalBlueprintSteps
+		);
+
+		const tracker = new ProgressTracker();
+		let lastCaption = '';
+		let progressReached100 = false;
+		tracker.addEventListener('progress', (e: any) => {
+			if (progressReached100) {
+				return;
+			}
+			progressReached100 = e.detail.progress === 100;
+			const progressInteger = Math.floor(e.detail.progress);
+			lastCaption =
+				e.detail.caption || lastCaption || 'Running Blueprint';
+			this.cliOutput.updateProgress(lastCaption.trim(), progressInteger);
+		});
+
+		const compiled = await compileBlueprintV2(blueprint.declaration, {
+			progress: tracker,
+			streamBundledFile: blueprint.streamBundledFile,
+		});
+		return {
+			...compiled,
+			declaration: blueprint.declaration,
+		};
+	}
+
+	/**
+	 * Returns a v2 declaration after applying CLI-level defaults.
+	 *
+	 * Bundled Blueprints keep a `streamBundledFile` callback because v2 lowering
+	 * still needs the original archive to resolve bundled resources.
+	 */
+	private async getEffectiveBlueprint(additionalBlueprintSteps: any[] = []) {
+		const resolvedBlueprint =
+			this.args.blueprint || ({ version: 2 } as BlueprintV2Declaration);
+		if (isBlueprintBundle(resolvedBlueprint)) {
+			const blueprintBundle = resolvedBlueprint as BlueprintBundle;
+			const reflection =
+				await BlueprintReflection.create(blueprintBundle);
+			return {
+				declaration: applyCliOptionsToBlueprint(
+					assertBlueprintV2Declaration(reflection.getDeclaration()),
+					this.args,
+					additionalBlueprintSteps
+				),
+				streamBundledFile: (path: string) => blueprintBundle.read(path),
+			};
+		}
+
+		return {
+			declaration: applyCliOptionsToBlueprint(
+				assertBlueprintV2Declaration(resolvedBlueprint),
+				this.args,
+				additionalBlueprintSteps
+			),
+			streamBundledFile: undefined,
+		};
+	}
+}
+
+/**
+ * Detects v1 PHP-only mode before upgrading declarations to v2.
+ *
+ * `preferredVersions.wp: false` is not a public v2 field, but the CLI must
+ * still preserve it when a v1 declaration is migrated through the v2 compiler.
+ */
+async function v1BlueprintRequestsPhpOnlyMode(
+	blueprint: RunCLIArgs['blueprint']
+) {
+	if (!blueprint) {
+		return false;
+	}
+	const reflection = await BlueprintReflection.create(blueprint as any);
+	return (
+		reflection.getVersion() === 1 &&
+		(reflection.getDeclaration() as any).preferredVersions?.wp === false
+	);
+}
+
+/**
+ * Maps Blueprint v2 CLI modes onto the worker's WordPress install modes.
+ *
+ * V1 PHP-only mode wins over CLI defaults because downloading WordPress would
+ * change the semantics of a migrated `preferredVersions.wp: false` Blueprint.
+ */
+function resolveV2WordPressInstallMode(
+	args: RunCLIArgs,
+	v1PhpOnlyMode = false
+): WordPressInstallMode {
+	if (v1PhpOnlyMode) {
+		if (args.mode && args.mode !== 'mount-only') {
+			throw new Error(
+				'Conflicting options: WordPress was requested, but the Blueprint sets `preferredVersions.wp: false`. Pick one.'
+			);
+		}
+		if (
+			!args.mode &&
+			args.wordpressInstallMode &&
+			args.wordpressInstallMode !== 'do-not-attempt-installing'
+		) {
+			throw new Error(
+				'Conflicting options: WordPress was requested, but the Blueprint sets `preferredVersions.wp: false`. Pick one.'
+			);
+		}
+		return 'do-not-attempt-installing';
+	}
+	switch (args.mode) {
+		case 'apply-to-existing-site':
+			return 'install-from-existing-files-if-needed';
+		case 'mount-only':
+			return 'do-not-attempt-installing';
+		case 'create-new-site':
+			return 'download-and-install';
+	}
+	return args.wordpressInstallMode || 'download-and-install';
+}
+
+function assertCliSupportedPHPVersion(phpVersion: string) {
+	if (phpVersion === 'next') {
+		throw new Error(
+			'Blueprint v2 phpVersion "next" is supported by the web runtime only and cannot be used by Playground CLI. Choose a stable PHP version such as 8.3.'
+		);
+	}
+}
+
+/**
+ * Applies CLI defaults without mutating caller data.
+ *
+ * V1 declarations are upgraded first so the CLI has one lowering path while
+ * preserving CLI defaults for PHP, WordPress, login, and appended steps.
+ */
+function applyCliOptionsToBlueprint(
+	resolvedBlueprint: BlueprintV2Declaration,
+	args: RunCLIArgs,
+	additionalBlueprintSteps: any[] = []
+) {
+	const blueprint = { ...resolvedBlueprint } as any;
+
+	// TODO: Decide whether explicit CLI flags should override Blueprint v2
+	// runtime fields. For now, match the v1 CLI behavior: the Blueprint wins.
+	if (blueprint.phpVersion === undefined) {
+		blueprint.phpVersion = args.php || RecommendedPHPVersion;
+	}
+	if (blueprint.wordpressVersion === undefined) {
+		blueprint.wordpressVersion = args.wp || 'latest';
+	}
+	const playgroundOptions =
+		blueprint.applicationOptions?.['wordpress-playground'];
+	if (playgroundOptions?.login === undefined && args.login === true) {
+		blueprint.applicationOptions = {
+			...(blueprint.applicationOptions || {}),
+			'wordpress-playground': {
+				...(playgroundOptions || {}),
+				login: args.login === true,
+			},
+		};
+	}
+	if (additionalBlueprintSteps.length > 0) {
+		blueprint.additionalStepsAfterExecution = [
+			...(blueprint.additionalStepsAfterExecution || []),
+			...normalizeAdditionalBlueprintSteps(additionalBlueprintSteps),
+		];
+	}
+	return blueprint as BlueprintV2Declaration;
+}
+
+function normalizeAdditionalBlueprintSteps(steps: any[]) {
+	return steps.flatMap((step) => {
+		if (step?.step === 'activateTheme' && step.themeFolderName) {
+			return [
+				{
+					step: 'activateTheme',
+					themeDirectoryName: step.themeFolderName,
+				},
+			];
+		}
+		return [step];
+	});
+}
+
+function filterExtensionArgsForPHPVersion(
+	args: RunCLIArgs,
+	phpVersion: string | undefined
+): RunCLIArgs {
+	if (!isLegacyPHPVersion(phpVersion)) {
+		return args;
+	}
+	return {
+		...args,
+		intl: false,
+		redis: false,
+		memcached: false,
+		xdebug: false,
+	};
+}
+
+function mergeDefinedConstantsForPHPVersion(
+	args: RunCLIArgs,
+	phpVersion: string | undefined
+) {
+	const defineBool = { ...(args['define-bool'] || {}) };
+	if (isLegacyPHPVersion(phpVersion)) {
+		for (const name of args.defaultedDebugConstants || []) {
+			delete defineBool[name];
+		}
+	}
+	return mergeDefinedConstants({
+		...args,
+		'define-bool': defineBool,
+	});
+}
+
+function assertBlueprintV2Declaration(
+	declaration: unknown
+): BlueprintV2Declaration {
+	if ((declaration as BlueprintV2Declaration | undefined)?.version === 2) {
+		return declaration as BlueprintV2Declaration;
+	}
+	throw new Error(
+		'The native Blueprint v2 handler requires a Blueprint v2 declaration.'
+	);
 }

--- a/packages/playground/cli/src/blueprints-v2/worker-thread-v2.ts
+++ b/packages/playground/cli/src/blueprints-v2/worker-thread-v2.ts
@@ -1,75 +1,57 @@
-import { errorLogPath, logger } from '@php-wasm/logger';
 import type { FileLockManager } from '@php-wasm/universal';
-import {
-	bindUserSpace,
-	createNodeFsMountHandler,
-	loadNodeRuntime,
-	type PHPExtension,
-	type WasmUserSpaceContext,
-} from '@php-wasm/node';
+import { loadNodeRuntime, type PHPExtension } from '@php-wasm/node';
 import { EmscriptenDownloadMonitor } from '@php-wasm/progress';
-import type {
-	PathAlias,
-	PHP,
-	FileTree,
-	RemoteAPI,
-	SupportedPHPVersion,
-	SpawnHandler,
-} from '@php-wasm/universal';
+import type { AllPHPVersion, PathAlias } from '@php-wasm/universal';
 import {
-	PHPExecutionFailureError,
-	PHPResponse,
 	PHPWorker,
 	releaseApiProxy,
 	consumeAPI,
 	consumeAPISync,
 	exposeAPI,
+	exposeSyncAPI,
 	sandboxedSpawnHandlerFactory,
-	setPhpIniEntries,
-	writeFiles,
 } from '@php-wasm/universal';
-import { joinPaths, sprintf } from '@php-wasm/util';
+import { sprintf } from '@php-wasm/util';
+import { RecommendedPHPVersion } from '@wp-playground/common';
 import {
-	type BlueprintMessage,
-	runBlueprintV2,
-	type BlueprintV1Declaration,
-} from '@wp-playground/blueprints';
-import {
-	type ParsedBlueprintV2String,
-	type RawBlueprintV2Data,
-} from '@wp-playground/blueprints';
-import {
+	type WordPressInstallMode,
 	bootRequestHandler,
-	preloadPhpInfoRoute,
-	setupPlatformLevelMuPlugins,
+	bootWordPress,
 } from '@wp-playground/wordpress';
-import { existsSync } from 'fs';
-import path from 'path';
 import { rootCertificates } from 'tls';
 import { MessageChannel, type MessagePort, parentPort } from 'worker_threads';
-import { type RunCLIArgs, spawnWorkerThread } from '../run-cli';
-import type {
-	PhpIniOptions,
-	PHPInstanceCreatedHook,
-} from '@wp-playground/wordpress';
-import { shouldRenderProgress } from '../utils/progress';
+import { mountResources } from '../mounts';
+import { logger } from '@php-wasm/logger';
+import { spawnWorkerThread } from '../run-cli';
+
 import type { Mount } from '@php-wasm/cli-util';
 
-async function mountResources(php: PHP, mounts: Mount[]) {
-	for (const mount of mounts) {
-		try {
-			php.mkdir(mount.vfsPath);
-			await php.mount(
-				mount.vfsPath,
-				createNodeFsMountHandler(mount.hostPath)
-			);
-		} catch {
-			output.stderr(
-				`\x1b[31m\x1b[1mError mounting path ${mount.hostPath} at ${mount.vfsPath}\x1b[0m\n`
-			);
-			process.exit(1);
-		}
-	}
+export type WorkerBootWordPressOptions = {
+	siteUrl: string;
+	phpVersion?: string;
+	wordpressInstallMode: WordPressInstallMode;
+	wordPressZip?: ArrayBuffer;
+	networking?: boolean;
+	sqliteIntegrationPluginZip?: ArrayBuffer;
+	dataSqlPath?: string;
+	/**
+	 * PHP constants to define via php.defineConstant().
+	 */
+	constants?: Record<string, string | number | boolean>;
+};
+
+interface WorkerBootRequestHandlerOptions {
+	siteUrl: string;
+	phpVersion: AllPHPVersion;
+	processId: number;
+	trace: boolean;
+	networking?: boolean;
+	nativeInternalDirPath: string;
+	mountsBeforeWpInstall: Array<Mount>;
+	mountsAfterWpInstall: Array<Mount>;
+	followSymlinks: boolean;
+	extensions?: PHPExtension[];
+	pathAliases?: PathAlias[];
 }
 
 /**
@@ -88,105 +70,20 @@ function tracePhpWasm(processId: number, format: string, ...args: any[]) {
 	);
 }
 
-/**
- * Force TTY status to preserve ANSI control codes in the output
- * when the environment is interactive.
- *
- * This script is spawned as `new Worker()` and process.stdout and process.stderr are
- * WritableWorkerStdio objects. By default, they strip ANSI control codes from the output
- * causing every progress bar update to be printed in a new line instead of updating the
- * same line.
- */
-Object.defineProperty(process.stdout, 'isTTY', { value: true });
-Object.defineProperty(process.stderr, 'isTTY', { value: true });
-
-/**
- * Output writer that ensures that progress bars are not printed on the same line as other output.
- */
-const output = {
-	lastWriteWasProgress: false,
-	progress(data: string) {
-		if (!shouldRenderProgress(process.stdout)) {
-			return;
-		}
-		if (!process.stdout.isTTY) {
-			// eslint-disable-next-line no-console
-			console.log(data);
-		} else {
-			if (!output.lastWriteWasProgress) {
-				process.stdout.write('\n');
-			}
-			process.stdout.write('\r\x1b[K' + data);
-			output.lastWriteWasProgress = true;
-		}
-	},
-	stdout(data: string) {
-		process.stdout.write('\n\n\n');
-		if (output.lastWriteWasProgress) {
-			output.lastWriteWasProgress = false;
-		}
-		process.stdout.write(data);
-	},
-	stderr(data: string) {
-		process.stdout.write('\n\n\n');
-		if (output.lastWriteWasProgress) {
-			output.lastWriteWasProgress = false;
-		}
-		process.stderr.write(data);
-	},
-};
-
-export type WorkerWordPressBootArgs = Omit<
-	RunCLIArgs,
-	'mount-before-install' | 'mount'
-> & {
-	siteUrl: string;
-	blueprint:
-		| RawBlueprintV2Data
-		| ParsedBlueprintV2String
-		| BlueprintV1Declaration;
-};
-
-type WorkerRunBlueprintArgs = Omit<
-	RunCLIArgs,
-	'mount-before-install' | 'mount'
-> & {
-	siteUrl: string;
-	blueprint:
-		| RawBlueprintV2Data
-		| ParsedBlueprintV2String
-		| BlueprintV1Declaration;
-	mountsAfterWpInstall?: Array<Mount>;
-};
-
-export type SecondaryWorkerBootArgs = {
-	siteUrl: string;
-	allow?: string;
-	phpVersion: SupportedPHPVersion;
-	phpIniEntries?: PhpIniOptions;
-	constants?: Record<string, string | number | boolean | null>;
-	createFiles?: FileTree;
-	processId: number;
-	trace: boolean;
-	nativeInternalDirPath: string;
-	extensions?: PHPExtension[];
-	pathAliases?: PathAlias[];
-	mountsBeforeWpInstall?: Array<Mount>;
-	mountsAfterWpInstall?: Array<Mount>;
-};
-
-export type WorkerBootRequestHandlerOptions = Omit<
-	SecondaryWorkerBootArgs,
-	'mountsBeforeWpInstall' | 'mountsAfterWpInstall'
-> & {
-	onPHPInstanceCreated: PHPInstanceCreatedHook;
-	spawnHandler: () => SpawnHandler;
-};
+function getNetworkingPhpIniEntries(networking: boolean) {
+	return {
+		'openssl.cafile': '/internal/shared/ca-bundle.crt',
+		'curl.cainfo': '/internal/shared/ca-bundle.crt',
+		allow_url_fopen: networking ? '1' : '0',
+		disable_functions: networking
+			? ''
+			: 'fsockopen,pfsockopen,curl_init,curl_exec,curl_multi_exec,mail',
+	};
+}
 
 export class PlaygroundCliBlueprintV2Worker extends PHPWorker {
-	booted = false;
-	blueprintTargetResolved = false;
-	phpInstancesThatNeedMountsAfterTargetResolved = new Set<PHP>();
+	bootedRequestHandler = false;
+	bootedWordPress = false;
 	fileLockManager: FileLockManager | undefined;
 
 	constructor(monitor: EmscriptenDownloadMonitor) {
@@ -203,300 +100,121 @@ export class PlaygroundCliBlueprintV2Worker extends PHPWorker {
 	 * @see phpwasm-emscripten-library-file-locking-for-node.js
 	 */
 	async useFileLockManager(port: MessagePort) {
-		/**
-		 * If JSPI is not available, php.js only supports synchronous locking syscalls.
-		 * Let's use the synchronous API. Every method call will block this thread
-		 * until the result is available.
-		 *
-		 * @see comlink-sync.ts
-		 * @see phpwasm-emscripten-library-file-locking-for-node.js
-		 */
 		this.fileLockManager = await consumeAPISync<FileLockManager>(port);
 	}
 
 	async bootWordPress(
-		args: WorkerWordPressBootArgs,
+		options: WorkerBootWordPressOptions,
 		workerPostInstallMountsPort: MessagePort
 	) {
-		// TODO: Should we move a process like this back into the
-		// `@wp-playground/wordpress` package?
-		const php = await this.__internal_getRequestHandler()!.getPrimaryPhp();
-		php.defineConstant('WP_DEBUG', 'true');
-		php.defineConstant('WP_DEBUG_LOG', 'true');
-		php.defineConstant('WP_DEBUG_DISPLAY', 'false');
-		php.defineConstant('WP_HOME', args.siteUrl);
-		php.defineConstant('WP_SITEURL', args.siteUrl);
-
-		await setPhpIniEntries(php, {
-			'openssl.cafile': '/internal/shared/ca-bundle.crt',
-			'curl.cainfo': '/internal/shared/ca-bundle.crt',
-			allow_url_fopen: '1',
-			disable_functions: '',
-		});
-
-		await setupPlatformLevelMuPlugins(php);
-		await writeFiles(php, '/', {
-			'/internal/shared/ca-bundle.crt': rootCertificates.join('\n'),
-		});
-		await preloadPhpInfoRoute(
-			php,
-			joinPaths(new URL(args.siteUrl).pathname, 'phpinfo.php')
-		);
-
-		if (args.mode === 'mount-only') {
-			await this.applyPostInstallMountsToAllWorkers(
-				workerPostInstallMountsPort
-			);
-			return;
+		if (this.bootedWordPress) {
+			throw new Error('WordPress already booted');
 		}
-
-		await this.runBlueprintV2(
-			{
-				// TODO: Do we really want to create a new object or can we pass args directly?
-				...args,
-			},
-			workerPostInstallMountsPort
-		);
-	}
-
-	async bootWorker(args: SecondaryWorkerBootArgs) {
-		await this.bootRequestHandler({
-			...args,
-			onPHPInstanceCreated: async (php: PHP) => {
-				await mountResources(php, args.mountsBeforeWpInstall || []);
-				await mountResources(php, args.mountsAfterWpInstall || []);
-
-				// Temporary workaround for LOCK_EX in sqlite-database-integration.
-				// Creation of these files results in this error:
-				// PHP Warning:  file_put_contents(): Exclusive locks are not supported for this stream
-				// in
-				// /wordpress/wp-content/plugins/sqlite-database-integration/wp-includes/sqlite/class-wp-sqlite-db.php
-				// on line 670
-				if (!php.isDir('/wordpress/wp-content')) {
-					php.mkdir('/wordpress/wp-content');
-				}
-				if (!php.isDir('/wordpress/wp-content/database')) {
-					php.mkdir('/wordpress/wp-content/database');
-				}
-				if (!php.isFile('/wordpress/wp-content/database/.htaccess')) {
-					php.writeFile(
-						'/wordpress/wp-content/database/.htaccess',
-						'deny from all'
-					);
-				}
-				if (!php.isFile('/wordpress/wp-content/database/index.php')) {
-					php.writeFile(
-						'/wordpress/wp-content/database/index.php',
-						'deny from all'
-					);
-				}
-			},
-			spawnHandler: () =>
-				sandboxedSpawnHandlerFactory(() =>
-					createPHPWorker(args, this.fileLockManager!)
-				),
-		});
-	}
-
-	async runBlueprintV2(
-		args: WorkerRunBlueprintArgs,
-		workerPostInstallMountsPort: MessagePort
-	) {
-		const requestHandler = this.__internal_getRequestHandler()!;
-		const { php, reap } =
-			await requestHandler.instanceManager.acquirePHPInstance();
-
-		// Mount the current working directory to the PHP runtime for the purposes of
-		// Blueprint resolution.
-		const primaryPhp = this.__internal_getPHP()!;
-		let unmountCwd = () => {};
-		if (typeof args.blueprint === 'string') {
-			const blueprintPath = path.resolve(process.cwd(), args.blueprint);
-			if (existsSync(blueprintPath)) {
-				primaryPhp.mkdir('/internal/shared/cwd');
-				unmountCwd = await primaryPhp.mount(
-					'/internal/shared/cwd',
-					createNodeFsMountHandler(path.dirname(blueprintPath))
-				);
-				args.blueprint = path.join(
-					'/internal/shared/cwd',
-					path.basename(args.blueprint)
-				);
-			}
-		}
+		this.bootedWordPress = true;
+		const {
+			siteUrl,
+			phpVersion,
+			wordpressInstallMode,
+			wordPressZip,
+			networking = true,
+			sqliteIntegrationPluginZip,
+			dataSqlPath,
+			constants,
+		} = options;
 
 		try {
-			const cliArgsToPass: (keyof WorkerRunBlueprintArgs)[] = [
-				'mode',
-				'db-engine',
-				'db-host',
-				'db-user',
-				'db-pass',
-				'db-name',
-				'db-path',
-				'truncate-new-site-directory',
-				'allow',
-			];
-			const cliArgs = cliArgsToPass
-				.filter((arg) => arg in args)
-				.map((arg) => `--${arg}=${args[arg]}`);
-			cliArgs.push(`--site-url=${args.siteUrl}`);
-
-			const streamedResponse = await runBlueprintV2({
-				php,
-				blueprint: args.blueprint,
-				blueprintOverrides: {
-					additionalSteps: args['additional-blueprint-steps'],
-					wordpressVersion: args.wp,
+			await bootWordPress(this.__internal_getRequestHandler()!, {
+				siteUrl,
+				phpVersion,
+				wordpressInstallMode,
+				wordPressZip:
+					wordPressZip !== undefined
+						? new File([wordPressZip], 'wordpress.zip')
+						: undefined,
+				sqliteIntegrationPluginZip:
+					sqliteIntegrationPluginZip !== undefined
+						? new File(
+								[sqliteIntegrationPluginZip],
+								'sqlite-integration-plugin.zip'
+							)
+						: undefined,
+				// TODO: Are these redundant creations?
+				createFiles: {
+					'/internal/shared/ca-bundle.crt':
+						rootCertificates.join('\n'),
 				},
-				cliArgs,
-				onMessage: async (message: BlueprintMessage) => {
-					switch (message.type) {
-						case 'blueprint.target_resolved': {
-							if (!this.blueprintTargetResolved) {
-								this.blueprintTargetResolved = true;
-								await this.applyPostInstallMountsToAllWorkers(
-									workerPostInstallMountsPort
-								);
-							}
-							break;
-						}
-						case 'blueprint.progress': {
-							const progressMessage = `${message.caption.trim()} – ${message.progress.toFixed(
-								2
-							)}%`;
-							output.progress(progressMessage);
-							break;
-						}
-						case 'blueprint.error': {
-							const red = '\x1b[31m';
-							const bold = '\x1b[1m';
-							const reset = '\x1b[0m';
-							if (args.verbosity === 'debug' && message.details) {
-								output.stderr(
-									`${red}${bold}Fatal error:${reset} Uncaught ${message.details.exception}: ${message.details.message}\n` +
-										`  at ${message.details.file}:${message.details.line}\n` +
-										(message.details.trace
-											? message.details.trace + '\n'
-											: '')
-								);
-							} else {
-								output.stderr(
-									`${red}${bold}Error:${reset} ${message.message}\n`
-								);
-							}
-							break;
-						}
-					}
-				},
+				phpIniEntries: getNetworkingPhpIniEntries(networking),
+				dataSqlPath,
+				constants,
 			});
-			/**
-			 * When we're debugging, every bit of information matters – let's immediately output
-			 * everything we get from the PHP output streams.
-			 */
-			if (args.verbosity === 'debug') {
-				streamedResponse!.stdout.pipeTo(
-					new WritableStream({
-						write(chunk) {
-							process.stdout.write(chunk);
-						},
-					})
-				);
-				streamedResponse!.stderr.pipeTo(
-					new WritableStream({
-						write(chunk) {
-							process.stderr.write(chunk);
-						},
-					})
-				);
-			}
-			await streamedResponse!.finished;
-			if ((await streamedResponse!.exitCode) !== 0) {
-				// exitCode != 1 means the blueprint execution failed. Let's throw an error.
-				// and clean up.
-				const syncResponse =
-					await PHPResponse.fromStreamedResponse(streamedResponse);
-				throw new PHPExecutionFailureError(
-					`PHP.run() failed with exit code ${syncResponse.exitCode}. ${syncResponse.errors} ${syncResponse.text}`,
-					syncResponse,
-					'request'
-				);
-			}
-		} catch (error) {
-			// Capture the PHP error log details to provide more context for debugging.
-			let phpLogs = '';
-			try {
-				// @TODO: Don't assume errorLogPath starts with /wordpress/
-				//        ...or maybe we can assume that in Playground CLI?
-				phpLogs = php.readFileAsText(errorLogPath);
-			} catch {
-				// Ignore errors reading the PHP error log.
-			}
-			(error as any).phpLogs = phpLogs;
-			throw error;
-		} finally {
-			reap();
-			unmountCwd();
+
+			// Notify all workers to apply post-install mounts.
+			const postInstall = consumeAPI<{
+				applyPostInstallMountsToAllWorkers: () => Promise<void>;
+			}>(workerPostInstallMountsPort);
+			await postInstall.applyPostInstallMountsToAllWorkers();
+			postInstall[releaseApiProxy]();
+
+			setApiReady();
+		} catch (e) {
+			setAPIError(e as Error);
+			throw e;
 		}
 	}
 
-	async bootRequestHandler({
-		siteUrl,
-		allow,
-		phpVersion,
-		processId,
-		createFiles,
-		constants,
-		phpIniEntries,
-		trace,
-		nativeInternalDirPath,
-		extensions,
-		pathAliases,
-		onPHPInstanceCreated,
-		spawnHandler,
-	}: WorkerBootRequestHandlerOptions) {
-		if (this.booted) {
+	async bootRequestHandler(options: WorkerBootRequestHandlerOptions) {
+		if (this.bootedRequestHandler) {
 			throw new Error('Playground already booted');
 		}
-		this.booted = true;
+		this.bootedRequestHandler = true;
 
 		try {
 			const requestHandler = await bootRequestHandler({
-				siteUrl,
-				createPhpRuntime: async () => {
-					return await loadNodeRuntime(phpVersion, {
-						fileLockManager: this.fileLockManager!,
-						emscriptenOptions: {
-							processId,
-							trace: trace ? tracePhpWasm : undefined,
-							ENV: {
-								DOCROOT: '/wordpress',
-							},
-							nativeInternalDirPath,
-							bindUserSpace: (
-								userSpaceContext: WasmUserSpaceContext
-							) => {
-								return bindUserSpace(
-									{
-										fileLockManager: this.fileLockManager!,
-									},
-									userSpaceContext
-								);
-							},
-						},
-						followSymlinks: allow?.includes('follow-symlinks'),
-						extensions,
-					});
-				},
+				siteUrl: options.siteUrl,
+				phpVersion: options.phpVersion,
 				maxPhpInstances: 1,
-				onPHPInstanceCreated,
+				createFiles: {
+					'/internal/shared/ca-bundle.crt':
+						rootCertificates.join('\n'),
+				},
+				phpIniEntries: getNetworkingPhpIniEntries(
+					options.networking ?? true
+				),
+				createPhpRuntime: createPhpRuntimeFactory(
+					options,
+					this.fileLockManager!
+				),
+				onPHPInstanceCreated: async (php) => {
+					await mountResources(php, options.mountsBeforeWpInstall);
+
+					// NOTE: We currently create all request workers up front
+					// and apply post-install mounts to all the workers immediately
+					// following WordPress install. But if we start creating
+					// request-handling workers on-demand, we will to apply post-install
+					// mounts here.
+					if (this.bootedWordPress) {
+						await mountResources(php, options.mountsAfterWpInstall);
+					}
+				},
 				sapiName: 'cli',
-				createFiles,
-				constants,
-				phpIniEntries,
-				pathAliases,
 				cookieStore: false,
-				spawnHandler,
+				pathAliases: options.pathAliases,
+				spawnHandler: () =>
+					sandboxedSpawnHandlerFactory(() => {
+						let effectiveOptions = options;
+						if (!this.bootedWordPress) {
+							// WordPress is not yet booted so skip the post-install mounts.
+							effectiveOptions = {
+								...options,
+								mountsAfterWpInstall: [],
+							};
+						}
+
+						return createPHPWorker(
+							effectiveOptions,
+							this.fileLockManager!
+						);
+					}),
 			});
 			this.__internal_setRequestHandler(requestHandler);
 
@@ -511,17 +229,11 @@ export class PlaygroundCliBlueprintV2Worker extends PHPWorker {
 	}
 
 	async mountAfterWordPressInstall(mounts: Array<Mount>) {
+		// Make sure workers not involved in the WordPress install
+		// process know whether WordPress booted so they can
+		// apply post-install mounts when spawning new PHP workers.
+		this.bootedWordPress = true;
 		await mountResources(this.__internal_getPHP()!, mounts);
-	}
-
-	async applyPostInstallMountsToAllWorkers(
-		postInstallMountsPort: MessagePort
-	): Promise<void> {
-		const applyPostInstallMountsToAllWorkers = consumeAPI<
-			() => Promise<void>
-		>(postInstallMountsPort);
-		await applyPostInstallMountsToAllWorkers();
-		applyPostInstallMountsToAllWorkers[releaseApiProxy]();
 	}
 
 	// Provide a named disposal method that can be invoked via comlink.
@@ -531,8 +243,33 @@ export class PlaygroundCliBlueprintV2Worker extends PHPWorker {
 }
 
 /**
+ * Returns a factory function that starts a new PHP runtime in the currently
+ * running process. This is used for rotating the PHP runtime periodically.
+ */
+function createPhpRuntimeFactory(
+	options: WorkerBootRequestHandlerOptions,
+	fileLockManager: FileLockManager
+) {
+	return async () => {
+		return await loadNodeRuntime(
+			options.phpVersion || RecommendedPHPVersion,
+			{
+				fileLockManager,
+				emscriptenOptions: {
+					processId: options.processId,
+					trace: options.trace ? tracePhpWasm : undefined,
+					nativeInternalDirPath: options.nativeInternalDirPath,
+				},
+				followSymlinks: options.followSymlinks,
+				extensions: options.extensions,
+			}
+		);
+	};
+}
+
+/**
  * Spawns a new PHP process to be used in the PHP spawn handler (in proc_open() etc. calls).
- * It boots from this worker-thread-v1.ts file, but is a separate process.
+ * It boots from this worker-thread-v2.ts file, but is a separate process.
  *
  * We explicitly avoid using PHPProcessManager.acquirePHPInstance() here.
  *
@@ -548,45 +285,23 @@ export class PlaygroundCliBlueprintV2Worker extends PHPWorker {
  * @returns A promise that resolves to the PHP worker.
  */
 async function createPHPWorker(
-	{
-		siteUrl,
-		allow,
-		phpVersion,
-		createFiles,
-		constants,
-		phpIniEntries,
-		trace,
-		nativeInternalDirPath,
-		extensions,
-		pathAliases,
-		mountsBeforeWpInstall,
-		mountsAfterWpInstall,
-	}: // NOTE: We explicitly remove processId from the options
+	// NOTE: We explicitly remove processId from the options
 	// type so the type system will catch if we try to reuse
 	// our parent's process ID.
-	Omit<SecondaryWorkerBootArgs, 'processId'>,
-	fileLockManager: FileLockManager | RemoteAPI<FileLockManager>
+	options: Omit<WorkerBootRequestHandlerOptions, 'processId'>,
+	fileLockManager: FileLockManager
 ) {
 	const spawnedWorker = await spawnWorkerThread('v2');
 
 	const handler = consumeAPI<PlaygroundCliBlueprintV2Worker>(
 		spawnedWorker.phpPort
 	);
-	handler.useFileLockManager(fileLockManager as any);
-	await handler.bootWorker({
-		siteUrl,
-		allow,
-		phpVersion,
-		createFiles,
-		constants,
-		phpIniEntries,
+	const fileLockManagerChannel = new MessageChannel();
+	await exposeSyncAPI(fileLockManager, fileLockManagerChannel.port1);
+	await handler.useFileLockManager(fileLockManagerChannel.port2);
+	await handler.bootRequestHandler({
+		...options,
 		processId: spawnedWorker.processId,
-		trace,
-		nativeInternalDirPath,
-		extensions,
-		pathAliases,
-		mountsBeforeWpInstall,
-		mountsAfterWpInstall,
 	});
 
 	return {

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -24,6 +24,7 @@ import type {
 } from '@wp-playground/blueprints';
 import {
 	compileBlueprintV1,
+	BlueprintReflection,
 	runBlueprintV1Steps,
 } from '@wp-playground/blueprints';
 import { RecommendedPHPVersion } from '@wp-playground/common';
@@ -217,7 +218,7 @@ export async function parseOptionsAndRunCLI(argsToParse: string[]) {
 				describe:
 					'Control how Playground prepares WordPress before booting.',
 				type: 'string',
-				default: 'download-and-install',
+				defaultDescription: 'download-and-install',
 				choices: [
 					'download-and-install',
 					'install-from-existing-files',
@@ -337,7 +338,11 @@ export async function parseOptionsAndRunCLI(argsToParse: string[]) {
 				describe:
 					'Blueprints v2 runner mode to use. This option is required when using the --experimental-blueprints-v2-runner flag with a blueprint.',
 				type: 'string',
-				choices: ['create-new-site', 'apply-to-existing-site'],
+				choices: [
+					'create-new-site',
+					'apply-to-existing-site',
+					'mount-only',
+				],
 				// Remove the "hidden" flag once Blueprint V2 is fully supported
 				hidden: true,
 			},
@@ -626,41 +631,66 @@ export async function parseOptionsAndRunCLI(argsToParse: string[]) {
 					}
 				}
 
-				if (args['experimental-blueprints-v2-runner'] === true) {
-					// TODO: Remove this once we have reworked the Blueprints v2 runner.
-					throw new Error(
-						'Blueprints v2 are temporarily disabled while we rework their runtime implementation.'
-					);
+				const hasExplicitBlueprintsV2Mode = argsToParse.some(
+					(arg) => arg === '--mode' || arg.startsWith('--mode=')
+				);
 
+				if (args['experimental-blueprints-v2-runner'] === true) {
 					if (args['mode'] !== undefined) {
 						if (args['wordpress-install-mode'] !== undefined) {
 							throw new Error(
 								'The --wordpress-install-mode option cannot be used with the --mode option. Use one or the other.'
 							);
 						}
-						if ('skip-sqlite-setup' in args) {
+						if (
+							argsToParse.some(
+								(arg) =>
+									arg === '--skip-sqlite-setup' ||
+									arg.startsWith('--skip-sqlite-setup=')
+							)
+						) {
 							throw new Error(
 								'The --skipSqliteSetup option is not supported in Blueprint V2 mode.'
 							);
 						}
-						if (args['auto-mount'] !== undefined) {
+						// `--mode` is an explicit v2 execution-mode choice,
+						// while `--auto-mount` infers the mode from the
+						// detected project type. Check the raw argv here
+						// because parsed `auto-mount` values include parser
+						// defaults and do not reliably tell us whether the
+						// user passed the option explicitly.
+						if (
+							argsToParse.some(
+								(arg) =>
+									arg === '--auto-mount' ||
+									arg.startsWith('--auto-mount=') ||
+									arg === '--no-auto-mount' ||
+									arg.startsWith('--no-auto-mount=')
+							)
+						) {
 							throw new Error(
 								'The --mode option cannot be used with --auto-mount because --auto-mount automatically sets the mode.'
 							);
 						}
 					} else {
-						// Support the legacy v1 runner options
+						// Support the legacy v1 runner option while the native
+						// v2 CLI path remains experimental. The old v2 runner
+						// only had two modes and used `apply-to-existing-site`
+						// for this case; the native v2 path has `mount-only`,
+						// which maps directly to the same "do not install
+						// WordPress" worker behavior.
 						if (
 							args['wordpress-install-mode'] ===
 							'do-not-attempt-installing'
 						) {
-							args['mode'] = 'apply-to-existing-site';
+							args['mode'] = 'mount-only';
 						} else {
 							args['mode'] = 'create-new-site';
 						}
 					}
 
-					// Support the legacy v1 runner options
+					// Support the legacy v1 runner options while the native
+					// v2 CLI path remains experimental.
 					const allow = (args['allow'] as string[]) || [];
 
 					if (args['followSymlinks'] === true) {
@@ -672,13 +702,14 @@ export async function parseOptionsAndRunCLI(argsToParse: string[]) {
 					}
 
 					args['allow'] = allow;
-				} else {
-					if (args['mode'] !== undefined) {
-						throw new Error(
-							'The --mode option requires the --experimentalBlueprintsV2Runner flag.'
-						);
-					}
+				} else if (hasExplicitBlueprintsV2Mode) {
+					throw new Error(
+						'The --mode option requires the --experimentalBlueprintsV2Runner flag.'
+					);
 				}
+
+				args['hasExplicitBlueprintsV2Mode'] =
+					hasExplicitBlueprintsV2Mode;
 
 				return true;
 			});
@@ -716,20 +747,23 @@ export async function parseOptionsAndRunCLI(argsToParse: string[]) {
 		// Don't default WP_DEBUG* on for legacy PHP: old WordPress
 		// (pre-2.3) prints E_NOTICE output before headers are sent,
 		// which corrupts redirects and breaks the installer. The web
-		// worker path applies the same gate in
-		// @wp-playground/client/src/blueprints-v1-handler.ts.
+		// worker path applies the same gate when resolving runtime options.
 		const phpVersionForDebug = (args['php'] ||
 			RecommendedPHPVersion) as AllPHPVersion;
 		const isLegacyPhpForDebug = isLegacyPHPVersion(phpVersionForDebug);
+		const defaultedDebugConstants: string[] = [];
 		if (!isLegacyPhpForDebug) {
 			if (!hasDebugDefine('WP_DEBUG')) {
 				defineBool['WP_DEBUG'] = true;
+				defaultedDebugConstants.push('WP_DEBUG');
 			}
 			if (!hasDebugDefine('WP_DEBUG_LOG')) {
 				defineBool['WP_DEBUG_LOG'] = true;
+				defaultedDebugConstants.push('WP_DEBUG_LOG');
 			}
 			if (!hasDebugDefine('WP_DEBUG_DISPLAY')) {
 				defineBool['WP_DEBUG_DISPLAY'] = false;
+				defaultedDebugConstants.push('WP_DEBUG_DISPLAY');
 			}
 		}
 
@@ -738,6 +772,7 @@ export async function parseOptionsAndRunCLI(argsToParse: string[]) {
 			define,
 			'define-bool': defineBool,
 			'define-number': defineNumber,
+			defaultedDebugConstants,
 			command,
 			mount: [
 				...((args['mount'] as Mount[]) || []),
@@ -889,6 +924,7 @@ export interface RunCLIArgs {
 	 * Set via php.defineConstant(), process-specific only.
 	 */
 	'define-number'?: Record<string, number>;
+	defaultedDebugConstants?: string[];
 
 	// --------- Blueprint V1 args -----------
 	skipSqliteSetup?: boolean;
@@ -897,6 +933,7 @@ export interface RunCLIArgs {
 
 	// --------- Blueprint V2 args -----------
 	mode?: 'mount-only' | 'create-new-site' | 'apply-to-existing-site';
+	hasExplicitBlueprintsV2Mode?: boolean;
 
 	// --------- Blueprint V2 args (not available via CLI yet) -----------
 	'db-engine'?: 'sqlite' | 'mysql';
@@ -914,7 +951,6 @@ export interface RunCLIArgs {
 	reset?: boolean;
 }
 
-// TODO: Maybe we should just be declaring an interface instead of a type union
 export type PlaygroundCliWorker =
 	| PlaygroundCliBlueprintV1Worker
 	| PlaygroundCliBlueprintV2Worker;
@@ -969,6 +1005,13 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer | void> {
 		verbosity: args.verbosity || 'normal',
 	});
 
+	// Full WordPress auto-mounts have historically set
+	// `mode=apply-to-existing-site` even for the v1 flow. Capture whether the
+	// user supplied a mode before `start` or auto-mount expansion can add that
+	// compatibility value.
+	const hasExplicitBlueprintsV2Mode =
+		args.hasExplicitBlueprintsV2Mode ?? args.mode !== undefined;
+
 	if (args.command === 'start') {
 		args = expandStartCommandArgs(args, cliOutput);
 	}
@@ -981,10 +1024,6 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer | void> {
 			args = { ...args, autoMount: process.cwd() };
 		}
 		args = expandAutoMounts(args);
-	}
-
-	if (args.wordpressInstallMode === undefined) {
-		args.wordpressInstallMode = 'download-and-install';
 	}
 
 	// Keeping the '--quiet' option to preserve backward compatibility
@@ -1421,8 +1460,30 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer | void> {
 				}
 			}
 
+			if (typeof args.blueprint === 'string') {
+				args.blueprint = await resolveBlueprint({
+					sourceString: args.blueprint,
+					blueprintMayReadAdjacentFiles:
+						args['blueprint-may-read-adjacent-files'] === true,
+				});
+			}
+
 			let handler: BlueprintsV1Handler | BlueprintsV2Handler;
-			if (args['experimental-blueprints-v2-runner']) {
+			const useBlueprintsV2Handler =
+				await shouldUseBlueprintsV2Handler(
+					args,
+					hasExplicitBlueprintsV2Mode
+				);
+			if (useBlueprintsV2Handler) {
+				validateAndNormalizeBlueprintsV2Args(
+					args,
+					hasExplicitBlueprintsV2Mode
+				);
+			}
+			if (args.wordpressInstallMode === undefined) {
+				args.wordpressInstallMode = 'download-and-install';
+			}
+			if (useBlueprintsV2Handler) {
 				handler = new BlueprintsV2Handler(args, {
 					siteUrl,
 					cliOutput,
@@ -1432,14 +1493,6 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer | void> {
 					siteUrl,
 					cliOutput,
 				});
-
-				if (typeof args.blueprint === 'string') {
-					args.blueprint = await resolveBlueprint({
-						sourceString: args.blueprint,
-						blueprintMayReadAdjacentFiles:
-							args['blueprint-may-read-adjacent-files'] === true,
-					});
-				}
 			}
 
 			// Remember whether we are already disposing so we can avoid:
@@ -1582,7 +1635,15 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer | void> {
 
 					wordPressReady = true;
 
-					if (!args['experimental-blueprints-v2-runner']) {
+					if (useBlueprintsV2Handler) {
+						const compiledInputBlueprint =
+							await handler.compileInputBlueprint(
+								args['additional-blueprint-steps'] || []
+							);
+						if (compiledInputBlueprint) {
+							await compiledInputBlueprint.run(playgroundPool);
+						}
+					} else {
 						const compiledBlueprint = await (
 							handler as BlueprintsV1Handler
 						).compileInputBlueprint(
@@ -1768,6 +1829,87 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer | void> {
 }
 
 /**
+ * Selects the native Blueprint v2 CLI path.
+ *
+ * The default CLI path remains the v1 handler. We switch to v2 only when the
+ * caller opts in with `--experimental-blueprints-v2-runner`, passes a resolved
+ * Blueprint v2 declaration, or calls `runCLI()` directly with a v2 `mode`.
+ * The yargs parser still rejects public `--mode` usage without the experimental
+ * flag while the option remains hidden.
+ *
+ * `hasExplicitBlueprintsV2Mode` must be captured before `start` or auto-mount
+ * expansion because full WordPress auto-mounts still set
+ * `mode=apply-to-existing-site` for compatibility with the existing v1 CLI
+ * shape. That internal value must not route ordinary v1 auto-mounts to the
+ * native v2 handler. `args.blueprint` must already be resolved before this
+ * function runs so bundled Blueprints can be inspected via
+ * `BlueprintReflection`.
+ */
+async function shouldUseBlueprintsV2Handler(
+	args: RunCLIArgs,
+	hasExplicitBlueprintsV2Mode: boolean
+) {
+	if (args['experimental-blueprints-v2-runner']) {
+		return true;
+	}
+	if (hasExplicitBlueprintsV2Mode) {
+		return true;
+	}
+	if (!args.blueprint) {
+		return false;
+	}
+	const reflection = await BlueprintReflection.create(args.blueprint);
+	return reflection.getVersion() === 2;
+}
+
+function validateAndNormalizeBlueprintsV2Args(
+	args: RunCLIArgs,
+	hasExplicitBlueprintsV2Mode: boolean
+) {
+	if (hasExplicitBlueprintsV2Mode) {
+		// `--auto-mount` infers how to prepare WordPress from the detected
+		// project type. `--mode` is an explicit user choice for the same
+		// decision, so accepting both would hide which one won. For `start`,
+		// auto-mount expansion may already have consumed `autoMount`, so also
+		// check the generated auto-mounted WordPress root mount.
+		const autoMountedSiteRoot =
+			getMountForVfsPath(
+				args['mount-before-install'] || [],
+				'/wordpress'
+			) || getMountForVfsPath(args.mount || [], '/wordpress');
+		if (
+			typeof args.autoMount === 'string' ||
+			autoMountedSiteRoot?.autoMounted
+		) {
+			throw new Error(
+				'The --mode option cannot be used with --auto-mount because --auto-mount automatically sets the mode.'
+			);
+		}
+		// `--mode` is the v2 execution model. Keep it separate from the
+		// older install-mode switch until we settle a public compatibility
+		// story between the two option families.
+		if (args.wordpressInstallMode !== undefined) {
+			throw new Error(
+				'The --wordpress-install-mode option cannot be used with the --mode option. Use one or the other.'
+			);
+		}
+		// `--skip-sqlite-setup` belongs to the v1-style boot/install path.
+		// The native v2 mode path resolves database setup from the v2 runtime
+		// configuration instead.
+		if (args.skipSqliteSetup === true) {
+			throw new Error(
+				'The --skipSqliteSetup option is not supported in Blueprint V2 mode.'
+			);
+		}
+		return;
+	}
+
+	if (args.wordpressInstallMode === 'do-not-attempt-installing') {
+		args.mode = 'mount-only';
+	}
+}
+
+/**
  * Transforms CLI args for the `start` command into the `server` command arguments.
  *
  * (Yes, the `start` command is just a convenience wrapper to provide useful defaults
@@ -1806,6 +1948,14 @@ function expandStartCommandArgs(
 			newArgs['mount-before-install'] || [],
 			'/wordpress'
 		) || getMountForVfsPath(newArgs.mount || [], '/wordpress');
+	if (
+		existingSiteRootMount?.autoMounted &&
+		newArgs.mode === 'create-new-site'
+	) {
+		throw new Error(
+			'Cannot use --mode=create-new-site with an auto-detected WordPress directory. Use --no-auto-mount, or choose --mode=apply-to-existing-site or --mode=mount-only.'
+		);
+	}
 
 	/**
 	 * Persist the site into a ~/.wordpress-playground/sites/<site-id> directory,

--- a/packages/playground/cli/tests/blueprints-v2-handler.spec.ts
+++ b/packages/playground/cli/tests/blueprints-v2-handler.spec.ts
@@ -1,0 +1,550 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { BlueprintsV2Handler } from '../src/blueprints-v2/blueprints-v2-handler';
+import type { RunCLIArgs } from '../src/run-cli';
+import type { CLIOutput } from '../src/cli-output';
+import type {
+	BlueprintBundle,
+	BlueprintV1Declaration,
+	BlueprintV2Declaration,
+} from '@wp-playground/blueprints';
+import { consumeAPI } from '@php-wasm/universal';
+import { fetchSqliteIntegration } from '../src/blueprints-v1/download';
+
+vi.mock('@php-wasm/universal', async (importOriginal) => {
+	const actual = (await importOriginal()) as Record<string, unknown>;
+	return {
+		...actual,
+		consumeAPI: vi.fn(),
+	};
+});
+
+vi.mock('../src/blueprints-v1/download', async (importOriginal) => {
+	const actual = (await importOriginal()) as Record<string, unknown>;
+	return {
+		...actual,
+		fetchSqliteIntegration: vi.fn(
+			async () => new File(['sqlite'], 'sqlite.zip')
+		),
+	};
+});
+
+describe('BlueprintsV2Handler', () => {
+	const cliOutput = {
+		updateProgress: vi.fn(),
+	} as unknown as CLIOutput;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	test('applies CLI defaults and normalizes additional steps before compiling', async () => {
+		const handler = new BlueprintsV2Handler(
+			{
+				command: 'server',
+				php: '8.1',
+				wp: '6.4',
+				login: true,
+				blueprint: {
+					version: 2,
+					additionalStepsAfterExecution: [
+						{
+							step: 'mkdir',
+							path: 'wp-content/uploads/demo',
+						},
+					],
+				},
+			} as RunCLIArgs,
+			{
+				siteUrl: 'http://127.0.0.1:9400',
+				cliOutput,
+			}
+		);
+
+		const compiled = await handler.compileInputBlueprint([
+			{
+				step: 'activateTheme',
+				themeFolderName: 'mounted-theme',
+			},
+		]);
+
+		expect(compiled.declaration).toMatchObject({
+			version: 2,
+			phpVersion: '8.1',
+			wordpressVersion: '6.4',
+			applicationOptions: {
+				'wordpress-playground': {
+					login: true,
+				},
+			},
+			additionalStepsAfterExecution: [
+				{
+					step: 'mkdir',
+					path: 'wp-content/uploads/demo',
+				},
+				{
+					step: 'activateTheme',
+					themeDirectoryName: 'mounted-theme',
+				},
+			],
+		});
+	});
+
+	test('preserves v2 versions over CLI values', async () => {
+		const handler = new BlueprintsV2Handler(
+			{
+				command: 'server',
+				php: '8.4',
+				wp: 'latest',
+				blueprint: {
+					version: 2,
+					phpVersion: '7.4',
+					wordpressVersion: '6.4',
+				},
+			} as RunCLIArgs,
+			{
+				siteUrl: 'http://127.0.0.1:9400',
+				cliOutput,
+			}
+		);
+
+		const compiled = await handler.compileInputBlueprint([]);
+
+		expect(compiled.declaration).toMatchObject({
+			version: 2,
+			phpVersion: '7.4',
+			wordpressVersion: '6.4',
+		});
+	});
+
+	test('applies CLI runtime defaults to v2 declarations when omitted', async () => {
+		const handler = new BlueprintsV2Handler(
+			{
+				command: 'server',
+				php: '8.3',
+				wp: 'latest',
+				blueprint: {
+					version: 2,
+				},
+			} as RunCLIArgs,
+			{
+				siteUrl: 'http://127.0.0.1:9400',
+				cliOutput,
+			}
+		);
+
+		const compiled = await handler.compileInputBlueprint([]);
+
+		expect(compiled.declaration).toMatchObject({
+			version: 2,
+			phpVersion: '8.3',
+			wordpressVersion: 'latest',
+		});
+	});
+
+	test('preserves v2 login intent over parsed CLI login defaults', async () => {
+		const handler = new BlueprintsV2Handler(
+			{
+				command: 'server',
+				login: false,
+				blueprint: {
+					version: 2,
+					applicationOptions: {
+						'wordpress-playground': {
+							login: true,
+						},
+					},
+				},
+			} as RunCLIArgs,
+			{
+				siteUrl: 'http://127.0.0.1:9400',
+				cliOutput,
+			}
+		);
+
+		const compiled = await handler.compileInputBlueprint([]);
+
+		expect(compiled.declaration).toMatchObject({
+			applicationOptions: {
+				'wordpress-playground': {
+					login: true,
+				},
+			},
+		});
+	});
+
+	test('applies parsed CLI login defaults when v2 declaration has no login opinion', async () => {
+		const handler = new BlueprintsV2Handler(
+			{
+				command: 'server',
+				login: true,
+				blueprint: {
+					version: 2,
+				},
+			} as RunCLIArgs,
+			{
+				siteUrl: 'http://127.0.0.1:9400',
+				cliOutput,
+			}
+		);
+
+		const compiled = await handler.compileInputBlueprint([]);
+
+		expect(compiled.declaration).toMatchObject({
+			applicationOptions: {
+				'wordpress-playground': {
+					login: true,
+				},
+			},
+		});
+	});
+
+	test('preserves v2 login intent over parsed CLI login defaults', async () => {
+		const handler = new BlueprintsV2Handler(
+			{
+				command: 'server',
+				login: true,
+				blueprint: {
+					version: 2,
+					applicationOptions: {
+						'wordpress-playground': {
+							login: false,
+						},
+					},
+				},
+			} as RunCLIArgs,
+			{
+				siteUrl: 'http://127.0.0.1:9400',
+				cliOutput,
+			}
+		);
+
+		const compiled = await handler.compileInputBlueprint([]);
+
+		expect(compiled.declaration).toMatchObject({
+			applicationOptions: {
+				'wordpress-playground': {
+					login: false,
+				},
+			},
+		});
+	});
+
+	test('preserves v2 login intent over CLI login values', async () => {
+		const createHandler = (login: boolean) =>
+			new BlueprintsV2Handler(
+				{
+					command: 'server',
+					login,
+					blueprint: {
+						version: 2,
+						applicationOptions: {
+							'wordpress-playground': {
+								login: !login,
+							},
+						},
+					},
+				} as RunCLIArgs,
+				{
+					siteUrl: 'http://127.0.0.1:9400',
+					cliOutput,
+				}
+			);
+
+		await expect(
+			createHandler(true).compileInputBlueprint([])
+		).resolves.toMatchObject({
+			declaration: {
+				applicationOptions: {
+					'wordpress-playground': {
+						login: false,
+					},
+				},
+			},
+		});
+		await expect(
+			createHandler(false).compileInputBlueprint([])
+		).resolves.toMatchObject({
+			declaration: {
+				applicationOptions: {
+					'wordpress-playground': {
+						login: true,
+					},
+				},
+			},
+		});
+	});
+
+	test('applies CLI defaults and additional steps to blueprint bundles', async () => {
+		const handler = new BlueprintsV2Handler(
+			{
+				command: 'server',
+				php: '8.2',
+				login: true,
+				blueprint: createBundle({
+					version: 2,
+					siteOptions: {
+						blogname: 'Bundled site',
+					},
+				}),
+			} as RunCLIArgs,
+			{
+				siteUrl: 'http://127.0.0.1:9400',
+				cliOutput,
+			}
+		);
+
+		const compiled = await handler.compileInputBlueprint([
+			{
+				step: 'mkdir',
+				path: 'wp-content/uploads/from-bundle',
+			},
+		]);
+
+		expect(compiled.declaration).toMatchObject({
+			version: 2,
+			phpVersion: '8.2',
+			siteOptions: {
+				blogname: 'Bundled site',
+			},
+			applicationOptions: {
+				'wordpress-playground': {
+					login: true,
+				},
+			},
+			additionalStepsAfterExecution: [
+				{
+					step: 'mkdir',
+					path: 'wp-content/uploads/from-bundle',
+				},
+			],
+		});
+	});
+
+	test('uses v2 runtime intl settings when booting the worker', async () => {
+		const playground = createMockBlueprintV1Worker();
+		vi.mocked(consumeAPI).mockReturnValue(playground as any);
+		const handler = new BlueprintsV2Handler(
+			{
+				command: 'server',
+				intl: true,
+				blueprint: {
+					version: 2,
+				},
+			} as RunCLIArgs,
+			{
+				siteUrl: 'http://127.0.0.1:9400',
+				cliOutput,
+			}
+		);
+
+		await handler.bootRequestHandler({
+			worker: { phpPort: {}, processId: 7 } as any,
+			fileLockManagerPort: {} as any,
+			nativeInternalDirPath: '/tmp/playground',
+		});
+
+		expect(playground.bootRequestHandler).toHaveBeenCalledWith(
+			expect.objectContaining({
+				extensions: [],
+			})
+		);
+	});
+
+	test('translates v2 apply-to-existing-site mode to the v1 worker install mode', async () => {
+		const handler = new BlueprintsV2Handler(
+			{
+				command: 'server',
+				mode: 'apply-to-existing-site',
+				wordpressInstallMode: 'download-and-install',
+				skipSqliteSetup: true,
+			} as RunCLIArgs,
+			{
+				siteUrl: 'http://127.0.0.1:9400',
+				cliOutput,
+			}
+		);
+		const playground = {
+			bootWordPress: vi.fn().mockResolvedValue(undefined),
+		};
+
+		await handler.bootWordPress(playground as any, {} as any);
+
+		expect(playground.bootWordPress).toHaveBeenCalledWith(
+			expect.objectContaining({
+				wordpressInstallMode: 'install-from-existing-files-if-needed',
+			}),
+			expect.anything()
+		);
+	});
+
+	test('preserves v2 mount-only mode from legacy install mode', async () => {
+		const handler = new BlueprintsV2Handler(
+			{
+				command: 'server',
+				wordpressInstallMode: 'do-not-attempt-installing',
+				skipSqliteSetup: true,
+			} as RunCLIArgs,
+			{
+				siteUrl: 'http://127.0.0.1:9400',
+				cliOutput,
+			}
+		);
+		const playground = {
+			bootWordPress: vi.fn().mockResolvedValue(undefined),
+		};
+
+		await handler.bootWordPress(playground as any, {} as any);
+
+		expect(playground.bootWordPress).toHaveBeenCalledWith(
+			expect.objectContaining({
+				wordpressInstallMode: 'do-not-attempt-installing',
+			}),
+			expect.anything()
+		);
+	});
+
+	test('skips SQLite setup in v2 mount-only mode', async () => {
+		const handler = new BlueprintsV2Handler(
+			{
+				command: 'server',
+				mode: 'mount-only',
+			} as RunCLIArgs,
+			{
+				siteUrl: 'http://127.0.0.1:9400',
+				cliOutput,
+			}
+		);
+		const playground = {
+			bootWordPress: vi.fn().mockResolvedValue(undefined),
+		};
+
+		await handler.bootWordPress(playground as any, {} as any);
+
+		expect(fetchSqliteIntegration).not.toHaveBeenCalled();
+		expect(playground.bootWordPress).toHaveBeenCalledWith(
+			expect.objectContaining({
+				wordpressInstallMode: 'do-not-attempt-installing',
+				sqliteIntegrationPluginZip: undefined,
+			}),
+			expect.anything()
+		);
+	});
+
+	test('passes v2 network access to the worker boot', async () => {
+		const handler = new BlueprintsV2Handler(
+			{
+				command: 'server',
+				mode: 'apply-to-existing-site',
+				skipSqliteSetup: true,
+				blueprint: {
+					version: 2,
+					applicationOptions: {
+						'wordpress-playground': {
+							networkAccess: false,
+						},
+					},
+				},
+			} as RunCLIArgs,
+			{
+				siteUrl: 'http://127.0.0.1:9400',
+				cliOutput,
+			}
+		);
+		const playground = {
+			bootWordPress: vi.fn().mockResolvedValue(undefined),
+		};
+
+		await handler.bootWordPress(playground as any, {} as any);
+
+		expect(playground.bootWordPress).toHaveBeenCalledWith(
+			expect.objectContaining({
+				networking: false,
+			}),
+			expect.anything()
+		);
+	});
+
+	test('uses the v2 runtime PHP version when selecting the SQLite integration', async () => {
+		const handler = new BlueprintsV2Handler(
+			{
+				command: 'server',
+				mode: 'apply-to-existing-site',
+				php: '8.4',
+				blueprint: {
+					version: 2,
+					phpVersion: '5.2',
+				},
+			} as RunCLIArgs,
+			{
+				siteUrl: 'http://127.0.0.1:9400',
+				cliOutput,
+			}
+		);
+		const playground = {
+			bootWordPress: vi.fn().mockResolvedValue(undefined),
+		};
+
+		await handler.bootWordPress(playground as any, {} as any);
+
+		expect(fetchSqliteIntegration).toHaveBeenCalledWith(
+			'v3.0.0-rc.3-php52'
+		);
+		expect(playground.bootWordPress).toHaveBeenCalledWith(
+			expect.objectContaining({
+				phpVersion: '5.2',
+			}),
+			expect.anything()
+		);
+	});
+
+	test('rejects web-only phpVersion next before booting the Node runtime', async () => {
+		const handler = new BlueprintsV2Handler(
+			{
+				command: 'server',
+				blueprint: {
+					version: 2,
+					phpVersion: 'next',
+				},
+			} as RunCLIArgs,
+			{
+				siteUrl: 'http://127.0.0.1:9400',
+				cliOutput,
+			}
+		);
+		const playground = {
+			bootWordPress: vi.fn().mockResolvedValue(undefined),
+		};
+
+		await expect(
+			handler.bootWordPress(playground as any, {} as any)
+		).rejects.toThrow(/web runtime only/);
+		expect(playground.bootWordPress).not.toHaveBeenCalled();
+	});
+});
+
+function createMockBlueprintV1Worker() {
+	return {
+		isConnected: vi.fn().mockResolvedValue(undefined),
+		useFileLockManager: vi.fn().mockResolvedValue(undefined),
+		bootRequestHandler: vi.fn().mockResolvedValue(undefined),
+		isReady: vi.fn().mockResolvedValue(undefined),
+	};
+}
+
+function createBundle(
+	blueprint: BlueprintV1Declaration | BlueprintV2Declaration,
+	files: Record<string, string> = {}
+): BlueprintBundle {
+	return {
+		read: vi.fn(async (filePath: string) => {
+			const normalizedPath = filePath.replace(/^\.?\//, '');
+			if (normalizedPath === 'blueprint.json') {
+				return new File([JSON.stringify(blueprint)], 'blueprint.json');
+			}
+			if (normalizedPath in files) {
+				return new File([files[normalizedPath]], normalizedPath);
+			}
+			throw new Error(`Unexpected bundled file: ${filePath}`);
+		}),
+	} as unknown as BlueprintBundle;
+}

--- a/packages/playground/cli/tests/run-cli.spec.ts
+++ b/packages/playground/cli/tests/run-cli.spec.ts
@@ -1,6 +1,7 @@
 import path from 'node:path';
 import os from 'node:os';
 import http from 'node:http';
+import type * as ChildProcess from 'child_process';
 import {
 	runCLI,
 	parseOptionsAndRunCLI,
@@ -10,10 +11,8 @@ import {
 import type { RunCLIArgs, RunCLIServer } from '../src/run-cli';
 import type { MockInstance } from 'vitest';
 import { vi } from 'vitest';
-import { mkdtemp, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { promisify } from 'node:util';
-import { exec } from 'node:child_process';
 import {
 	copyFileSync,
 	mkdirSync,
@@ -26,8 +25,22 @@ import {
 	rmSync,
 } from 'node:fs';
 import { createHash } from 'node:crypto';
+import { decodeZip } from '@php-wasm/stream-compression';
 import { PHPMYADMIN_INSTALL_PATH } from '@wp-playground/tools';
 import { type Log, logger } from '@php-wasm/logger';
+
+vi.mock('child_process', async (importOriginal) => {
+	const actual = await importOriginal<typeof ChildProcess>();
+	return {
+		...actual,
+		exec: vi.fn((_command, callback) => {
+			if (typeof callback === 'function') {
+				callback(null as any, '' as any, '' as any);
+			}
+			return {} as any;
+		}),
+	};
+});
 
 const blueprintVersions = [
 	{
@@ -38,6 +51,9 @@ const blueprintVersions = [
 		},
 	},
 ];
+
+const fullNativeBlueprintV2ModeTest =
+	process.platform === 'win32' ? test.skip : test;
 
 describe.each(blueprintVersions)(
 	'run-cli with Blueprints v$version',
@@ -216,6 +232,202 @@ describe.each(blueprintVersions)(
 			expect(response.status).toBe(200);
 			const text = await response.text();
 			expect(text).toContain('<title>My Blog Name</title>');
+		});
+
+		test('should route v2 blueprints to the native v2 handler without the experimental flag', async () => {
+			await using cliServer = await runCLI({
+				command: 'server',
+				workers: 1,
+				wordpressInstallMode: 'do-not-attempt-installing',
+				skipSqliteSetup: true,
+				blueprint: {
+					version: 2,
+					additionalStepsAfterExecution: [
+						{
+							step: 'mkdir',
+							path: 'routed-v2',
+						},
+					],
+				},
+			});
+
+			await expect(
+				cliServer.playground.fileExists('/wordpress/routed-v2')
+			).resolves.toBe(true);
+		});
+
+		test('should accept --mode with the experimental v2 flag when legacy options are omitted', async () => {
+			const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((
+				code?: number | string | null
+			) => {
+				throw new Error(
+					`process.exit unexpectedly called with "${code}"`
+				);
+			}) as any);
+
+			try {
+				await using cliResult = await parseOptionsAndRunCLI([
+					'server',
+					'--experimental-blueprints-v2-runner',
+					'--mode=mount-only',
+					'--verbosity=quiet',
+					'--port=0',
+					'--workers=1',
+				]);
+				const cliServer = cliResult[internalsKeyForTesting].cliServer;
+
+				expect(
+					await cliServer.playground.fileExists(
+						'/wordpress/wp-load.php'
+					)
+				).toBe(false);
+			} finally {
+				exitSpy.mockRestore();
+			}
+		});
+
+		test('should reject URL WordPress sources with the experimental v2 flag', async () => {
+			const fetchMock = vi.fn(async () => {
+				throw new Error('Unexpected WordPress ZIP fetch');
+			});
+			vi.stubGlobal('fetch', fetchMock);
+			const stdoutChunks: string[] = [];
+			const stdoutSpy = vi
+				.spyOn(process.stdout, 'write')
+				.mockImplementation((chunk: any) => {
+					stdoutChunks.push(
+						typeof chunk === 'string'
+							? chunk
+							: new TextDecoder().decode(chunk)
+					);
+					return true;
+				});
+			const exitSpy = vi
+				.spyOn(process, 'exit')
+				.mockImplementation((code?: number | string | null) => {
+					throw new Error(`process.exit(${code})`);
+				});
+
+			try {
+				await expect(
+					parseOptionsAndRunCLI([
+						'server',
+						'--experimental-blueprints-v2-runner',
+						'--wordpress-install-mode=install-from-existing-files-if-needed',
+						'--wp=https://example.com/wordpress.zip',
+						'--skip-sqlite-setup',
+						'--verbosity=quiet',
+						'--port=0',
+					])
+				).rejects.toThrow('process.exit(1)');
+				expect(stdoutChunks.join('')).toContain(
+					'Unsupported Blueprint v2 WordPress version "https://example.com/wordpress.zip".'
+				);
+				expect(exitSpy).toHaveBeenCalledWith(1);
+				expect(fetchMock).not.toHaveBeenCalled();
+			} finally {
+				stdoutSpy.mockRestore();
+				exitSpy.mockRestore();
+				vi.unstubAllGlobals();
+			}
+		});
+
+		test('should reject --mode without the experimental v2 flag', async () => {
+			const consoleErrorSpy = vi
+				.spyOn(console, 'error')
+				.mockImplementation(() => {});
+			const exitSpy = vi
+				.spyOn(process, 'exit')
+				.mockImplementation((code?: number | string | null) => {
+					throw new Error(`process.exit(${code})`);
+				});
+
+			try {
+				await expect(
+					parseOptionsAndRunCLI([
+						'server',
+						'--mode=mount-only',
+						'--wordpress-install-mode=do-not-attempt-installing',
+						'--verbosity=quiet',
+						'--port=0',
+					])
+				).rejects.toThrow('process.exit(1)');
+				expect(consoleErrorSpy).toHaveBeenCalledWith(
+					expect.stringContaining(
+						'The --mode option requires the --experimentalBlueprintsV2Runner flag.'
+					)
+				);
+				expect(exitSpy).toHaveBeenCalledWith(1);
+			} finally {
+				consoleErrorSpy.mockRestore();
+				exitSpy.mockRestore();
+			}
+		});
+
+		test('should reject --mode with SQLite setup disabled in experimental v2 mode', async () => {
+			const consoleErrorSpy = vi
+				.spyOn(console, 'error')
+				.mockImplementation(() => {});
+			const exitSpy = vi
+				.spyOn(process, 'exit')
+				.mockImplementation((code?: number | string | null) => {
+					throw new Error(`process.exit(${code})`);
+				});
+
+			try {
+				await expect(
+					parseOptionsAndRunCLI([
+						'server',
+						'--experimental-blueprints-v2-runner',
+						'--mode=mount-only',
+						'--skip-sqlite-setup',
+						'--verbosity=quiet',
+						'--port=0',
+					])
+				).rejects.toThrow('process.exit(1)');
+				expect(consoleErrorSpy).toHaveBeenCalledWith(
+					expect.stringContaining(
+						'The --skipSqliteSetup option is not supported in Blueprint V2 mode.'
+					)
+				);
+				expect(exitSpy).toHaveBeenCalledWith(1);
+			} finally {
+				consoleErrorSpy.mockRestore();
+				exitSpy.mockRestore();
+			}
+		});
+
+		test('should reject --mode with auto-mount in experimental v2 mode', async () => {
+			const consoleErrorSpy = vi
+				.spyOn(console, 'error')
+				.mockImplementation(() => {});
+			const exitSpy = vi
+				.spyOn(process, 'exit')
+				.mockImplementation((code?: number | string | null) => {
+					throw new Error(`process.exit(${code})`);
+				});
+
+			try {
+				await expect(
+					parseOptionsAndRunCLI([
+						'server',
+						'--experimental-blueprints-v2-runner',
+						'--mode=mount-only',
+						'--auto-mount=.',
+						'--verbosity=quiet',
+						'--port=0',
+					])
+				).rejects.toThrow('process.exit(1)');
+				expect(consoleErrorSpy).toHaveBeenCalledWith(
+					expect.stringContaining(
+						'The --mode option cannot be used with --auto-mount because --auto-mount automatically sets the mode.'
+					)
+				);
+				expect(exitSpy).toHaveBeenCalledWith(1);
+			} finally {
+				consoleErrorSpy.mockRestore();
+				exitSpy.mockRestore();
+			}
 		});
 
 		test('should be able to follow external symlinks in primary and secondary PHP instances', async ({
@@ -441,113 +653,6 @@ describe.each(blueprintVersions)(
 			}
 		});
 
-		if (version === 2) {
-			// @TODO: Test modes
-			test('should support --mode=create-new-site', async () => {
-				const tmpDir = await mkdtemp(
-					path.join(tmpdir(), 'playground-test-')
-				);
-				await using cliServer = await runCLI({
-					...suiteCliArgs,
-					command: 'server',
-					'experimental-blueprints-v2-runner': true,
-					mode: 'create-new-site',
-					'mount-before-install': [
-						{
-							hostPath: tmpDir,
-							vfsPath: '/wordpress',
-						},
-					],
-				});
-				const homeUrl = new URL('/', cliServer.serverUrl);
-				const response = await fetch(homeUrl);
-				expect(response.status).toBe(200);
-				const text = await response.text();
-				expect(text).toContain(
-					`<title>${expectedHomePageTitle}</title>`
-				);
-			});
-
-			test('should support --mode=apply-to-existing-site', async () => {
-				const tmpDir = await mkdtemp(
-					path.join(tmpdir(), 'playground-test-')
-				);
-
-				const port = 3019;
-				let homeUrl: URL;
-
-				{
-					// Create a new site so we can load it as an existing site later.
-					await using cliServer = await runCLI({
-						...suiteCliArgs,
-						port,
-						command: 'server',
-						'experimental-blueprints-v2-runner': true,
-						mode: 'create-new-site',
-						'mount-before-install': [
-							{
-								hostPath: tmpDir,
-								vfsPath: '/wordpress',
-							},
-						],
-					});
-					// Confirm the new site looks intact with its WP installed.
-					homeUrl = new URL('/', cliServer.serverUrl);
-					const setupResponse = await fetch(homeUrl);
-					expect(setupResponse.status).toBe(200);
-					const setupText = await setupResponse.text();
-					expect(setupText).toContain(
-						`<title>${expectedHomePageTitle}</title>`
-					);
-				}
-
-				// eslint-disable-next-line
-				await using cliServer = await runCLI({
-					...suiteCliArgs,
-					port,
-					command: 'server',
-					'experimental-blueprints-v2-runner': true,
-					mode: 'apply-to-existing-site',
-					'mount-before-install': [
-						{
-							hostPath: tmpDir,
-							vfsPath: '/wordpress',
-						},
-					],
-				});
-				const redirectResponse = await fetch(homeUrl);
-				expect(redirectResponse.status).toBe(200);
-				const redirectText = await redirectResponse.text();
-				expect(redirectText).toContain(
-					`<title>${expectedHomePageTitle}</title>`
-				);
-			});
-
-			test('should put WordPress in the document root', async () => {
-				const tmpDir = await mkdtemp(
-					path.join(tmpdir(), 'playground-test-')
-				);
-
-				// Create a new site so we can load it as an existing site later.
-				// eslint-disable-next-line
-				await using cliServer = await runCLI({
-					...suiteCliArgs,
-					'site-url': 'http://playground-domain/',
-					'db-engine': 'sqlite',
-					command: 'server',
-					mode: 'create-new-site',
-					'mount-before-install': [
-						{
-							hostPath: tmpDir,
-							vfsPath: '/wordpress',
-						},
-					],
-				});
-				const wpContentDirPath = path.join(tmpDir, 'wp-content');
-				expect(lstatSync(wpContentDirPath)?.isDirectory()).toBe(true);
-			}, 60000);
-		}
-
 		// TODO: Test resolving absolute symlinks within a mounted dir with and without follow-symlinks
 
 		describe('auto-mount', () => {
@@ -676,7 +781,7 @@ describe.each(blueprintVersions)(
 					zipPath,
 					new Uint8Array(await zip.arrayBuffer())
 				);
-				await promisify(exec)(`unzip "${zipPath}" -d "${tmpDir}"`);
+				await extractZip(zipPath, tmpDir);
 
 				const checksum = await getDirectoryChecksum(tmpDir);
 
@@ -723,7 +828,7 @@ describe.each(blueprintVersions)(
 					await cliServer[Symbol.asyncDispose]();
 					cliServer = undefined;
 				}
-			});
+			}, 30000);
 
 			test('should start server successfully with default verbosity', async () => {
 				cliServer = await runCLI({
@@ -943,6 +1048,98 @@ describe.each(blueprintVersions)(
 	},
 	60_000 * 5
 );
+
+describe('native Blueprint v2 modes', () => {
+	fullNativeBlueprintV2ModeTest(
+		'should support --mode=create-new-site',
+		async () => {
+			const tmpDir = await mkdtemp(
+				path.join(tmpdir(), 'playground-test-')
+			);
+			try {
+				await using cliServer = await runCLI({
+					command: 'server',
+					workers: 1,
+					'experimental-blueprints-v2-runner': true,
+					mode: 'create-new-site',
+					'mount-before-install': [
+						{
+							hostPath: tmpDir,
+							vfsPath: '/wordpress',
+						},
+					],
+				});
+				const homeUrl = new URL('/', cliServer.serverUrl);
+				const response = await fetch(homeUrl);
+				expect(response.status).toBe(200);
+				const text = await response.text();
+				expect(text).toContain('<title>My WordPress Website</title>');
+				const wpContentDirPath = path.join(tmpDir, 'wp-content');
+				expect(lstatSync(wpContentDirPath)?.isDirectory()).toBe(true);
+			} finally {
+				rmSync(tmpDir, { recursive: true, force: true });
+			}
+		}
+	);
+
+	fullNativeBlueprintV2ModeTest(
+		'should support --mode=apply-to-existing-site',
+		async () => {
+			const tmpDir = await mkdtemp(
+				path.join(tmpdir(), 'playground-test-')
+			);
+
+			try {
+				await using cliServer = await runCLI({
+					command: 'server',
+					workers: 1,
+					'experimental-blueprints-v2-runner': true,
+					mode: 'create-new-site',
+					'mount-before-install': [
+						{
+							hostPath: tmpDir,
+							vfsPath: '/wordpress',
+						},
+					],
+				});
+				// Confirm the new site looks intact with its WP installed.
+				const homeUrl = new URL('/', cliServer.serverUrl);
+				const setupResponse = await fetch(homeUrl);
+				expect(setupResponse.status).toBe(200);
+				const setupText = await setupResponse.text();
+				expect(setupText).toContain(
+					'<title>My WordPress Website</title>'
+				);
+
+				// eslint-disable-next-line
+				await using existingSiteServer = await runCLI({
+					command: 'server',
+					workers: 1,
+					'experimental-blueprints-v2-runner': true,
+					mode: 'apply-to-existing-site',
+					'mount-before-install': [
+						{
+							hostPath: tmpDir,
+							vfsPath: '/wordpress',
+						},
+					],
+				});
+				const existingSiteUrl = new URL(
+					'/',
+					existingSiteServer.serverUrl
+				);
+				const redirectResponse = await fetch(existingSiteUrl);
+				expect(redirectResponse.status).toBe(200);
+				const redirectText = await redirectResponse.text();
+				expect(redirectText).toContain(
+					'<title>My WordPress Website</title>'
+				);
+			} finally {
+				rmSync(tmpDir, { recursive: true, force: true });
+			}
+		}
+	);
+});
 
 describe('start command', () => {
 	test('should work with default options', async () => {
@@ -1193,6 +1390,44 @@ describe('start command', () => {
 			);
 			expect(autoMountedPluginExists).toBe(false);
 		} finally {
+			exitSpy.mockRestore();
+			rmSync(tmpDir, { recursive: true, force: true });
+		}
+	}, 180000);
+
+	test('does not expose v2 --mode on the start command', async () => {
+		const tmpDir = await mkdtemp(
+			path.join(tmpdir(), 'playground-test-start-existing-wp-')
+		);
+		const wordpressDir = path.join(tmpDir, 'wordpress');
+		mkdirSync(path.join(wordpressDir, 'wp-admin'), { recursive: true });
+		mkdirSync(path.join(wordpressDir, 'wp-content'), { recursive: true });
+		mkdirSync(path.join(wordpressDir, 'wp-includes'), { recursive: true });
+		const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((
+			code?: number | string | null
+		) => {
+			throw new Error(`process.exit(${code})`);
+		}) as any);
+		const consoleErrorSpy = vi
+			.spyOn(console, 'error')
+			.mockImplementation(() => {});
+
+		try {
+			await expect(
+				parseOptionsAndRunCLI([
+					'start',
+					`--path=${wordpressDir}`,
+					'--mode=create-new-site',
+					'--skip-browser',
+					'--quiet',
+					'--port=0',
+				])
+			).rejects.toThrow('process.exit(1)');
+			expect(consoleErrorSpy).toHaveBeenCalledWith(
+				expect.stringContaining('Unknown argument: mode')
+			);
+		} finally {
+			consoleErrorSpy.mockRestore();
 			exitSpy.mockRestore();
 			rmSync(tmpDir, { recursive: true, force: true });
 		}
@@ -1460,6 +1695,7 @@ describe('other run-cli behaviors', () => {
 					req.end();
 				}
 			);
+
 			expect(res.statusCode).toBe(302);
 			expect(res.headers['set-cookie']).toContain(
 				'playground_auto_login_already_happened=1; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Path=/'
@@ -1468,6 +1704,33 @@ describe('other run-cli behaviors', () => {
 	});
 
 	describe('phpMyAdmin CLI argument validation', () => {
+		test('should reject invalid WordPress version slugs before startup', async () => {
+			const stderrChunks: string[] = [];
+			const consoleSpy = vi
+				.spyOn(console, 'error')
+				.mockImplementation((...args: any[]) => {
+					stderrChunks.push(args.map(String).join(' '));
+				});
+			const exitSpy = vi
+				.spyOn(process, 'exit')
+				.mockImplementation((code?: number | string | null) => {
+					throw new Error(`process.exit(${code})`);
+				});
+
+			try {
+				await expect(
+					parseOptionsAndRunCLI(['server', '--wp=brazil'])
+				).rejects.toThrow('process.exit(1)');
+				expect(stderrChunks.join('\n')).toContain(
+					'Unrecognized WordPress version'
+				);
+				expect(exitSpy).toHaveBeenCalledWith(1);
+			} finally {
+				consoleSpy.mockRestore();
+				exitSpy.mockRestore();
+			}
+		});
+
 		test('should reject --phpmyadmin with --skip-sqlite-setup', async () => {
 			// Suppress console.error during this test since yargs outputs to stderr
 			const consoleSpy = vi
@@ -1842,6 +2105,7 @@ describe('other run-cli behaviors', () => {
 					'--skip-sqlite-setup',
 					'--verbosity=quiet',
 					'--port=0',
+					'--workers=1',
 					...cliArgs,
 				]);
 				const cliServer = cliResult[internalsKeyForTesting].cliServer;
@@ -2223,3 +2487,25 @@ describe('resolveWorkerCount', () => {
 		});
 	});
 });
+
+async function extractZip(zipPath: string, extractTo: string) {
+	const extractRoot = path.resolve(extractTo);
+	const zipStream = decodeZip(new Blob([await readFile(zipPath)]).stream());
+	for await (const file of zipStream) {
+		const target = path.resolve(extractRoot, file.name);
+		if (
+			target !== extractRoot &&
+			!target.startsWith(`${extractRoot}${path.sep}`)
+		) {
+			throw new Error(
+				`Refusing to extract ZIP entry outside target: ${file.name}`
+			);
+		}
+		if (file.type === 'directory' || file.name.endsWith('/')) {
+			await mkdir(target, { recursive: true });
+			continue;
+		}
+		await mkdir(path.dirname(target), { recursive: true });
+		await writeFile(target, new Uint8Array(await file.arrayBuffer()));
+	}
+}


### PR DESCRIPTION
## What it does

Adds the native Blueprint v2 execution flow to Playground CLI.

The CLI now routes Blueprint v2 declarations and explicit `--mode` runs through the TypeScript v2 compiler and v2 worker path. Existing v1 declarations stay on the v1 handler.

## Rationale

The web/client v2 declaration path landed first. This follows with the matching CLI slice: enough to boot WordPress, apply v2 runtime options, and run the compiled v2 steps without pulling in website, remote, or package-manager changes.

## Implementation

- Exports `compileBlueprintV2()` from `@wp-playground/blueprints` and passes progress tracking through v2 compilation.
- Adds `BlueprintsV2Handler` support for resolving v2 runtime configuration, downloading WordPress, preparing SQLite, booting the v2 worker, and running compiled v2 steps.
- Reworks `worker-thread-v2.ts` around `bootRequestHandler()` and `bootWordPress()` instead of delegating the whole flow to the old PHP-side v2 runner.
- Routes v2 declarations, `--experimental-blueprints-v2-runner`, and explicit `--mode` invocations to the v2 handler while preserving v1 handling for v1 declarations.
- Applies CLI defaults for missing v2 runtime fields while preserving `phpVersion`, `wordpressVersion`, and login settings declared by the Blueprint.

## Testing instructions

```bash
npx nx typecheck playground-cli
npx nx typecheck playground-blueprints
npx nx lint playground-cli
npx nx lint playground-blueprints
npx nx test-playground-cli playground-cli
npx nx build playground-cli
```

Part of #2592.