### PR TITLE
[Blueprints] Preserve resources through install workflows

### DIFF
--- a/packages/playground/blueprints/src/lib/compile.ts
+++ b/packages/playground/blueprints/src/lib/compile.ts
@@ -9,7 +9,11 @@ import {
 } from './v1/compile';
 import type { BlueprintV1Declaration } from './v1/types';
 import type { BlueprintV2Declaration } from './v2/blueprint-v2-declaration';
-import { compileBlueprintV2, type CompiledBlueprintV2 } from './v2/compile';
+import {
+	compileBlueprintV2,
+	type CompileBlueprintV2Options,
+	type CompiledBlueprintV2,
+} from './v2/compile';
 
 export type BlueprintExecutionPath = 'v1' | 'v2';
 
@@ -47,21 +51,27 @@ export async function compileBlueprintForExecution(
 ): Promise<CompiledBlueprintForExecution> {
 	const declaration = await getBlueprintDeclaration(input);
 	if (isBlueprintV2Declaration(declaration)) {
-		return compileBlueprintV2ForExecution(input, declaration);
+		return compileBlueprintV2ForExecution(input, declaration, options);
 	}
 	return compileBlueprintV1ForExecution(input, declaration, options);
 }
 
 async function compileBlueprintV2ForExecution(
 	input: Blueprint | BlueprintBundle,
-	declaration: BlueprintV2Declaration
+	declaration: BlueprintV2Declaration,
+	options: CompileBlueprintForExecutionOptions
 ): Promise<CompiledBlueprintForExecution> {
-	const compiled = await compileBlueprintV2(
-		declaration,
-		isBlueprintBundle(input)
-			? { streamBundledFile: (...args: [any]) => input.read(...args) }
-			: {}
-	);
+	const { onBlueprintValidated, ...runnerOptions } = options;
+	const compileOptions: CompileBlueprintV2Options = {
+		...(runnerOptions as CompileBlueprintV2Options),
+	};
+	if (isBlueprintBundle(input)) {
+		compileOptions.streamBundledFile = function (...args: [any]) {
+			return input.read(...args);
+		};
+	}
+	const compiled = await compileBlueprintV2(declaration, compileOptions);
+	onBlueprintValidated?.(declaration);
 	return {
 		version: 2,
 		declaration,

--- a/packages/playground/blueprints/src/lib/compile.ts
+++ b/packages/playground/blueprints/src/lib/compile.ts
@@ -56,6 +56,13 @@ export async function compileBlueprintForExecution(
 	return compileBlueprintV1ForExecution(input, declaration, options);
 }
 
+/**
+ * Compiles a v2 Blueprint while preserving bundle-relative resource access.
+ *
+ * Bundled resources are streamed from the BlueprintBundle rather than fetched
+ * over the network. The validation callback still receives the original v2
+ * declaration after compile-time resolution succeeds.
+ */
 async function compileBlueprintV2ForExecution(
 	input: Blueprint | BlueprintBundle,
 	declaration: BlueprintV2Declaration,

--- a/packages/playground/blueprints/src/lib/resolve-remote-blueprint.ts
+++ b/packages/playground/blueprints/src/lib/resolve-remote-blueprint.ts
@@ -147,6 +147,13 @@ async function createBlueprintBundleFromZip(
 	return dir === '' ? zipFs : new ChrootFilesystem(dir, zipFs);
 }
 
+/**
+ * Validates raw ZIP entry paths before they are exposed as bundle files.
+ *
+ * Path helpers such as `normalizePath()` collapse traversal segments, but a
+ * remote bundle must reject those raw entries instead of silently rewriting
+ * where they point.
+ */
 function assertZipEntryPathsStayInsideBundle(entryPaths: string[]) {
 	for (const entryPath of entryPaths) {
 		const normalizedSeparators = entryPath.replace(/\\/g, '/');

--- a/packages/playground/blueprints/src/lib/resolve-remote-blueprint.ts
+++ b/packages/playground/blueprints/src/lib/resolve-remote-blueprint.ts
@@ -141,9 +141,25 @@ async function createBlueprintBundleFromZip(
 ): Promise<BlueprintBundle> {
 	const zipFs = ZipFilesystem.fromArrayBuffer(arrayBuffer);
 	const entryPaths = await zipFs.getAllFilePaths();
+	assertZipEntryPathsStayInsideBundle(entryPaths);
 	const blueprintPath = findBlueprintJsonPath(entryPaths);
 	const dir = dirname(blueprintPath);
 	return dir === '' ? zipFs : new ChrootFilesystem(dir, zipFs);
+}
+
+function assertZipEntryPathsStayInsideBundle(entryPaths: string[]) {
+	for (const entryPath of entryPaths) {
+		const normalizedSeparators = entryPath.replace(/\\/g, '/');
+		if (
+			!entryPath ||
+			entryPath.includes('\0') ||
+			normalizedSeparators.startsWith('/') ||
+			/^[A-Za-z]:\//.test(normalizedSeparators) ||
+			normalizedSeparators.split('/').includes('..')
+		) {
+			throw new Error(`Unsafe Blueprint ZIP entry path: ${entryPath}`);
+		}
+	}
 }
 
 async function looksLikeZipFile(bytes: ArrayBuffer): Promise<boolean> {

--- a/packages/playground/blueprints/src/lib/steps/install-asset.ts
+++ b/packages/playground/blueprints/src/lib/steps/install-asset.ts
@@ -1,5 +1,5 @@
 import type { UniversalPHP } from '@php-wasm/universal';
-import { joinPaths, randomFilename } from '@php-wasm/util';
+import { basename, joinPaths, randomFilename } from '@php-wasm/util';
 import { unzip } from './unzip';
 
 export interface InstallAssetOptions {
@@ -91,9 +91,21 @@ export async function installAsset(
 		if (targetFolderName && targetFolderName.length) {
 			assetFolderName = targetFolderName;
 		}
+		if (
+			!assetFolderName ||
+			assetFolderName === '.' ||
+			assetFolderName === '..' ||
+			assetFolderName.includes('\\') ||
+			assetFolderName.includes('\0') ||
+			basename(assetFolderName) !== assetFolderName
+		) {
+			throw new Error(
+				'Asset folder name must be a single directory name.'
+			);
+		}
 
 		// Move asset folder to target path
-		const assetFolderPath = `${targetPath}/${assetFolderName}`;
+		const assetFolderPath = joinPaths(targetPath, assetFolderName);
 
 		// Handle the scenario when the asset is already installed.
 		if (await playground.fileExists(assetFolderPath)) {

--- a/packages/playground/blueprints/src/lib/steps/install-plugin.ts
+++ b/packages/playground/blueprints/src/lib/steps/install-plugin.ts
@@ -287,6 +287,13 @@ export const installPlugin: StepHandler<
 	}
 };
 
+/**
+ * Validates plugin file and folder names before joining them into wp-content.
+ *
+ * `basename()` catches POSIX path separators after normalization; the explicit
+ * checks reject backslashes, null bytes, and dot segments before a plugin name
+ * can be interpreted as a path.
+ */
 function assertSinglePluginEntryName(name: string) {
 	if (
 		!name ||

--- a/packages/playground/blueprints/src/lib/steps/install-plugin.ts
+++ b/packages/playground/blueprints/src/lib/steps/install-plugin.ts
@@ -5,7 +5,7 @@ import { activatePlugin } from './activate-plugin';
 import { writeFile } from './write-file';
 import { zipNameToHumanName } from '../utils/zip-name-to-human-name';
 import type { Directory } from '../v1/resources';
-import { joinPaths } from '@php-wasm/util';
+import { basename, joinPaths } from '@php-wasm/util';
 import { writeFiles, type UniversalPHP } from '@php-wasm/universal';
 import { logger } from '@php-wasm/logger';
 
@@ -126,7 +126,10 @@ export const installPlugin: StepHandler<
 			return true;
 		}
 
-		const filePrefix = new Uint8Array(await file.arrayBuffer(), 0, 4);
+		const filePrefix = new Uint8Array(await file.slice(0, 4).arrayBuffer());
+		if (filePrefix.length < 4) {
+			return false;
+		}
 		// Check against the signature for non-empty, non-spanned zip files.
 		const matchesZipSignature =
 			filePrefix[0] === 0x50 &&
@@ -165,14 +168,33 @@ export const installPlugin: StepHandler<
 				assetFolderPath = assetResult.assetFolderPath;
 				assetNiceName = assetResult.assetFolderName;
 			} else if (pluginData.name.endsWith('.php')) {
+				assertSinglePluginEntryName(pluginData.name);
 				const destinationFilePath = joinPaths(
 					pluginsDirectoryPath,
 					pluginData.name
 				);
-				await writeFile(playground, {
-					path: destinationFilePath,
-					data: pluginData,
-				});
+				let shouldWritePluginFile = true;
+				if (await playground.fileExists(destinationFilePath)) {
+					if (await playground.isDir(destinationFilePath)) {
+						throw new Error(
+							`Cannot install plugin ${pluginData.name} to ${destinationFilePath} because a directory with the same name already exists.`
+						);
+					}
+					if ((ifAlreadyInstalled ?? 'overwrite') === 'skip') {
+						shouldWritePluginFile = false;
+					} else if (ifAlreadyInstalled === 'error') {
+						throw new Error(
+							`Cannot install plugin ${pluginData.name} to ${pluginsDirectoryPath} because it already exists and ` +
+								`the ifAlreadyInstalled option was set to ${ifAlreadyInstalled}`
+						);
+					}
+				}
+				if (shouldWritePluginFile) {
+					await writeFile(playground, {
+						path: destinationFilePath,
+						data: pluginData,
+					});
+				}
 				assetFolderPath = pluginsDirectoryPath;
 				assetNiceName = pluginData.name;
 			} else {
@@ -183,6 +205,7 @@ export const installPlugin: StepHandler<
 			}
 		} else if (pluginData) {
 			assetNiceName = pluginData.name;
+			assertSinglePluginEntryName(targetFolderName || pluginData.name);
 			progress?.tracker.setCaption(
 				`Installing the ${progressName()} plugin`
 			);
@@ -191,14 +214,32 @@ export const installPlugin: StepHandler<
 				pluginsDirectoryPath,
 				targetFolderName || pluginData.name
 			);
-			await writeFiles(
-				playground,
-				pluginDirectoryPath,
-				pluginData.files,
-				{
-					rmRoot: true,
+			let shouldWritePluginFiles = true;
+			if (await playground.fileExists(pluginDirectoryPath)) {
+				if (!(await playground.isDir(pluginDirectoryPath))) {
+					throw new Error(
+						`Cannot install plugin ${targetFolderName || pluginData.name} to ${pluginDirectoryPath} because a file with the same name already exists. Note it's a file, not a directory! Is this by mistake?`
+					);
 				}
-			);
+				if ((ifAlreadyInstalled ?? 'overwrite') === 'skip') {
+					shouldWritePluginFiles = false;
+				} else if (ifAlreadyInstalled === 'error') {
+					throw new Error(
+						`Cannot install plugin ${targetFolderName || pluginData.name} to ${pluginsDirectoryPath} because it already exists and ` +
+							`the ifAlreadyInstalled option was set to ${ifAlreadyInstalled}`
+					);
+				}
+			}
+			if (shouldWritePluginFiles) {
+				await writeFiles(
+					playground,
+					pluginDirectoryPath,
+					pluginData.files,
+					{
+						rmRoot: true,
+					}
+				);
+			}
 			assetFolderPath = pluginDirectoryPath;
 		}
 
@@ -245,6 +286,21 @@ export const installPlugin: StepHandler<
 		throw error;
 	}
 };
+
+function assertSinglePluginEntryName(name: string) {
+	if (
+		!name ||
+		name === '.' ||
+		name === '..' ||
+		name.includes('\\') ||
+		name.includes('\0') ||
+		basename(name) !== name
+	) {
+		throw new Error(
+			'Plugin file or folder name must be a single path segment.'
+		);
+	}
+}
 
 /**
  * Stages activation options for a plugin before its activation hook runs.

--- a/packages/playground/blueprints/src/lib/steps/install-theme.ts
+++ b/packages/playground/blueprints/src/lib/steps/install-theme.ts
@@ -124,6 +124,10 @@ export const installTheme: StepHandler<
 			assetFolderName = targetFolderName || assetNiceName;
 			if (
 				!assetFolderName ||
+				assetFolderName === '.' ||
+				assetFolderName === '..' ||
+				assetFolderName.includes('\\') ||
+				assetFolderName.includes('\0') ||
 				basename(assetFolderName) !== assetFolderName
 			) {
 				throw new Error(

--- a/packages/playground/blueprints/src/lib/v1/compile.ts
+++ b/packages/playground/blueprints/src/lib/v1/compile.ts
@@ -142,7 +142,7 @@ export interface CompileBlueprintV1Options {
 
 export async function compileBlueprintV1(
 	input: BlueprintV1Declaration | BlueprintBundle,
-	options: CompileBlueprintV1Options = {}
+	options: Omit<CompileBlueprintV1Options, 'streamBundledFile'> = {}
 ): Promise<CompiledBlueprintV1> {
 	const finalOptions: CompileBlueprintV1Options = {
 		...options,

--- a/packages/playground/blueprints/src/lib/v2/compile.ts
+++ b/packages/playground/blueprints/src/lib/v2/compile.ts
@@ -178,9 +178,9 @@ export type CompiledBlueprintV2 = {
  * understand today.
  *
  * It resolves runtime options, creates an ordered v2 execution plan, and lowers
- * supported plan items into v1 step records the existing runner can execute.
- * Unsupported plan items stay visible and fail at run time instead of being
- * silently dropped.
+ * supported plan items into v1 step records. Fully lowered plans run through the
+ * existing v1 runner; unsupported items stay visible and block execution before
+ * any partial work is applied.
  */
 export async function compileBlueprintV2(
 	declaration: BlueprintV2Declaration,

--- a/packages/playground/blueprints/src/lib/v2/compile.ts
+++ b/packages/playground/blueprints/src/lib/v2/compile.ts
@@ -86,6 +86,10 @@ type BlueprintV2InstallAssetDefinition = {
 	humanReadableName?: string;
 };
 
+export type CompileBlueprintV2Options = Omit<
+	CompileBlueprintV1Options,
+	'onBlueprintValidated'
+>;
 export type BlueprintV2ExecutionPlan = BlueprintV2ExecutionPlanItem[];
 export type BlueprintV2StepPlan = StepDefinition[];
 export type BlueprintV2StepPlanLoweringResult = {
@@ -169,19 +173,14 @@ export type CompiledBlueprintV2 = {
 	run: (playground: UniversalPHP) => Promise<void>;
 };
 
-export type CompileBlueprintV2Options = Pick<
-	CompileBlueprintV1Options,
-	'progress' | 'streamBundledFile'
->;
-
 /**
  * Compiles a Blueprint v2 declaration into the pieces the TypeScript runner can
  * understand today.
  *
  * It resolves runtime options, creates an ordered v2 execution plan, and lowers
- * supported plan items into v1 step records. Fully lowered plans run through the
- * existing v1 runner; unsupported items stay visible and block execution before
- * any partial work is applied.
+ * supported plan items into v1 step records the existing runner can execute.
+ * Unsupported plan items stay visible and fail at run time instead of being
+ * silently dropped.
  */
 export async function compileBlueprintV2(
 	declaration: BlueprintV2Declaration,
@@ -697,6 +696,12 @@ function convertV2DataReferenceToV1(
 	context: 'plugin' | 'theme'
 ): FileReference | DirectoryReference {
 	if (typeof reference === 'string') {
+		if (reference.includes('\0')) {
+			throw new UnsupportedBlueprintV2FeatureError(
+				context,
+				'Invalid Blueprint v2 data reference: must not contain null bytes.'
+			);
+		}
 		if (seemsLikeGitRepoUrl(reference)) {
 			return {
 				resource: 'zip',
@@ -762,10 +767,20 @@ function convertV2DataReferenceToV1(
  * they would make destructive steps like `rm` ambiguous or unsafe.
  */
 function toPlaygroundPath(path: string): string {
-	if (typeof path !== 'string' || path.trim() === '') {
+	if (
+		typeof path !== 'string' ||
+		path.trim() === '' ||
+		isEmptyTargetSitePath(path)
+	) {
 		throw new UnsupportedBlueprintV2FeatureError(
 			'path',
 			'Invalid Blueprint v2 path: must not be empty.'
+		);
+	}
+	if (path.includes('\0')) {
+		throw new UnsupportedBlueprintV2FeatureError(
+			'path',
+			'Invalid Blueprint v2 path: must not contain null bytes.'
 		);
 	}
 	if (pathContainsParentDirectorySegment(path)) {
@@ -815,7 +830,7 @@ function isExecutionContextPath(value: string) {
  * path relative to the bundle root.
  */
 function normalizeExecutionContextPath(path: string) {
-	return path.replace(/^\.?\//, '');
+	return path.replace(/^\.?\/+/, '');
 }
 
 /**
@@ -829,6 +844,16 @@ function pathContainsParentDirectorySegment(path: string) {
 	return vfsPath.replace(/\\/g, '/').split('/').includes('..');
 }
 
+function isEmptyTargetSitePath(path: string) {
+	const vfsPath = path.startsWith('site:')
+		? path.slice('site:'.length)
+		: path;
+	return vfsPath
+		.replace(/\\/g, '/')
+		.split('/')
+		.every((segment) => segment === '' || segment === '.');
+}
+
 /**
  * Converts a WordPress.org slug, optionally with `@version`, to the v1 resource
  * shape that the existing plugin/theme installers already consume.
@@ -837,7 +862,7 @@ function wordpressOrgResource(
 	reference: string,
 	type: 'plugins' | 'themes'
 ): FileReference {
-	const [slug, version] = reference.split('@');
+	const { slug, version } = parseWordPressOrgReference(reference, type);
 	if (version && version !== 'latest') {
 		const singular = type === 'plugins' ? 'plugin' : 'theme';
 		return {
@@ -852,6 +877,27 @@ function wordpressOrgResource(
 				: 'wordpress.org/themes',
 		slug,
 	} as FileReference;
+}
+
+function parseWordPressOrgReference(
+	reference: string,
+	type: 'plugins' | 'themes'
+) {
+	const match = /^([a-zA-Z0-9_-]+)(?:@(latest|\d+\.\d+(?:\.\d+)?))?$/.exec(
+		reference
+	);
+	if (!match) {
+		const singular = type === 'plugins' ? 'plugin' : 'theme';
+		throw new UnsupportedBlueprintV2FeatureError(
+			type,
+			`Invalid WordPress.org ${singular} reference "${reference}". ` +
+				'Use a slug, optionally followed by @latest, @x.y, or @x.y.z.'
+		);
+	}
+	return {
+		slug: match[1],
+		version: match[2],
+	};
 }
 
 /**

--- a/packages/playground/blueprints/src/lib/v2/compile.ts
+++ b/packages/playground/blueprints/src/lib/v2/compile.ts
@@ -844,6 +844,12 @@ function pathContainsParentDirectorySegment(path: string) {
 	return vfsPath.replace(/\\/g, '/').split('/').includes('..');
 }
 
+/**
+ * Indicates whether a v2 target-site path names only the site root marker.
+ *
+ * Empty, slash-only, and dot-only paths are rejected for destructive file
+ * operations because they would target the whole WordPress document root.
+ */
 function isEmptyTargetSitePath(path: string) {
 	const vfsPath = path.startsWith('site:')
 		? path.slice('site:'.length)
@@ -879,6 +885,12 @@ function wordpressOrgResource(
 	} as FileReference;
 }
 
+/**
+ * Parses the limited WordPress.org reference syntax supported by Blueprint v2.
+ *
+ * Only slugs and explicit `@latest`, `@x.y`, or `@x.y.z` versions are accepted
+ * so arbitrary strings cannot be mistaken for download URLs or file paths.
+ */
 function parseWordPressOrgReference(
 	reference: string,
 	type: 'plugins' | 'themes'

--- a/packages/playground/blueprints/src/lib/v2/wep-1-blueprint-v2-schema/appendix-A-blueprint-v2-schema.ts
+++ b/packages/playground/blueprints/src/lib/v2/wep-1-blueprint-v2-schema/appendix-A-blueprint-v2-schema.ts
@@ -561,7 +561,6 @@ export namespace V2Schema {
 		 * @default false.
 		 */
 		importComments?: boolean;
-
 	} & URLMappingConfig;
 
 	type MediaDefinition =

--- a/packages/playground/blueprints/src/tests/compile.spec.ts
+++ b/packages/playground/blueprints/src/tests/compile.spec.ts
@@ -90,32 +90,81 @@ describe('compileBlueprintForExecution', () => {
 		expect(compiled.compiled.plan).toEqual([]);
 	});
 
-	it('runs Blueprint v2 bundles with bundled execution-context resources', async () => {
+	it('compiles minimal Blueprint v2 bundles through the TypeScript runner', async () => {
 		const bundle = new InMemoryFilesystem({
-			'plugin.php': '<?php /* Plugin Name: Bundled Plugin */',
 			'blueprint.json': JSON.stringify({
 				version: 2,
-				plugins: [
+				additionalStepsAfterExecution: [
 					{
-						source: './plugin.php',
-						active: false,
+						step: 'mkdir',
+						path: 'site:wp-content/uploads/from-v2-bundle',
 					},
 				],
 			}),
 		});
 		const playground = {
-			documentRoot: '/wordpress',
-			writeFile: vi.fn(),
+			mkdir: vi.fn(),
 		};
 
 		const compiled = await compileBlueprintForExecution(bundle);
 		await compiled.run(playground as any);
 
 		expect(compiled.version).toBe(2);
-		expect(playground.writeFile).toHaveBeenCalledWith(
-			'/wordpress/wp-content/plugins/plugin.php',
-			expect.any(Uint8Array)
+		expect(compiled.declaration).toEqual({
+			version: 2,
+			additionalStepsAfterExecution: [
+				{
+					step: 'mkdir',
+					path: 'site:wp-content/uploads/from-v2-bundle',
+				},
+			],
+		});
+		expect(playground.mkdir).toHaveBeenCalledWith(
+			'/wordpress/wp-content/uploads/from-v2-bundle'
 		);
+	});
+
+	it('compiles Blueprint v2 bundles with execution-context resources', async () => {
+		const bundle = new InMemoryFilesystem({
+			'plugin.zip': 'fake zip bytes',
+			'blueprint.json': JSON.stringify({
+				version: 2,
+				plugins: [
+					{
+						source: './plugin.zip',
+					},
+				],
+			}),
+		});
+
+		const compiled = await compileBlueprintForExecution(bundle);
+
+		expect(compiled.version).toBe(2);
+		if (compiled.version !== 2) {
+			throw new Error('Expected a compiled Blueprint v2 result.');
+		}
+		expect(compiled.compiled.steps[0]).toMatchObject({
+			step: 'installPlugin',
+			pluginData: {
+				resource: 'bundled',
+				path: 'plugin.zip',
+			},
+		});
+	});
+
+	it('reports Blueprint v2 declarations through onBlueprintValidated', async () => {
+		const declaration = {
+			version: 2,
+			phpVersion: '8.3',
+		} as const;
+		const onBlueprintValidated = vi.fn();
+
+		await compileBlueprintForExecution(declaration, {
+			onBlueprintValidated,
+		});
+
+		expect(onBlueprintValidated).toHaveBeenCalledTimes(1);
+		expect(onBlueprintValidated).toHaveBeenCalledWith(declaration);
 	});
 
 	it('compiles Blueprint v2 declarations into an ordered execution plan', async () => {
@@ -459,17 +508,67 @@ describe('compileBlueprintForExecution', () => {
 	});
 
 	it('rejects empty Blueprint v2 target-site paths', async () => {
+		for (const path of ['', '.', '/', 'site:', 'site:/', 'site:.']) {
+			await expect(
+				compileBlueprintForExecution({
+					version: 2,
+					additionalStepsAfterExecution: [
+						{
+							step: 'rm',
+							path,
+						},
+					],
+				} as BlueprintV2Declaration)
+			).rejects.toThrow('Invalid Blueprint v2 path: must not be empty.');
+		}
+	});
+
+	it('rejects Blueprint v2 target-site paths with parent directory segments', async () => {
+		for (const path of [
+			'../wp-config.php',
+			'wp-content/../wp-config.php',
+			'site:../wp-config.php',
+			'site:wp-content\\..\\wp-config.php',
+		]) {
+			await expect(
+				compileBlueprintForExecution({
+					version: 2,
+					additionalStepsAfterExecution: [
+						{
+							step: 'rm',
+							path,
+						},
+					],
+				} as BlueprintV2Declaration)
+			).rejects.toThrow('Invalid Blueprint v2 path');
+		}
+	});
+
+	it('rejects Blueprint v2 target-site paths with null bytes', async () => {
 		await expect(
 			compileBlueprintForExecution({
 				version: 2,
 				additionalStepsAfterExecution: [
 					{
 						step: 'rm',
-						path: '',
+						path: 'site:wp-content/uploads/image\0.php',
 					},
 				],
 			} as BlueprintV2Declaration)
-		).rejects.toThrow('Invalid Blueprint v2 path: must not be empty.');
+		).rejects.toThrow(
+			'Invalid Blueprint v2 path: must not contain null bytes.'
+		);
+	});
+
+	it('rejects Blueprint v2 data references with null bytes', async () => {
+		await expect(
+			compileBlueprintForExecution({
+				version: 2,
+				plugins: ['./plugins/query-monitor\0.zip'],
+			} as BlueprintV2Declaration)
+		).rejects.toThrow(
+			'Invalid Blueprint v2 data reference: must not contain null bytes.'
+		);
 	});
 
 	it('treats absolute data paths as Blueprint execution-context paths', async () => {
@@ -493,6 +592,41 @@ describe('compileBlueprintForExecution', () => {
 				path: 'plugins/local-plugin.zip',
 			},
 		});
+	});
+
+	it('normalizes repeated execution-context path prefixes', async () => {
+		const compiled = await compileBlueprintForExecution({
+			version: 2,
+			plugins: [
+				{
+					source: '//plugins/local-plugin.zip',
+				},
+				{
+					source: './/plugins/other-plugin.zip',
+				},
+			],
+		});
+
+		expect(compiled.version).toBe(2);
+		if (compiled.version !== 2) {
+			throw new Error('Expected a compiled Blueprint v2 result.');
+		}
+		expect(compiled.compiled.steps).toMatchObject([
+			{
+				step: 'installPlugin',
+				pluginData: {
+					resource: 'bundled',
+					path: 'plugins/local-plugin.zip',
+				},
+			},
+			{
+				step: 'installPlugin',
+				pluginData: {
+					resource: 'bundled',
+					path: 'plugins/other-plugin.zip',
+				},
+			},
+		]);
 	});
 
 	it('preserves special inline directory filenames as plain file entries', async () => {
@@ -522,6 +656,24 @@ describe('compileBlueprintForExecution', () => {
 		expect(Object.getPrototypeOf(pluginData.files)).toBe(Object.prototype);
 	});
 
+	it('rejects invalid Blueprint v2 WordPress.org plugin references', async () => {
+		await expect(
+			compileBlueprintForExecution({
+				version: 2,
+				plugins: ['akismet@1.2@unexpected'],
+			} as BlueprintV2Declaration)
+		).rejects.toThrow('Invalid WordPress.org plugin reference');
+	});
+
+	it('rejects invalid Blueprint v2 WordPress.org theme references', async () => {
+		await expect(
+			compileBlueprintForExecution({
+				version: 2,
+				themes: ['../twentytwentyfour'],
+			} as BlueprintV2Declaration)
+		).rejects.toThrow('Invalid WordPress.org theme reference');
+	});
+
 	it('runs fully lowered Blueprint v2 plans through the v1 runner', async () => {
 		const compiled = await compileBlueprintForExecution({
 			version: 2,
@@ -541,6 +693,33 @@ describe('compileBlueprintForExecution', () => {
 		expect(playground.mkdir).toHaveBeenCalledWith(
 			'/wordpress/wp-content/uploads/from-v2'
 		);
+	});
+
+	it('passes runner options to lowered Blueprint v2 steps', async () => {
+		const onStepCompleted = vi.fn();
+		const compiled = await compileBlueprintForExecution(
+			{
+				version: 2,
+				additionalStepsAfterExecution: [
+					{
+						step: 'mkdir',
+						path: 'site:wp-content/uploads/from-v2',
+					},
+				],
+			},
+			{ onStepCompleted }
+		);
+		const playground = {
+			mkdir: vi.fn(),
+		};
+
+		await compiled.run(playground as any);
+
+		expect(onStepCompleted).toHaveBeenCalledTimes(1);
+		expect(onStepCompleted.mock.calls[0][1]).toMatchObject({
+			step: 'mkdir',
+			path: '/wordpress/wp-content/uploads/from-v2',
+		});
 	});
 
 	it('rejects unsupported Blueprint v2 plans before running lowered steps', async () => {

--- a/packages/playground/blueprints/src/tests/resolve-remote-blueprint.spec.ts
+++ b/packages/playground/blueprints/src/tests/resolve-remote-blueprint.spec.ts
@@ -1,0 +1,40 @@
+import { BlobWriter, TextReader, ZipWriter } from '@zip.js/zip.js';
+import { resolveRemoteBlueprint } from '../lib/resolve-remote-blueprint';
+
+it('rejects Blueprint ZIP entries outside the bundle root', async () => {
+	const zip = await createZipBuffer({
+		'../blueprint.json': JSON.stringify({ steps: [] }),
+	});
+
+	await expect(
+		resolveRemoteBlueprint('https://example.com/blueprint.zip', {
+			fetch: async () => new Response(zip),
+		})
+	).rejects.toThrow('Unsafe Blueprint ZIP entry path: ../blueprint.json');
+});
+
+it('loads Blueprint ZIPs with blueprint.json inside one directory', async () => {
+	const zip = await createZipBuffer({
+		'bundle/blueprint.json': JSON.stringify({ steps: [] }),
+		'bundle/resource.txt': 'resource',
+	});
+
+	const bundle = await resolveRemoteBlueprint(
+		'https://example.com/blueprint.zip',
+		{
+			fetch: async () => new Response(zip),
+		}
+	);
+
+	await expect(
+		bundle.read('resource.txt').then((file) => file.text())
+	).resolves.toBe('resource');
+});
+
+async function createZipBuffer(entries: Record<string, string>) {
+	const zipWriter = new ZipWriter(new BlobWriter('application/zip'));
+	for (const [path, content] of Object.entries(entries)) {
+		await zipWriter.add(path, new TextReader(content));
+	}
+	return await zipWriter.close();
+}

--- a/packages/playground/blueprints/src/tests/resolve-remote-blueprint.spec.ts
+++ b/packages/playground/blueprints/src/tests/resolve-remote-blueprint.spec.ts
@@ -31,6 +31,9 @@ it('loads Blueprint ZIPs with blueprint.json inside one directory', async () => 
 	).resolves.toBe('resource');
 });
 
+/**
+ * Creates a ZIP fixture with exact archive paths for bundle-layout tests.
+ */
 async function createZipBuffer(entries: Record<string, string>) {
 	const zipWriter = new ZipWriter(new BlobWriter('application/zip'));
 	for (const [path, content] of Object.entries(entries)) {

--- a/packages/playground/blueprints/src/tests/steps/install-plugin.spec.ts
+++ b/packages/playground/blueprints/src/tests/steps/install-plugin.spec.ts
@@ -10,6 +10,7 @@ import {
 	getWordPressModule,
 } from '@wp-playground/wordpress-builds';
 import { bootWordPressAndRequestHandler } from '@wp-playground/wordpress';
+import { vi } from 'vitest';
 
 async function zipFiles(
 	php: PHP,
@@ -126,6 +127,33 @@ describe('Blueprint step installPlugin', () => {
 		expect(php.readFileAsText(pluginFilePath)).toBe(rawPluginContent);
 	});
 
+	it('should install a short single PHP file as a plugin', async () => {
+		await installPlugin(php, {
+			pluginData: new File(['<?'], 'short-plugin.php'),
+			ifAlreadyInstalled: 'overwrite',
+			options: {
+				activate: false,
+			},
+		});
+
+		expect(php.readFileAsText(`${pluginsPath}/short-plugin.php`)).toBe(
+			'<?'
+		);
+	});
+
+	it('rejects single PHP plugin filenames with path separators', async () => {
+		await expect(
+			installPlugin(php, {
+				pluginData: new File(['<?php'], '..\\escape.php'),
+				options: {
+					activate: false,
+				},
+			})
+		).rejects.toThrow(
+			'Plugin file or folder name must be a single path segment.'
+		);
+	});
+
 	it('should throw plugin installation errors by default', async () => {
 		await expect(
 			installPlugin(php, {
@@ -134,6 +162,23 @@ describe('Blueprint step installPlugin', () => {
 		).rejects.toThrow(
 			'pluginData looks like a file but does not look like a .zip or .php file.'
 		);
+	});
+
+	it('checks only the zip signature when classifying non-zip files', async () => {
+		const pluginData = new File(['not a plugin'], 'not-a-plugin.txt');
+		const arrayBufferSpy = vi
+			.spyOn(pluginData, 'arrayBuffer')
+			.mockRejectedValue(new Error('Full file read'));
+
+		await expect(
+			installPlugin(php, {
+				pluginData,
+			})
+		).rejects.toThrow(
+			'pluginData looks like a file but does not look like a .zip or .php file.'
+		);
+
+		expect(arrayBufferSpy).not.toHaveBeenCalled();
 	});
 
 	it('should skip plugin installation errors when onError is skip-plugin', async () => {
@@ -367,6 +412,110 @@ echo json_encode(array(
 				})
 			).rejects.toThrowError();
 		});
+
+		it('should apply ifAlreadyInstalled to directory plugin resources', async () => {
+			await installPlugin(php, {
+				pluginData: {
+					name: pluginName,
+					files: {
+						'index.php': `/**\n * Plugin Name: Skipped Plugin`,
+					},
+				},
+				ifAlreadyInstalled: 'skip',
+				options: {
+					activate: false,
+				},
+			});
+			expect(
+				php.readFileAsText(`${installedPluginPath}/index.php`)
+			).toContain('Plugin Name: Test Plugin');
+
+			await installPlugin(php, {
+				pluginData: {
+					name: pluginName,
+					files: {
+						'index.php': `/**\n * Plugin Name: Overwritten Plugin`,
+					},
+				},
+				ifAlreadyInstalled: 'overwrite',
+				options: {
+					activate: false,
+				},
+			});
+			expect(
+				php.readFileAsText(`${installedPluginPath}/index.php`)
+			).toContain('Plugin Name: Overwritten Plugin');
+
+			await expect(
+				installPlugin(php, {
+					pluginData: {
+						name: pluginName,
+						files: {
+							'index.php': `/**\n * Plugin Name: Error Plugin`,
+						},
+					},
+					ifAlreadyInstalled: 'error',
+					options: {
+						activate: false,
+					},
+				})
+			).rejects.toThrow(/already exists/);
+		});
+
+		it('should apply ifAlreadyInstalled to single-file plugins', async () => {
+			const pluginFilePath = `${pluginsPath}/single-plugin.php`;
+			await installPlugin(php, {
+				pluginData: new File(
+					['<?php\n/**\n * Plugin Name: Existing Plugin'],
+					'single-plugin.php'
+				),
+				ifAlreadyInstalled: 'overwrite',
+				options: {
+					activate: false,
+				},
+			});
+
+			await installPlugin(php, {
+				pluginData: new File(
+					['<?php\n/**\n * Plugin Name: Skipped Plugin'],
+					'single-plugin.php'
+				),
+				ifAlreadyInstalled: 'skip',
+				options: {
+					activate: false,
+				},
+			});
+			expect(php.readFileAsText(pluginFilePath)).toContain(
+				'Plugin Name: Existing Plugin'
+			);
+
+			await installPlugin(php, {
+				pluginData: new File(
+					['<?php\n/**\n * Plugin Name: Overwritten Plugin'],
+					'single-plugin.php'
+				),
+				ifAlreadyInstalled: 'overwrite',
+				options: {
+					activate: false,
+				},
+			});
+			expect(php.readFileAsText(pluginFilePath)).toContain(
+				'Plugin Name: Overwritten Plugin'
+			);
+
+			await expect(
+				installPlugin(php, {
+					pluginData: new File(
+						['<?php\n/**\n * Plugin Name: Error Plugin'],
+						'single-plugin.php'
+					),
+					ifAlreadyInstalled: 'error',
+					options: {
+						activate: false,
+					},
+				})
+			).rejects.toThrow(/already exists/);
+		});
 	});
 
 	describe('targetFolderName option', () => {
@@ -383,6 +532,112 @@ echo json_encode(array(
 				},
 			});
 			expect(php.fileExists(installedPluginPath)).toBe(true);
+		});
+
+		it('rejects target folder names with path separators', async () => {
+			await expect(
+				installPlugin(php, {
+					pluginData: await zipFiles(php, zipFileName, {
+						[`unexpected-path/index.php`]: `/**\n * Plugin Name: Test Plugin`,
+					}),
+					options: {
+						activate: false,
+						targetFolderName: '../mu-plugins/test-plugin',
+					},
+				})
+			).rejects.toThrow(
+				'Asset folder name must be a single directory name.'
+			);
+
+			expect(php.fileExists(`${rootPath}/wp-content/mu-plugins`)).toBe(
+				false
+			);
+
+			await expect(
+				installPlugin(php, {
+					pluginData: await zipFiles(php, zipFileName, {
+						[`unexpected-path/index.php`]: `/**\n * Plugin Name: Test Plugin`,
+					}),
+					options: {
+						activate: false,
+						targetFolderName: '..\\mu-plugins\\test-plugin',
+					},
+				})
+			).rejects.toThrow(
+				'Asset folder name must be a single directory name.'
+			);
+		});
+
+		it('rejects dot-segment target folder names', async () => {
+			await expect(
+				installPlugin(php, {
+					pluginData: await zipFiles(php, zipFileName, {
+						[`unexpected-path/index.php`]: `/**\n * Plugin Name: Test Plugin`,
+					}),
+					options: {
+						activate: false,
+						targetFolderName: '..',
+					},
+				})
+			).rejects.toThrow(
+				'Asset folder name must be a single directory name.'
+			);
+		});
+
+		it('rejects directory resource names with path separators', async () => {
+			await expect(
+				installPlugin(php, {
+					pluginData: {
+						name: '../test-plugin',
+						files: {
+							'index.php': `/**\n * Plugin Name: Test Plugin`,
+						},
+					},
+					options: {
+						activate: false,
+					},
+				})
+			).rejects.toThrow(
+				'Plugin file or folder name must be a single path segment.'
+			);
+
+			expect(php.fileExists(`${rootPath}/wp-content/test-plugin`)).toBe(
+				false
+			);
+
+			await expect(
+				installPlugin(php, {
+					pluginData: {
+						name: '..\\test-plugin',
+						files: {
+							'index.php': `/**\n * Plugin Name: Test Plugin`,
+						},
+					},
+					options: {
+						activate: false,
+					},
+				})
+			).rejects.toThrow(
+				'Plugin file or folder name must be a single path segment.'
+			);
+		});
+
+		it('rejects dot-segment directory resource names', async () => {
+			await expect(
+				installPlugin(php, {
+					pluginData: {
+						name: '..',
+						files: {
+							'index.php': `/**\n * Plugin Name: Test Plugin`,
+						},
+					},
+					options: {
+						activate: false,
+					},
+				})
+			).rejects.toThrow(
+				'Plugin file or folder name must be a single path segment.'
+			);
 		});
 	});
 });

--- a/packages/playground/blueprints/src/tests/steps/install-theme.spec.ts
+++ b/packages/playground/blueprints/src/tests/steps/install-theme.spec.ts
@@ -117,6 +117,36 @@ describe('Blueprint step installTheme', () => {
 		).rejects.toThrow('Theme folder name must be a single directory name.');
 
 		expect(php.fileExists('/wordpress/wp-content/escape')).toBe(false);
+
+		await expect(
+			installTheme(php, {
+				themeData: {
+					name: '..\\escape',
+					files: {
+						'index.php': `/**\n * Theme Name: Test Theme`,
+					},
+				},
+				options: {
+					activate: false,
+				},
+			})
+		).rejects.toThrow('Theme folder name must be a single directory name.');
+	});
+
+	it('should reject dot-segment directory theme names', async () => {
+		await expect(
+			installTheme(php, {
+				themeData: {
+					name: '..',
+					files: {
+						'index.php': `/**\n * Theme Name: Test Theme`,
+					},
+				},
+				options: {
+					activate: false,
+				},
+			})
+		).rejects.toThrow('Theme folder name must be a single directory name.');
 	});
 
 	it('should reject directory theme targetFolderName values with subdirectories', async () => {
@@ -138,6 +168,21 @@ describe('Blueprint step installTheme', () => {
 		expect(php.fileExists('/wordpress/wp-content/themes/nested')).toBe(
 			false
 		);
+
+		await expect(
+			installTheme(php, {
+				themeData: {
+					name: 'test-theme',
+					files: {
+						'index.php': `/**\n * Theme Name: Test Theme`,
+					},
+				},
+				options: {
+					activate: false,
+					targetFolderName: 'nested\\theme',
+				},
+			})
+		).rejects.toThrow('Theme folder name must be a single directory name.');
 	});
 
 	it('should reject directory theme file paths outside the theme directory', async () => {

--- a/packages/playground/blueprints/src/tests/v1/resources.spec.ts
+++ b/packages/playground/blueprints/src/tests/v1/resources.spec.ts
@@ -142,7 +142,7 @@ describe('GitDirectoryResource', () => {
 				const remoteUrl = execSync('git remote get-url origin', gitEnv)
 					.toString()
 					.trim();
-				expect(remoteUrl).toBe(
+				expect(stripGitRemoteCredentials(remoteUrl)).toBe(
 					'https://github.com/WordPress/wordpress-playground'
 				);
 
@@ -605,3 +605,10 @@ describe('Resource.create with github-proxy.com URLs', () => {
 		expect(consoleWarnSpy).not.toHaveBeenCalled();
 	});
 });
+
+function stripGitRemoteCredentials(rawRemoteUrl: string) {
+	const remoteUrl = new URL(rawRemoteUrl);
+	remoteUrl.username = '';
+	remoteUrl.password = '';
+	return remoteUrl.toString();
+}

--- a/packages/playground/blueprints/src/tests/v1/resources.spec.ts
+++ b/packages/playground/blueprints/src/tests/v1/resources.spec.ts
@@ -606,6 +606,9 @@ describe('Resource.create with github-proxy.com URLs', () => {
 	});
 });
 
+/**
+ * Removes credentials before asserting on git remotes echoed by test fixtures.
+ */
 function stripGitRemoteCredentials(rawRemoteUrl: string) {
 	const remoteUrl = new URL(rawRemoteUrl);
 	remoteUrl.username = '';


### PR DESCRIPTION
## What it does

Preserves Blueprint bundle resources when Blueprint v2 install steps are lowered into the existing v1 runner.

For example, a bundled Blueprint can now reference a plugin next to `blueprint.json` and still install it through the v1 `installPlugin` step:

```json
{
	"version": 2,
	"plugins": [
		{
			"source": "./plugins/query-monitor.zip"
		}
	]
}
```

The compiled v2 step keeps that as a `bundled` resource instead of losing the bundle read hook before execution.

## Rationale

The dock/import flows need Blueprint resources to survive compile and install boundaries. If a bundle-relative file, inline directory, WordPress.org slug, URL, or Git directory is flattened too early, the install step no longer knows how to fetch or name the original resource.

That matters for packaged Blueprints: `./plugin.zip` must be read from the `BlueprintBundle`, not fetched as a network URL or interpreted as a WordPress path.

## Implementation

`compileBlueprintForExecution()` now passes bundle-backed `streamBundledFile` access and runner options into the v2-to-v1 execution path. The v2 compiler maps supported data references to the corresponding v1 resource shapes:

- `./file.zip` and `/file.zip` -> `bundled`
- plugin/theme slugs -> WordPress.org resources
- URLs -> `url`
- inline files/directories -> literal resources
- Git references -> `git:directory`

The install steps also keep existing use cases intact:

- directory-backed plugin/theme installs now honor `ifAlreadyInstalled`
- single-file plugin installs honor `skip` and `error`
- target folder names must remain one path segment
- remote Blueprint ZIPs reject traversal entries before exposing bundle files

## Testing instructions

```bash
npm exec nx run playground-blueprints:test -- --runInBand
npm exec nx run playground-blueprints:lint
npm exec nx run playground-blueprints:typecheck
git diff --check origin/trunk...HEAD
```

Part of #2592.
