### PR TITLE
[PHP] Add path containment resolver

### DIFF
--- a/packages/php-wasm/util/src/lib/index.ts
+++ b/packages/php-wasm/util/src/lib/index.ts
@@ -8,6 +8,7 @@ export {
 	basename,
 	normalizePath,
 	isParentOf,
+	resolvePathUnder,
 	ensureAbsolutePath,
 	toPosixPath,
 } from './paths';

--- a/packages/php-wasm/util/src/lib/paths.ts
+++ b/packages/php-wasm/util/src/lib/paths.ts
@@ -52,12 +52,12 @@ export function joinPaths(...paths: string[]) {
  * parent path. The parent itself is not considered to be under the parent.
  * Paths containing null bytes are rejected before resolution.
  *
- * @param parentPath The path the result must stay under.
  * @param path The absolute or relative path to resolve.
+ * @param parentPath The path the result must stay under.
  * @returns The normalized resolved path, or undefined when it is not a child.
  */
-export function resolvePathUnder(parentPath: string, path: string) {
-	if (parentPath.includes('\0') || path.includes('\0')) {
+export function resolvePathUnder(path: string, parentPath: string) {
+	if (path.includes('\0') || parentPath.includes('\0')) {
 		return undefined;
 	}
 	const normalizedParentPath = normalizePath(parentPath);

--- a/packages/php-wasm/util/src/lib/paths.ts
+++ b/packages/php-wasm/util/src/lib/paths.ts
@@ -61,6 +61,9 @@ export function resolvePathUnder(parentPath: string, path: string) {
 		return undefined;
 	}
 	const normalizedParentPath = normalizePath(parentPath);
+	if (!normalizedParentPath) {
+		return undefined;
+	}
 	const resolvedPath = normalizePath(
 		path.startsWith('/') ? path : joinPaths(normalizedParentPath, path)
 	);

--- a/packages/php-wasm/util/src/lib/paths.ts
+++ b/packages/php-wasm/util/src/lib/paths.ts
@@ -46,6 +46,34 @@ export function joinPaths(...paths: string[]) {
 }
 
 /**
+ * Resolves a path and returns it only when it stays under a parent path.
+ *
+ * Absolute paths are checked as-is. Relative paths are resolved from the
+ * parent path. The parent itself is not considered to be under the parent.
+ * Paths containing null bytes are rejected before resolution.
+ *
+ * @param parentPath The path the result must stay under.
+ * @param path The absolute or relative path to resolve.
+ * @returns The normalized resolved path, or undefined when it is not a child.
+ */
+export function resolvePathUnder(parentPath: string, path: string) {
+	if (parentPath.includes('\0') || path.includes('\0')) {
+		return undefined;
+	}
+	const normalizedParentPath = normalizePath(parentPath);
+	const resolvedPath = normalizePath(
+		path.startsWith('/') ? path : joinPaths(normalizedParentPath, path)
+	);
+	if (
+		resolvedPath === normalizedParentPath ||
+		!isParentOf(normalizedParentPath, resolvedPath)
+	) {
+		return undefined;
+	}
+	return resolvedPath;
+}
+
+/**
  * Returns the directory name of a path.
  *
  * @param path

--- a/packages/php-wasm/util/src/test/paths.spec.ts
+++ b/packages/php-wasm/util/src/test/paths.spec.ts
@@ -63,6 +63,13 @@ describe('resolvePathUnder', () => {
 		expect(resolvePathUnder('/', 'tmp/file.php')).toEqual('/tmp/file.php');
 	});
 
+	it('returns undefined for empty or current-directory parent paths', () => {
+		expect(resolvePathUnder('', 'file.php')).toBeUndefined();
+		expect(resolvePathUnder('.', 'file.php')).toBeUndefined();
+		expect(resolvePathUnder('./', 'file.php')).toBeUndefined();
+		expect(resolvePathUnder('', '/file.php')).toBeUndefined();
+	});
+
 	it('returns undefined when the path names the parent itself', () => {
 		expect(resolvePathUnder('/wordpress', '')).toBeUndefined();
 		expect(resolvePathUnder('/wordpress', '.')).toBeUndefined();

--- a/packages/php-wasm/util/src/test/paths.spec.ts
+++ b/packages/php-wasm/util/src/test/paths.spec.ts
@@ -33,75 +33,75 @@ describe('joinPaths', () => {
 
 describe('resolvePathUnder', () => {
 	it('resolves relative paths under the parent path', () => {
-		expect(resolvePathUnder('/wordpress', 'wp-content/plugin.php')).toEqual(
+		expect(resolvePathUnder('wp-content/plugin.php', '/wordpress')).toEqual(
 			'/wordpress/wp-content/plugin.php'
 		);
 	});
 
 	it('normalizes redundant path segments that stay under the parent path', () => {
 		expect(
-			resolvePathUnder('/wordpress', 'wp-content/./plugins//plugin.php')
+			resolvePathUnder('wp-content/./plugins//plugin.php', '/wordpress')
 		).toEqual('/wordpress/wp-content/plugins/plugin.php');
 		expect(
-			resolvePathUnder('/wordpress', 'wp-content/../index.php')
+			resolvePathUnder('wp-content/../index.php', '/wordpress')
 		).toEqual('/wordpress/index.php');
 	});
 
 	it('checks absolute paths as already-resolved paths', () => {
 		expect(
-			resolvePathUnder('/wordpress', '/wordpress/wp-content/index.php')
+			resolvePathUnder('/wordpress/wp-content/index.php', '/wordpress')
 		).toEqual('/wordpress/wp-content/index.php');
 		expect(
-			resolvePathUnder('/wordpress', '/tmp/index.php')
+			resolvePathUnder('/tmp/index.php', '/wordpress')
 		).toBeUndefined();
 	});
 
 	it('allows absolute paths under the filesystem root', () => {
-		expect(resolvePathUnder('/', '/./tmp/file.php')).toEqual(
+		expect(resolvePathUnder('/./tmp/file.php', '/')).toEqual(
 			'/tmp/file.php'
 		);
-		expect(resolvePathUnder('/', 'tmp/file.php')).toEqual('/tmp/file.php');
+		expect(resolvePathUnder('tmp/file.php', '/')).toEqual('/tmp/file.php');
 	});
 
 	it('returns undefined for empty or current-directory parent paths', () => {
-		expect(resolvePathUnder('', 'file.php')).toBeUndefined();
-		expect(resolvePathUnder('.', 'file.php')).toBeUndefined();
-		expect(resolvePathUnder('./', 'file.php')).toBeUndefined();
-		expect(resolvePathUnder('', '/file.php')).toBeUndefined();
+		expect(resolvePathUnder('file.php', '')).toBeUndefined();
+		expect(resolvePathUnder('file.php', '.')).toBeUndefined();
+		expect(resolvePathUnder('file.php', './')).toBeUndefined();
+		expect(resolvePathUnder('/file.php', '')).toBeUndefined();
 	});
 
 	it('returns undefined when the path names the parent itself', () => {
-		expect(resolvePathUnder('/wordpress', '')).toBeUndefined();
-		expect(resolvePathUnder('/wordpress', '.')).toBeUndefined();
+		expect(resolvePathUnder('', '/wordpress')).toBeUndefined();
+		expect(resolvePathUnder('.', '/wordpress')).toBeUndefined();
 		expect(resolvePathUnder('/wordpress', '/wordpress')).toBeUndefined();
-		expect(resolvePathUnder('/wordpress', '/wordpress/')).toBeUndefined();
+		expect(resolvePathUnder('/wordpress/', '/wordpress')).toBeUndefined();
 		expect(resolvePathUnder('/', '/')).toBeUndefined();
 	});
 
 	it('returns undefined when the resolved path escapes the parent path', () => {
-		expect(resolvePathUnder('/wordpress', '../escape.php')).toBeUndefined();
+		expect(resolvePathUnder('../escape.php', '/wordpress')).toBeUndefined();
 		expect(
-			resolvePathUnder('/wordpress', 'wp-content/../../escape.php')
+			resolvePathUnder('wp-content/../../escape.php', '/wordpress')
 		).toBeUndefined();
 		expect(
-			resolvePathUnder('/wordpress', '/wordpress-backup/file.php')
+			resolvePathUnder('/wordpress-backup/file.php', '/wordpress')
 		).toBeUndefined();
 	});
 
 	it('returns undefined for paths containing null bytes', () => {
 		expect(
-			resolvePathUnder('/wordpress', 'wp-content/\0.php')
+			resolvePathUnder('wp-content/\0.php', '/wordpress')
 		).toBeUndefined();
 		expect(
-			resolvePathUnder('/wordpress\0', 'wp-content/file.php')
+			resolvePathUnder('wp-content/file.php', '/wordpress\0')
 		).toBeUndefined();
 	});
 
 	it('supports relative parent paths', () => {
-		expect(resolvePathUnder('wordpress', 'wp-content/plugin.php')).toEqual(
+		expect(resolvePathUnder('wp-content/plugin.php', 'wordpress')).toEqual(
 			'wordpress/wp-content/plugin.php'
 		);
-		expect(resolvePathUnder('wordpress', '../escape.php')).toBeUndefined();
+		expect(resolvePathUnder('../escape.php', 'wordpress')).toBeUndefined();
 	});
 });
 

--- a/packages/php-wasm/util/src/test/paths.spec.ts
+++ b/packages/php-wasm/util/src/test/paths.spec.ts
@@ -3,6 +3,7 @@ import {
 	dirname,
 	joinPaths,
 	normalizePath,
+	resolvePathUnder,
 	toPosixPath,
 } from '../lib/paths';
 
@@ -27,6 +28,73 @@ describe('joinPaths', () => {
 			'../wp-content'
 		);
 		expect(joinPaths('/', '/')).toEqual('/');
+	});
+});
+
+describe('resolvePathUnder', () => {
+	it('resolves relative paths under the parent path', () => {
+		expect(resolvePathUnder('/wordpress', 'wp-content/plugin.php')).toEqual(
+			'/wordpress/wp-content/plugin.php'
+		);
+	});
+
+	it('normalizes redundant path segments that stay under the parent path', () => {
+		expect(
+			resolvePathUnder('/wordpress', 'wp-content/./plugins//plugin.php')
+		).toEqual('/wordpress/wp-content/plugins/plugin.php');
+		expect(
+			resolvePathUnder('/wordpress', 'wp-content/../index.php')
+		).toEqual('/wordpress/index.php');
+	});
+
+	it('checks absolute paths as already-resolved paths', () => {
+		expect(
+			resolvePathUnder('/wordpress', '/wordpress/wp-content/index.php')
+		).toEqual('/wordpress/wp-content/index.php');
+		expect(
+			resolvePathUnder('/wordpress', '/tmp/index.php')
+		).toBeUndefined();
+	});
+
+	it('allows absolute paths under the filesystem root', () => {
+		expect(resolvePathUnder('/', '/./tmp/file.php')).toEqual(
+			'/tmp/file.php'
+		);
+		expect(resolvePathUnder('/', 'tmp/file.php')).toEqual('/tmp/file.php');
+	});
+
+	it('returns undefined when the path names the parent itself', () => {
+		expect(resolvePathUnder('/wordpress', '')).toBeUndefined();
+		expect(resolvePathUnder('/wordpress', '.')).toBeUndefined();
+		expect(resolvePathUnder('/wordpress', '/wordpress')).toBeUndefined();
+		expect(resolvePathUnder('/wordpress', '/wordpress/')).toBeUndefined();
+		expect(resolvePathUnder('/', '/')).toBeUndefined();
+	});
+
+	it('returns undefined when the resolved path escapes the parent path', () => {
+		expect(resolvePathUnder('/wordpress', '../escape.php')).toBeUndefined();
+		expect(
+			resolvePathUnder('/wordpress', 'wp-content/../../escape.php')
+		).toBeUndefined();
+		expect(
+			resolvePathUnder('/wordpress', '/wordpress-backup/file.php')
+		).toBeUndefined();
+	});
+
+	it('returns undefined for paths containing null bytes', () => {
+		expect(
+			resolvePathUnder('/wordpress', 'wp-content/\0.php')
+		).toBeUndefined();
+		expect(
+			resolvePathUnder('/wordpress\0', 'wp-content/file.php')
+		).toBeUndefined();
+	});
+
+	it('supports relative parent paths', () => {
+		expect(resolvePathUnder('wordpress', 'wp-content/plugin.php')).toEqual(
+			'wordpress/wp-content/plugin.php'
+		);
+		expect(resolvePathUnder('wordpress', '../escape.php')).toBeUndefined();
 	});
 });
 


### PR DESCRIPTION
## What changed

Adds `resolvePathUnder(path, parentPath)` to the PHP.wasm path utilities. The helper resolves absolute or relative paths with the existing POSIX path helpers, then returns the normalized path only when it is a child of the requested parent path.

## Why

Callers that need path containment checks should not have to reimplement local segment parsing or compare raw input against normalized output. This keeps the low-level path normalization rules in one utility and gives higher-level code a clearer invariant: resolve the path, then use it only if it remains under the target parent.

## Testing

- `npm exec nx run php-wasm-util:test -- --testFiles=paths.spec.ts`
- `npm exec nx run php-wasm-util:lint`
- `npm exec nx run php-wasm-util:build:bundle`
- `npx tsc -p packages/php-wasm/util/tsconfig.lib.json --noEmit`
- `npx tsc -p packages/php-wasm/util/tsconfig.spec.json --noEmit`
- `git diff --check`
