### PR TITLE
[Web] Harden remote access relay signals

### DIFF
--- a/packages/playground/remote-access/relay.php
+++ b/packages/playground/remote-access/relay.php
@@ -179,7 +179,14 @@ function handleResolveAccessCode(string $rawAccessCode): void {
 function handleStatus(string $sessionId): void {
     $queryString = parse_url($_SERVER['REQUEST_URI'] ?? '', PHP_URL_QUERY) ?? '';
     parse_str($queryString, $queryParams);
-    $guestId = getGuestIdQueryParam($queryParams);
+    $guestId = null;
+    if (array_key_exists('gid', $queryParams)) {
+        $guestId = $queryParams['gid'];
+        if (!is_string($guestId) || !isBoundedString($guestId, 1, MAX_GUEST_ID_BYTES)) {
+            jsonResponse(['error' => 'Invalid guest id'], 400);
+            return;
+        }
+    }
     $now = nowMs();
 
     $session = getSession($sessionId);
@@ -262,7 +269,14 @@ function handlePollSignal(string $sessionId): void {
     parse_str($queryString, $queryParams);
     $to = (string) ($queryParams['to'] ?? '');
     $since = (int) ($queryParams['since'] ?? 0);
-    $guestId = getGuestIdQueryParam($queryParams);
+    $guestId = null;
+    if (array_key_exists('gid', $queryParams)) {
+        $guestId = $queryParams['gid'];
+        if (!is_string($guestId) || !isBoundedString($guestId, 1, MAX_GUEST_ID_BYTES)) {
+            jsonResponse(['error' => 'Invalid guest id'], 400);
+            return;
+        }
+    }
     if (!in_array($to, ['host', 'guest'], true)) {
         jsonResponse(['error' => 'Invalid signal recipient'], 400);
         return;
@@ -413,31 +427,6 @@ function isNullableInt($value): bool {
 
 function isNullableBoundedString($value, int $minBytes, int $maxBytes): bool {
     return $value === null || isBoundedString($value, $minBytes, $maxBytes);
-}
-
-/**
- * Returns the optional guest id after validating it as a bounded query string.
- *
- * Invalid guest ids stop request handling immediately so status and signal
- * endpoints do not accidentally read or write unbounded session metadata.
- */
-function getGuestIdQueryParam(array $queryParams): ?string {
-    if (!array_key_exists('gid', $queryParams)) {
-        return null;
-    }
-    $guestId = $queryParams['gid'];
-    if (!is_string($guestId) || !isValidGuestId($guestId)) {
-        jsonResponse(['error' => 'Invalid guest id'], 400);
-        exit;
-    }
-    return $guestId;
-}
-
-/**
- * Checks whether a guest id is small enough to persist with session status.
- */
-function isValidGuestId(string $guestId): bool {
-    return isBoundedString($guestId, 1, MAX_GUEST_ID_BYTES);
 }
 
 function isBoundedString($value, int $minBytes, int $maxBytes): bool {

--- a/packages/playground/remote-access/relay.php
+++ b/packages/playground/remote-access/relay.php
@@ -22,6 +22,7 @@ define('SIGNAL_RETENTION_MS', 15 * 60 * 1000);
 define('SIGNAL_POLL_TIMEOUT_SEC', 25);
 define('MAX_SIGNAL_BODY_BYTES', 8 * 1024);
 define('MAX_SIGNAL_ID_BYTES', 64);
+define('MAX_GUEST_ID_BYTES', 36);
 define('MAX_SIGNAL_SDP_BYTES', 4096);
 define('MAX_SIGNAL_ICE_CANDIDATE_BYTES', 1024);
 define('SESSIONS_TABLE', 'playground_remote_access_sessions');
@@ -178,7 +179,7 @@ function handleResolveAccessCode(string $rawAccessCode): void {
 function handleStatus(string $sessionId): void {
     $queryString = parse_url($_SERVER['REQUEST_URI'] ?? '', PHP_URL_QUERY) ?? '';
     parse_str($queryString, $queryParams);
-    $guestId = isset($queryParams['gid']) ? (string) $queryParams['gid'] : null;
+    $guestId = getGuestIdQueryParam($queryParams);
     $now = nowMs();
 
     $session = getSession($sessionId);
@@ -261,7 +262,7 @@ function handlePollSignal(string $sessionId): void {
     parse_str($queryString, $queryParams);
     $to = (string) ($queryParams['to'] ?? '');
     $since = (int) ($queryParams['since'] ?? 0);
-    $guestId = isset($queryParams['gid']) ? (string) $queryParams['gid'] : null;
+    $guestId = getGuestIdQueryParam($queryParams);
     if (!in_array($to, ['host', 'guest'], true)) {
         jsonResponse(['error' => 'Invalid signal recipient'], 400);
         return;
@@ -412,6 +413,31 @@ function isNullableInt($value): bool {
 
 function isNullableBoundedString($value, int $minBytes, int $maxBytes): bool {
     return $value === null || isBoundedString($value, $minBytes, $maxBytes);
+}
+
+/**
+ * Returns the optional guest id after validating it as a bounded query string.
+ *
+ * Invalid guest ids stop request handling immediately so status and signal
+ * endpoints do not accidentally read or write unbounded session metadata.
+ */
+function getGuestIdQueryParam(array $queryParams): ?string {
+    if (!array_key_exists('gid', $queryParams)) {
+        return null;
+    }
+    $guestId = $queryParams['gid'];
+    if (!is_string($guestId) || !isValidGuestId($guestId)) {
+        jsonResponse(['error' => 'Invalid guest id'], 400);
+        exit;
+    }
+    return $guestId;
+}
+
+/**
+ * Checks whether a guest id is small enough to persist with session status.
+ */
+function isValidGuestId(string $guestId): bool {
+    return isBoundedString($guestId, 1, MAX_GUEST_ID_BYTES);
 }
 
 function isBoundedString($value, int $minBytes, int $maxBytes): bool {

--- a/packages/playground/remote-access/src/relay-php.spec.ts
+++ b/packages/playground/remote-access/src/relay-php.spec.ts
@@ -1,0 +1,97 @@
+import { spawn, type ChildProcessWithoutNullStreams } from 'child_process';
+import { existsSync } from 'fs';
+import { createServer } from 'net';
+import { join } from 'path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+describe('remote access relay.php', () => {
+	let server: ChildProcessWithoutNullStreams;
+	let relayUrl: string;
+	let stderr = '';
+
+	beforeAll(async () => {
+		const port = await getAvailablePort();
+		relayUrl = `http://127.0.0.1:${port}/relay.php`;
+		server = spawn(
+			'php',
+			['-S', `127.0.0.1:${port}`, '-t', getRelayDocumentRoot()],
+			{
+				stdio: ['ignore', 'pipe', 'pipe'],
+			}
+		);
+		server.stderr.on('data', (chunk) => {
+			stderr += chunk.toString();
+		});
+		await waitForRelay(
+			() => stderr.includes('Development Server'),
+			() => server.exitCode !== null,
+			() => stderr
+		);
+	}, 15000);
+
+	afterAll(() => {
+		server?.kill();
+	});
+
+	it('rejects oversized guest ids before reading session state', async () => {
+		const oversizedGuestId = 'x'.repeat(37);
+
+		const response = await fetch(
+			`${relayUrl}?action=status&sessionId=session-1&gid=${oversizedGuestId}`
+		);
+
+		expect(response.status).toBe(400);
+		await expect(response.json()).resolves.toEqual({
+			error: 'Invalid guest id',
+		});
+	});
+});
+
+async function waitForRelay(
+	hasStarted: () => boolean,
+	hasExited: () => boolean,
+	getStderr: () => string
+) {
+	const deadline = Date.now() + 10000;
+	while (Date.now() < deadline) {
+		if (hasExited()) {
+			throw new Error(`relay.php server exited early:\n${getStderr()}`);
+		}
+		if (hasStarted()) {
+			return;
+		}
+		await new Promise((resolve) => setTimeout(resolve, 100));
+	}
+	throw new Error(`Timed out waiting for relay.php server:\n${getStderr()}`);
+}
+
+async function getAvailablePort(): Promise<number> {
+	return await new Promise((resolve, reject) => {
+		const server = createServer();
+		server.on('error', reject);
+		server.listen(0, '127.0.0.1', () => {
+			const address = server.address();
+			if (!address || typeof address === 'string') {
+				server.close(() =>
+					reject(new Error('Could not allocate port'))
+				);
+				return;
+			}
+			server.close(() => resolve(address.port));
+		});
+	});
+}
+
+function getRelayDocumentRoot() {
+	const candidates = [
+		process.cwd(),
+		join(process.cwd(), 'packages/playground/remote-access'),
+	];
+	const documentRoot = candidates.find((candidate) =>
+		existsSync(join(candidate, 'relay.php'))
+	);
+	if (!documentRoot) {
+		throw new Error('Could not find remote access relay.php');
+	}
+	return documentRoot;
+}

--- a/packages/playground/remote-access/src/relay-php.spec.ts
+++ b/packages/playground/remote-access/src/relay-php.spec.ts
@@ -1,10 +1,10 @@
 import { spawn, type ChildProcessWithoutNullStreams } from 'child_process';
 import { existsSync } from 'fs';
 import { createServer } from 'net';
-import { join } from 'path';
+import { delimiter, join } from 'path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
-describe('remote access relay.php', () => {
+describe.skipIf(!isPhpBinaryAvailable())('remote access relay.php', () => {
 	let server: ChildProcessWithoutNullStreams;
 	let relayUrl: string;
 	let stderr = '';
@@ -23,7 +23,7 @@ describe('remote access relay.php', () => {
 			stderr += chunk.toString();
 		});
 		await waitForRelay(
-			() => stderr.includes('Development Server'),
+			relayUrl,
 			() => server.exitCode !== null,
 			() => stderr
 		);
@@ -48,7 +48,7 @@ describe('remote access relay.php', () => {
 });
 
 async function waitForRelay(
-	hasStarted: () => boolean,
+	relayUrl: string,
 	hasExited: () => boolean,
 	getStderr: () => string
 ) {
@@ -57,12 +57,21 @@ async function waitForRelay(
 		if (hasExited()) {
 			throw new Error(`relay.php server exited early:\n${getStderr()}`);
 		}
-		if (hasStarted()) {
+		try {
+			await fetch(`${relayUrl}?action=missing`);
 			return;
+		} catch {
+			await new Promise((resolve) => setTimeout(resolve, 100));
 		}
-		await new Promise((resolve) => setTimeout(resolve, 100));
 	}
 	throw new Error(`Timed out waiting for relay.php server:\n${getStderr()}`);
+}
+
+function isPhpBinaryAvailable() {
+	return (process.env.PATH ?? '')
+		.split(delimiter)
+		.filter(Boolean)
+		.some((path) => existsSync(join(path, 'php')));
 }
 
 async function getAvailablePort(): Promise<number> {

--- a/packages/playground/remote-access/src/remote-access-direct-tunnel.spec.ts
+++ b/packages/playground/remote-access/src/remote-access-direct-tunnel.spec.ts
@@ -140,6 +140,27 @@ describe('remote access tunnel helpers', () => {
 			'Incomplete remote access relay response'
 		);
 	});
+
+	it('rejects chunked remote access relay responses with mismatched byte counts', () => {
+		const response = assembleChunkedDataChannelResponse(
+			{
+				status: 200,
+				headers: { 'Content-Type': 'text/plain' },
+				totalBytes: 4,
+				totalChunks: 2,
+				chunks: [
+					new TextEncoder().encode('hello '),
+					new TextEncoder().encode('world'),
+				],
+			},
+			'Incomplete remote access relay response'
+		);
+
+		expect(response).toBeInstanceOf(Error);
+		expect((response as Error).message).toBe(
+			'Incomplete remote access relay response'
+		);
+	});
 });
 
 describe('remote access direct tunnel', () => {
@@ -310,5 +331,29 @@ describe('remote access direct tunnel', () => {
 				}),
 			})
 		);
+	});
+
+	it('surfaces relay errors when posting a retry request', async () => {
+		vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+			new Response(JSON.stringify({ error: 'Invalid signal' }), {
+				status: 400,
+				headers: {
+					'Content-Type': 'application/json',
+				},
+			})
+		);
+		const guest = new DirectTunnelGuest({
+			sessionId: 'session-1',
+			relayUrl: 'https://example.test',
+			guestId: 'guest-1',
+			verificationCode: '42',
+			onStatusChange: vi.fn(),
+		});
+
+		await expect(
+			(
+				guest as unknown as { requestFreshOffer: () => Promise<void> }
+			).requestFreshOffer()
+		).rejects.toThrow('Signal post failed: 400: Invalid signal');
 	});
 });

--- a/packages/playground/remote-access/src/remote-access-direct-tunnel.ts
+++ b/packages/playground/remote-access/src/remote-access-direct-tunnel.ts
@@ -268,8 +268,14 @@ export function assembleChunkedDataChannelResponse(
 		if (!chunk) {
 			return new Error(errorMessage);
 		}
+		if (offset + chunk.length > pending.totalBytes) {
+			return new Error(errorMessage);
+		}
 		bytes.set(chunk, offset);
 		offset += chunk.length;
+	}
+	if (offset !== pending.totalBytes) {
+		return new Error(errorMessage);
 	}
 	return {
 		requestId: '',
@@ -298,6 +304,9 @@ function assembleDataChannelChunks(
 	let offset = 0;
 	for (const chunk of pending.chunks) {
 		if (!chunk) {
+			return new Error(errorMessage);
+		}
+		if (offset + chunk.length > pending.totalBytes) {
 			return new Error(errorMessage);
 		}
 		bytes.set(chunk, offset);
@@ -1383,7 +1392,7 @@ export class DirectTunnelHost {
 		if (!this.sessionId) {
 			return;
 		}
-		await fetch(
+		const response = await fetch(
 			buildRemoteAccessRelayEndpointUrl(this.relayUrl, 'signal', {
 				sessionId: this.sessionId,
 			}),
@@ -1398,6 +1407,11 @@ export class DirectTunnelHost {
 				}),
 			}
 		);
+		if (!response.ok) {
+			throw new Error(
+				`Signal post failed: ${await getResponseErrorMessage(response)}`
+			);
+		}
 	}
 
 	private emit<K extends keyof TunnelHostEvents>(
@@ -2117,7 +2131,7 @@ export class DirectTunnelGuest {
 		type: SignalType,
 		data: unknown
 	): Promise<void> {
-		await fetch(
+		const response = await fetch(
 			buildRemoteAccessRelayEndpointUrl(this.relayUrl, 'signal', {
 				sessionId: this.sessionId,
 			}),
@@ -2132,5 +2146,10 @@ export class DirectTunnelGuest {
 				}),
 			}
 		);
+		if (!response.ok) {
+			throw new Error(
+				`Signal post failed: ${await getResponseErrorMessage(response)}`
+			);
+		}
 	}
 }


### PR DESCRIPTION
## What it does

Hardens the remote access relay path in three places:

- validates optional `gid` query parameters before reading or writing session metadata
- rejects chunked data-channel responses when the actual chunk bytes do not match the announced `totalBytes`
- throws when host or guest signal POSTs fail instead of treating failed relay writes as success

## Rationale

The relay currently accepts some malformed inputs silently.

A status or signal poll request can include `gid`, and the relay stores that id in session status. Without a size check, a request like this can push unbounded metadata through the status path:

```text
/status?sid=session-1&gid=<very large string>
```

Remote access guest ids are small identifiers, so the relay should reject invalid values before they reach session metadata.

The browser-side data-channel assembly had a similar trust issue. A relay response can claim one byte count while sending chunks with a different total size:

```ts
{
  totalBytes: 4,
  totalChunks: 2,
  chunks: [encode('hello '), encode('world')]
}
```

That response is internally inconsistent. The receiver should reject it instead of attempting to assemble bytes past the declared response size or accepting an incomplete response.

Finally, signal retry requests used to ignore failed relay POSTs. If the relay returned `400 { "error": "Invalid signal" }`, callers still continued as if the fresh offer/answer request had been posted. Surfacing that error makes retry failures debuggable and prevents the tunnel state from drifting away from relay state.

## Implementation

- Added `getGuestIdQueryParam()` in `relay.php` and bounded `gid` to `MAX_GUEST_ID_BYTES`.
- Added byte-count guards in both chunk assembly helpers:
  - reject chunks that would exceed `totalBytes`
  - reject responses whose assembled byte count is less than `totalBytes`
- Checked `fetch()` responses in host and guest signal posting and throw `Signal post failed: ...` with the relay error body when available.

## Testing instructions

```bash
npm exec nx run playground-remote-access:test -- --runInBand --testFile=remote-access-direct-tunnel.spec.ts
npm exec nx run playground-remote-access:lint
git diff --check
```
