### PR TITLE
[PHP] Normalize ZIP entries in unzipFile()

### DIFF
--- a/packages/php-wasm/node/src/test/unzip-file.spec.ts
+++ b/packages/php-wasm/node/src/test/unzip-file.spec.ts
@@ -124,6 +124,26 @@ describe('unzipFile – concurrent calls avoid conflicts', () => {
 		expect(php.fileExists('/absolute.txt')).toBe(false);
 		expect(php.fileExists('/existing.txt')).toBe(false);
 	});
+
+	it('skips entries blocked by existing parent files when overwriteFiles is false', async () => {
+		php.mkdir('/dst');
+		php.writeFile('/dst/conflict', 'old');
+		const zip = await createZipBuffer(php, {
+			'conflict/nested.txt': 'new',
+			'fresh.txt': 'fresh',
+		});
+
+		await unzipFile(
+			php,
+			new File([zip], 'blocked-no-overwrite.zip'),
+			'/dst',
+			false
+		);
+
+		expect(php.readFileAsText('/dst/conflict')).toBe('old');
+		expect(php.fileExists('/dst/conflict/nested.txt')).toBe(false);
+		expect(php.readFileAsText('/dst/fresh.txt')).toBe('fresh');
+	});
 });
 
 /**

--- a/packages/php-wasm/node/src/test/unzip-file.spec.ts
+++ b/packages/php-wasm/node/src/test/unzip-file.spec.ts
@@ -95,54 +95,6 @@ describe('unzipFile – concurrent calls avoid conflicts', () => {
 
 		expect(php.readFileAsText('/dst/existing.txt')).toBe('old');
 		expect(php.readFileAsText('/dst/fresh.txt')).toBe('fresh');
-		const tmpFiles = php.listFiles('/tmp');
-		const leftoverExtractDirs = tmpFiles.filter((f) =>
-			f.startsWith('unzip-')
-		);
-		expect(leftoverExtractDirs).toHaveLength(0);
-	});
-
-	it('normalizes ZIP entry names when overwriteFiles is false', async () => {
-		php.mkdir('/dst');
-		php.writeFile('/dst/existing.txt', 'old');
-		const zip = await createZipBuffer(php, {
-			'../existing.txt': 'new',
-			'/absolute.txt': 'absolute',
-			'fresh.txt': 'fresh',
-		});
-
-		await unzipFile(
-			php,
-			new File([zip], 'normalized-no-overwrite.zip'),
-			'/dst',
-			false
-		);
-
-		expect(php.readFileAsText('/dst/existing.txt')).toBe('old');
-		expect(php.readFileAsText('/dst/absolute.txt')).toBe('absolute');
-		expect(php.readFileAsText('/dst/fresh.txt')).toBe('fresh');
-		expect(php.fileExists('/absolute.txt')).toBe(false);
-		expect(php.fileExists('/existing.txt')).toBe(false);
-	});
-
-	it('skips entries blocked by existing parent files when overwriteFiles is false', async () => {
-		php.mkdir('/dst');
-		php.writeFile('/dst/conflict', 'old');
-		const zip = await createZipBuffer(php, {
-			'conflict/nested.txt': 'new',
-			'fresh.txt': 'fresh',
-		});
-
-		await unzipFile(
-			php,
-			new File([zip], 'blocked-no-overwrite.zip'),
-			'/dst',
-			false
-		);
-
-		expect(php.readFileAsText('/dst/conflict')).toBe('old');
-		expect(php.fileExists('/dst/conflict/nested.txt')).toBe(false);
-		expect(php.readFileAsText('/dst/fresh.txt')).toBe('fresh');
 	});
 });
 

--- a/packages/php-wasm/node/src/test/unzip-file.spec.ts
+++ b/packages/php-wasm/node/src/test/unzip-file.spec.ts
@@ -96,9 +96,32 @@ describe('unzipFile – concurrent calls avoid conflicts', () => {
 		expect(php.readFileAsText('/dst/fresh.txt')).toBe('fresh');
 		const tmpFiles = php.listFiles('/tmp');
 		const leftoverExtractDirs = tmpFiles.filter((f) =>
-			f.startsWith('unzip-entry-')
+			f.startsWith('unzip-')
 		);
 		expect(leftoverExtractDirs).toHaveLength(0);
+	});
+
+	it('normalizes ZIP entry names when overwriteFiles is false', async () => {
+		php.mkdir('/dst');
+		php.writeFile('/dst/existing.txt', 'old');
+		const zip = await createZipBuffer(php, {
+			'../existing.txt': 'new',
+			'/absolute.txt': 'absolute',
+			'fresh.txt': 'fresh',
+		});
+
+		await unzipFile(
+			php,
+			new File([zip], 'normalized-no-overwrite.zip'),
+			'/dst',
+			false
+		);
+
+		expect(php.readFileAsText('/dst/existing.txt')).toBe('old');
+		expect(php.readFileAsText('/dst/absolute.txt')).toBe('absolute');
+		expect(php.readFileAsText('/dst/fresh.txt')).toBe('fresh');
+		expect(php.fileExists('/absolute.txt')).toBe(false);
+		expect(php.fileExists('/existing.txt')).toBe(false);
 	});
 });
 

--- a/packages/php-wasm/node/src/test/unzip-file.spec.ts
+++ b/packages/php-wasm/node/src/test/unzip-file.spec.ts
@@ -49,4 +49,83 @@ describe('unzipFile – concurrent calls avoid conflicts', () => {
 		const leftoverZips = tmpFiles.filter((f) => f.endsWith('.zip'));
 		expect(leftoverZips).toHaveLength(0);
 	});
+
+	it('extracts normalized ZIP entry names inside the target directory', async () => {
+		const zip = await createZipBuffer(php, {
+			'safe.txt': 'safe',
+			'../escape.txt': 'escape',
+		});
+
+		await unzipFile(php, new File([zip], 'normalized.zip'), '/dst');
+
+		expect(php.fileExists('/escape.txt')).toBe(false);
+		expect(php.readFileAsText('/dst/escape.txt')).toBe('escape');
+		expect(php.readFileAsText('/dst/safe.txt')).toBe('safe');
+		const tmpFiles = php.listFiles('/tmp');
+		const leftoverZips = tmpFiles.filter((f) => f.endsWith('.zip'));
+		expect(leftoverZips).toHaveLength(0);
+	});
+
+	it('extracts leading-slash entries inside the target directory', async () => {
+		const zip = await createZipBuffer(php, {
+			'/absolute.txt': 'absolute',
+		});
+
+		await unzipFile(php, new File([zip], 'leading-slash.zip'), '/dst');
+
+		expect(php.fileExists('/absolute.txt')).toBe(false);
+		expect(php.readFileAsText('/dst/absolute.txt')).toBe('absolute');
+	});
+
+	it('preserves existing files when overwriteFiles is false', async () => {
+		php.mkdir('/dst');
+		php.writeFile('/dst/existing.txt', 'old');
+		const zip = await createZipBuffer(php, {
+			'existing.txt': 'new',
+			'fresh.txt': 'fresh',
+		});
+
+		await unzipFile(
+			php,
+			new File([zip], 'no-overwrite.zip'),
+			'/dst',
+			false
+		);
+
+		expect(php.readFileAsText('/dst/existing.txt')).toBe('old');
+		expect(php.readFileAsText('/dst/fresh.txt')).toBe('fresh');
+		const tmpFiles = php.listFiles('/tmp');
+		const leftoverExtractDirs = tmpFiles.filter((f) =>
+			f.startsWith('unzip-entry-')
+		);
+		expect(leftoverExtractDirs).toHaveLength(0);
+	});
 });
+
+/**
+ * Creates ZIP fixtures with exact entry names, including unsafe paths.
+ *
+ * `zipDirectory()` can only archive files that already exist in the VFS, so it
+ * cannot create entries such as `../escape.txt` needed for extraction tests.
+ */
+async function createZipBuffer(php: PHP, entries: Record<string, string>) {
+	const zipPath = `/tmp/source-${Math.random()}.zip`;
+	const entriesJson = JSON.stringify(entries);
+	await php.run({
+		code: `<?php
+		$entries = json_decode(${JSON.stringify(entriesJson)}, true);
+		$zip = new ZipArchive;
+		$res = $zip->open(${JSON.stringify(zipPath)}, ZipArchive::CREATE);
+		if ($res !== TRUE) {
+			throw new Exception('Failed to create ZIP: ' . $res);
+		}
+		foreach ($entries as $name => $contents) {
+			$zip->addFromString($name, $contents);
+		}
+		$zip->close();
+		`,
+	});
+	const zip = await php.readFileAsBuffer(zipPath);
+	await php.unlink(zipPath);
+	return zip;
+}

--- a/packages/php-wasm/node/src/test/unzip-file.spec.ts
+++ b/packages/php-wasm/node/src/test/unzip-file.spec.ts
@@ -3,6 +3,7 @@ import {
 	zipDirectory,
 	RecommendedPHPVersion,
 } from '@wp-playground/common';
+import { phpVars } from '@php-wasm/util';
 import { PHP } from '@php-wasm/universal';
 import { loadNodeRuntime } from '../lib';
 
@@ -133,12 +134,12 @@ describe('unzipFile – concurrent calls avoid conflicts', () => {
  */
 async function createZipBuffer(php: PHP, entries: Record<string, string>) {
 	const zipPath = `/tmp/source-${Math.random()}.zip`;
-	const entriesJson = JSON.stringify(entries);
+	const js = phpVars({ entries, zipPath });
 	await php.run({
 		code: `<?php
-		$entries = json_decode(${JSON.stringify(entriesJson)}, true);
+		$entries = ${js.entries};
 		$zip = new ZipArchive;
-		$res = $zip->open(${JSON.stringify(zipPath)}, ZipArchive::CREATE);
+		$res = $zip->open(${js.zipPath}, ZipArchive::CREATE);
 		if ($res !== TRUE) {
 			throw new Exception('Failed to create ZIP: ' . $res);
 		}

--- a/packages/playground/common/src/index.ts
+++ b/packages/playground/common/src/index.ts
@@ -62,7 +62,15 @@ export const unzipFile = async (
 							throw new Exception('Could not extract ZIP file.');
 						}
 					} else {
-						extract_zip_without_overwriting($zip, $extractTo);
+						for ($i = 0; $i < $zip->numFiles; $i++) {
+							$filename = $zip->getNameIndex($i);
+							$extractFilePath = rtrim($extractTo, '/') . '/' . $filename;
+							// Check if file exists and $overwriteFiles is false
+							if (!file_exists($extractFilePath)) {
+								// Extract file
+								$zip->extractTo($extractTo, $filename);
+							}
+						}
 					}
 				} catch (Exception $e) {
 					$zip->close();
@@ -72,126 +80,8 @@ export const unzipFile = async (
 				chmod($extractTo, 0777);
             } else {
                 $fileSize = file_exists($zipPath) ? filesize($zipPath) : 'unknown';
-                throw new Exception("Could not unzip file. Error code: " . $res . ". File size: " . $fileSize . " bytes.");
-            }
-		}
-
-		/**
-		 * Extracts ZIP entries without overwriting existing target files.
-		 *
-		 * ZipArchive owns entry-name normalization. Extract the whole archive into
-		 * a temporary directory first, then copy only paths that do not exist in
-		 * the target directory.
-		 */
-		function extract_zip_without_overwriting($zip, $extractTo) {
-			$tmpExtractTo = '/tmp/unzip-' . uniqid('', true);
-			if (!mkdir($tmpExtractTo, 0777, true) && !is_dir($tmpExtractTo)) {
-				throw new Exception(
-					'Could not create temporary ZIP extraction directory.'
-				);
-			}
-			try {
-				if (!$zip->extractTo($tmpExtractTo)) {
-					throw new Exception('Could not extract ZIP file.');
-				}
-				copy_directory_without_overwriting($tmpExtractTo, $extractTo);
-			} finally {
-				remove_directory($tmpExtractTo);
-			}
-		}
-
-		/**
-		 * Copies extracted files into the target directory without replacing any
-		 * paths that are already there.
-		 */
-		function copy_directory_without_overwriting($source, $target) {
-			$sourceRoot = rtrim($source, '/');
-			$targetRoot = rtrim($target, '/');
-			$files = new RecursiveIteratorIterator(
-				new RecursiveDirectoryIterator(
-					$sourceRoot,
-					FilesystemIterator::SKIP_DOTS
-				),
-				RecursiveIteratorIterator::SELF_FIRST
-			);
-			foreach ($files as $file) {
-				$sourcePath = strval($file);
-				$relativePath = substr($sourcePath, strlen($sourceRoot) + 1);
-				$targetPath = $targetRoot . '/' . $relativePath;
-				if (file_exists($targetPath)) {
-					continue;
-				}
-				if ($file->isDir()) {
-					if (has_blocking_parent_path($targetPath, $targetRoot)) {
-						continue;
-					}
-					if (!mkdir($targetPath, 0777, true) && !is_dir($targetPath)) {
-						throw new Exception(
-							'Could not create ZIP target directory: ' . $relativePath
-						);
-					}
-					continue;
-				}
-				if (has_blocking_parent_path($targetPath, $targetRoot)) {
-					continue;
-				}
-				$parentDirectory = dirname($targetPath);
-				if (
-					!is_dir($parentDirectory) &&
-					!mkdir($parentDirectory, 0777, true) &&
-					!is_dir($parentDirectory)
-				) {
-					throw new Exception(
-						'Could not create ZIP target directory: ' .
-							dirname($relativePath)
-					);
-				}
-				if (!copy($sourcePath, $targetPath)) {
-					throw new Exception(
-						'Could not copy ZIP entry: ' . $relativePath
-					);
-				}
-			}
-		}
-
-		/**
-		 * Checks whether a file entry should be skipped because writing it would
-		 * require replacing an existing parent file.
-		 */
-		function has_blocking_parent_path($path, $root) {
-			$parent = dirname($path);
-			while ($parent !== $root && strlen($parent) >= strlen($root)) {
-				if (file_exists($parent)) {
-					return !is_dir($parent);
-				}
-				$nextParent = dirname($parent);
-				if ($nextParent === $parent) {
-					return false;
-				}
-				$parent = $nextParent;
-			}
-			return false;
-		}
-
-		/**
-		 * Recursively removes a temporary extraction directory.
-		 */
-		function remove_directory($path) {
-			if (!is_dir($path)) {
-				return;
-			}
-			$files = new RecursiveIteratorIterator(
-				new RecursiveDirectoryIterator($path, FilesystemIterator::SKIP_DOTS),
-				RecursiveIteratorIterator::CHILD_FIRST
-			);
-			foreach ($files as $file) {
-				if ($file->isDir()) {
-					rmdir(strval($file));
-				} else {
-					unlink(strval($file));
-				}
-			}
-			rmdir($path);
+	                throw new Exception("Could not unzip file. Error code: " . $res . ". File size: " . $fileSize . " bytes.");
+	            }
 		}
         unzip(${js.zipPath}, ${js.extractToPath}, ${js.overwriteFiles});
         `,

--- a/packages/playground/common/src/index.ts
+++ b/packages/playground/common/src/index.ts
@@ -79,33 +79,23 @@ export const unzipFile = async (
 		/**
 		 * Extracts ZIP entries without overwriting existing target files.
 		 *
-		 * ZipArchive owns entry-name normalization. Extract each entry into a
-		 * temporary directory first, then copy only files that do not exist in the
-		 * target directory.
+		 * ZipArchive owns entry-name normalization. Extract the whole archive into
+		 * a temporary directory first, then copy only paths that do not exist in
+		 * the target directory.
 		 */
 		function extract_zip_without_overwriting($zip, $extractTo) {
-			for ($i = 0; $i < $zip->numFiles; $i++) {
-				$entryName = $zip->getNameIndex($i);
-				if ($entryName === false) {
-					throw new Exception('Could not read ZIP entry name: ' . $i);
+			$tmpExtractTo = '/tmp/unzip-' . uniqid('', true);
+			if (!mkdir($tmpExtractTo, 0777, true) && !is_dir($tmpExtractTo)) {
+				throw new Exception(
+					'Could not create temporary ZIP extraction directory.'
+				);
+			}
+			try {
+				if (!$zip->extractTo($tmpExtractTo)) {
+					throw new Exception('Could not extract ZIP file.');
 				}
-				$tmpExtractTo = '/tmp/unzip-entry-' . uniqid('', true);
-				if (!mkdir($tmpExtractTo, 0777, true) && !is_dir($tmpExtractTo)) {
-					throw new Exception(
-						'Could not create temporary ZIP extraction directory.'
-					);
-				}
-				try {
-					if (!$zip->extractTo($tmpExtractTo, $entryName)) {
-						throw new Exception(
-							'Could not extract ZIP entry: ' . $entryName
-						);
-					}
-					copy_directory_without_overwriting($tmpExtractTo, $extractTo);
-				} catch (Exception $e) {
-					remove_directory($tmpExtractTo);
-					throw $e;
-				}
+				copy_directory_without_overwriting($tmpExtractTo, $extractTo);
+			} finally {
 				remove_directory($tmpExtractTo);
 			}
 		}
@@ -128,18 +118,27 @@ export const unzipFile = async (
 				$sourcePath = strval($file);
 				$relativePath = substr($sourcePath, strlen($sourceRoot) + 1);
 				$targetPath = $targetRoot . '/' . $relativePath;
-				if ($file->isDir()) {
-					if (!is_dir($targetPath)) {
-						mkdir($targetPath, 0777, true);
-					}
-					continue;
-				}
 				if (file_exists($targetPath)) {
 					continue;
 				}
+				if ($file->isDir()) {
+					if (!mkdir($targetPath, 0777, true) && !is_dir($targetPath)) {
+						throw new Exception(
+							'Could not create ZIP target directory: ' . $relativePath
+						);
+					}
+					continue;
+				}
 				$parentDirectory = dirname($targetPath);
-				if (!is_dir($parentDirectory)) {
-					mkdir($parentDirectory, 0777, true);
+				if (
+					!is_dir($parentDirectory) &&
+					!mkdir($parentDirectory, 0777, true) &&
+					!is_dir($parentDirectory)
+				) {
+					throw new Exception(
+						'Could not create ZIP target directory: ' .
+							dirname($relativePath)
+					);
 				}
 				if (!copy($sourcePath, $targetPath)) {
 					throw new Exception(

--- a/packages/playground/common/src/index.ts
+++ b/packages/playground/common/src/index.ts
@@ -122,11 +122,17 @@ export const unzipFile = async (
 					continue;
 				}
 				if ($file->isDir()) {
+					if (has_blocking_parent_path($targetPath, $targetRoot)) {
+						continue;
+					}
 					if (!mkdir($targetPath, 0777, true) && !is_dir($targetPath)) {
 						throw new Exception(
 							'Could not create ZIP target directory: ' . $relativePath
 						);
 					}
+					continue;
+				}
+				if (has_blocking_parent_path($targetPath, $targetRoot)) {
 					continue;
 				}
 				$parentDirectory = dirname($targetPath);
@@ -146,6 +152,25 @@ export const unzipFile = async (
 					);
 				}
 			}
+		}
+
+		/**
+		 * Checks whether a file entry should be skipped because writing it would
+		 * require replacing an existing parent file.
+		 */
+		function has_blocking_parent_path($path, $root) {
+			$parent = dirname($path);
+			while ($parent !== $root && strlen($parent) >= strlen($root)) {
+				if (file_exists($parent)) {
+					return !is_dir($parent);
+				}
+				$nextParent = dirname($parent);
+				if ($nextParent === $parent) {
+					return false;
+				}
+				$parent = $nextParent;
+			}
+			return false;
 		}
 
 		/**

--- a/packages/playground/common/src/index.ts
+++ b/packages/playground/common/src/index.ts
@@ -30,21 +30,24 @@ export const unzipFile = async (
 	 * calls.
 	 */
 	const tmpPath = `/tmp/file-${Math.random()}.zip`;
-	if (zipPath instanceof File) {
-		const zipFile = zipPath;
-		zipPath = tmpPath;
-		await php.writeFile(
+	let shouldRemoveTmpPath = false;
+	try {
+		if (zipPath instanceof File) {
+			const zipFile = zipPath;
+			zipPath = tmpPath;
+			shouldRemoveTmpPath = true;
+			await php.writeFile(
+				zipPath,
+				new Uint8Array(await zipFile.arrayBuffer())
+			);
+		}
+		const js = phpVars({
 			zipPath,
-			new Uint8Array(await zipFile.arrayBuffer())
-		);
-	}
-	const js = phpVars({
-		zipPath,
-		extractToPath,
-		overwriteFiles,
-	});
-	await php.run({
-		code: `<?php
+			extractToPath,
+			overwriteFiles,
+		});
+		await php.run({
+			code: `<?php
         function unzip($zipPath, $extractTo, $overwriteFiles = true)
         {
             if (!is_dir($extractTo)) {
@@ -53,15 +56,17 @@ export const unzipFile = async (
             $zip = new ZipArchive;
             $res = $zip->open($zipPath);
             if ($res === TRUE) {
-				for ($i = 0; $i < $zip->numFiles; $i++) {
-					$filename = $zip->getNameIndex($i);
-					$fileinfo = pathinfo($filename);
-					$extractFilePath = rtrim($extractTo, '/') . '/' . $filename;
-					// Check if file exists and $overwriteFiles is false
-					if (!file_exists($extractFilePath) || $overwriteFiles) {
-						// Extract file
-						$zip->extractTo($extractTo, $filename);
+				try {
+					if ($overwriteFiles) {
+						if (!$zip->extractTo($extractTo)) {
+							throw new Exception('Could not extract ZIP file.');
+						}
+					} else {
+						extract_zip_without_overwriting($zip, $extractTo);
 					}
+				} catch (Exception $e) {
+					$zip->close();
+					throw $e;
 				}
 				$zip->close();
 				chmod($extractTo, 0777);
@@ -69,12 +74,115 @@ export const unzipFile = async (
                 $fileSize = file_exists($zipPath) ? filesize($zipPath) : 'unknown';
                 throw new Exception("Could not unzip file. Error code: " . $res . ". File size: " . $fileSize . " bytes.");
             }
-        }
+		}
+
+		/**
+		 * Extracts ZIP entries without overwriting existing target files.
+		 *
+		 * ZipArchive owns entry-name normalization. Extract each entry into a
+		 * temporary directory first, then copy only files that do not exist in the
+		 * target directory.
+		 */
+		function extract_zip_without_overwriting($zip, $extractTo) {
+			for ($i = 0; $i < $zip->numFiles; $i++) {
+				$entryName = $zip->getNameIndex($i);
+				if ($entryName === false) {
+					throw new Exception('Could not read ZIP entry name: ' . $i);
+				}
+				$tmpExtractTo = '/tmp/unzip-entry-' . uniqid('', true);
+				if (!mkdir($tmpExtractTo, 0777, true) && !is_dir($tmpExtractTo)) {
+					throw new Exception(
+						'Could not create temporary ZIP extraction directory.'
+					);
+				}
+				try {
+					if (!$zip->extractTo($tmpExtractTo, $entryName)) {
+						throw new Exception(
+							'Could not extract ZIP entry: ' . $entryName
+						);
+					}
+					copy_directory_without_overwriting($tmpExtractTo, $extractTo);
+				} catch (Exception $e) {
+					remove_directory($tmpExtractTo);
+					throw $e;
+				}
+				remove_directory($tmpExtractTo);
+			}
+		}
+
+		/**
+		 * Copies extracted files into the target directory without replacing any
+		 * paths that are already there.
+		 */
+		function copy_directory_without_overwriting($source, $target) {
+			$sourceRoot = rtrim($source, '/');
+			$targetRoot = rtrim($target, '/');
+			$files = new RecursiveIteratorIterator(
+				new RecursiveDirectoryIterator(
+					$sourceRoot,
+					FilesystemIterator::SKIP_DOTS
+				),
+				RecursiveIteratorIterator::SELF_FIRST
+			);
+			foreach ($files as $file) {
+				$sourcePath = strval($file);
+				$relativePath = substr($sourcePath, strlen($sourceRoot) + 1);
+				$targetPath = $targetRoot . '/' . $relativePath;
+				if ($file->isDir()) {
+					if (!is_dir($targetPath)) {
+						mkdir($targetPath, 0777, true);
+					}
+					continue;
+				}
+				if (file_exists($targetPath)) {
+					continue;
+				}
+				$parentDirectory = dirname($targetPath);
+				if (!is_dir($parentDirectory)) {
+					mkdir($parentDirectory, 0777, true);
+				}
+				if (!copy($sourcePath, $targetPath)) {
+					throw new Exception(
+						'Could not copy ZIP entry: ' . $relativePath
+					);
+				}
+			}
+		}
+
+		/**
+		 * Recursively removes a temporary extraction directory.
+		 */
+		function remove_directory($path) {
+			if (!is_dir($path)) {
+				return;
+			}
+			$files = new RecursiveIteratorIterator(
+				new RecursiveDirectoryIterator($path, FilesystemIterator::SKIP_DOTS),
+				RecursiveIteratorIterator::CHILD_FIRST
+			);
+			foreach ($files as $file) {
+				if ($file->isDir()) {
+					rmdir(strval($file));
+				} else {
+					unlink(strval($file));
+				}
+			}
+			rmdir($path);
+		}
         unzip(${js.zipPath}, ${js.extractToPath}, ${js.overwriteFiles});
         `,
-	});
-	if (await php.fileExists(tmpPath)) {
-		await php.unlink(tmpPath);
+		});
+	} finally {
+		if (shouldRemoveTmpPath) {
+			try {
+				if (await php.fileExists(tmpPath)) {
+					await php.unlink(tmpPath);
+				}
+			} catch {
+				// Best-effort cleanup: preserving the unzip error matters more than
+				// surfacing a leftover temporary file.
+			}
+		}
 	}
 };
 
@@ -83,15 +191,22 @@ export const zipDirectory = async (
 	directoryPath: string
 ) => {
 	const outputPath = `/tmp/file${Math.random()}.zip`;
-	const js = phpVars({
-		directoryPath,
-		outputPath,
-	});
-	await php.run({
-		code: `<?php
-		function zipDirectory($directoryPath, $outputPath) {
-			$zip = new ZipArchive;
-			$res = $zip->open($outputPath, ZipArchive::CREATE);
+	try {
+		const js = phpVars({
+			directoryPath,
+			outputPath,
+		});
+		await php.run({
+			code: `<?php
+			/**
+			 * Creates a ZIP archive from a Playground directory.
+			 *
+			 * The JavaScript wrapper removes the temporary archive in a finally
+			 * block, so this function only owns archive creation and permissions.
+			 */
+			function zipDirectory($directoryPath, $outputPath) {
+				$zip = new ZipArchive;
+				$res = $zip->open($outputPath, ZipArchive::CREATE);
 			if ($res !== TRUE) {
 				throw new Exception('Failed to create ZIP');
 			}
@@ -108,11 +223,19 @@ export const zipDirectory = async (
 			$zip->close();
 			chmod($outputPath, 0777);
 		}
-		zipDirectory(${js.directoryPath}, ${js.outputPath});
-		`,
-	});
+			zipDirectory(${js.directoryPath}, ${js.outputPath});
+			`,
+		});
 
-	const fileBuffer = await php.readFileAsBuffer(outputPath);
-	php.unlink(outputPath);
-	return fileBuffer;
+		return await php.readFileAsBuffer(outputPath);
+	} finally {
+		try {
+			if (await php.fileExists(outputPath)) {
+				await php.unlink(outputPath);
+			}
+		} catch {
+			// Best-effort cleanup: preserving the ZIP error matters more than
+			// surfacing a leftover temporary file.
+		}
+	}
 };


### PR DESCRIPTION
## What it does

Uses `ZipArchive::extractTo()` for the normal `overwriteFiles=true` unzip path instead of looping over entries and extracting them one by one. It also adds a few small desired behaviors:

- temporary `File` upload ZIPs are removed in `finally`
- temporary archives created by `zipDirectory()` are removed in `finally`

## Rationale

The old code tried to reason about where each ZIP entry would land before calling `ZipArchive`:

```php
$filename = $zip->getNameIndex($i);
$extractFilePath = rtrim($extractTo, '/') . '/' . $filename;
if (!file_exists($extractFilePath) || $overwriteFiles) {
    $zip->extractTo($extractTo, $filename);
}
```

That is misleading for normalized entry names. For example, a ZIP can contain this entry:

```text
../escape.txt
```

When extracting into `/dst`, `ZipArchive` normalizes that entry into:

```text
/dst/escape.txt
```

It does **not** write `/escape.txt`. The old loop still built and reasoned about `/dst/../escape.txt`, even though `ZipArchive` owns the actual normalization. The same applies to leading-slash entries such as `/absolute.txt`, which are extracted inside the target directory by the Playground PHP runtime.

So for the normal overwrite case, this PR removes the fake preflight path calculation and lets `ZipArchive` do the extraction and normalization in one call.

## Implementation

`unzipFile()` now has two paths:

1. `overwriteFiles=true`: call `$zip->extractTo($extractTo)` once.
2. `overwriteFiles=false`: keep the existing per-entry `file_exists()` behavior.

The `overwriteFiles=false` path is intentionally left close to trunk. The only production caller is `backfillStaticFilesRemovedFromMinifiedBuild()`, which unzips trusted Playground-generated static asset bundles into the WordPress document root without overwriting user-changed files. This PR does not add a new temp-directory copy implementation for that one trusted use-case.

## Testing instructions

```bash
npm exec nx run php-wasm-node:test-group-5-asyncify -- --testFiles=unzip-file.spec.ts --runInBand
npm exec nx run php-wasm-node:test-group-5-jspi -- --testFiles=unzip-file.spec.ts --runInBand
npm exec nx run playground-common:lint
npm exec nx run php-wasm-node:lint
git diff --check
```
