### PR TITLE
[PHP] Expose more metadata about each WordPress zip bundle

### DIFF
--- a/packages/playground/wordpress-builds/build/build.js
+++ b/packages/playground/wordpress-builds/build/build.js
@@ -3,6 +3,8 @@ import { spawn } from 'child_process';
 import yargs from 'yargs';
 import { promises as fs, statSync } from 'fs';
 import semver from 'semver';
+import { createHash } from 'crypto';
+import { Uint8ArrayReader, ZipReader } from '@zip.js/zip.js';
 
 const remoteWordPressModules = {
 	trunk: {
@@ -271,13 +273,23 @@ const latestStableVersion = Object.keys(versions).filter((v) =>
 	v.match(/^\d/)
 )[0];
 
-const sizes = {};
+const bundleMetadata = {};
 for (const version of Object.keys(versions)) {
 	const zipPath = `${outputJsDir}/wp-${version}.zip`;
 	try {
-		sizes[version] = statSync(zipPath).size;
+		const bytes = await fs.readFile(zipPath);
+		const reader = new ZipReader(new Uint8ArrayReader(new Uint8Array(bytes)));
+		const entries = await reader.getEntries();
+		await reader.close();
+		bundleMetadata[version] = {
+			size: statSync(zipPath).size,
+			sha256: createHash('sha256').update(bytes).digest('hex'),
+			fileCount: entries.filter((entry) => !entry.directory).length,
+		};
 	} catch (e) {
-		sizes[version] = 0;
+		bundleMetadata[version] = {
+			size: 0,
+		};
 	}
 }
 
@@ -298,9 +310,28 @@ import url_${slugify(version)} from './wp-${version}.zip?url';`
  * This file must statically exists in the project because of the way
  * vite resolves imports.
  */
-export function getWordPressModuleDetails(wpVersion: string = ${JSON.stringify(
-	latestStableVersion
-)}): { size: number, url: string } {
+export interface WordPressModuleDetails {
+	/** Archive file format used by the WordPress core bundle. */
+	format: 'zip' | 'tar.zst';
+	/** Archive container. */
+	container: 'zip' | 'tar';
+	/** Compression codec used by the archive payload. */
+	codec: 'deflate' | 'zstd';
+	/** Compressed byte length of the bundle. */
+	size: number;
+	/** URL (or dev filesystem path) of the bundle. */
+	url: string;
+	/** SHA-256 of the compressed bundle, when known for committed local bundles. */
+	sha256?: string;
+	/** Number of regular files in the bundle, when known for committed local bundles. */
+	fileCount?: number;
+}
+
+export function getWordPressModuleDetails(
+	wpVersion: string = ${JSON.stringify(
+		latestStableVersion
+	)}
+): WordPressModuleDetails {
 	switch (wpVersion) {
 		${Object.keys(versions)
 			.map(
@@ -309,6 +340,9 @@ export function getWordPressModuleDetails(wpVersion: string = ${JSON.stringify(
 						? `
 		case '${version}':
 			return {
+				format: 'zip',
+				container: 'zip',
+				codec: 'deflate',
 				size: ${JSON.stringify(
 					remoteWordPressModules[version].size ?? 0
 				)},
@@ -319,7 +353,12 @@ export function getWordPressModuleDetails(wpVersion: string = ${JSON.stringify(
 		case '${version}':
 			/** @ts-ignore */
 			return {
-				size: ${JSON.stringify(sizes[version])},
+				format: 'zip',
+				container: 'zip',
+				codec: 'deflate',
+				size: ${JSON.stringify(bundleMetadata[version].size)},
+				sha256: ${JSON.stringify(bundleMetadata[version].sha256)},
+				fileCount: ${JSON.stringify(bundleMetadata[version].fileCount)},
 				url: url_${slugify(version)},
 			};
 			`
@@ -330,6 +369,9 @@ export function getWordPressModuleDetails(wpVersion: string = ${JSON.stringify(
 				? `
 		case 'nightly':
 			return {
+				format: 'zip',
+				container: 'zip',
+				codec: 'deflate',
 				size: ${JSON.stringify(remoteWordPressModules.trunk.size ?? 0)},
 				url: ${JSON.stringify(remoteWordPressModules.trunk.url)},
 			};

--- a/packages/playground/wordpress-builds/src/test/get-wordpress-module-details.spec.ts
+++ b/packages/playground/wordpress-builds/src/test/get-wordpress-module-details.spec.ts
@@ -7,11 +7,70 @@
  * and should still be linted and picked up by the test runner.
  */
 
+import { createHash } from 'node:crypto';
+import { statSync, readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { Uint8ArrayReader, ZipReader } from '@zip.js/zip.js';
+import { getWordPressModule } from '../wordpress/get-wordpress-module';
 import { getWordPressModuleDetails } from '../wordpress/get-wordpress-module-details';
 
 describe('getWordPressModuleDetails()', () => {
 	it('should return a data loader module', async () => {
 		const module = getWordPressModuleDetails();
 		expect(module.url).toMatch(/\/wp-\d\.\d\.zip$/);
+		expect(module.format).toBe('zip');
+		expect(module.container).toBe('zip');
+		expect(module.codec).toBe('deflate');
+		expect(module.sha256).toMatch(/^[0-9a-f]{64}$/);
+		expect(module.fileCount).toBeGreaterThan(0);
+	});
+
+	it('reports committed ZIP artifact metadata', async () => {
+		const module = getWordPressModuleDetails('6.8');
+		const zipPath = fileURLToPath(
+			new URL('../wordpress/wp-6.8.zip', import.meta.url)
+		);
+		const zipBytes = readFileSync(zipPath);
+		const reader = new ZipReader(
+			new Uint8ArrayReader(new Uint8Array(zipBytes))
+		);
+		let entries;
+		try {
+			entries = await reader.getEntries();
+		} finally {
+			await reader.close();
+		}
+
+		expect(module.size).toBe(statSync(zipPath).size);
+		expect(module.sha256).toBe(
+			createHash('sha256').update(zipBytes).digest('hex')
+		);
+		expect(module.fileCount).toBe(
+			entries.filter((entry) => !entry.directory).length
+		);
+	});
+
+	it('keeps remote trunk modules classified as ZIPs without local metadata', () => {
+		const module = getWordPressModuleDetails('trunk');
+		expect(module.format).toBe('zip');
+		expect(module.container).toBe('zip');
+		expect(module.codec).toBe('deflate');
+		expect(module.sha256).toBeUndefined();
+		expect(module.fileCount).toBeUndefined();
+	});
+
+	it('uses descriptor metadata when creating the module File', async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockResolvedValue(new Response(new Uint8Array([1, 2, 3])))
+		);
+
+		try {
+			const module = await getWordPressModule('trunk');
+			expect(module.name).toBe('trunk.zip');
+			expect(module.type).toBe('application/zip');
+		} finally {
+			vi.unstubAllGlobals();
+		}
 	});
 });

--- a/packages/playground/wordpress-builds/src/wordpress/get-wordpress-module-details.ts
+++ b/packages/playground/wordpress-builds/src/wordpress/get-wordpress-module-details.ts
@@ -1,4 +1,3 @@
-
 // @ts-ignore
 import url_beta from './wp-beta.zip?url';
 // @ts-ignore
@@ -24,85 +23,153 @@ import url_6_3 from './wp-6.3.zip?url';
  * This file must statically exists in the project because of the way
  * vite resolves imports.
  */
-export function getWordPressModuleDetails(wpVersion: string = "7.0"): { size: number, url: string } {
+export interface WordPressModuleDetails {
+	/** Archive file format used by the WordPress core bundle. */
+	format: 'zip' | 'tar.zst';
+	/** Archive container. */
+	container: 'zip' | 'tar';
+	/** Compression codec used by the archive payload. */
+	codec: 'deflate' | 'zstd';
+	/** Compressed byte length of the bundle. */
+	size: number;
+	/** URL (or dev filesystem path) of the bundle. */
+	url: string;
+	/** SHA-256 of the compressed bundle, when known for committed local bundles. */
+	sha256?: string;
+	/** Number of regular files in the bundle, when known for committed local bundles. */
+	fileCount?: number;
+}
+
+export function getWordPressModuleDetails(
+	wpVersion: string = "7.0"
+): WordPressModuleDetails {
 	switch (wpVersion) {
-		
+
 		case 'trunk':
 			return {
+				format: 'zip',
+				container: 'zip',
+				codec: 'deflate',
 				size: 0,
 				url: "https://github.com/WordPress/WordPress/archive/refs/heads/master.zip",
 			};
-			
+
 		case 'beta':
 			/** @ts-ignore */
 			return {
+				format: 'zip',
+				container: 'zip',
+				codec: 'deflate',
 				size: 6535647,
+				sha256: "38548d16c90ca6b3ac044ff1882e15fafab6f765dac506fb14892110a07cb010",
+				fileCount: 1816,
 				url: url_beta,
 			};
-			
+
 		case '7.0':
 			/** @ts-ignore */
 			return {
+				format: 'zip',
+				container: 'zip',
+				codec: 'deflate',
 				size: 6530259,
+				sha256: "1adcb69b4e695ff16346188021155d94b7b07e173d0794e3a33847b8edf2ed96",
+				fileCount: 1815,
 				url: url_7_0,
 			};
-			
+
 		case '6.9':
 			/** @ts-ignore */
 			return {
+				format: 'zip',
+				container: 'zip',
+				codec: 'deflate',
 				size: 5966666,
+				sha256: "3b4df38aa00a5868ed580bfc1643e32e8cc6ee2b0f4fd38ce36177b3a6a7d4f9",
+				fileCount: 1594,
 				url: url_6_9,
 			};
-			
+
 		case '6.8':
 			/** @ts-ignore */
 			return {
+				format: 'zip',
+				container: 'zip',
+				codec: 'deflate',
 				size: 5987405,
+				sha256: "bf783f24b94b06811c2d30f7780f32bf33359457819de93d92c01a4ce8889635",
+				fileCount: 1534,
 				url: url_6_8,
 			};
-			
+
 		case '6.7':
 			/** @ts-ignore */
 			return {
+				format: 'zip',
+				container: 'zip',
+				codec: 'deflate',
 				size: 5941818,
+				sha256: "99aa6f0315a047d89619d1523c14832703926c6429b88ae5df125c95f6c8836e",
+				fileCount: 1528,
 				url: url_6_7,
 			};
-			
+
 		case '6.6':
 			/** @ts-ignore */
 			return {
+				format: 'zip',
+				container: 'zip',
+				codec: 'deflate',
 				size: 4964307,
+				sha256: "6dc98257dd3a354e1bf2c33b33d557b99ee294824597cef30ec87e07c95d125e",
+				fileCount: 1367,
 				url: url_6_6,
 			};
-			
+
 		case '6.5':
 			/** @ts-ignore */
 			return {
+				format: 'zip',
+				container: 'zip',
+				codec: 'deflate',
 				size: 4886359,
+				sha256: "5b5a62038d6c57e9e5965dd5c89ddc6003242ae52958f8d567bb50827fe25d30",
+				fileCount: 1359,
 				url: url_6_5,
 			};
-			
+
 		case '6.4':
 			/** @ts-ignore */
 			return {
+				format: 'zip',
+				container: 'zip',
+				codec: 'deflate',
 				size: 4768241,
+				sha256: "b0d62625210cc47c0cbc05ed828825e15da8123d4206fd431241f69559716b5d",
+				fileCount: 1331,
 				url: url_6_4,
 			};
-			
+
 		case '6.3':
 			/** @ts-ignore */
 			return {
+				format: 'zip',
+				container: 'zip',
+				codec: 'deflate',
 				size: 3595053,
+				sha256: "cad7e42ece26fb462d40b2b249bf80a2f791c1fca3f9b986ff9bce277ed89a50",
+				fileCount: 1253,
 				url: url_6_3,
 			};
-			
-		
+
 		case 'nightly':
 			return {
+				format: 'zip',
+				container: 'zip',
+				codec: 'deflate',
 				size: 0,
 				url: "https://github.com/WordPress/WordPress/archive/refs/heads/master.zip",
 			};
-		
 
 	}
 	throw new Error('Unsupported WordPress module: ' + wpVersion);

--- a/packages/playground/wordpress-builds/src/wordpress/get-wordpress-module.ts
+++ b/packages/playground/wordpress-builds/src/wordpress/get-wordpress-module.ts
@@ -1,7 +1,11 @@
-import { getWordPressModuleDetails } from './get-wordpress-module-details';
+import {
+	getWordPressModuleDetails,
+	type WordPressModuleDetails,
+} from './get-wordpress-module-details';
 
 export async function getWordPressModule(wpVersion = '6.8'): Promise<File> {
-	const url = getWordPressModuleDetails(wpVersion).url;
+	const details = getWordPressModuleDetails(wpVersion);
+	const url = details.url;
 	let data = null;
 	if (url.startsWith('/')) {
 		let path = url;
@@ -19,7 +23,30 @@ export async function getWordPressModule(wpVersion = '6.8'): Promise<File> {
 		// @see https://github.com/WordPress/wordpress-playground/issues/2769
 		data = await response.arrayBuffer();
 	}
-	return new File([data as any], `${wpVersion || 'wp'}.zip`, {
-		type: 'application/zip',
-	});
+	const bundleFileMetadata = getWordPressBundleFileMetadata(details);
+	return new File(
+		[data as any],
+		`${wpVersion || 'wp'}.${bundleFileMetadata.extension}`,
+		{
+			type: bundleFileMetadata.mimeType,
+		}
+	);
+}
+
+const WORDPRESS_BUNDLE_FILE_METADATA = {
+	zip: {
+		extension: 'zip',
+		mimeType: 'application/zip',
+	},
+	'tar.zst': {
+		extension: 'tar.zst',
+		mimeType: 'application/zstd',
+	},
+} satisfies Record<
+	WordPressModuleDetails['format'],
+	{ extension: string; mimeType: string }
+>;
+
+function getWordPressBundleFileMetadata(details: WordPressModuleDetails) {
+	return WORDPRESS_BUNDLE_FILE_METADATA[details.format];
 }


### PR DESCRIPTION
## What it does

Related to #3913.

Adds a richer descriptor shape to `getWordPressModuleDetails()` while keeping every current WordPress core bundle as ZIP.

Each committed local ZIP now reports:

```ts
{
  url,
  size,
  format: 'zip',
  container: 'zip',
  codec: 'deflate',
  sha256,
  fileCount,
}
```

Remote `trunk`/`nightly` downloads are still ZIP descriptors, but keep `sha256` and `fileCount` unset because those URLs are not committed local artifacts.

## Rationale

This is the first small step toward the `tar.zst` bundle work. It separates the metadata/API shape change from the later runtime extraction and artifact replacement changes, so reviewers can check the descriptor contract without reviewing compression code or binary artifact churn.

## Implementation

- Updates the generated `WordPressModuleDetails` type.
- Teaches the WordPress build script to compute ZIP `sha256` and regular-file counts.
- Updates `getWordPressModule()` to derive the returned `File` name and MIME type from the descriptor format.
- Adds tests that verify descriptor fields match the committed ZIP artifact.

## Testing instructions

```bash
npx nx test playground-wordpress-builds
npx nx typecheck playground-remote
npx nx run-many -t lint -p playground-wordpress-builds,playground-remote
npx nx build playground-wordpress-builds
npx nx test playground-remote
```
