### PR TITLE
[PHP] Add streaming tar.zst WordPress bundle extraction

### DIFF
--- a/packages/playground/cli/tsconfig.lib.json
+++ b/packages/playground/cli/tsconfig.lib.json
@@ -7,6 +7,7 @@
 	},
 	"include": [
 		"src/**/*.ts",
+		"../wordpress/src/zstddec-stream.d.ts",
 		"tests/mounts.spec.ts",
 		"../blueprints/src/lib/v2/get-v2-runner.ts",
 		"../blueprints/src/lib/v2/run-blueprint-v2.ts",

--- a/packages/playground/cli/tsconfig.spec.json
+++ b/packages/playground/cli/tsconfig.spec.json
@@ -4,5 +4,10 @@
 		"outDir": "../../../dist/out-tsc",
 		"types": ["vitest/globals", "vitest/importMeta", "node"]
 	},
-	"include": ["tests/**/*.test.ts", "tests/**/*.spec.ts", "tests/**/*.d.ts"]
+	"include": [
+		"../wordpress/src/zstddec-stream.d.ts",
+		"tests/**/*.test.ts",
+		"tests/**/*.spec.ts",
+		"tests/**/*.d.ts"
+	]
 }

--- a/packages/playground/remote/src/lib/playground-worker-endpoint-blueprints-v1.ts
+++ b/packages/playground/remote/src/lib/playground-worker-endpoint-blueprints-v1.ts
@@ -87,6 +87,9 @@ class PlaygroundWorkerEndpointBlueprintsV1 extends PlaygroundWorkerEndpoint {
 
 			const wpDetails = getWordPressModuleDetails(wpVersion);
 			let wordPressRequest: Promise<Response> | null = null;
+			// Only tar.zst descriptors opt into the streaming extractor's file-count
+			// parity check. Custom URLs and wordpress.org ZIPs skip it.
+			let expectedBundleFileCount: number | undefined;
 			if (resolvedWordPressInstallMode === 'download-and-install') {
 				if (this.requestedWordPressVersion!.startsWith('http')) {
 					wordPressRequest = this.downloadMonitor
@@ -152,6 +155,10 @@ class PlaygroundWorkerEndpointBlueprintsV1 extends PlaygroundWorkerEndpoint {
 					this.downloadMonitor.expectAssets({
 						[downloadUrl]: wpDetails.size,
 					});
+					expectedBundleFileCount =
+						wpDetails.format === 'tar.zst'
+							? wpDetails.fileCount
+							: undefined;
 					wordPressRequest = this.downloadMonitor.monitorFetch(
 						fetch(downloadUrl)
 					);
@@ -222,7 +229,8 @@ class PlaygroundWorkerEndpointBlueprintsV1 extends PlaygroundWorkerEndpoint {
 				// @see https://github.com/WordPress/wordpress-playground/issues/2769
 				wordPressZip: wordPressRequest
 					?.then((r) => r.arrayBuffer())
-					.then((b) => new File([b], 'wp.zip')),
+					.then((b) => new File([b], 'wp.bundle')),
+				wordPressBundleFileCount: expectedBundleFileCount,
 				sqliteIntegrationPluginZip: sqliteIntegrationRequest
 					.then((r) => r.arrayBuffer())
 					.then((b) => new File([b], 'sqlite.zip')),

--- a/packages/playground/wordpress/src/boot.ts
+++ b/packages/playground/wordpress/src/boot.ts
@@ -167,8 +167,20 @@ export interface BootWordPressOptions {
 	dataSqlPath?: string;
 	/** How to handle WordPress installation. */
 	wordpressInstallMode?: WordPressInstallMode;
-	/** Zip with the WordPress installation to extract in /wordpress. */
+	/**
+	 * Core bundle with the WordPress installation to extract in /wordpress.
+	 * Either a solid `tar.zst` (stream-extracted) or a ZIP (wordpress.org
+	 * release, custom URL, GitHub artifact); the format is detected from the
+	 * bundle's magic bytes.
+	 */
 	wordPressZip?: File | Promise<File> | undefined;
+	/**
+	 * Expected regular-file count of the `tar.zst` core bundle, used for a
+	 * streaming-extraction parity check (fails loud on a truncated/corrupt
+	 * download). Ignored for ZIP bundles. Sourced from the bundle descriptor
+	 * (`getWordPressModuleDetails().fileCount`).
+	 */
+	wordPressBundleFileCount?: number;
 	/** Preloaded SQLite integration plugin. */
 	sqliteIntegrationPluginZip?: File | Promise<File>;
 	/**
@@ -232,7 +244,9 @@ export async function bootWordPress(
 	}
 
 	if (options.wordPressZip) {
-		await unzipWordPress(php, await options.wordPressZip);
+		await unzipWordPress(php, await options.wordPressZip, {
+			expectedFileCount: options.wordPressBundleFileCount,
+		});
 	}
 
 	if (options.constants) {

--- a/packages/playground/wordpress/src/index.ts
+++ b/packages/playground/wordpress/src/index.ts
@@ -7,6 +7,11 @@ import { writeCommonPlatformMuPlugins } from './platform-mu-plugins';
 import { SQLITE_PRELOAD_LOADER_CLASS } from './sqlite-preload-loader';
 import { setupLegacyPlatformLevelMuPlugins } from './legacy-wp/legacy-mu-plugins';
 import { preloadLegacySqliteIntegration } from './legacy-wp/legacy-sqlite-preload';
+import {
+	createDecodedTarStream,
+	extractTarStreamToPhp,
+	isZstdBundle,
+} from './streaming-tar-extract';
 
 export {
 	bootWordPress,
@@ -14,6 +19,7 @@ export {
 	bootRequestHandler,
 	getFileNotFoundActionForWordPress,
 } from './boot';
+export * from './streaming-tar-extract';
 export type {
 	PhpIniOptions,
 	PHPInstanceCreatedHook,
@@ -485,9 +491,40 @@ if(!function_exists('mysqli_connect')) {
  * accept the limitation, and switch to the PHP implementation as soon
  * as that's viable.
  */
-export async function unzipWordPress(php: PHP, wpZip: File) {
+export async function unzipWordPress(
+	php: PHP,
+	wpZip: File,
+	options: { expectedFileCount?: number } = {}
+) {
 	php.mkdir('/tmp/unzipped-wordpress');
-	await unzipFile(php, wpZip, '/tmp/unzipped-wordpress');
+
+	// Keep the public `wordPressZip` API name, but route by magic bytes.
+	// Core bundles can use a solid `tar.zst`; wordpress.org releases, custom
+	// URLs, nightly/trunk GitHub master.zip files, API-supplied archives, and
+	// GitHub artifacts continue to use the PHP `ZipArchive` path. The full
+	// uncompressed tar is never materialized.
+	const magic = new Uint8Array(await wpZip.slice(0, 4).arrayBuffer());
+	if (isZstdBundle(magic)) {
+		const bytes = new Uint8Array(await wpZip.arrayBuffer());
+		const tarStream = await createDecodedTarStream(bytes, 'zstd');
+		const stats = await extractTarStreamToPhp(
+			tarStream,
+			php,
+			'/tmp/unzipped-wordpress'
+		);
+		if (
+			options.expectedFileCount != null &&
+			stats.fileCount !== options.expectedFileCount
+		) {
+			throw new Error(
+				`WordPress core bundle file-count parity check failed: ` +
+					`extracted ${stats.fileCount} files, expected ${options.expectedFileCount}. ` +
+					`The download may be truncated or corrupt.`
+			);
+		}
+	} else {
+		await unzipFile(php, wpZip, '/tmp/unzipped-wordpress');
+	}
 
 	// The zip file may contain another zip file if it's coming from GitHub
 	// artifacts @TODO: Don't make so many guesses about the zip file contents.

--- a/packages/playground/wordpress/src/index.ts
+++ b/packages/playground/wordpress/src/index.ts
@@ -505,8 +505,7 @@ export async function unzipWordPress(
 	// uncompressed tar is never materialized.
 	const magic = new Uint8Array(await wpZip.slice(0, 4).arrayBuffer());
 	if (isZstdBundle(magic)) {
-		const bytes = new Uint8Array(await wpZip.arrayBuffer());
-		const tarStream = await createDecodedTarStream(bytes, 'zstd');
+		const tarStream = await createDecodedTarStream(wpZip.stream(), 'zstd');
 		const stats = await extractTarStreamToPhp(
 			tarStream,
 			php,

--- a/packages/playground/wordpress/src/legacy-wp/legacy-boot.ts
+++ b/packages/playground/wordpress/src/legacy-wp/legacy-boot.ts
@@ -103,7 +103,9 @@ export async function bootLegacyWordPress(
 	}
 
 	if (options.wordPressZip) {
-		await unzipWordPress(php, await options.wordPressZip);
+		await unzipWordPress(php, await options.wordPressZip, {
+			expectedFileCount: options.wordPressBundleFileCount,
+		});
 	}
 
 	if (options.constants) {

--- a/packages/playground/wordpress/src/streaming-tar-extract.spec.ts
+++ b/packages/playground/wordpress/src/streaming-tar-extract.spec.ts
@@ -1,8 +1,12 @@
 import { readFileSync } from 'node:fs';
 import {
 	createDecodedTarStream,
+	extractTarStreamToPhp,
+	isZipBundle,
+	isZstdBundle,
 	sanitizeTarPath,
 	StreamingTarParser,
+	type PhpFsTarget,
 	type TarEntry,
 } from './streaming-tar-extract';
 
@@ -149,6 +153,35 @@ function readFixture(name: string): Uint8Array {
 	);
 }
 
+/** In-memory PHP-WASM filesystem stand-in. */
+function fakePhp() {
+	const files = new Map<string, Uint8Array>();
+	const dirs = new Set<string>(['']);
+	const php: PhpFsTarget = {
+		mkdirTree(p: string) {
+			dirs.add(p.replace(/\/+$/, ''));
+		},
+		writeFile(p: string, data: Uint8Array) {
+			files.set(p, data);
+		},
+		fileExists(p: string) {
+			return files.has(p) || dirs.has(p.replace(/\/+$/, ''));
+		},
+	};
+	return { php, files, dirs };
+}
+
+function streamOf(bytes: Uint8Array, chunkSize = 65536) {
+	return new ReadableStream<Uint8Array>({
+		start(controller) {
+			for (let i = 0; i < bytes.length; i += chunkSize) {
+				controller.enqueue(bytes.subarray(i, i + chunkSize));
+			}
+			controller.close();
+		},
+	});
+}
+
 // ---------------------------------------------------------------------------
 
 describe('sanitizeTarPath', () => {
@@ -182,6 +215,26 @@ describe('sanitizeTarPath', () => {
 	it('returns "" for empty / dot-only names', () => {
 		expect(sanitizeTarPath('.')).toBe('');
 		expect(sanitizeTarPath('')).toBe('');
+	});
+});
+
+describe('isZstdBundle / isZipBundle', () => {
+	it('detects zstd magic', () => {
+		expect(
+			isZstdBundle(new Uint8Array([0x28, 0xb5, 0x2f, 0xfd, 0x0]))
+		).toBe(true);
+		expect(isZstdBundle(new Uint8Array([0x50, 0x4b, 0x03, 0x04]))).toBe(
+			false
+		);
+	});
+
+	it('detects zip magic', () => {
+		expect(isZipBundle(new Uint8Array([0x50, 0x4b, 0x03, 0x04]))).toBe(
+			true
+		);
+		expect(isZipBundle(new Uint8Array([0x28, 0xb5, 0x2f, 0xfd]))).toBe(
+			false
+		);
 	});
 });
 
@@ -492,6 +545,57 @@ describe('StreamingTarParser', () => {
 		// Never buffers more than one entry (~10 KiB) + a chunk + a header.
 		expect(stats.maxBuffered).toBeLessThan(32 * 1024);
 		expect(stats.fileCount).toBe(40);
+	});
+});
+
+
+describe('extractTarStreamToPhp', () => {
+	it('writes files and creates parent directories in MEMFS', async () => {
+		const { php, files, dirs } = fakePhp();
+		const stream = streamOf(
+			buildTar([
+				{ name: 'index.php', data: '<?php' },
+				{ name: 'wp-includes/version.php', data: 'v' },
+			])
+		);
+		const stats = await extractTarStreamToPhp(stream, php, '/wordpress');
+
+		expect(text(files.get('/wordpress/index.php'))).toBe('<?php');
+		expect(text(files.get('/wordpress/wp-includes/version.php'))).toBe('v');
+		expect(dirs.has('/wordpress/wp-includes')).toBe(true);
+		expect(stats.fileCount).toBe(2);
+	});
+
+	it('respects overwriteFiles=false by skipping existing files', async () => {
+		const { php, files } = fakePhp();
+		files.set('/wp/keep.txt', new TextEncoder().encode('original'));
+		const stream = streamOf(
+			buildTar([
+				{ name: 'keep.txt', data: 'REPLACED' },
+				{ name: 'new.txt', data: 'added' },
+			])
+		);
+
+		await extractTarStreamToPhp(stream, php, '/wp', {
+			overwriteFiles: false,
+		});
+
+		expect(text(files.get('/wp/keep.txt'))).toBe('original');
+		expect(text(files.get('/wp/new.txt'))).toBe('added');
+	});
+
+	it('rejects traversal entries before writing outside the root', async () => {
+		const { php, files } = fakePhp();
+		const stream = streamOf(
+			buildTar([{ name: '../../etc/evil', data: 'pwn' }])
+		);
+
+		await expect(extractTarStreamToPhp(stream, php, '/wp')).rejects.toThrow(
+			/path traversal/
+		);
+		expect([...files.keys()].some((k) => k.includes('etc/evil'))).toBe(
+			false
+		);
 	});
 });
 

--- a/packages/playground/wordpress/src/streaming-tar-extract.spec.ts
+++ b/packages/playground/wordpress/src/streaming-tar-extract.spec.ts
@@ -597,6 +597,18 @@ describe('extractTarStreamToPhp', () => {
 			false
 		);
 	});
+
+	it('keeps targetRoot=/ writes absolute', async () => {
+		const { php, files } = fakePhp();
+		const stream = streamOf(
+			buildTar([{ name: 'index.php', data: 'x' }])
+		);
+
+		await extractTarStreamToPhp(stream, php, '/');
+
+		expect(text(files.get('/index.php'))).toBe('x');
+		expect(files.has('index.php')).toBe(false);
+	});
 });
 
 

--- a/packages/playground/wordpress/src/streaming-tar-extract.ts
+++ b/packages/playground/wordpress/src/streaming-tar-extract.ts
@@ -554,7 +554,7 @@ export async function extractTarStreamToPhp(
 	options: ExtractTarStreamOptions = {}
 ): Promise<TarExtractStats> {
 	const { onProgress = () => {}, overwriteFiles = true } = options;
-	const root = String(targetRoot).replace(/\/+$/, '');
+	const root = String(targetRoot).replace(/\/+$/, '') || '/';
 	const createdDirs = new Set<string>();
 
 	const ensureDir = (dir: string): void => {

--- a/packages/playground/wordpress/src/streaming-tar-extract.ts
+++ b/packages/playground/wordpress/src/streaming-tar-extract.ts
@@ -31,10 +31,20 @@
  * erseco/wordpress-playground#2 and the sibling *-playground forks.
  */
 
-import { normalizePath, resolvePathUnder } from '@php-wasm/util';
+import {
+	dirname,
+	joinPaths,
+	normalizePath,
+	resolvePathUnder,
+} from '@php-wasm/util';
 
 const BLOCK = 512;
 const TAR_ROOT = '/__tar-root__';
+
+/** zstd frame magic number: 0x28 0xB5 0x2F 0xFD (little-endian 0xFD2FB528). */
+const ZSTD_MAGIC = [0x28, 0xb5, 0x2f, 0xfd];
+/** ZIP local-file-header magic: "PK\x03\x04". */
+const ZIP_MAGIC = [0x50, 0x4b, 0x03, 0x04];
 const textDecoder = new TextDecoder();
 
 export type TarCodec = 'zstd' | 'gzip' | 'deflate' | 'br';
@@ -57,6 +67,23 @@ export interface TarExtractStats {
 	bytesWritten: number;
 	/** Peak JS-side working buffer in bytes (leftover + current entry). */
 	maxBuffered: number;
+}
+
+/** Minimal PHP-WASM filesystem surface needed to write an extracted tree. */
+export interface PhpFsTarget {
+	mkdirTree(path: string): void;
+	writeFile(path: string, data: Uint8Array): void;
+	fileExists?(path: string): boolean;
+}
+
+/** Indicates whether bytes start with the zstd frame magic. */
+export function isZstdBundle(bytes: Uint8Array): boolean {
+	return ZSTD_MAGIC.every((b, i) => bytes[i] === b);
+}
+
+/** Indicates whether bytes start with the ZIP local-file-header magic. */
+export function isZipBundle(bytes: Uint8Array): boolean {
+	return ZIP_MAGIC.every((b, i) => bytes[i] === b);
 }
 
 /**
@@ -503,6 +530,73 @@ export async function createDecodedTarStream(
 		});
 	}
 	throw new Error(`No streaming decoder available for codec "${codec}".`);
+}
+
+export interface ExtractTarStreamOptions {
+	onProgress?: (progress: { fileCount: number; bytes: number }) => void;
+	/** When false, existing files are skipped (parity with unzip overwrite=false). */
+	overwriteFiles?: boolean;
+}
+
+/**
+ * Streams decoded tar bytes into MEMFS one entry at a time.
+ *
+ * The parser validates entry paths before this function joins them under the
+ * target root. Directory entries create directories immediately. File entries
+ * ensure their parent directory exists, then write or skip according to
+ * `overwriteFiles`. The full tar is never buffered here; each file body is
+ * passed through as soon as the parser completes that entry.
+ */
+export async function extractTarStreamToPhp(
+	tarStream: ReadableStream<Uint8Array>,
+	php: PhpFsTarget,
+	targetRoot: string,
+	options: ExtractTarStreamOptions = {}
+): Promise<TarExtractStats> {
+	const { onProgress = () => {}, overwriteFiles = true } = options;
+	const root = String(targetRoot).replace(/\/+$/, '');
+	const createdDirs = new Set<string>();
+
+	const ensureDir = (dir: string): void => {
+		if (!dir || createdDirs.has(dir)) return;
+		php.mkdirTree(dir);
+		let d: string | null = dir;
+		while (d && !createdDirs.has(d)) {
+			createdDirs.add(d);
+			const parent = dirname(d);
+			d = parent && parent !== d ? parent : null;
+		}
+	};
+
+	const parser = new StreamingTarParser({
+		onEntry: (entry) => {
+			const dest = joinPaths(root, entry.path);
+			if (entry.type === 'dir') {
+				ensureDir(dest);
+				return;
+			}
+			ensureDir(dirname(dest));
+			if (!overwriteFiles && php.fileExists?.(dest)) {
+				return;
+			}
+			php.writeFile(dest, entry.data);
+			if (parser.fileCount % 1000 === 0) {
+				onProgress({
+					fileCount: parser.fileCount,
+					bytes: parser.bytesWritten,
+				});
+			}
+		},
+	});
+
+	ensureDir(root);
+	const reader = tarStream.getReader();
+	for (;;) {
+		const { done, value } = await reader.read();
+		if (done) break;
+		if (value) parser.push(value);
+	}
+	return parser.end();
 }
 
 /**

--- a/packages/playground/wordpress/src/zstddec-stream.d.ts
+++ b/packages/playground/wordpress/src/zstddec-stream.d.ts
@@ -1,0 +1,13 @@
+/**
+ * zstddec exposes this subpath's types through package.json `exports`.
+ * The CLI typecheck still uses TypeScript's legacy `node` module resolution,
+ * which does not read those conditional subpath types. Keep this shim local to
+ * the WordPress package until the CLI project adopts the repo default bundler
+ * resolution.
+ */
+declare module 'zstddec/stream' {
+	export class ZSTDDecoder {
+		init(): Promise<void>;
+		decodeStreaming(chunks: Iterable<Uint8Array>): Generator<Uint8Array>;
+	}
+}

--- a/packages/playground/wordpress/vite.config.ts
+++ b/packages/playground/wordpress/vite.config.ts
@@ -12,7 +12,7 @@ import viteGlobalExtensions from '../../vite-extensions/vite-global-extensions';
 const path = (filename: string) => new URL(filename, import.meta.url).pathname;
 export default defineConfig({
 	root: __dirname,
-	assetsInclude: ['**/*.wasm', '**/*.dat', '*.zip'],
+	assetsInclude: ['**/*.wasm', '**/*.dat', '*.zip', '**/*.tar.zst'],
 	cacheDir: '../../../node_modules/.vite/playground-wordpress',
 	plugins: [
 		viteTsConfigPaths({


### PR DESCRIPTION
## What it does

Adds the runtime extraction path for `tar.zst` WordPress core bundles while keeping the existing `wordPressZip` / `unzipWordPress()` API names.

This PR does not switch committed WordPress core bundle artifacts to `tar.zst`. ZIP inputs from wordpress.org, custom URLs, trunk/nightly downloads, plugins, themes, Blueprints, and GitHub artifacts stay on the existing ZIP path.

## Rationale

#3926 added the TAR parser and #3927 added the zstd decoder stream. The next step for #3913 is making WordPress boot able to consume a `tar.zst` core bundle before changing the produced bundle artifacts.

Keeping runtime support separate from the artifact switch lets reviewers validate the extraction behavior, API compatibility, and ZIP fallback path independently.

## Implementation

`unzipWordPress()` now sniffs the first four bytes of the supplied `File`:

1. zstd magic (`28 b5 2f fd`) routes through `createDecodedTarStream(..., 'zstd')`.
2. Decoded TAR bytes stream into `extractTarStreamToPhp()` one entry at a time.
3. ZIP and all other inputs continue through `unzipFile()` / PHP `ZipArchive`.
4. `wordPressBundleFileCount` enables a tar.zst-only file-count parity check when bundle metadata provides one.

The extractor writes files under `/tmp/unzipped-wordpress`, rejects unsafe TAR entries through the parser, preserves `overwriteFiles=false`, and handles `targetRoot='/'` as an absolute root instead of producing relative paths.

## Testing instructions

```bash
npx nx test playground-wordpress --testFile=streaming-tar-extract.spec.ts
npx nx run playground-wordpress:lint
```

CI should run the broader package, typecheck, and browser/CLI coverage for the rebased PR.
