### PR TITLE
[PHP] Add zstd decoder stream for tar bundles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,8 @@
 				"wasm-feature-detect": "1.8.0",
 				"xml2js": "0.6.2",
 				"yargs": "17.7.2",
-				"zod": "4.3.6"
+				"zod": "4.3.6",
+				"zstddec": "^0.2.0"
 			},
 			"devDependencies": {
 				"@docusaurus/core": "3.9.2",
@@ -53770,6 +53771,12 @@
 			"peerDependencies": {
 				"zod": "^3.25.28 || ^4"
 			}
+		},
+		"node_modules/zstddec": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/zstddec/-/zstddec-0.2.0.tgz",
+			"integrity": "sha512-oyPnDa1X5c13+Y7mA/FDMNJrn4S8UNBe0KCqtDmor40Re7ALrPN6npFwyYVRRh+PqozZQdeg23QtbcamZnG5rA==",
+			"license": "MIT AND BSD-3-Clause"
 		},
 		"node_modules/zwitch": {
 			"version": "2.0.4",

--- a/package.json
+++ b/package.json
@@ -123,7 +123,8 @@
 		"wasm-feature-detect": "1.8.0",
 		"xml2js": "0.6.2",
 		"yargs": "17.7.2",
-		"zod": "4.3.6"
+		"zod": "4.3.6",
+		"zstddec": "^0.2.0"
 	},
 	"devDependencies": {
 		"@docusaurus/core": "3.9.2",

--- a/packages/playground/wordpress/src/streaming-tar-extract.spec.ts
+++ b/packages/playground/wordpress/src/streaming-tar-extract.spec.ts
@@ -1,5 +1,4 @@
 import { readFileSync } from 'node:fs';
-import zlib from 'node:zlib';
 import {
 	createDecodedTarStream,
 	sanitizeTarPath,
@@ -510,63 +509,102 @@ async function collectStream(stream: ReadableStream<Uint8Array>) {
 	return { entries, stats };
 }
 
-// node:zlib gained zstd in Node 22.15; the CI unit-test job runs Node 20, where
-// the fixture compression below is unavailable. The zstddec decode path still
-// typechecks and bundles on Node 20, and this round-trip runs on newer Node.
-const HAS_NODE_ZSTD = typeof (zlib as any).zstdCompressSync === 'function';
+const ZSTD_FIXTURE_LONG_NAME =
+	'wp-content/plugins/' + 'z'.repeat(80) + '/main.php';
 
-describe.skipIf(!HAS_NODE_ZSTD)(
-	'createDecodedTarStream + round-trip (real zstd)',
-	() => {
-		function zstd(bytes: Uint8Array): Uint8Array {
-			// node:zlib zstd (Node >= 22.15) — cast because the installed
-			// @types/node may predate the zstd typings.
-			const z = zlib as any;
-			return new Uint8Array(
-				z.zstdCompressSync(bytes, {
-					params: {
-						[z.constants.ZSTD_c_compressionLevel]: 19,
-						[z.constants.ZSTD_c_windowLog]: 24,
-					},
-				})
-			);
-		}
+// Generated with bsdtar 3.7.7 and zstd 1.5.6 from a deterministic USTAR
+// archive. Keeping pre-compressed bytes here lets Node 20 CI exercise the
+// zstddec fallback without relying on node:zlib's newer zstd compressor.
+const ZSTD_TAR_FIXTURE = Buffer.from(
+	[
+		'KLUv/WQAIz0RAHQaaW5kZXgucGhwADAwMDY0NCAAMDE1IDA3MDMzMjMyNTYwIDAxMjY1MAAgMAB1',
+		'c3RhcgAwMHJvb3QAPD8gLy8gd3AtaW5jbHVkZXMvdmVyc2lvbjIyNTQ1NiR3cF89JzYuOSc7Y29u',
+		'dGVudC83NTUwMDMxMzIAIDVwbHVnaW5zLzQ2MTN6LzM3N21haTA2NDEzMDRhc3NldHMvYmxvYi5i',
+		'aW41NjcwMzcABw4VHCMqMTg/Rk1UW2JpcHd+hYyTmqGor7a9xMvS2eDn7vX8AwoRGB8mLTQ7QklQ',
+		'V15lbHN6gYiPlp2kq7K5wMfO1dzj6vH4/wYNFBsiKTA3PkVMU1phaG92fYSLkpmgp661vMPK0djf',
+		'5u30+wIJEBceJSwzOkFIT1ZdZGtyeYCHjpWco6qxuL/GzdTb4unw9/4FDBMaISgvNj1ES1JZYGdu',
+		'dXyDipGYn6attLvCydDX3uXs8/oBCA8WHSQrMjlAR05VXGNqcXh/ho2Um6KpsLe+xczT2uHo7/b9',
+		'BAsSGSAnLjU8Q0pRWF9mbXR7gomQl56lrLO6wcjP1t3k6/L5LSDATCIJhjYPS1DBfe2pAgC1GqA/',
+		'ywacikFHxAGZCu7C83dVG1AXkaDAlQF2UNoyHhBJaBKFMXxOoKzqKEfHgDK7agY45QGMAIZqdPgw',
+		'CYB04u5Imf0uGVsl0KEPYFMYwed4R8qOXSD/A0iSVID9DGMDHP7ANBNMGRDOTQoJWdFM+Q==',
+	].join(''),
+	'base64'
+);
 
-		it('streams a .tar.zst through zstddec into the tar parser', async () => {
-			const longName =
-				'wp-content/plugins/' + 'z'.repeat(140) + '/main.php';
-			const binary = Buffer.alloc(3000);
-			for (let i = 0; i < binary.length; i += 1)
-				binary[i] = (i * 7) % 256;
-			const tar = buildTar([
-				{ name: 'index.php', data: '<?php // root' },
-				{ name: 'wp-includes/version.php', data: "$wp_version='6.9';" },
-				{ longLink: longName, name: 'trunc', data: 'plugin' },
-				{ name: 'assets/blob.bin', data: binary },
-			]);
+function chunkedStream(bytes: Uint8Array, chunkSizes: number[]) {
+	let offset = 0;
+	let chunkIndex = 0;
+	return new ReadableStream<Uint8Array>({
+		pull(controller) {
+			if (offset >= bytes.length) {
+				controller.close();
+				return;
+			}
+			const size = chunkSizes[chunkIndex++] ?? 17;
+			const nextOffset = Math.min(offset + size, bytes.length);
+			controller.enqueue(bytes.slice(offset, nextOffset));
+			offset = nextOffset;
+		},
+	});
+}
 
-			const stream = await createDecodedTarStream(zstd(tar), 'zstd');
+async function withoutNativeDecompressionStream<T>(callback: () => Promise<T>) {
+	const original = globalThis.DecompressionStream;
+	Object.defineProperty(globalThis, 'DecompressionStream', {
+		configurable: true,
+		value: undefined,
+		writable: true,
+	});
+	try {
+		return await callback();
+	} finally {
+		Object.defineProperty(globalThis, 'DecompressionStream', {
+			configurable: true,
+			value: original,
+			writable: true,
+		});
+	}
+}
+
+describe('createDecodedTarStream + zstddec fallback', () => {
+	it('streams a .tar.zst fixture through zstddec into the tar parser', async () => {
+		await withoutNativeDecompressionStream(async () => {
+			const stream = await createDecodedTarStream(ZSTD_TAR_FIXTURE, 'zstd');
 			const { entries, stats } = await collectStream(stream);
+			const binary = Buffer.alloc(3000);
+			for (let i = 0; i < binary.length; i += 1) {
+				binary[i] = (i * 7) % 256;
+			}
 
 			expect(stats.fileCount).toBe(4);
 			expect(text((entries[0] as any).data)).toBe('<?php // root');
-			expect(entries[2].path).toBe(longName);
-			expect(text((entries[2] as any).data)).toBe('plugin');
-			expect(Buffer.from((entries[3] as any).data).equals(binary)).toBe(
+			expect(text((entries[1] as any).data)).toBe("$wp_version='6.9';");
+			expect(entries[5].path).toBe(ZSTD_FIXTURE_LONG_NAME);
+			expect(text((entries[5] as any).data)).toBe('plugin');
+			expect(Buffer.from((entries[6] as any).data).equals(binary)).toBe(
 				true
 			);
 		});
+	});
 
-		it('returns parser stats so callers can enforce file-count parity', async () => {
-			const tar = buildTar([
-				{ name: 'a.txt', data: '1' },
-				{ name: 'b.txt', data: '2' },
-			]);
-			const stream = await createDecodedTarStream(zstd(tar), 'zstd');
-			const { stats } = await collectStream(stream);
+	it('accepts compressed source streams split across chunk boundaries', async () => {
+		await withoutNativeDecompressionStream(async () => {
+			const source = chunkedStream(ZSTD_TAR_FIXTURE, [1, 2, 3, 5, 8, 13]);
+			const stream = await createDecodedTarStream(source, 'zstd');
+			const { entries, stats } = await collectStream(stream);
 			const expectedFileCount = 3; // deliberately wrong
+
 			expect(stats.fileCount).not.toBe(expectedFileCount);
-			expect(stats.fileCount).toBe(2);
+			expect(stats.fileCount).toBe(4);
+			expect(entries.map((entry) => entry.path)).toEqual([
+				'index.php',
+				'wp-includes/version.php',
+				'wp-content',
+				'wp-content/plugins',
+				'wp-content/plugins/' + 'z'.repeat(80),
+				ZSTD_FIXTURE_LONG_NAME,
+				'assets/blob.bin',
+			]);
 		});
-	}
-);
+	});
+});

--- a/packages/playground/wordpress/src/streaming-tar-extract.spec.ts
+++ b/packages/playground/wordpress/src/streaming-tar-extract.spec.ts
@@ -1,5 +1,7 @@
 import { readFileSync } from 'node:fs';
+import zlib from 'node:zlib';
 import {
+	createDecodedTarStream,
 	sanitizeTarPath,
 	StreamingTarParser,
 	type TarEntry,
@@ -493,3 +495,78 @@ describe('StreamingTarParser', () => {
 		expect(stats.fileCount).toBe(40);
 	});
 });
+
+
+async function collectStream(stream: ReadableStream<Uint8Array>) {
+	const entries: TarEntry[] = [];
+	const parser = new StreamingTarParser({ onEntry: (e) => entries.push(e) });
+	const reader = stream.getReader();
+	for (;;) {
+		const { done, value } = await reader.read();
+		if (done) break;
+		if (value) parser.push(value);
+	}
+	const stats = parser.end();
+	return { entries, stats };
+}
+
+// node:zlib gained zstd in Node 22.15; the CI unit-test job runs Node 20, where
+// the fixture compression below is unavailable. The zstddec decode path still
+// typechecks and bundles on Node 20, and this round-trip runs on newer Node.
+const HAS_NODE_ZSTD = typeof (zlib as any).zstdCompressSync === 'function';
+
+describe.skipIf(!HAS_NODE_ZSTD)(
+	'createDecodedTarStream + round-trip (real zstd)',
+	() => {
+		function zstd(bytes: Uint8Array): Uint8Array {
+			// node:zlib zstd (Node >= 22.15) — cast because the installed
+			// @types/node may predate the zstd typings.
+			const z = zlib as any;
+			return new Uint8Array(
+				z.zstdCompressSync(bytes, {
+					params: {
+						[z.constants.ZSTD_c_compressionLevel]: 19,
+						[z.constants.ZSTD_c_windowLog]: 24,
+					},
+				})
+			);
+		}
+
+		it('streams a .tar.zst through zstddec into the tar parser', async () => {
+			const longName =
+				'wp-content/plugins/' + 'z'.repeat(140) + '/main.php';
+			const binary = Buffer.alloc(3000);
+			for (let i = 0; i < binary.length; i += 1)
+				binary[i] = (i * 7) % 256;
+			const tar = buildTar([
+				{ name: 'index.php', data: '<?php // root' },
+				{ name: 'wp-includes/version.php', data: "$wp_version='6.9';" },
+				{ longLink: longName, name: 'trunc', data: 'plugin' },
+				{ name: 'assets/blob.bin', data: binary },
+			]);
+
+			const stream = await createDecodedTarStream(zstd(tar), 'zstd');
+			const { entries, stats } = await collectStream(stream);
+
+			expect(stats.fileCount).toBe(4);
+			expect(text((entries[0] as any).data)).toBe('<?php // root');
+			expect(entries[2].path).toBe(longName);
+			expect(text((entries[2] as any).data)).toBe('plugin');
+			expect(Buffer.from((entries[3] as any).data).equals(binary)).toBe(
+				true
+			);
+		});
+
+		it('returns parser stats so callers can enforce file-count parity', async () => {
+			const tar = buildTar([
+				{ name: 'a.txt', data: '1' },
+				{ name: 'b.txt', data: '2' },
+			]);
+			const stream = await createDecodedTarStream(zstd(tar), 'zstd');
+			const { stats } = await collectStream(stream);
+			const expectedFileCount = 3; // deliberately wrong
+			expect(stats.fileCount).not.toBe(expectedFileCount);
+			expect(stats.fileCount).toBe(2);
+		});
+	}
+);

--- a/packages/playground/wordpress/src/streaming-tar-extract.ts
+++ b/packages/playground/wordpress/src/streaming-tar-extract.ts
@@ -429,65 +429,43 @@ export class StreamingTarParser {
 
 /**
  * Build a ReadableStream of decoded tar bytes from the compressed bundle.
+ *
  * Feature-detected native DecompressionStream is used first. zstd falls back to
- * zstddec's streaming generator. The generator is lazy — it yields ~128 KiB
- * chunks and holds only the zstd window in WASM, so the JS side never sees the
- * whole tar.
+ * zstddec's streaming generator. zstddec consumes a synchronous iterable, so a
+ * ReadableStream source is first collected as compressed chunks. The fallback
+ * still yields decompressed ~128 KiB chunks and never materializes the full tar
+ * in JS.
  */
 export async function createDecodedTarStream(
 	compressed: Uint8Array | ReadableStream<Uint8Array>,
 	codec: TarCodec
 ): Promise<ReadableStream<Uint8Array>> {
-	const normalized = codec === 'br' ? 'brotli' : codec;
 	const compressedStream = toReadableStream(compressed);
 	if (typeof DecompressionStream !== 'undefined') {
 		try {
-			const ds = new DecompressionStream(normalized as CompressionFormat);
+			const ds = new DecompressionStream(codec as CompressionFormat);
 			return compressedStream.pipeThrough(ds);
 		} catch {
 			// Not natively supported — fall through to a bundled decoder.
 		}
 	}
-	if (normalized === 'zstd') {
+	if (codec === 'zstd') {
 		// zstddec exposes the streaming decoder via its './stream' subpath export.
 		const { ZSTDDecoder } = await import('zstddec/stream');
 		const decoder = new ZSTDDecoder();
 		await decoder.init();
 
-		const reader = compressedStream.getReader();
-		let currentChunk: Uint8Array | undefined;
-		let sourceDone = false;
-		let decoderDone = false;
-		const compressedChunks: Iterable<Uint8Array> = {
-			[Symbol.iterator]() {
-				return {
-					next(): IteratorResult<Uint8Array> {
-						if (currentChunk) {
-							const value = currentChunk;
-							currentChunk = undefined;
-							return { value, done: false };
-						}
-						return { value: undefined, done: true };
-					},
-				};
-			},
-		};
+		const compressedChunks = await toChunkIterable(compressed);
 		const generator = decoder.decodeStreaming(compressedChunks);
+		let decoderDone = false;
 		return new ReadableStream<Uint8Array>({
-			async pull(controller) {
+			pull(controller) {
 				if (decoderDone) {
 					controller.close();
 					return;
 				}
 				try {
 					for (;;) {
-						if (!currentChunk && !sourceDone) {
-							const next = await reader.read();
-							sourceDone = next.done;
-							if (!next.done) {
-								currentChunk = next.value;
-							}
-						}
 						const { value, done } = generator.next();
 						if (done) {
 							decoderDone = true;
@@ -502,13 +480,12 @@ export async function createDecodedTarStream(
 					}
 				} catch (e) {
 					decoderDone = true;
-					await reader.cancel(e).catch(() => {});
 					controller.error(e);
 				}
 			},
-			async cancel(reason) {
+			cancel() {
 				decoderDone = true;
-				await reader.cancel(reason);
+				generator.return?.(undefined);
 			},
 		});
 	}
@@ -522,6 +499,29 @@ function toReadableStream(
 		return bytesOrStream;
 	}
 	return new Blob([bytesOrStream]).stream();
+}
+
+async function toChunkIterable(
+	bytesOrStream: Uint8Array | ReadableStream<Uint8Array>
+): Promise<Iterable<Uint8Array>> {
+	if (!isReadableStream(bytesOrStream)) {
+		return [bytesOrStream];
+	}
+	const reader = bytesOrStream.getReader();
+	const chunks: Uint8Array[] = [];
+	try {
+		for (;;) {
+			const { done, value } = await reader.read();
+			if (done) break;
+			chunks.push(value);
+		}
+		return chunks;
+	} catch (e) {
+		await reader.cancel(e).catch(() => {});
+		throw e;
+	} finally {
+		reader.releaseLock();
+	}
 }
 
 function isReadableStream(

--- a/packages/playground/wordpress/src/streaming-tar-extract.ts
+++ b/packages/playground/wordpress/src/streaming-tar-extract.ts
@@ -29,6 +29,8 @@ const BLOCK = 512;
 const TAR_ROOT = '/__tar-root__';
 const textDecoder = new TextDecoder();
 
+export type TarCodec = 'zstd' | 'gzip' | 'deflate' | 'br';
+
 export interface TarFileEntry {
 	type: 'file';
 	path: string;
@@ -423,6 +425,111 @@ export class StreamingTarParser {
 		if (path.endsWith('.php')) this.phpCount += 1;
 		this.onEntry({ type: 'file', path, data });
 	}
+}
+
+/**
+ * Build a ReadableStream of decoded tar bytes from the compressed bundle.
+ * Feature-detected native DecompressionStream is used first. zstd falls back to
+ * zstddec's streaming generator. The generator is lazy — it yields ~128 KiB
+ * chunks and holds only the zstd window in WASM, so the JS side never sees the
+ * whole tar.
+ */
+export async function createDecodedTarStream(
+	compressed: Uint8Array | ReadableStream<Uint8Array>,
+	codec: TarCodec
+): Promise<ReadableStream<Uint8Array>> {
+	const normalized = codec === 'br' ? 'brotli' : codec;
+	const compressedStream = toReadableStream(compressed);
+	if (typeof DecompressionStream !== 'undefined') {
+		try {
+			const ds = new DecompressionStream(normalized as CompressionFormat);
+			return compressedStream.pipeThrough(ds);
+		} catch {
+			// Not natively supported — fall through to a bundled decoder.
+		}
+	}
+	if (normalized === 'zstd') {
+		// zstddec exposes the streaming decoder via its './stream' subpath export.
+		const { ZSTDDecoder } = await import('zstddec/stream');
+		const decoder = new ZSTDDecoder();
+		await decoder.init();
+
+		const reader = compressedStream.getReader();
+		let currentChunk: Uint8Array | undefined;
+		let sourceDone = false;
+		let decoderDone = false;
+		const compressedChunks: Iterable<Uint8Array> = {
+			[Symbol.iterator]() {
+				return {
+					next(): IteratorResult<Uint8Array> {
+						if (currentChunk) {
+							const value = currentChunk;
+							currentChunk = undefined;
+							return { value, done: false };
+						}
+						return { value: undefined, done: true };
+					},
+				};
+			},
+		};
+		const generator = decoder.decodeStreaming(compressedChunks);
+		return new ReadableStream<Uint8Array>({
+			async pull(controller) {
+				if (decoderDone) {
+					controller.close();
+					return;
+				}
+				try {
+					for (;;) {
+						if (!currentChunk && !sourceDone) {
+							const next = await reader.read();
+							sourceDone = next.done;
+							if (!next.done) {
+								currentChunk = next.value;
+							}
+						}
+						const { value, done } = generator.next();
+						if (done) {
+							decoderDone = true;
+							controller.close();
+							return;
+						}
+						if (value.length === 0) {
+							continue;
+						}
+						controller.enqueue(value);
+						return;
+					}
+				} catch (e) {
+					decoderDone = true;
+					await reader.cancel(e).catch(() => {});
+					controller.error(e);
+				}
+			},
+			async cancel(reason) {
+				decoderDone = true;
+				await reader.cancel(reason);
+			},
+		});
+	}
+	throw new Error(`No streaming decoder available for codec "${codec}".`);
+}
+
+function toReadableStream(
+	bytesOrStream: Uint8Array | ReadableStream<Uint8Array>
+): ReadableStream<Uint8Array> {
+	if (isReadableStream(bytesOrStream)) {
+		return bytesOrStream;
+	}
+	return new Blob([bytesOrStream]).stream();
+}
+
+function isReadableStream(
+	value: Uint8Array | ReadableStream<Uint8Array>
+): value is ReadableStream<Uint8Array> {
+	return (
+		typeof ReadableStream !== 'undefined' && value instanceof ReadableStream
+	);
 }
 
 /**

--- a/packages/playground/wordpress/src/streaming-tar-extract.ts
+++ b/packages/playground/wordpress/src/streaming-tar-extract.ts
@@ -19,6 +19,14 @@
  * TAR-slip. Symlinks and other exotic entry types are rejected. Malformed or
  * truncated archives throw before callers write files.
  *
+ * Compressed tar decoding lives in this file so callers can keep one extraction
+ * path. Native `DecompressionStream` is used for browser-supported codecs.
+ * zstd has a bundled `zstddec` fallback for browsers without native zstd
+ * support. That fallback receives a synchronous iterable, so `ReadableStream`
+ * input is first drained as compressed chunks; decoded tar bytes are still
+ * emitted incrementally and the full decompressed tar is never materialized in
+ * JS.
+ *
  * Adapted for wordpress-playground from the measured PoC in
  * erseco/wordpress-playground#2 and the sibling *-playground forks.
  */
@@ -428,13 +436,18 @@ export class StreamingTarParser {
 }
 
 /**
- * Build a ReadableStream of decoded tar bytes from the compressed bundle.
+ * Returns a stream of decoded tar bytes from a compressed tar bundle.
  *
- * Feature-detected native DecompressionStream is used first. zstd falls back to
- * zstddec's streaming generator. zstddec consumes a synchronous iterable, so a
- * ReadableStream source is first collected as compressed chunks. The fallback
- * still yields decompressed ~128 KiB chunks and never materializes the full tar
- * in JS.
+ * Native `DecompressionStream` is tried first for every codec, including `br`.
+ * If the runtime does not support the requested codec, only `zstd` has a
+ * bundled fallback. Unsupported native codecs without a fallback fail loudly
+ * instead of silently returning compressed bytes.
+ *
+ * The `zstddec` fallback is streaming on output but not on input: its API takes
+ * a synchronous iterable of compressed chunks. `ReadableStream` sources are
+ * therefore drained into compressed chunks before the decoded stream is
+ * returned. This keeps the full decompressed tar out of JS memory while making
+ * the input buffering tradeoff explicit.
  */
 export async function createDecodedTarStream(
 	compressed: Uint8Array | ReadableStream<Uint8Array>,
@@ -492,6 +505,13 @@ export async function createDecodedTarStream(
 	throw new Error(`No streaming decoder available for codec "${codec}".`);
 }
 
+/**
+ * Normalizes compressed bundle input for the native decompression path.
+ *
+ * Native `DecompressionStream` works with Web streams. `Uint8Array` input is
+ * wrapped with `Blob.stream()` so callers can pass either already-fetched bytes
+ * or a streaming response body.
+ */
 function toReadableStream(
 	bytesOrStream: Uint8Array | ReadableStream<Uint8Array>
 ): ReadableStream<Uint8Array> {
@@ -501,6 +521,15 @@ function toReadableStream(
 	return new Blob([bytesOrStream]).stream();
 }
 
+/**
+ * Returns compressed chunks in the synchronous shape required by `zstddec`.
+ *
+ * `zstddec/stream` exposes `decodeStreaming()` as a synchronous generator over
+ * compressed chunks. It cannot await a `ReadableStream` between pulls, so stream
+ * input is drained here before decoding starts. Only compressed bytes are
+ * buffered; decoded tar chunks are still produced lazily by the returned
+ * decoder stream.
+ */
 async function toChunkIterable(
 	bytesOrStream: Uint8Array | ReadableStream<Uint8Array>
 ): Promise<Iterable<Uint8Array>> {


### PR DESCRIPTION
## What it does

Adds `createDecodedTarStream()`, a streaming codec layer that turns compressed TAR bundle bytes into a `ReadableStream<Uint8Array>` for `StreamingTarParser` from #3926.

This PR adds the `zstddec` fallback needed for future `tar.zst` WordPress core bundles. It does not switch any WordPress bundle URLs or boot paths to `tar.zst` yet.

## Rationale

The parser from #3926 consumes plain TAR bytes. The bundle work in #3913 needs to feed it `.tar.zst` bytes, but browser support for native `DecompressionStream('zstd')` is not universal.

Keeping this as a small follow-up makes the dependency and decoder behavior reviewable on their own before the PR that changes the actual WordPress bundle format.

## Implementation

`createDecodedTarStream(compressed, codec)`:

1. Accepts either a `Uint8Array` or `ReadableStream<Uint8Array>`.
2. Uses native `DecompressionStream` when the runtime supports the requested codec.
3. Falls back to `zstddec/stream` for `codec === 'zstd'`.
4. Propagates decoder failures through the returned stream.

The zstd fallback uses `ZSTDDecoder.decodeStreaming()` to emit decoded TAR chunks without materializing the full decompressed archive in JS. Because `zstddec` consumes a synchronous iterable, `ReadableStream` input is first collected as compressed chunks before the decoder stream is returned.

Related: #3913

## Testing instructions

```bash
npx nx test playground-wordpress --testFile=streaming-tar-extract.spec.ts
npx nx run playground-wordpress:lint
npx nx build playground-wordpress
```

The zstd fallback test uses a checked-in `.tar.zst` byte fixture generated with `bsdtar` and `zstd`, so it runs on Node 20 without `node:zlib` zstd compression support.
