### PR TITLE
[Blueprints] Type Blueprint v2 SQL dump content

### DIFF
--- a/packages/playground/blueprints/src/lib/v2/wep-1-blueprint-v2-schema/appendix-A-blueprint-v2-schema.ts
+++ b/packages/playground/blueprints/src/lib/v2/wep-1-blueprint-v2-schema/appendix-A-blueprint-v2-schema.ts
@@ -459,12 +459,12 @@ export namespace V2Schema {
 	};
 
 	type ContentDefinition =
-		| ({
+		| {
 				type: 'mysql-dump';
 				source:
 					| DataSources.FileDataReference
 					| DataSources.FileDataReference[];
-		  } & URLMappingConfig)
+		  }
 		| ({
 				type: 'posts';
 				source:

--- a/packages/playground/blueprints/src/tests/v2/blueprint-v2-declaration.spec.ts
+++ b/packages/playground/blueprints/src/tests/v2/blueprint-v2-declaration.spec.ts
@@ -343,6 +343,18 @@ const blueprintWithNonComparablePHPVersionRecommendation = {
 	},
 } satisfies BlueprintV2Declaration;
 
+const blueprintWithUrlMappingForMysqlDump = {
+	version: 2,
+	content: [
+		{
+			type: 'mysql-dump',
+			source: './dump.sql',
+			// @ts-expect-error URL mapping does not apply to SQL dump imports.
+			urlsMode: 'rewrite',
+		},
+	],
+} satisfies BlueprintV2Declaration;
+
 void blueprintWithDirectoryAsRunPHPCode;
 void blueprintWithDirectoryAsMediaSource;
 void blueprintWithNestedDirectoryName;
@@ -354,3 +366,4 @@ void blueprintWithNonComparableWordPressVersionMinimum;
 void blueprintWithExtraWordPressVersionComponent;
 void blueprintWithUnsupportedWordPressVersionRecommendation;
 void blueprintWithNonComparablePHPVersionRecommendation;
+void blueprintWithUrlMappingForMysqlDump;


### PR DESCRIPTION
## What it does

Removes URL rewrite options from Blueprint v2 `mysql-dump` content entries.

Part of #2592.

## Rationale

`urlsMode` and `urlsMap` apply to structured content imports such as WXR and posts. A raw SQL dump does not go through that URL rewrite path, so exposing those fields on `mysql-dump` suggests behavior the runner should not promise.

## Implementation

Keeps `mysql-dump` content entries typed as `{ type, source }` instead of intersecting them with `URLMappingConfig`.

Added a type-level regression for this invalid shape:

```ts
{
	type: 'mysql-dump',
	source: './dump.sql',
	urlsMode: 'rewrite',
}
```

## Testing instructions

```bash
npx nx typecheck playground-blueprints
npx vitest run src/tests/v2/blueprint-v2-declaration.spec.ts --config vite.config.ts
npx nx lint playground-blueprints
```