### PR TITLE
[Website] Keep MCP sessions out of autosave restore prompts

### DIFF
--- a/packages/playground/mcp/tests/e2e/mcp-tools.spec.ts
+++ b/packages/playground/mcp/tests/e2e/mcp-tools.spec.ts
@@ -60,16 +60,6 @@ const test = base.extend<McpTestFixtures, McpWorkerFixtures>({
 				`http://127.0.0.1:5400/website-server/?mcp-port=${MCP_WS_PORT}`
 			);
 
-			// Wait for WordPress to load inside the nested iframes
-			await expect(
-				page
-					.frameLocator(
-						'#playground-viewport:visible,.playground-viewport:visible'
-					)
-					.frameLocator('#wp')
-					.locator('body')
-			).not.toBeEmpty();
-
 			// Wait for the MCP bridge to register at least one active
 			// site. The Playground website may do internal navigation
 			// after the initial load, causing the bridge to disconnect
@@ -226,14 +216,7 @@ test('playground_open_site_in_new_tab activates an inactive site in a new tab', 
 	await playgroundPage.goto(
 		`http://127.0.0.1:5400/website-server/?mcp-port=${MCP_WS_PORT}`
 	);
-	await expect(
-		playgroundPage
-			.frameLocator(
-				'#playground-viewport:visible,.playground-viewport:visible'
-			)
-			.frameLocator('#wp')
-			.locator('body')
-	).not.toBeEmpty();
+	await waitForActiveSite(mcpClient);
 
 	// Wait for the saved site to appear as inactive
 	await expect

--- a/packages/playground/website/playwright/e2e/website-ui.spec.ts
+++ b/packages/playground/website/playwright/e2e/website-ui.spec.ts
@@ -1406,10 +1406,6 @@ test.describe('Default Playground storage', () => {
 				/Another Playground was created .* from the same URL\./
 			)
 		).toBeVisible();
-		await website.waitForNestedIframes();
-		await expect(
-			website.page.getByRole('button', { name: 'Unsaved' })
-		).toBeVisible();
 		await website.page
 			.getByRole('button', { name: 'Restore Autosave' })
 			.click();
@@ -1431,6 +1427,47 @@ echo get_option('blogname');
 			return result.text;
 		});
 		expect(blogName).toBe(expectedBlogName);
+	});
+
+	test('should keep the new Playground when the restore nudge is dismissed immediately', async ({
+		website,
+		browserName,
+	}) => {
+		test.skip(
+			browserName !== 'chromium',
+			`Saved-by-default Playgrounds rely on OPFS, which is not available in Playwright's ${browserName}.`
+		);
+
+		const setupUrl = getUniqueSavedPlaygroundSetupUrl('keep-new', {
+			php: '8.3',
+		});
+		const consoleErrors: string[] = [];
+		website.page.on('console', (message) => {
+			if (message.type() === 'error') {
+				consoleErrors.push(message.text());
+			}
+		});
+
+		await website.goto(setupUrl);
+		await expect(
+			website.page.getByRole('button', { name: 'Autosaved' })
+		).toBeVisible({ timeout: 120000 });
+		await runPHPAndFlushOpfs(
+			website.page,
+			updateBlogNameCode(`Keep New Playground ${Date.now()}`)
+		);
+
+		await website.goto(setupUrl);
+		await website.page.getByRole('button', { name: 'No, thanks' }).click();
+		await expect(
+			website.page.getByText('Recent autosave available')
+		).toHaveCount(0);
+		await expect(
+			website.page.getByRole('button', { name: 'Autosaved' })
+		).toBeVisible({ timeout: 120000 });
+		expect(consoleErrors.join('\n')).not.toContain(
+			'must have an active client to be saved'
+		);
 	});
 
 	test('should start fresh from a setup URL when an autosave exists', async ({

--- a/packages/playground/website/src/components/ensure-playground-site/ensure-playground-site-is-selected.tsx
+++ b/packages/playground/website/src/components/ensure-playground-site/ensure-playground-site-is-selected.tsx
@@ -55,9 +55,11 @@ export function EnsurePlaygroundSiteIsSelected({
 		selectSiteBySlug(state, requestedSiteSlug!)
 	);
 	const isSavingDisabled = isSiteSavingDisabled(url);
+	const isMcpServerBridgeEnabled = url.searchParams.has('mcp-port');
 	const shouldUseTemporarySite =
 		url.searchParams.get('storage') === 'temp' ||
 		isSavingDisabled ||
+		isMcpServerBridgeEnabled ||
 		!opfsSiteStorage;
 	const requestedClientInfo = useAppSelector(
 		(state) =>
@@ -200,6 +202,7 @@ export function EnsurePlaygroundSiteIsSelected({
 					);
 				if (
 					matchingAutosave &&
+					!isMcpServerBridgeEnabled &&
 					isInitialPageLoadUrl &&
 					!declinedAutosaveRestoreFingerprints.includes(
 						currentSetupUrlFingerprint

--- a/packages/playground/website/src/components/ensure-playground-site/ensure-playground-site-is-selected.tsx
+++ b/packages/playground/website/src/components/ensure-playground-site/ensure-playground-site-is-selected.tsx
@@ -69,7 +69,10 @@ export function EnsurePlaygroundSiteIsSelected({
 	const [autosaveNudge, setAutosaveNudge] = useState<{
 		site: SiteInfo;
 		setupUrlFingerprint: string;
+		temporarySiteSlug?: string;
+		temporarySiteSlugPromise: Promise<string>;
 	}>();
+	const autosaveTemporarySiteSlugPromiseRef = useRef<Promise<string>>();
 	const [
 		declinedAutosaveRestoreFingerprints,
 		setDeclinedAutosaveRestoreFingerprints,
@@ -104,6 +107,7 @@ export function EnsurePlaygroundSiteIsSelected({
 		async function ensureSiteIsSelected() {
 			const isInitialPageLoadUrl = url.href === initialUrlHref.current;
 			if (!isInitialPageLoadUrl) {
+				autosaveTemporarySiteSlugPromiseRef.current = undefined;
 				setAutosaveNudge(undefined);
 				setAutosaveNudgeError(undefined);
 			}
@@ -202,11 +206,41 @@ export function EnsurePlaygroundSiteIsSelected({
 					) &&
 					wasSiteRecentlyInteractedWith(matchingAutosave)
 				) {
+					// Start the fresh Playground in the background and activate
+					// it as soon as its site record exists. Clearing the ref
+					// prevents a late temporary-site activation from winning
+					// the race after the user restores the autosave.
+					const temporarySiteSlugPromise =
+						sitesAPI.createNewTemporarySite(undefined, undefined, {
+							activate: false,
+						});
+					autosaveTemporarySiteSlugPromiseRef.current =
+						temporarySiteSlugPromise;
 					setAutosaveNudge({
 						site: matchingAutosave,
 						setupUrlFingerprint: currentSetupUrlFingerprint,
+						temporarySiteSlugPromise,
 					});
-					await sitesAPI.createNewTemporarySite();
+
+					const temporarySiteSlug = await temporarySiteSlugPromise;
+					if (
+						autosaveTemporarySiteSlugPromiseRef.current !==
+						temporarySiteSlugPromise
+					) {
+						return;
+					}
+					setAutosaveNudge((currentNudge) =>
+						currentNudge?.temporarySiteSlugPromise ===
+						temporarySiteSlugPromise
+							? {
+									...currentNudge,
+									temporarySiteSlug,
+								}
+							: currentNudge
+					);
+					void sitesAPI.setActiveSite(temporarySiteSlug, {
+						updateUrl: false,
+					});
 					return;
 				}
 
@@ -270,6 +304,7 @@ export function EnsurePlaygroundSiteIsSelected({
 					error={autosaveNudgeError}
 					isBusy={isAutosaveNudgeActionPending}
 					onRestore={async () => {
+						autosaveTemporarySiteSlugPromiseRef.current = undefined;
 						setAutosaveNudgeError(undefined);
 						setIsAutosaveNudgeActionPending(true);
 						try {
@@ -293,16 +328,29 @@ export function EnsurePlaygroundSiteIsSelected({
 						setAutosaveNudgeError(undefined);
 						setIsAutosaveNudgeActionPending(true);
 						try {
-							await sitesAPI.autosaveTemporarySite(undefined, {
+							const temporarySiteSlug =
+								autosaveNudge.temporarySiteSlug ??
+								(await autosaveNudge.temporarySiteSlugPromise);
+							await sitesAPI.setActiveSite(temporarySiteSlug, {
 								updateUrl: false,
-								excludeFromPruning: [autosaveNudge.site.slug],
 							});
+							await sitesAPI.autosaveTemporarySite(
+								temporarySiteSlug,
+								{
+									updateUrl: false,
+									excludeFromPruning: [
+										autosaveNudge.site.slug,
+									],
+								}
+							);
 							setDeclinedAutosaveRestoreFingerprints(
 								(fingerprints) => [
 									...fingerprints,
 									autosaveNudge.setupUrlFingerprint,
 								]
 							);
+							autosaveTemporarySiteSlugPromiseRef.current =
+								undefined;
 							setAutosaveNudge(undefined);
 						} catch (error) {
 							logger.error(

--- a/packages/playground/website/src/lib/state/redux/boot-site-client.ts
+++ b/packages/playground/website/src/lib/state/redux/boot-site-client.ts
@@ -27,7 +27,11 @@ import {
 	setActiveSiteError,
 	setGitHubAuthRepoUrl,
 } from './slice-ui';
-import type { PlaygroundDispatch, PlaygroundReduxState } from './store';
+import {
+	selectActiveSite,
+	type PlaygroundDispatch,
+	type PlaygroundReduxState,
+} from './store';
 import {
 	isAutosavedSite,
 	selectSiteBySlug,
@@ -215,8 +219,10 @@ export function bootSiteClient(
 				// Intercept the Playground client even if the
 				// Blueprint fails.
 				onClientConnected: (playgroundClient) => {
-					playground = (window as any)['playground'] =
-						playgroundClient;
+					playground = playgroundClient;
+					if (selectActiveSite(getState())?.slug === site.slug) {
+						(window as any)['playground'] = playgroundClient;
+					}
 				},
 				// Log Blueprint events
 				onBlueprintValidated: logSupportedBlueprintEvents,

--- a/packages/playground/website/src/lib/state/redux/site-management-api-middleware.ts
+++ b/packages/playground/website/src/lib/state/redux/site-management-api-middleware.ts
@@ -519,6 +519,12 @@ export function createSitesAPI(
 			if (activeSite?.slug === siteSlug) {
 				return;
 			}
+			const existingClient = selectClientBySiteSlug(state, siteSlug);
+			if (existingClient) {
+				dispatch(setActiveSite(siteSlug, options));
+				(window as any)['playground'] = existingClient;
+				return;
+			}
 			const bootPromise = new Promise<void>((resolve, reject) => {
 				const unsubscribe = startListening({
 					predicate: (action) =>
@@ -553,11 +559,13 @@ export function createSitesAPI(
 		 *   Blueprint title becomes the site name if available; otherwise a
 		 *   random name is generated.
 		 * @param settings Optional site settings.
+		 * @param options Optional activation behavior.
 		 * @returns The new site's slug.
 		 */
 		async createNewTemporarySite(
 			requestedSiteSlug?: string,
-			settings?: SiteSettings
+			settings?: SiteSettings,
+			options: { activate?: boolean } = {}
 		): Promise<string> {
 			const siteName = requestedSiteSlug
 				? deriveSiteNameFromSlug(requestedSiteSlug)
@@ -566,7 +574,9 @@ export function createSitesAPI(
 			const newSiteInfo = await dispatch(
 				setTemporarySiteSpec(siteName, url, requestedSiteSlug)
 			);
-			await api.setActiveSite(newSiteInfo.slug);
+			if (options.activate !== false) {
+				await api.setActiveSite(newSiteInfo.slug);
+			}
 			return newSiteInfo.slug;
 		},
 


### PR DESCRIPTION
## What it does

Stacked on #3823.

Keeps MCP-launched Playground sessions (`?mcp-port`) on temporary Playgrounds and skips the autosave restore prompt for those sessions.

Also hardens the MCP e2e coverage so tests wait for the MCP bridge's active-site registration instead of requiring visible WordPress iframe DOM during setup. That keeps the tests aligned with the MCP contract and avoids coupling them to the website loading UI.

## Rationale

MCP sessions need a deterministic active Playground without waiting for a user-facing restore decision. The autosave restore prompt is useful for interactive website loads, but an MCP bridge session should keep using the temporary Playground path.

## Testing instructions

```bash
npm exec nx run playground-mcp:lint
npm exec nx run playground-website:typecheck
npx playwright test --config=packages/playground/mcp/playwright.config.ts packages/playground/mcp/tests/e2e/mcp-tools.spec.ts
```
