### PR TITLE
[Blueprints] Validate install target path segments

### DIFF
--- a/packages/playground/blueprints/src/lib/steps/install-plugin.ts
+++ b/packages/playground/blueprints/src/lib/steps/install-plugin.ts
@@ -8,6 +8,10 @@ import type { Directory } from '../v1/resources';
 import { joinPaths } from '@php-wasm/util';
 import { writeFiles, type UniversalPHP } from '@php-wasm/universal';
 import { logger } from '@php-wasm/logger';
+import {
+	validateInstallFileName,
+	validateInstallFolderName,
+} from './validate-install-folder-name';
 
 const ACTIVATION_OPTIONS_PAYLOAD_PREFIX = 'PLAYGROUND_ACTIVATION_OPTIONS:';
 
@@ -143,7 +147,12 @@ export const installPlugin: StepHandler<
 			'plugins'
 		);
 		const targetFolderName =
-			'targetFolderName' in options ? options.targetFolderName : '';
+			'targetFolderName' in options && options.targetFolderName
+				? validateInstallFolderName(
+						options.targetFolderName,
+						'Plugin target folder name'
+					)
+				: '';
 
 		if (pluginData instanceof File) {
 			if (await looksLikeZipFile(pluginData)) {
@@ -167,7 +176,7 @@ export const installPlugin: StepHandler<
 			} else if (pluginData.name.endsWith('.php')) {
 				const destinationFilePath = joinPaths(
 					pluginsDirectoryPath,
-					pluginData.name
+					validateInstallFileName(pluginData.name, 'Plugin file name')
 				);
 				await writeFile(playground, {
 					path: destinationFilePath,
@@ -189,7 +198,10 @@ export const installPlugin: StepHandler<
 
 			const pluginDirectoryPath = joinPaths(
 				pluginsDirectoryPath,
-				targetFolderName || pluginData.name
+				validateInstallFolderName(
+					targetFolderName || pluginData.name,
+					'Plugin folder name'
+				)
 			);
 			await writeFiles(
 				playground,

--- a/packages/playground/blueprints/src/lib/steps/install-theme.ts
+++ b/packages/playground/blueprints/src/lib/steps/install-theme.ts
@@ -6,8 +6,9 @@ import type { Directory } from '../v1/resources';
 import { importThemeStarterContent } from './import-theme-starter-content';
 import { zipNameToHumanName } from '../utils/zip-name-to-human-name';
 import { writeFiles } from '@php-wasm/universal';
-import { basename, joinPaths } from '@php-wasm/util';
+import { joinPaths } from '@php-wasm/util';
 import { logger } from '@php-wasm/logger';
+import { validateInstallFolderName } from './validate-install-folder-name';
 
 /**
  * @inheritDoc installTheme
@@ -102,7 +103,12 @@ export const installTheme: StepHandler<
 	const progressName = () => options.humanReadableName || assetNiceName;
 	try {
 		const targetFolderName =
-			'targetFolderName' in options ? options.targetFolderName : '';
+			'targetFolderName' in options && options.targetFolderName
+				? validateInstallFolderName(
+						options.targetFolderName,
+						'Theme target folder name'
+					)
+				: '';
 		let assetFolderName = '';
 		if (themeData instanceof File) {
 			// @TODO: Consider validating whether this is a zip file?
@@ -121,15 +127,10 @@ export const installTheme: StepHandler<
 			assetFolderName = assetResult.assetFolderName;
 		} else {
 			assetNiceName = themeData.name;
-			assetFolderName = targetFolderName || assetNiceName;
-			if (
-				!assetFolderName ||
-				basename(assetFolderName) !== assetFolderName
-			) {
-				throw new Error(
-					'Theme folder name must be a single directory name.'
-				);
-			}
+			assetFolderName = validateInstallFolderName(
+				targetFolderName || assetNiceName,
+				'Theme folder name'
+			);
 
 			progress?.tracker.setCaption(
 				`Installing the ${progressName()} theme`

--- a/packages/playground/blueprints/src/lib/steps/validate-install-folder-name.ts
+++ b/packages/playground/blueprints/src/lib/steps/validate-install-folder-name.ts
@@ -1,0 +1,31 @@
+function isSinglePathSegmentName(name: string) {
+	return (
+		!!name &&
+		name !== '.' &&
+		name !== '..' &&
+		!name.includes('/') &&
+		!name.includes('\\') &&
+		!name.includes('\0')
+	);
+}
+
+/**
+ * Validates the folder name used directly under wp-content/plugins or
+ * wp-content/themes. This is a name, not a path, so do not normalize it.
+ */
+export function validateInstallFolderName(folderName: string, label: string) {
+	if (!isSinglePathSegmentName(folderName)) {
+		throw new Error(`${label} must be a single directory name.`);
+	}
+	return folderName;
+}
+
+/**
+ * Validates a file name used directly under wp-content/plugins.
+ */
+export function validateInstallFileName(fileName: string, label: string) {
+	if (!isSinglePathSegmentName(fileName)) {
+		throw new Error(`${label} must be a single file name.`);
+	}
+	return fileName;
+}

--- a/packages/playground/blueprints/src/tests/steps/install-plugin.spec.ts
+++ b/packages/playground/blueprints/src/tests/steps/install-plugin.spec.ts
@@ -136,6 +136,16 @@ describe('Blueprint step installPlugin', () => {
 		);
 	});
 
+	it('should reject single-file plugin names outside the plugins directory', async () => {
+		await expect(
+			installPlugin(php, {
+				pluginData: new File(['<?php'], '../escape.php'),
+			})
+		).rejects.toThrow('Plugin file name must be a single file name.');
+
+		expect(php.fileExists('/wordpress/wp-content/escape.php')).toBe(false);
+	});
+
 	it('should skip plugin installation errors when onError is skip-plugin', async () => {
 		const loggerWarnSpy = vi
 			.spyOn(logger, 'warn')
@@ -308,6 +318,26 @@ echo json_encode(array(
 		expect(php.fileExists(installedPluginPath)).toBe(true);
 	});
 
+	it('should reject directory plugin names outside the plugins directory', async () => {
+		await expect(
+			installPlugin(php, {
+				pluginData: {
+					name: '../escape',
+					files: {
+						'index.php': `/**\n * Plugin Name: Test Plugin`,
+					},
+				},
+				options: {
+					activate: false,
+				},
+			})
+		).rejects.toThrow(
+			'Plugin folder name must be a single directory name.'
+		);
+
+		expect(php.fileExists('/wordpress/wp-content/escape')).toBe(false);
+	});
+
 	describe('ifAlreadyInstalled option', () => {
 		beforeEach(async () => {
 			await installPlugin(php, {
@@ -384,5 +414,25 @@ echo json_encode(array(
 			});
 			expect(php.fileExists(installedPluginPath)).toBe(true);
 		});
+
+		it.each(['.', './.'])(
+			'should reject %s as a plugin target folder name',
+			async (targetFolderName) => {
+				await expect(
+					installPlugin(php, {
+						pluginData: await zipFiles(php, zipFileName, {
+							[`unexpected-path/index.php`]: `/**\n * Plugin Name: Test Plugin`,
+						}),
+						ifAlreadyInstalled: 'overwrite',
+						options: {
+							activate: false,
+							targetFolderName,
+						},
+					})
+				).rejects.toThrow(
+					'Plugin target folder name must be a single directory name.'
+				);
+			}
+		);
 	});
 });

--- a/packages/playground/blueprints/src/tests/steps/install-theme.spec.ts
+++ b/packages/playground/blueprints/src/tests/steps/install-theme.spec.ts
@@ -133,7 +133,9 @@ describe('Blueprint step installTheme', () => {
 					targetFolderName: 'nested/theme',
 				},
 			})
-		).rejects.toThrow('Theme folder name must be a single directory name.');
+		).rejects.toThrow(
+			'Theme target folder name must be a single directory name.'
+		);
 
 		expect(php.fileExists('/wordpress/wp-content/themes/nested')).toBe(
 			false
@@ -380,5 +382,26 @@ describe('Blueprint step installTheme', () => {
 				)
 			).toBe(true);
 		});
+
+		it.each(['.', './.'])(
+			'should reject %s as a theme target folder name',
+			async (targetFolderName) => {
+				await expect(
+					installTheme(php, {
+						themeData: new File(
+							[php.readFileAsBuffer(zipFilePath)],
+							zipFileName
+						),
+						ifAlreadyInstalled: 'overwrite',
+						options: {
+							activate: false,
+							targetFolderName,
+						},
+					})
+				).rejects.toThrow(
+					'Theme target folder name must be a single directory name.'
+				);
+			}
+		);
 	});
 });


### PR DESCRIPTION
## What it does

Validates plugin and theme install names before they are joined into `wp-content/plugins` or `wp-content/themes` paths.

## Rationale

`targetFolderName`, directory resource names, and single-file plugin names are path segments, not paths. Values such as `.` and `./.` should not be normalized into something acceptable, and values such as `../escape` should not be able to install outside the intended directory.

## Implementation

Adds a shared install-name validator and applies it at the step-handler boundary for:

- plugin `options.targetFolderName`
- theme `options.targetFolderName`
- directory plugin names
- directory theme names
- single-file plugin names

`installAsset()` remains focused on extracting and moving zip contents.

## Testing instructions

```bash
npx vitest run src/tests/steps/install-plugin.spec.ts --config vite.config.ts
npx vitest run src/tests/steps/install-theme.spec.ts --config vite.config.ts
npx nx typecheck playground-blueprints
npx nx lint playground-blueprints
```
