### PR TITLE
[CI] Disable unrelated Microsoft apt feeds before runner dependency installs

### DIFF
--- a/.github/actions/prepare-playground/action.yml
+++ b/.github/actions/prepare-playground/action.yml
@@ -36,6 +36,18 @@ runs:
           shell: bash
           if: steps.cache-nodemodules.outputs.cache-hit != 'true'
           run: npm ci
+        - name: Disable unrelated Microsoft package feeds
+          if: runner.os == 'Linux'
+          shell: bash
+          run: |
+              # Playwright's --with-deps runs apt-get update. The GitHub Ubuntu
+              # runner includes Microsoft feeds for preinstalled tools that are
+              # unrelated to browser dependencies. When those feeds serve a bad
+              # InRelease file, apt exits 100 before reaching Ubuntu packages.
+              sudo find /etc/apt/sources.list.d -maxdepth 1 -type f \( \
+                  -name 'azure-cli.*' -o \
+                  -name 'microsoft-prod.*' \
+              \) -delete
         - name: Set NX_BASE
           shell: bash
           run: echo "NX_BASE=$(git rev-parse origin/trunk)" >> $GITHUB_ENV

--- a/.github/actions/prepare-playground/action.yml
+++ b/.github/actions/prepare-playground/action.yml
@@ -36,18 +36,18 @@ runs:
           shell: bash
           if: steps.cache-nodemodules.outputs.cache-hit != 'true'
           run: npm ci
-        - name: Disable unrelated Microsoft package feeds
-          if: runner.os == 'Linux'
+        - name: Disable unrelated Microsoft apt feeds
           shell: bash
           run: |
               # Playwright's --with-deps runs apt-get update. The GitHub Ubuntu
               # runner includes Microsoft feeds for preinstalled tools that are
               # unrelated to browser dependencies. When those feeds serve a bad
               # InRelease file, apt exits 100 before reaching Ubuntu packages.
-              sudo find /etc/apt/sources.list.d -maxdepth 1 -type f \( \
-                  -name 'azure-cli.*' -o \
-                  -name 'microsoft-prod.*' \
-              \) -delete
+              sudo rm -f \
+                  /etc/apt/sources.list.d/azure-cli.list \
+                  /etc/apt/sources.list.d/azure-cli.sources \
+                  /etc/apt/sources.list.d/microsoft-prod.list \
+                  /etc/apt/sources.list.d/microsoft-prod.sources || true
         - name: Set NX_BASE
           shell: bash
           run: echo "NX_BASE=$(git rev-parse origin/trunk)" >> $GITHUB_ENV


### PR DESCRIPTION
## What it does

Disables the GitHub-hosted Ubuntu runner's Azure CLI and Microsoft product apt
feeds in the shared `prepare-playground` action before jobs call Playwright's
`--with-deps` installer.

## Rationale

The latest trunk CI run failed before tests started. Both failing jobs exited in
`npx playwright install --with-deps chromium` while `apt-get update` was reading
unrelated `packages.microsoft.com` feeds:

- `test-e2e-mcp`: https://github.com/WordPress/wordpress-playground/actions/runs/28896070925/job/85720792467
- `test-e2e-playwright (chromium, 2/3)`: https://github.com/WordPress/wordpress-playground/actions/runs/28896070925/job/85720792515

The latest merged commit only touched website files, so the code under test did
not cause these install failures. The Microsoft feeds are preinstalled on the
runner for Azure/PowerShell tooling and are not needed for Playwright's browser
dependencies. Removing them keeps `apt-get update` focused on Ubuntu package
sources needed by the browser dependency install.

## Implementation

Adds one step to `.github/actions/prepare-playground/action.yml` that removes
only the exact Microsoft apt source files that can break the Playwright
dependency install:

- `azure-cli.list`
- `azure-cli.sources`
- `microsoft-prod.list`
- `microsoft-prod.sources`

The command tolerates missing files so non-matching runners do not fail just
because the feeds are absent.

## Testing instructions

- `ruby -e 'require "yaml"; YAML.load_file(".github/actions/prepare-playground/action.yml"); YAML.load_file(".github/workflows/ci.yml")'`
- `git diff --check`
- Confirm the PR CI reaches Playwright test execution instead of failing during
  `npx playwright install --with-deps chromium`.
