### PR TITLE
[Blueprints] Align Blueprint v2 schema types

### DIFF
--- a/packages/playground/blueprints/src/lib/v2/compile.ts
+++ b/packages/playground/blueprints/src/lib/v2/compile.ts
@@ -837,7 +837,7 @@ function wordpressOrgResource(
 	reference: string,
 	type: 'plugins' | 'themes'
 ): FileReference {
-	const [slug, version] = reference.split('@');
+	const { slug, version } = splitWordPressOrgVersionSuffix(reference);
 	if (version && version !== 'latest') {
 		const singular = type === 'plugins' ? 'plugin' : 'theme';
 		return {
@@ -852,6 +852,31 @@ function wordpressOrgResource(
 				: 'wordpress.org/themes',
 		slug,
 	} as FileReference;
+}
+
+/**
+ * Splits only the optional `@version` suffix defined by Blueprint v2. The slug
+ * itself stays opaque so future WordPress.org slug formats keep working.
+ */
+function splitWordPressOrgVersionSuffix(reference: string) {
+	const separatorIndex = reference.lastIndexOf('@');
+	if (separatorIndex === -1) {
+		return { slug: reference };
+	}
+
+	const version = reference.slice(separatorIndex + 1);
+	if (!isSupportedWordPressOrgReferenceVersion(version)) {
+		return { slug: reference };
+	}
+
+	return {
+		slug: reference.slice(0, separatorIndex),
+		version,
+	};
+}
+
+function isSupportedWordPressOrgReferenceVersion(version: string) {
+	return version === 'latest' || /^\d+\.\d+(?:\.\d+)?$/.test(version);
 }
 
 /**

--- a/packages/playground/blueprints/src/lib/v2/wep-1-blueprint-v2-schema/appendix-A-blueprint-v2-schema.ts
+++ b/packages/playground/blueprints/src/lib/v2/wep-1-blueprint-v2-schema/appendix-A-blueprint-v2-schema.ts
@@ -459,12 +459,12 @@ export namespace V2Schema {
 	};
 
 	type ContentDefinition =
-		| ({
+		| {
 				type: 'mysql-dump';
 				source:
 					| DataSources.FileDataReference
 					| DataSources.FileDataReference[];
-		  } & URLMappingConfig)
+		  }
 		| ({
 				type: 'posts';
 				source:

--- a/packages/playground/blueprints/src/lib/v2/wep-1-blueprint-v2-schema/appendix-B-data-sources.ts
+++ b/packages/playground/blueprints/src/lib/v2/wep-1-blueprint-v2-schema/appendix-B-data-sources.ts
@@ -141,16 +141,11 @@ export namespace DataSources {
 
 	/** Helper types {{{ */
 	/**
-	 * A slug is a string matching the following regex:
+	 * A WordPress.org directory slug.
 	 *
-	 * ```
-	 * ^[a-zA-Z0-9_-]+$
-	 * ```
-	 *
-	 * This constraint may be expressed in TypeScript, but it would come at the
-	 * expense of readability. This document will thus alias the general `string`
-	 * type to `Slug`. Every reference to the `Slug` type should be treated as a
-	 * string matching the above regex.
+	 * Slugs are intentionally treated as opaque strings. Playground should not
+	 * reject future WordPress.org slug formats just because they do not match the
+	 * directory conventions common today.
 	 */
 	export type Slug = string;
 	export type SimpleVersionExpression =

--- a/packages/playground/blueprints/src/tests/compile.spec.ts
+++ b/packages/playground/blueprints/src/tests/compile.spec.ts
@@ -495,6 +495,41 @@ describe('compileBlueprintForExecution', () => {
 		});
 	});
 
+	it('treats Blueprint v2 WordPress.org slugs as opaque strings', async () => {
+		const compiled = await compileBlueprintForExecution({
+			version: 2,
+			plugins: [
+				{
+					source: 'wtyczka-żółć',
+				},
+				{
+					source: 'opaque@not-a-supported-version',
+				},
+			],
+		});
+
+		expect(compiled.version).toBe(2);
+		if (compiled.version !== 2) {
+			throw new Error('Expected a compiled Blueprint v2 result.');
+		}
+		expect(compiled.compiled.steps).toMatchObject([
+			{
+				step: 'installPlugin',
+				pluginData: {
+					resource: 'wordpress.org/plugins',
+					slug: 'wtyczka-żółć',
+				},
+			},
+			{
+				step: 'installPlugin',
+				pluginData: {
+					resource: 'wordpress.org/plugins',
+					slug: 'opaque@not-a-supported-version',
+				},
+			},
+		]);
+	});
+
 	it('preserves special inline directory filenames as plain file entries', async () => {
 		const compiled = await compileBlueprintForExecution({
 			version: 2,

--- a/packages/playground/blueprints/src/tests/v2/blueprint-v2-declaration.spec.ts
+++ b/packages/playground/blueprints/src/tests/v2/blueprint-v2-declaration.spec.ts
@@ -343,6 +343,18 @@ const blueprintWithNonComparablePHPVersionRecommendation = {
 	},
 } satisfies BlueprintV2Declaration;
 
+const blueprintWithUrlMappingForMysqlDump = {
+	version: 2,
+	content: [
+		{
+			type: 'mysql-dump',
+			source: './dump.sql',
+			// @ts-expect-error URL mapping does not apply to SQL dump imports.
+			urlsMode: 'rewrite',
+		},
+	],
+} satisfies BlueprintV2Declaration;
+
 void blueprintWithDirectoryAsRunPHPCode;
 void blueprintWithDirectoryAsMediaSource;
 void blueprintWithNestedDirectoryName;
@@ -354,3 +366,4 @@ void blueprintWithNonComparableWordPressVersionMinimum;
 void blueprintWithExtraWordPressVersionComponent;
 void blueprintWithUnsupportedWordPressVersionRecommendation;
 void blueprintWithNonComparablePHPVersionRecommendation;
+void blueprintWithUrlMappingForMysqlDump;


### PR DESCRIPTION
## What it does

Finishes the remaining Blueprint v2 type/schema cleanup needed before moving deeper into implementation work.

This PR:

- removes URL rewrite options from `mysql-dump` content entries
- treats WordPress.org plugin/theme slugs as opaque strings
- parses only supported trailing `@version` suffixes for WordPress.org references

Part of #2592.

## Rationale

`urlsMode` and `urlsMap` apply to structured content imports such as WXR and posts. A raw SQL dump does not go through that URL rewrite path, so `mysql-dump` should not expose those fields.

WordPress.org slugs should not be validated against a guessed ASCII-only format. Playground only needs to identify the optional Blueprint v2 `@version` suffix; the slug itself should pass through unchanged.

## Implementation

`mysql-dump` content entries now stay typed as `{ type, source }` instead of being intersected with `URLMappingConfig`.

WordPress.org reference lowering now uses `splitWordPressOrgVersionSuffix()`, which recognizes only:

```ts
@latest
@1.2
@1.2.3
```

Any other `@` remains part of the slug.

## Testing instructions

```bash
npx nx typecheck playground-blueprints
npx vitest run src/tests/v2/blueprint-v2-declaration.spec.ts --config vite.config.ts
npx vitest run src/tests/compile.spec.ts --config vite.config.ts
npx nx lint playground-blueprints
```
