### PR TITLE
[Blueprints] Compile Blueprint v2 declarations from raw JSON

### DIFF
--- a/packages/playground/blueprints/src/lib/compile.ts
+++ b/packages/playground/blueprints/src/lib/compile.ts
@@ -34,6 +34,8 @@ export interface CompileBlueprintForExecutionOptions extends Omit<
 	onBlueprintValidated?: (blueprint: BlueprintDeclaration) => void;
 }
 
+type BlueprintExecutionInput = Blueprint | BlueprintBundle | string;
+
 /**
  * Compiles a Blueprint into the shape consumers need before execution.
  *
@@ -42,12 +44,21 @@ export interface CompileBlueprintForExecutionOptions extends Omit<
  * newer callers can migrate to as Blueprint v2 support grows.
  */
 export async function compileBlueprintForExecution(
-	input: Blueprint | BlueprintBundle,
+	input: BlueprintExecutionInput,
 	options: CompileBlueprintForExecutionOptions = {}
 ): Promise<CompiledBlueprintForExecution> {
+	const isRawJsonInput = typeof input === 'string';
 	const declaration = await getBlueprintDeclaration(input);
 	if (isBlueprintV2Declaration(declaration)) {
-		return compileBlueprintV2ForExecution(input, declaration);
+		return compileBlueprintV2ForExecution(
+			isRawJsonInput ? declaration : input,
+			declaration
+		);
+	}
+	if (isRawJsonInput) {
+		throw new Error(
+			'Raw JSON input is only supported for Blueprint v2 declarations.'
+		);
 	}
 	return compileBlueprintV1ForExecution(input, declaration, options);
 }

--- a/packages/playground/blueprints/src/lib/reflection.ts
+++ b/packages/playground/blueprints/src/lib/reflection.ts
@@ -1,4 +1,4 @@
-import type { Blueprint, BlueprintBundle } from './types';
+import type { Blueprint, BlueprintBundle, BlueprintDeclaration } from './types';
 import type { BlueprintV1Declaration } from './v1/types';
 import type { BlueprintV2Declaration } from './v2/blueprint-v2-declaration';
 
@@ -7,8 +7,26 @@ export function isBlueprintBundle(input: any): input is BlueprintBundle {
 }
 
 export async function getBlueprintDeclaration(
-	blueprint: Blueprint
+	blueprint: Blueprint | string
 ): Promise<BlueprintV1Declaration | BlueprintV2Declaration> {
+	if (typeof blueprint === 'string') {
+		let declaration: unknown;
+		try {
+			declaration = JSON.parse(blueprint);
+		} catch {
+			throw new Error('Raw JSON input must be valid JSON.');
+		}
+		if (
+			!declaration ||
+			typeof declaration !== 'object' ||
+			Array.isArray(declaration)
+		) {
+			throw new Error(
+				'Raw JSON input must contain a Blueprint declaration object.'
+			);
+		}
+		return declaration as BlueprintDeclaration;
+	}
 	if (!isBlueprintBundle(blueprint)) {
 		return blueprint;
 	}

--- a/packages/playground/blueprints/src/tests/compile.spec.ts
+++ b/packages/playground/blueprints/src/tests/compile.spec.ts
@@ -90,6 +90,68 @@ describe('compileBlueprintForExecution', () => {
 		expect(compiled.compiled.plan).toEqual([]);
 	});
 
+	it('compiles Blueprint v2 declarations from raw JSON', async () => {
+		const compiled = await compileBlueprintForExecution(
+			JSON.stringify({
+				version: 2,
+				constants: {
+					WP_DEBUG: true,
+				},
+			})
+		);
+
+		expect(compiled.version).toBe(2);
+		if (compiled.version !== 2) {
+			throw new Error('Expected a compiled Blueprint v2 result.');
+		}
+		expect(compiled.declaration).toEqual({
+			version: 2,
+			constants: {
+				WP_DEBUG: true,
+			},
+		});
+		expect(compiled.compiled.plan).toEqual([
+			{
+				type: 'defineWpConfigConsts',
+				consts: {
+					WP_DEBUG: true,
+				},
+			},
+		]);
+	});
+
+	it('rejects Blueprint v1 declarations from raw JSON', async () => {
+		await expect(
+			compileBlueprintForExecution(
+				JSON.stringify({
+					steps: [
+						{
+							step: 'mkdir',
+							path: '/wordpress/cache',
+						},
+					],
+				})
+			)
+		).rejects.toThrow(
+			'Raw JSON input is only supported for Blueprint v2 declarations.'
+		);
+	});
+
+	it('rejects invalid raw JSON input', async () => {
+		await expect(
+			compileBlueprintForExecution('{ "version": 2')
+		).rejects.toThrow('Raw JSON input must be valid JSON.');
+	});
+
+	it.each(['null', '[]'])(
+		'rejects raw JSON %s as a Blueprint declaration',
+		async (rawJson) => {
+			await expect(compileBlueprintForExecution(rawJson)).rejects.toThrow(
+				'Raw JSON input must contain a Blueprint declaration object.'
+			);
+		}
+	);
+
 	it('runs Blueprint v2 bundles with bundled execution-context resources', async () => {
 		const bundle = new InMemoryFilesystem({
 			'plugin.php': '<?php /* Plugin Name: Bundled Plugin */',

--- a/packages/playground/blueprints/src/tests/reflection.spec.ts
+++ b/packages/playground/blueprints/src/tests/reflection.spec.ts
@@ -1,0 +1,36 @@
+import { getBlueprintDeclaration } from '../lib/reflection';
+
+describe('getBlueprintDeclaration', () => {
+	it('parses Blueprint declarations from raw JSON strings', async () => {
+		await expect(
+			getBlueprintDeclaration(
+				JSON.stringify({
+					version: 2,
+					constants: {
+						WP_DEBUG: true,
+					},
+				})
+			)
+		).resolves.toEqual({
+			version: 2,
+			constants: {
+				WP_DEBUG: true,
+			},
+		});
+	});
+
+	it('rejects invalid raw JSON strings', async () => {
+		await expect(getBlueprintDeclaration('{ "version": 2')).rejects.toThrow(
+			'Raw JSON input must be valid JSON.'
+		);
+	});
+
+	it.each(['null', '[]'])(
+		'rejects raw JSON %s as a Blueprint declaration',
+		async (rawJson) => {
+			await expect(getBlueprintDeclaration(rawJson)).rejects.toThrow(
+				'Raw JSON input must contain a Blueprint declaration object.'
+			);
+		}
+	);
+});


### PR DESCRIPTION
## What it does

Allows `compileBlueprintForExecution()` to compile Blueprint v2 declarations provided as raw JSON strings.

Part of #2592.

## Rationale

Raw JSON recognition belongs at the declaration boundary. `getBlueprintDeclaration()` already resolves declarations from objects and bundles; this extends that boundary to strings while keeping execution policy in `compileBlueprintForExecution()`.

This remains v2-only. Raw JSON that parses as a Blueprint v1 declaration is rejected instead of changing the legacy v1 compile path.

## Implementation

`getBlueprintDeclaration()` now accepts raw JSON strings and requires them to parse to a non-null object declaration.

`compileBlueprintForExecution()` tracks whether the original input was a string:

- parsed v2 JSON compiles through `compileBlueprintV2()`
- parsed v1 JSON throws a clear v2-only error
- object declarations and bundles keep their existing behavior

```ts
await compileBlueprintForExecution(
	JSON.stringify({ version: 2, constants: { WP_DEBUG: true } })
);
```

## Testing instructions

```bash
npx vitest run src/tests/compile.spec.ts src/tests/reflection.spec.ts --config vite.config.ts
npx nx typecheck playground-blueprints
npx nx lint playground-blueprints
```