### PR TITLE
[Website] Bound site manager file transfers and editor path changes

### DIFF
--- a/packages/playground/components/src/FilePickerTree/index.tsx
+++ b/packages/playground/components/src/FilePickerTree/index.tsx
@@ -1,3 +1,4 @@
+import { logger } from '@php-wasm/logger';
 import { basename, dirname, joinPaths } from '@php-wasm/util';
 import type { AsyncWritableFilesystem } from '@wp-playground/storage';
 import {
@@ -24,6 +25,8 @@ import { file, folder } from '../icons';
 import css from './style.module.css';
 
 type ExpandedNodePaths = Record<string, boolean>;
+
+const MAX_FILE_TRANSFER_BYTES = 100 * 1024 * 1024;
 
 type DropIndicatorState = 'valid' | 'invalid';
 
@@ -66,6 +69,31 @@ type FileSystemEntryLike =
 	| FileSystemFileEntryLike
 	| FileSystemDirectoryEntryLike;
 
+type FileTransferReadable = {
+	arrayBuffer(): Promise<ArrayBuffer>;
+	size?: number;
+	filesize?: number;
+};
+
+type FileTransferReadResult =
+	| { type: 'ready'; data: ArrayBuffer }
+	| { type: 'too-large'; sizeLimitLabel: string };
+
+type FileUploadReadResult =
+	| { type: 'ready'; data: Uint8Array }
+	| { type: 'too-large'; sizeLimitLabel: string };
+
+type FileUploadErrorSummary = {
+	failedCount: number;
+	tooLargeCount: number;
+	sizeLimitLabel: string;
+};
+
+type FileUploadBudget = {
+	usedBytes: number;
+	sizeLimitLabel: string;
+};
+
 export type FileNode = {
 	name: string;
 	type: 'file' | 'folder';
@@ -79,6 +107,11 @@ export type FilePickerTreeProps = {
 	initialSelectedPath?: string;
 	onSelect?: (path: string | null) => void;
 	onDoubleClickFile?: (path: string) => void;
+	onBeforePathChange?: (
+		path: string
+	) => Promise<boolean | void> | boolean | void;
+	onPathMoved?: (from: string, to: string) => Promise<void> | void;
+	onPathDeleted?: (path: string) => Promise<void> | void;
 };
 
 export type FilePickerTreeHandle = {
@@ -153,6 +186,9 @@ export const FilePickerTree = forwardRef<
 		initialSelectedPath,
 		onSelect = () => {},
 		onDoubleClickFile,
+		onBeforePathChange,
+		onPathMoved,
+		onPathDeleted,
 	},
 	ref
 ) {
@@ -167,6 +203,7 @@ export const FilePickerTree = forwardRef<
 	const isValidNameSegment = (name: string) => {
 		if (!name) return false;
 		if (name === '.' || name === '..') return false;
+		if (name.includes('\0')) return false;
 		return !/[\\/]/.test(name);
 	};
 
@@ -474,6 +511,31 @@ export const FilePickerTree = forwardRef<
 		setDraggedPath(null);
 		setDropIndicator(null);
 		clearAllDragExpandTimeouts();
+	};
+
+	const notifyBeforePathChange = async (path: string) => {
+		try {
+			return (await onBeforePathChange?.(path)) !== false;
+		} catch (error) {
+			logger.error('Failed to prepare file tree entry change', error);
+			return false;
+		}
+	};
+
+	const notifyPathMoved = async (from: string, to: string) => {
+		try {
+			await onPathMoved?.(from, to);
+		} catch (error) {
+			logger.error('Failed to notify file tree entry move', error);
+		}
+	};
+
+	const notifyPathDeleted = async (path: string) => {
+		try {
+			await onPathDeleted?.(path);
+		} catch (error) {
+			logger.error('Failed to notify file tree entry deletion', error);
+		}
 	};
 
 	const selectPath = (path: string, notify = true) => {
@@ -929,9 +991,13 @@ export const FilePickerTree = forwardRef<
 		if (await pathExists(destinationPath)) {
 			return;
 		}
+		if (!(await notifyBeforePathChange(sourcePath))) {
+			return;
+		}
 		const sourceParent = dirname(sourcePath);
 		try {
 			await filesystem.mv(sourcePath, destinationPath);
+			await notifyPathMoved(sourcePath, destinationPath);
 			remapPathState(sourcePath, destinationPath);
 			const mappedSelected = remapSinglePath(
 				selectedPath,
@@ -960,8 +1026,8 @@ export const FilePickerTree = forwardRef<
 				remapSinglePath(prev, sourcePath, destinationPath)
 			);
 			focusDomNode(destinationPath);
-		} catch {
-			// ignore move errors
+		} catch (error) {
+			logger.error('Failed to move file tree entry', error);
 		}
 	};
 
@@ -981,33 +1047,87 @@ export const FilePickerTree = forwardRef<
 		});
 	};
 
-	const importFileBlob = async (file: File, destinationDir: string) => {
+	const importFileBlob = async (
+		file: File,
+		destinationDir: string,
+		summary: FileUploadErrorSummary,
+		uploadBudget: FileUploadBudget
+	) => {
 		if (!filesystem) return;
-		const safeName = file.name || 'untitled';
-		const targetName = await findAvailableName(destinationDir, safeName);
-		const targetPath = joinPaths(destinationDir, targetName);
-		const buffer = new Uint8Array(await file.arrayBuffer());
-		await filesystem.writeFile(targetPath, buffer);
+		let targetPath: string | undefined;
+		try {
+			const uploadFile = await readFileForUploadWithinBudget(
+				file,
+				uploadBudget
+			);
+			if (uploadFile.type === 'too-large') {
+				summary.tooLargeCount += 1;
+				summary.sizeLimitLabel = uploadFile.sizeLimitLabel;
+				return;
+			}
+			const safeName = getFileTransferName(file.name, 'untitled');
+			const targetName = await findAvailableName(
+				destinationDir,
+				safeName
+			);
+			targetPath = joinPaths(destinationDir, targetName);
+			await filesystem.writeFile(targetPath, uploadFile.data);
+		} catch (error) {
+			if (targetPath) {
+				await discardFailedImportedFile(targetPath);
+			}
+			summary.failedCount += 1;
+			logger.error('Failed to import file tree entry', error);
+		}
+	};
+
+	const discardFailedImportedFile = async (path: string) => {
+		if (!filesystem) {
+			return;
+		}
+		try {
+			if (await filesystem.fileExists(path)) {
+				await filesystem.unlink(path);
+			}
+		} catch (error) {
+			logger.error('Failed to clean up imported file tree entry', error);
+		}
 	};
 
 	const importFileEntry = async (
 		entry: FileSystemFileEntryLike,
-		destinationDir: string
+		destinationDir: string,
+		summary: FileUploadErrorSummary,
+		uploadBudget: FileUploadBudget
 	) => {
-		const file = await fileFromEntry(entry);
-		await importFileBlob(file, destinationDir);
+		try {
+			const file = await fileFromEntry(entry);
+			await importFileBlob(file, destinationDir, summary, uploadBudget);
+		} catch (error) {
+			summary.failedCount += 1;
+			logger.error('Failed to import file tree entry', error);
+		}
 	};
 
 	const importDirectoryEntry = async (
 		entry: FileSystemDirectoryEntryLike,
-		destinationDir: string
+		destinationDir: string,
+		summary: FileUploadErrorSummary,
+		uploadBudget: FileUploadBudget
 	) => {
-		const folderName = await findAvailableName(
-			destinationDir,
-			entry.name || 'New Folder'
-		);
-		const folderPath = joinPaths(destinationDir, folderName);
-		await ensureDirectory(folderPath);
+		let folderPath: string;
+		try {
+			const folderName = await findAvailableName(
+				destinationDir,
+				getFileTransferName(entry.name, 'New Folder')
+			);
+			folderPath = joinPaths(destinationDir, folderName);
+			await ensureDirectory(folderPath);
+		} catch (error) {
+			summary.failedCount += 1;
+			logger.error('Failed to import file tree directory', error);
+			return;
+		}
 		const reader = entry.createReader();
 		const readEntries = () =>
 			new Promise<FileSystemEntryLike[]>((resolve, reject) => {
@@ -1017,7 +1137,14 @@ export const FilePickerTree = forwardRef<
 				);
 			});
 		while (true) {
-			const batch = await readEntries();
+			let batch: FileSystemEntryLike[];
+			try {
+				batch = await readEntries();
+			} catch (error) {
+				summary.failedCount += 1;
+				logger.error('Failed to read dropped directory entries', error);
+				return;
+			}
 			if (!batch.length) {
 				break;
 			}
@@ -1025,12 +1152,16 @@ export const FilePickerTree = forwardRef<
 				if (child.isFile) {
 					await importFileEntry(
 						child as FileSystemFileEntryLike,
-						folderPath
+						folderPath,
+						summary,
+						uploadBudget
 					);
 				} else if (child.isDirectory) {
 					await importDirectoryEntry(
 						child as FileSystemDirectoryEntryLike,
-						folderPath
+						folderPath,
+						summary,
+						uploadBudget
 					);
 				}
 			}
@@ -1042,40 +1173,70 @@ export const FilePickerTree = forwardRef<
 		destinationDir: string
 	) => {
 		if (!filesystem) return;
+		const summary: FileUploadErrorSummary = {
+			failedCount: 0,
+			tooLargeCount: 0,
+			sizeLimitLabel: '',
+		};
+		const uploadBudget = createFileUploadBudget();
 		const items = event.dataTransfer?.items
 			? Array.from(event.dataTransfer.items)
 			: [];
-		const entries = items
-			.filter((item) => item.kind === 'file')
-			.map((item) => getEntryFromItem(item))
-			.filter((entry): entry is FileSystemEntryLike => Boolean(entry));
-		if (entries.length > 0) {
-			for (const entry of entries) {
+		let importedFromItems = false;
+		for (const item of items.filter((item) => item.kind === 'file')) {
+			const entry = getEntryFromItem(item);
+			if (entry) {
+				importedFromItems = true;
 				if (entry.isFile) {
 					await importFileEntry(
 						entry as FileSystemFileEntryLike,
-						destinationDir
+						destinationDir,
+						summary,
+						uploadBudget
 					);
 				} else if (entry.isDirectory) {
 					await importDirectoryEntry(
 						entry as FileSystemDirectoryEntryLike,
-						destinationDir
+						destinationDir,
+						summary,
+						uploadBudget
 					);
 				}
+				continue;
 			}
-		} else {
+			const file = item.getAsFile();
+			if (file) {
+				importedFromItems = true;
+				await importFileBlob(
+					file,
+					destinationDir,
+					summary,
+					uploadBudget
+				);
+			}
+		}
+		if (!importedFromItems) {
 			const files = event.dataTransfer?.files
 				? Array.from(event.dataTransfer.files)
 				: [];
 			for (const file of files) {
-				await importFileBlob(file, destinationDir);
+				await importFileBlob(
+					file,
+					destinationDir,
+					summary,
+					uploadBudget
+				);
 			}
 		}
+		const uploadErrors = getFileUploadErrorMessages(summary);
 		await refreshChildren(destinationDir);
 		setExpanded((prev) => ({
 			...prev,
 			[destinationDir]: true,
 		}));
+		if (uploadErrors.length) {
+			alert(uploadErrors.join('\n'));
+		}
 	};
 
 	const handleDeletePath = async (
@@ -1084,27 +1245,34 @@ export const FilePickerTree = forwardRef<
 	) => {
 		if (!filesystem) return;
 		const normalized = absSelectedPath;
+		const parentDir = dirname(normalized);
+		let deleted = false;
 		setContextMenu(null);
 		try {
+			if (!(await notifyBeforePathChange(normalized))) {
+				return;
+			}
 			if (type === 'folder') {
 				await filesystem.rmdir(normalized, { recursive: true } as any);
 			} else {
 				await filesystem.unlink(normalized);
 			}
-		} catch {
-			// ignore
+			deleted = true;
+			await notifyPathDeleted(normalized);
+		} catch (error) {
+			logger.error('Failed to delete file tree entry', error);
 		} finally {
 			setRenamingAbsolutePath(null);
-			const parentDir = dirname(normalized);
 			await refreshChildren(parentDir);
-			// If current selection was removed, notify parent
-			if (
-				selectedPath &&
-				(selectedPath === normalized ||
-					selectedPath.startsWith(`${normalized}/`))
-			) {
-				onSelect(null);
-			}
+		}
+		// If current selection was removed, notify parent.
+		if (
+			deleted &&
+			selectedPath &&
+			(selectedPath === normalized ||
+				selectedPath.startsWith(`${normalized}/`))
+		) {
+			onSelect(null);
 		}
 	};
 
@@ -1114,18 +1282,30 @@ export const FilePickerTree = forwardRef<
 		}
 		try {
 			const file = await filesystem.read(absPath);
-			const buffer = await file.arrayBuffer();
-			const blob = new Blob([buffer as BlobPart]);
+			const downloadFile = await readFileWithinLimit(
+				file,
+				MAX_FILE_TRANSFER_BYTES
+			);
+			if (downloadFile.type === 'too-large') {
+				alert(
+					`Cannot download files larger than ${downloadFile.sizeLimitLabel}.`
+				);
+				return;
+			}
+			const blob = new Blob([downloadFile.data as BlobPart]);
 			const url = URL.createObjectURL(blob);
 			const anchor = document.createElement('a');
 			anchor.href = url;
 			anchor.download = basename(absPath) || 'download';
 			document.body.appendChild(anchor);
-			anchor.click();
-			document.body.removeChild(anchor);
-			setTimeout(() => URL.revokeObjectURL(url), 60_000);
+			try {
+				anchor.click();
+			} finally {
+				anchor.remove();
+				setTimeout(() => URL.revokeObjectURL(url), 60_000);
+			}
 		} catch (error) {
-			console.error('Failed to download file', error);
+			logger.error('Failed to download file', error);
 		}
 	};
 
@@ -1248,7 +1428,12 @@ export const FilePickerTree = forwardRef<
 		}
 		let candidateIsDir = pending?.type === 'folder';
 		try {
+			if (!(await notifyBeforePathChange(path))) {
+				setRenamingAbsolutePath(path);
+				return;
+			}
 			await filesystem.mv(path, candidate);
+			await notifyPathMoved(path, candidateNormalized);
 			if (!pending) {
 				const isDir = await filesystem.isDir(candidate);
 				candidateIsDir = isDir;
@@ -1266,7 +1451,8 @@ export const FilePickerTree = forwardRef<
 			if (isPending && !candidateIsDir && onDoubleClickFile) {
 				onDoubleClickFile(candidateNormalized);
 			}
-		} catch {
+		} catch (error) {
+			logger.error('Failed to rename file tree entry', error);
 			if (isPending) {
 				try {
 					if (pending?.type === 'folder') {
@@ -1861,5 +2047,124 @@ const FileName: React.FC<{
 		</>
 	);
 };
+
+function createFileUploadBudget(): FileUploadBudget {
+	return {
+		usedBytes: 0,
+		sizeLimitLabel: formatFileTransferSizeLimit(MAX_FILE_TRANSFER_BYTES),
+	};
+}
+
+async function readFileForUploadWithinBudget(
+	file: File,
+	budget: FileUploadBudget
+): Promise<FileUploadReadResult> {
+	const remainingBytes = Math.max(
+		0,
+		MAX_FILE_TRANSFER_BYTES - budget.usedBytes
+	);
+	const transferFile = await readFileWithinLimit(file, remainingBytes);
+	if (transferFile.type === 'too-large') {
+		return {
+			type: 'too-large',
+			sizeLimitLabel: budget.sizeLimitLabel,
+		};
+	}
+	budget.usedBytes += transferFile.data.byteLength;
+	return { type: 'ready', data: new Uint8Array(transferFile.data) };
+}
+
+async function readFileWithinLimit(
+	file: FileTransferReadable,
+	maxBytes: number
+): Promise<FileTransferReadResult> {
+	const knownSize = getKnownFileSize(file);
+	if (knownSize !== undefined && knownSize > maxBytes) {
+		return {
+			type: 'too-large',
+			sizeLimitLabel: formatFileTransferSizeLimit(maxBytes),
+		};
+	}
+
+	const data = await file.arrayBuffer();
+	if (data.byteLength > maxBytes) {
+		return {
+			type: 'too-large',
+			sizeLimitLabel: formatFileTransferSizeLimit(maxBytes),
+		};
+	}
+	return { type: 'ready', data };
+}
+
+function getKnownFileSize(file: FileTransferReadable): number | undefined {
+	if (isValidFileSize(file.filesize)) {
+		return file.filesize;
+	}
+	if (isValidFileSize(file.size)) {
+		return file.size;
+	}
+	return undefined;
+}
+
+function isValidFileSize(size: unknown): size is number {
+	return typeof size === 'number' && Number.isFinite(size) && size >= 0;
+}
+
+function getFileUploadErrorMessages({
+	failedCount,
+	tooLargeCount,
+	sizeLimitLabel,
+}: FileUploadErrorSummary): string[] {
+	const messages: string[] = [];
+	if (failedCount) {
+		messages.push(`Could not upload ${formatFileCount(failedCount)}.`);
+	}
+	if (tooLargeCount) {
+		messages.push(
+			`Could not upload ${formatFileCount(
+				tooLargeCount
+			)} because the transfer would exceed ${sizeLimitLabel}.`
+		);
+	}
+	return messages;
+}
+
+function getFileTransferName(
+	name: string | undefined,
+	fallback: string
+): string {
+	const segments = (name ?? '')
+		.replace(/\\+/g, '/')
+		.split('/')
+		.filter(Boolean);
+	const candidate = segments[segments.length - 1] ?? '';
+	if (
+		!candidate ||
+		candidate === '.' ||
+		candidate === '..' ||
+		candidate.includes('\0')
+	) {
+		return fallback;
+	}
+	return candidate;
+}
+
+function formatFileCount(count: number): string {
+	return count === 1 ? '1 file' : `${count} files`;
+}
+
+function formatFileTransferSizeLimit(bytes: number): string {
+	if (bytes < 1024) {
+		return bytes === 1 ? '1 byte' : `${bytes} bytes`;
+	}
+	if (bytes < 1024 * 1024) {
+		const kilobytes = bytes / 1024;
+		return `${
+			Number.isInteger(kilobytes) ? kilobytes : kilobytes.toFixed(1)
+		} KB`;
+	}
+	const megabytes = bytes / (1024 * 1024);
+	return `${Number.isInteger(megabytes) ? megabytes : megabytes.toFixed(1)} MB`;
+}
 
 export default FilePickerTree;

--- a/packages/playground/components/src/PlaygroundFileEditor/file-explorer-sidebar.tsx
+++ b/packages/playground/components/src/PlaygroundFileEditor/file-explorer-sidebar.tsx
@@ -17,11 +17,11 @@ import { logger } from '@php-wasm/logger';
 import { dirname, normalizePath } from '@php-wasm/util';
 import { BinaryFilePreview } from '@wp-playground/components';
 import {
-	MAX_INLINE_FILE_BYTES,
 	seemsLikeBinary,
 	createDownloadUrl,
 	getMimeType,
 	isPreviewableBinary,
+	readFileForInlinePreview,
 } from './file-utils';
 
 export type FileExplorerSidebarProps = {
@@ -39,6 +39,11 @@ export type FileExplorerSidebarProps = {
 		path: string | null,
 		message: string | JSX.Element
 	) => Promise<void> | void;
+	onBeforePathChange?: (
+		path: string
+	) => Promise<boolean | void> | boolean | void;
+	onPathMoved?: (from: string, to: string) => Promise<void> | void;
+	onPathDeleted?: (path: string) => Promise<void> | void;
 	documentRoot: string;
 };
 
@@ -50,6 +55,9 @@ export function FileExplorerSidebar({
 	onFileOpened,
 	onSelectionCleared,
 	onShowMessage,
+	onBeforePathChange,
+	onPathMoved,
+	onPathDeleted,
 	documentRoot,
 }: FileExplorerSidebarProps) {
 	const treeRef = useRef<FilePickerTreeHandle | null>(null);
@@ -71,29 +79,30 @@ export function FileExplorerSidebar({
 	const handleOpenFile = async (path: string, shouldFocus: boolean) => {
 		try {
 			const file = await filesystem.read(path);
-			const data = new Uint8Array(await file.arrayBuffer());
-			const size = data.byteLength;
+			const fileRead = await readFileForInlinePreview(file);
 			const filename = path.split('/').pop() || 'download';
-
-			if (size > MAX_INLINE_FILE_BYTES) {
-				const { url, filename: fname } = createDownloadUrl(
-					data,
-					filename
-				);
+			if (fileRead.type === 'too-large') {
 				await onShowMessage(
 					path,
 					<>
 						<p>File too large to open (&gt;1MB).</p>
 						<p>
-							<a href={url} download={fname}>
-								Download {fname}
-							</a>
+							{fileRead.downloadUrl ? (
+								<a
+									href={fileRead.downloadUrl}
+									download={filename}
+								>
+									Download {filename}
+								</a>
+							) : (
+								'Open or download it outside the in-browser editor.'
+							)}
 						</p>
 					</>
 				);
 				return;
 			}
-
+			const data = fileRead.data;
 			if (seemsLikeBinary(data)) {
 				const mimeType = getMimeType(filename);
 				const { url: downloadUrl, filename: fname } = createDownloadUrl(
@@ -208,6 +217,9 @@ export function FileExplorerSidebar({
 						// On double-click, open the file and move focus to the editor
 						await handleOpenFile(path, true);
 					}}
+					onBeforePathChange={onBeforePathChange}
+					onPathMoved={onPathMoved}
+					onPathDeleted={onPathDeleted}
 				/>
 			</div>
 		</div>

--- a/packages/playground/components/src/PlaygroundFileEditor/file-utils.spec.ts
+++ b/packages/playground/components/src/PlaygroundFileEditor/file-utils.spec.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from 'vitest';
+import { readFileForInlinePreview } from './file-utils';
+
+describe('readFileForInlinePreview', () => {
+	it('reads files within the inline preview limit', async () => {
+		const file = {
+			size: 5,
+			arrayBuffer: vi.fn(
+				async () => new TextEncoder().encode('hello').buffer
+			),
+		};
+
+		const result = await readFileForInlinePreview(file, 10);
+
+		expect(result).toEqual({
+			type: 'inline',
+			data: new TextEncoder().encode('hello'),
+		});
+		expect(file.arrayBuffer).toHaveBeenCalledOnce();
+	});
+
+	it('rejects oversized files before buffering them', async () => {
+		const file = {
+			size: 11,
+			arrayBuffer: vi.fn(async () => new Uint8Array(11).buffer),
+		};
+
+		const result = await readFileForInlinePreview(file, 10);
+
+		expect(result).toEqual({ type: 'too-large', downloadUrl: undefined });
+		expect(file.arrayBuffer).not.toHaveBeenCalled();
+	});
+
+	it('falls back to measured bytes when the known size is invalid', async () => {
+		const file = {
+			filesize: Number.NaN,
+			arrayBuffer: vi.fn(async () => new Uint8Array(11).buffer),
+		};
+
+		const result = await readFileForInlinePreview(file, 10);
+
+		expect(result).toEqual({ type: 'too-large', downloadUrl: undefined });
+		expect(file.arrayBuffer).toHaveBeenCalledOnce();
+	});
+});

--- a/packages/playground/components/src/PlaygroundFileEditor/file-utils.ts
+++ b/packages/playground/components/src/PlaygroundFileEditor/file-utils.ts
@@ -39,6 +39,68 @@ export const createDownloadUrl = (
 	return { url, filename };
 };
 
+export type InlineFilePreviewReadResult =
+	| { type: 'inline'; data: Uint8Array }
+	| { type: 'too-large'; downloadUrl?: string };
+
+type BrowserReadableFile = {
+	arrayBuffer(): Promise<ArrayBuffer>;
+	size?: number;
+	filesize?: number;
+};
+
+/**
+ * Reads a file for inline editing without buffering files that already report
+ * they are larger than the editor limit.
+ */
+export async function readFileForInlinePreview(
+	file: BrowserReadableFile,
+	maxInlineBytes = MAX_INLINE_FILE_BYTES
+): Promise<InlineFilePreviewReadResult> {
+	const knownSize = getKnownFileSize(file);
+	if (knownSize !== undefined && knownSize > maxInlineBytes) {
+		return {
+			type: 'too-large',
+			downloadUrl: createObjectUrlForNativeBlob(file, knownSize),
+		};
+	}
+
+	const data = new Uint8Array(await file.arrayBuffer());
+	if (data.byteLength > maxInlineBytes) {
+		return {
+			type: 'too-large',
+			downloadUrl: createObjectUrlForNativeBlob(file, data.byteLength),
+		};
+	}
+	return { type: 'inline', data };
+}
+
+function getKnownFileSize(file: BrowserReadableFile): number | undefined {
+	if (isValidFileSize(file.filesize)) {
+		return file.filesize;
+	}
+	if (isValidFileSize(file.size)) {
+		return file.size;
+	}
+	return undefined;
+}
+
+function isValidFileSize(size: unknown): size is number {
+	return typeof size === 'number' && Number.isFinite(size) && size >= 0;
+}
+
+function createObjectUrlForNativeBlob(
+	file: BrowserReadableFile,
+	expectedSize: number
+): string | undefined {
+	if (file instanceof Blob && file.size === expectedSize) {
+		const url = URL.createObjectURL(file);
+		setTimeout(() => URL.revokeObjectURL(url), 60_000);
+		return url;
+	}
+	return undefined;
+}
+
 /**
  * Gets the MIME type for a filename based on its extension.
  */

--- a/packages/playground/components/src/PlaygroundFileEditor/playground-file-editor.spec.tsx
+++ b/packages/playground/components/src/PlaygroundFileEditor/playground-file-editor.spec.tsx
@@ -1,0 +1,379 @@
+// @vitest-environment jsdom
+import type * as ReactModule from 'react';
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AsyncWritableFilesystem } from '@wp-playground/storage';
+import { basename, dirname, normalizePath } from '@php-wasm/util';
+import { PlaygroundFileEditor } from './playground-file-editor';
+
+(
+	globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const mocks = vi.hoisted(() => ({
+	latestSidebarProps: undefined as any,
+	latestEditorProps: undefined as any,
+	editorHandle: {
+		focus: vi.fn(),
+		blur: vi.fn(),
+		getCursorPosition: vi.fn(() => 0),
+		setCursorPosition: vi.fn(),
+	},
+}));
+
+vi.mock('@wordpress/components', async () => {
+	const ReactActual = await vi.importActual<typeof ReactModule>('react');
+	return {
+		Button: (props: any) => {
+			const buttonProps = { ...props };
+			for (const prop of [
+				'icon',
+				'iconPosition',
+				'iconSize',
+				'isBusy',
+				'isDestructive',
+				'variant',
+			]) {
+				delete buttonProps[prop];
+			}
+			return ReactActual.createElement(
+				'button',
+				buttonProps,
+				props.children
+			);
+		},
+		Notice: ({ children }: any) =>
+			ReactActual.createElement('div', { role: 'alert' }, children),
+	};
+});
+
+vi.mock('./file-explorer-sidebar', async () => {
+	const ReactActual = await vi.importActual<typeof ReactModule>('react');
+	return {
+		FileExplorerSidebar: (props: any) => {
+			mocks.latestSidebarProps = props;
+			return ReactActual.createElement('div', {
+				'aria-label': 'Files',
+			});
+		},
+	};
+});
+
+vi.mock('./code-editor', async () => {
+	const ReactActual = await vi.importActual<typeof ReactModule>('react');
+	return {
+		CodeEditor: ReactActual.forwardRef((props: any, ref) => {
+			mocks.latestEditorProps = props;
+			ReactActual.useImperativeHandle(ref, () => mocks.editorHandle);
+			return ReactActual.createElement('textarea', {
+				value: props.code,
+				readOnly: props.readOnly,
+				onChange: (event: React.ChangeEvent<HTMLTextAreaElement>) =>
+					props.onChange(event.target.value),
+			});
+		}),
+	};
+});
+
+describe('PlaygroundFileEditor file tree mutations', () => {
+	let container: HTMLDivElement;
+	let root: Root;
+
+	beforeEach(() => {
+		vi.useFakeTimers();
+		mocks.latestSidebarProps = undefined;
+		mocks.latestEditorProps = undefined;
+		mocks.editorHandle.focus.mockClear();
+		mocks.editorHandle.blur.mockClear();
+		mocks.editorHandle.getCursorPosition.mockClear();
+		mocks.editorHandle.getCursorPosition.mockReturnValue(0);
+		mocks.editorHandle.setCursorPosition.mockClear();
+		container = document.createElement('div');
+		document.body.appendChild(container);
+		root = createRoot(container);
+	});
+
+	afterEach(() => {
+		act(() => {
+			root.unmount();
+		});
+		container.remove();
+		vi.useRealTimers();
+	});
+
+	it('remaps the current file after rename without recreating the old path', async () => {
+		const filesystem = new InMemoryFilesystem({
+			'/wordpress/index.php': 'old content',
+		});
+		renderEditor(root, filesystem);
+		await openFile('/wordpress/index.php', 'old content');
+		await changeEditorContent('changed content');
+
+		await expectBeforePathChange('/wordpress/index.php', true);
+		await expect(
+			filesystem.readFileAsText('/wordpress/index.php')
+		).resolves.toBe('changed content');
+
+		await filesystem.mv('/wordpress/index.php', '/wordpress/main.php');
+		await act(async () => {
+			await mocks.latestSidebarProps.onPathMoved(
+				'/wordpress/index.php',
+				'/wordpress/main.php'
+			);
+		});
+		await act(async () => {
+			vi.advanceTimersByTime(1500);
+		});
+
+		expect(mocks.latestEditorProps.currentPath).toBe('/wordpress/main.php');
+		await expect(
+			filesystem.fileExists('/wordpress/index.php')
+		).resolves.toBe(false);
+		await expect(
+			filesystem.readFileAsText('/wordpress/main.php')
+		).resolves.toBe('changed content');
+	});
+
+	it('keeps pending saves for unrelated path changes', async () => {
+		const filesystem = new InMemoryFilesystem({
+			'/wordpress/index.php': 'old content',
+			'/wordpress/other.php': 'other content',
+		});
+		renderEditor(root, filesystem);
+		await openFile('/wordpress/index.php', 'old content');
+		await changeEditorContent('changed content');
+
+		await expectBeforePathChange('/wordpress/other.php', true);
+		await filesystem.mv('/wordpress/other.php', '/wordpress/moved.php');
+		await act(async () => {
+			await mocks.latestSidebarProps.onPathMoved(
+				'/wordpress/other.php',
+				'/wordpress/moved.php'
+			);
+		});
+		await act(async () => {
+			vi.advanceTimersByTime(1500);
+		});
+
+		await expect(
+			filesystem.readFileAsText('/wordpress/index.php')
+		).resolves.toBe('changed content');
+	});
+
+	it('clears a deleted open file without saving it again', async () => {
+		const filesystem = new InMemoryFilesystem({
+			'/wordpress/index.php': 'old content',
+		});
+		renderEditor(root, filesystem);
+		await openFile('/wordpress/index.php', 'old content');
+		await changeEditorContent('changed content');
+
+		await expectBeforePathChange('/wordpress/index.php', true);
+		await filesystem.unlink('/wordpress/index.php');
+		await act(async () => {
+			await mocks.latestSidebarProps.onPathDeleted(
+				'/wordpress/index.php'
+			);
+			await mocks.latestSidebarProps.onSelectionCleared();
+		});
+		await act(async () => {
+			vi.advanceTimersByTime(1500);
+		});
+
+		await expect(
+			filesystem.fileExists('/wordpress/index.php')
+		).resolves.toBe(false);
+		expect(filesystem.writeLog).toEqual([
+			{ path: '/wordpress/index.php', content: 'changed content' },
+		]);
+	});
+});
+
+function renderEditor(root: Root, filesystem: AsyncWritableFilesystem) {
+	act(() => {
+		root.render(
+			<PlaygroundFileEditor
+				filesystem={filesystem}
+				documentRoot="/wordpress"
+			/>
+		);
+	});
+}
+
+async function openFile(path: string, content: string) {
+	await act(async () => {
+		await mocks.latestSidebarProps.onFileOpened(path, content, false);
+	});
+}
+
+async function changeEditorContent(content: string) {
+	await act(async () => {
+		mocks.latestEditorProps.onChange(content);
+	});
+}
+
+async function expectBeforePathChange(path: string, expected: boolean) {
+	let result: unknown;
+	await act(async () => {
+		result = await mocks.latestSidebarProps.onBeforePathChange(path);
+	});
+	expect(result).toBe(expected);
+}
+
+class InMemoryFilesystem
+	extends EventTarget
+	implements AsyncWritableFilesystem
+{
+	readonly files = new Map<string, string>();
+	readonly directories = new Set<string>(['/']);
+	readonly writeLog: Array<{ path: string; content: string }> = [];
+
+	constructor(files: Record<string, string>) {
+		super();
+		for (const [path, content] of Object.entries(files)) {
+			const normalizedPath = normalizePath(path);
+			this.ensureDirectory(dirname(normalizedPath));
+			this.files.set(normalizedPath, content);
+		}
+	}
+
+	async isDir(path: string): Promise<boolean> {
+		return this.directories.has(normalizePath(path));
+	}
+
+	async fileExists(path: string): Promise<boolean> {
+		return this.files.has(normalizePath(path));
+	}
+
+	async read(path: string): Promise<{ arrayBuffer(): Promise<ArrayBuffer> }> {
+		const content = await this.readFileAsText(path);
+		const data = new TextEncoder().encode(content);
+		return {
+			arrayBuffer: async () => data.buffer,
+		};
+	}
+
+	async readFileAsText(path: string): Promise<string> {
+		const normalizedPath = normalizePath(path);
+		const content = this.files.get(normalizedPath);
+		if (content === undefined) {
+			throw new Error(`File not found: ${normalizedPath}`);
+		}
+		return content;
+	}
+
+	async listFiles(path: string): Promise<string[]> {
+		const normalizedPath = normalizePath(path);
+		const children = new Set<string>();
+		for (const directory of this.directories) {
+			if (
+				directory !== normalizedPath &&
+				dirname(directory) === normalizedPath
+			) {
+				children.add(basename(directory));
+			}
+		}
+		for (const filePath of this.files.keys()) {
+			if (dirname(filePath) === normalizedPath) {
+				children.add(basename(filePath));
+			}
+		}
+		return [...children];
+	}
+
+	async writeFile(path: string, data: Uint8Array | string): Promise<void> {
+		const normalizedPath = normalizePath(path);
+		const content =
+			typeof data === 'string' ? data : new TextDecoder().decode(data);
+		this.ensureDirectory(dirname(normalizedPath));
+		this.files.set(normalizedPath, content);
+		this.writeLog.push({ path: normalizedPath, content });
+	}
+
+	async mkdir(path: string): Promise<void> {
+		this.ensureDirectory(path);
+	}
+
+	async rmdir(path: string): Promise<void> {
+		const normalizedPath = normalizePath(path);
+		for (const filePath of [...this.files.keys()]) {
+			if (isSameOrChildPath(normalizedPath, filePath)) {
+				this.files.delete(filePath);
+			}
+		}
+		for (const directory of [...this.directories]) {
+			if (
+				directory !== '/' &&
+				isSameOrChildPath(normalizedPath, directory)
+			) {
+				this.directories.delete(directory);
+			}
+		}
+	}
+
+	async mv(source: string, destination: string): Promise<void> {
+		const normalizedSource = normalizePath(source);
+		const normalizedDestination = normalizePath(destination);
+		if (this.files.has(normalizedSource)) {
+			const content = this.files.get(normalizedSource) as string;
+			this.ensureDirectory(dirname(normalizedDestination));
+			this.files.set(normalizedDestination, content);
+			this.files.delete(normalizedSource);
+			return;
+		}
+		if (!this.directories.has(normalizedSource)) {
+			throw new Error(`Path not found: ${normalizedSource}`);
+		}
+		const renamedFiles = [...this.files.entries()].map(
+			([path, content]) =>
+				[
+					remapPath(path, normalizedSource, normalizedDestination),
+					content,
+				] as const
+		);
+		const renamedDirectories = [...this.directories].map((path) =>
+			remapPath(path, normalizedSource, normalizedDestination)
+		);
+		this.files.clear();
+		for (const [path, content] of renamedFiles) {
+			this.files.set(path, content);
+		}
+		this.directories.clear();
+		for (const path of renamedDirectories) {
+			this.directories.add(path);
+		}
+	}
+
+	async unlink(path: string): Promise<void> {
+		this.files.delete(normalizePath(path));
+	}
+
+	private ensureDirectory(path: string): void {
+		const normalizedPath = normalizePath(path || '/');
+		const parts = normalizedPath.split('/').filter(Boolean);
+		let current = '/';
+		this.directories.add(current);
+		for (const part of parts) {
+			current = current === '/' ? `/${part}` : `${current}/${part}`;
+			this.directories.add(current);
+		}
+	}
+}
+
+function remapPath(path: string, from: string, to: string): string {
+	if (path === from) {
+		return to;
+	}
+	if (path.startsWith(`${from}/`)) {
+		return `${to}${path.slice(from.length)}`;
+	}
+	return path;
+}
+
+function isSameOrChildPath(parentPath: string, candidatePath: string): boolean {
+	return (
+		candidatePath === parentPath ||
+		candidatePath.startsWith(`${parentPath}/`)
+	);
+}

--- a/packages/playground/components/src/PlaygroundFileEditor/playground-file-editor.tsx
+++ b/packages/playground/components/src/PlaygroundFileEditor/playground-file-editor.tsx
@@ -6,6 +6,7 @@ import { FileExplorerSidebar } from './file-explorer-sidebar';
 import { CodeEditor, type CodeEditorHandle } from './code-editor';
 import styles from './playground-file-editor.module.css';
 import { logger } from '@php-wasm/logger';
+import { dirname } from '@php-wasm/util';
 
 const SAVE_DEBOUNCE_MS = 1500;
 
@@ -394,6 +395,102 @@ export function PlaygroundFileEditor({
 		}
 	}, [onSaveFile]);
 
+	const flushCurrentFile = useCallback(async () => {
+		if (saveTimeoutRef.current !== null) {
+			window.clearTimeout(saveTimeoutRef.current);
+			saveTimeoutRef.current = null;
+		}
+		if (!filesystemRef.current || !currentPathRef.current) {
+			return true;
+		}
+		setSaveState(SaveState.SAVING);
+		try {
+			const pathToSave = currentPathRef.current;
+			const contentToSave = codeRef.current;
+			if (onSaveFile) {
+				await onSaveFile(pathToSave, contentToSave);
+			} else {
+				await filesystemRef.current.writeFile(
+					pathToSave,
+					contentToSave
+				);
+			}
+			setSaveState(SaveState.SAVED);
+			setSaveError(null);
+			return true;
+		} catch (error) {
+			logger.error('Failed to save file', error);
+			setSaveState(SaveState.ERROR);
+			setSaveError('Could not save changes. Try again.');
+			return false;
+		}
+	}, [onSaveFile]);
+
+	const handleBeforePathChange = useCallback(
+		async (path: string) => {
+			if (!pathContainsCurrentFile(path, currentPathRef.current)) {
+				return true;
+			}
+			const didFlush = await flushCurrentFile();
+			if (!didFlush) {
+				setSaveError(
+					'Could not save changes before modifying this file. Try again.'
+				);
+				return false;
+			}
+			return true;
+		},
+		[flushCurrentFile]
+	);
+
+	const handlePathMoved = useCallback((from: string, to: string) => {
+		remapCursorPositions(cursorPositionsRef.current, from, to);
+		setSelectedDirPath((previous) => remapEditorPath(previous, from, to));
+
+		const mappedCurrentPath = remapEditorPath(
+			currentPathRef.current,
+			from,
+			to
+		);
+		if (mappedCurrentPath === currentPathRef.current) {
+			return;
+		}
+		skipNextSaveRef.current = true;
+		currentPathRef.current = mappedCurrentPath;
+		setCurrentPath(mappedCurrentPath);
+		setSaveState(SaveState.IDLE);
+		setSaveError(null);
+	}, []);
+
+	const handlePathDeleted = useCallback(
+		(path: string) => {
+			removeCursorPositionsForPath(cursorPositionsRef.current, path);
+			setSelectedDirPath((previous) =>
+				pathContainsCurrentFile(path, previous)
+					? dirname(path) || documentRoot
+					: previous
+			);
+			if (!pathContainsCurrentFile(path, currentPathRef.current)) {
+				return;
+			}
+			skipNextSaveRef.current = true;
+			if (saveTimeoutRef.current !== null) {
+				window.clearTimeout(saveTimeoutRef.current);
+				saveTimeoutRef.current = null;
+			}
+			currentPathRef.current = null;
+			codeRef.current = '';
+			setCurrentPath(null);
+			setCode('');
+			setMessageContent(null);
+			setReadOnly(true);
+			setSaveState(SaveState.IDLE);
+			setSaveError(null);
+			setShowExplorerOnMobile(false);
+		},
+		[documentRoot]
+	);
+
 	const saveStatusLabel = getSaveStatusLabel(saveState, saveError);
 	const saveStatusClassName = getSaveStatusClassName(saveState, styles);
 
@@ -425,6 +522,9 @@ export function PlaygroundFileEditor({
 						onFileOpened={handleFileOpened}
 						onSelectionCleared={handleClearSelection}
 						onShowMessage={handleShowMessage}
+						onBeforePathChange={handleBeforePathChange}
+						onPathMoved={handlePathMoved}
+						onPathDeleted={handlePathDeleted}
 						documentRoot={documentRoot}
 					/>
 				</aside>
@@ -492,6 +592,58 @@ export function PlaygroundFileEditor({
 			</div>
 		</div>
 	);
+}
+
+function pathContainsCurrentFile(path: string, currentFilePath: string | null) {
+	if (!currentFilePath) {
+		return false;
+	}
+	return (
+		currentFilePath === path ||
+		currentFilePath.startsWith(path === '/' ? '/' : `${path}/`)
+	);
+}
+
+function remapEditorPath(
+	value: string | null,
+	from: string,
+	to: string
+): string | null {
+	if (!value) {
+		return value;
+	}
+	if (value === from) {
+		return to;
+	}
+	if (value.startsWith(from === '/' ? '/' : `${from}/`)) {
+		return to + value.slice(from.length);
+	}
+	return value;
+}
+
+function remapCursorPositions(
+	cursorPositions: Map<string, number>,
+	from: string,
+	to: string
+) {
+	for (const [path, position] of [...cursorPositions.entries()]) {
+		const mappedPath = remapEditorPath(path, from, to);
+		if (mappedPath && mappedPath !== path) {
+			cursorPositions.delete(path);
+			cursorPositions.set(mappedPath, position);
+		}
+	}
+}
+
+function removeCursorPositionsForPath(
+	cursorPositions: Map<string, number>,
+	pathToRemove: string
+) {
+	for (const path of [...cursorPositions.keys()]) {
+		if (pathContainsCurrentFile(pathToRemove, path)) {
+			cursorPositions.delete(path);
+		}
+	}
 }
 
 function getSaveStatusLabel(saveState: SaveState, saveError: string | null) {

--- a/packages/playground/components/src/download-database.spec.ts
+++ b/packages/playground/components/src/download-database.spec.ts
@@ -1,0 +1,100 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+	createDatabaseDownloadScript,
+	downloadDatabase,
+} from './download-database';
+
+describe('downloadDatabase', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('downloads through a token-gated PHP script instead of buffering in JS', async () => {
+		const databasePath = '/wordpress/wp-content/database/.ht.sqlite';
+		const playground = createPlaygroundClient(databasePath);
+		const appendChildSpy = vi.spyOn(document.body, 'appendChild');
+
+		try {
+			await downloadDatabase(playground, databasePath);
+
+			expect(playground.readFileAsBuffer).not.toHaveBeenCalled();
+			expect(playground.writeFile).toHaveBeenCalledOnce();
+			const [scriptPath, script] = playground.writeFile.mock.calls[0];
+			expect(scriptPath).toMatch(
+				/^\/wordpress\/\.playground-database-download-[a-f0-9]{32}\.php$/
+			);
+			expect(script).toContain(
+				"$databasePath = '/wordpress/wp-content/database/.ht.sqlite';"
+			);
+			expect(script).toContain('fread($handle, 1048576)');
+
+			const frame = appendChildSpy.mock.calls[0][0] as HTMLIFrameElement;
+			expect(frame.src).toMatch(
+				/^https:\/\/example\.test\/scope:test\/\.playground-database-download-[a-f0-9]{32}\.php\?token=[a-f0-9]{32}$/
+			);
+			expect(frame.hidden).toBe(true);
+			expect(frame.getAttribute('aria-hidden')).toBe('true');
+			expect(playground.unlink).not.toHaveBeenCalled();
+
+			await vi.advanceTimersByTimeAsync(60_000);
+			expect(playground.unlink).toHaveBeenCalledWith(scriptPath);
+			expect(frame.isConnected).toBe(true);
+
+			await vi.advanceTimersByTimeAsync(9 * 60_000);
+			expect(frame.isConnected).toBe(false);
+		} finally {
+			appendChildSpy.mockRestore();
+		}
+	});
+});
+
+describe('createDatabaseDownloadScript', () => {
+	it('escapes PHP string literals and stays compatible with legacy PHP', () => {
+		const script = createDatabaseDownloadScript(
+			"/wordpress/wp-content/weird'\\db.sqlite",
+			'abcdef0123456789abcdef0123456789'
+		);
+
+		expect(script).toContain(
+			"$databasePath = '/wordpress/wp-content/weird\\'\\\\db.sqlite';"
+		);
+		expect(script).toContain(
+			"register_shutdown_function('playground_database_download_cleanup_abcdef0123456789abcdef0123456789')"
+		);
+		expect(script).toContain('$providedToken !== $expectedToken');
+		expect(script).toContain("is_string($_GET['token'])");
+		expect(script).toContain('fread($handle, 1048576)');
+		expect(script).not.toContain('function ()');
+		expect(script).not.toContain('=>');
+	});
+
+	it('rejects tokens that cannot be embedded in PHP function names', () => {
+		expect(() =>
+			createDatabaseDownloadScript(
+				'/wordpress/database.sqlite',
+				'bad-token'
+			)
+		).toThrow('Invalid database download token.');
+	});
+});
+
+function createPlaygroundClient(databasePath: string) {
+	return {
+		absoluteUrl: Promise.resolve('https://example.test/scope:test'),
+		documentRoot: Promise.resolve('/wordpress'),
+		fileExists: vi.fn(async (path: string) => path === databasePath),
+		readFileAsBuffer: vi.fn(),
+		unlink: vi.fn(async (path: string) => {
+			void path;
+		}),
+		writeFile: vi.fn(async (path: string, contents: string) => {
+			void path;
+			void contents;
+		}),
+	};
+}

--- a/packages/playground/components/src/download-database.ts
+++ b/packages/playground/components/src/download-database.ts
@@ -1,0 +1,190 @@
+import { logger } from '@php-wasm/logger';
+import { joinPaths } from '@php-wasm/util';
+
+const DATABASE_DOWNLOAD_FILENAME = 'database.sqlite';
+// The download request goes through the Playground service worker/PHP queue.
+// Keep the script around longer than the PHP request timeout so cleanup cannot
+// delete it before a queued download starts.
+const TEMPORARY_DOWNLOAD_SCRIPT_TTL = 60_000;
+// Keep the iframe around longer than the temporary PHP script. Removing the
+// frame can cancel a slow browser download even after the PHP script started.
+const DOWNLOAD_FRAME_TTL = 10 * TEMPORARY_DOWNLOAD_SCRIPT_TTL;
+
+export type DatabaseDownloadPlayground = {
+	absoluteUrl: Promise<string>;
+	documentRoot: Promise<string>;
+	fileExists(path: string): Promise<boolean>;
+	writeFile(path: string, contents: string): Promise<void>;
+	unlink(path: string): Promise<void>;
+};
+
+export async function downloadDatabase(
+	playground: DatabaseDownloadPlayground,
+	databasePath: string
+): Promise<void> {
+	const fileExists = await playground.fileExists(databasePath);
+	if (!fileExists) {
+		throw new Error('Database file does not exist');
+	}
+
+	const token = createDownloadToken();
+	const scriptFileName = `.playground-database-download-${token}.php`;
+	const documentRoot = await playground.documentRoot;
+	const scriptPath = joinPaths(documentRoot, scriptFileName);
+	let downloadStarted = false;
+
+	try {
+		await playground.writeFile(
+			scriptPath,
+			createDatabaseDownloadScript(databasePath, token)
+		);
+		const playgroundUrl = await playground.absoluteUrl;
+		startDownloadInHiddenFrame(
+			createDatabaseDownloadUrl(playgroundUrl, scriptFileName, token)
+		);
+		downloadStarted = true;
+	} finally {
+		if (downloadStarted) {
+			scheduleDownloadScriptCleanup(playground, scriptPath);
+		} else {
+			await removeDownloadScript(playground, scriptPath);
+		}
+	}
+}
+
+export function createDatabaseDownloadScript(
+	databasePath: string,
+	token: string
+): string {
+	assertValidDownloadToken(token);
+	const cleanupFunction = `playground_database_download_cleanup_${token}`;
+	const statusFunction = `playground_database_download_status_${token}`;
+	return `<?php
+$databasePath = ${phpSingleQuotedString(databasePath)};
+$expectedToken = ${phpSingleQuotedString(token)};
+
+function ${cleanupFunction}() {
+	@unlink(__FILE__);
+}
+
+function ${statusFunction}($code, $text) {
+	header('HTTP/1.1 ' . $code . ' ' . $text, true, $code);
+}
+
+$providedToken = isset($_GET['token']) && is_string($_GET['token'])
+	? $_GET['token']
+	: '';
+if ($providedToken !== $expectedToken) {
+	${statusFunction}(403, 'Forbidden');
+	exit;
+}
+
+register_shutdown_function('${cleanupFunction}');
+
+if (!is_file($databasePath)) {
+	${statusFunction}(404, 'Not Found');
+	exit;
+}
+
+$databaseSize = filesize($databasePath);
+if ($databaseSize === false) {
+	${statusFunction}(500, 'Internal Server Error');
+	exit;
+}
+
+$handle = fopen($databasePath, 'rb');
+if ($handle === false) {
+	${statusFunction}(500, 'Internal Server Error');
+	exit;
+}
+
+header('Content-Type: application/x-sqlite3');
+header('Content-Disposition: attachment; filename="${DATABASE_DOWNLOAD_FILENAME}"');
+header('Content-Length: ' . $databaseSize);
+
+while (!feof($handle)) {
+	$chunk = fread($handle, 1048576);
+	if ($chunk === false) {
+		fclose($handle);
+		exit;
+	}
+	if ($chunk === '') {
+		break;
+	}
+	echo $chunk;
+	flush();
+}
+
+fclose($handle);
+`;
+}
+
+function assertValidDownloadToken(token: string): void {
+	if (!/^[a-f0-9]{32}$/.test(token)) {
+		throw new Error('Invalid database download token.');
+	}
+}
+
+function createDownloadToken(): string {
+	const bytes = new Uint8Array(16);
+	globalThis.crypto.getRandomValues(bytes);
+	return Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join(
+		''
+	);
+}
+
+function createDatabaseDownloadUrl(
+	playgroundUrl: string,
+	scriptFileName: string,
+	token: string
+): string {
+	const baseUrl = playgroundUrl.endsWith('/')
+		? playgroundUrl
+		: `${playgroundUrl}/`;
+	const url = new URL(scriptFileName, baseUrl);
+	url.searchParams.set('token', token);
+	return url.toString();
+}
+
+function startDownloadInHiddenFrame(downloadUrl: string): void {
+	const frame = document.createElement('iframe');
+	frame.hidden = true;
+	frame.src = downloadUrl;
+	frame.title = '';
+	frame.setAttribute('aria-hidden', 'true');
+	document.body.appendChild(frame);
+	window.setTimeout(() => {
+		frame.remove();
+	}, DOWNLOAD_FRAME_TTL);
+}
+
+function scheduleDownloadScriptCleanup(
+	playground: DatabaseDownloadPlayground,
+	scriptPath: string
+): void {
+	window.setTimeout(() => {
+		void removeDownloadScript(playground, scriptPath).catch((error) => {
+			logger.error(
+				'Failed to remove temporary database download script',
+				error
+			);
+		});
+	}, TEMPORARY_DOWNLOAD_SCRIPT_TTL);
+}
+
+async function removeDownloadScript(
+	playground: DatabaseDownloadPlayground,
+	scriptPath: string
+): Promise<void> {
+	try {
+		await playground.unlink(scriptPath);
+	} catch (error) {
+		if (await playground.fileExists(scriptPath).catch(() => false)) {
+			throw error;
+		}
+	}
+}
+
+function phpSingleQuotedString(value: string): string {
+	return `'${value.replace(/['\\]/g, '\\$&')}'`;
+}

--- a/packages/playground/components/src/get-remote-file-size.spec.ts
+++ b/packages/playground/components/src/get-remote-file-size.spec.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from 'vitest';
+import { getRemoteFileSize } from './get-remote-file-size';
+
+describe('getRemoteFileSize', () => {
+	it('asks PHP for the file size without reading the file into JavaScript', async () => {
+		const playground = {
+			run: vi.fn(async () => ({ text: '12345' })),
+		};
+
+		await expect(
+			getRemoteFileSize(playground, '/wordpress/wp-content/big.zip')
+		).resolves.toBe(12345);
+
+		expect(playground.run).toHaveBeenCalledWith({
+			code: expect.stringContaining('filesize($path)'),
+			env: {
+				PLAYGROUND_FILE_SIZE_PATH: '/wordpress/wp-content/big.zip',
+			},
+		});
+	});
+
+	it('throws when PHP does not print a numeric file size', async () => {
+		const playground = {
+			run: vi.fn(async () => ({ text: '' })),
+		};
+
+		await expect(
+			getRemoteFileSize(playground, '/wordpress/missing.zip')
+		).rejects.toThrow('Could not read the size of /wordpress/missing.zip.');
+	});
+
+	it('throws when PHP prints a size JavaScript cannot represent safely', async () => {
+		const playground = {
+			run: vi.fn(async () => ({
+				text: String(Number.MAX_SAFE_INTEGER + 1),
+			})),
+		};
+
+		await expect(
+			getRemoteFileSize(playground, '/wordpress/huge.zip')
+		).rejects.toThrow('Could not read the size of /wordpress/huge.zip.');
+	});
+});

--- a/packages/playground/components/src/get-remote-file-size.ts
+++ b/packages/playground/components/src/get-remote-file-size.ts
@@ -1,0 +1,34 @@
+export type PlaygroundFileSizeClient = {
+	run(options: {
+		code: string;
+		env: Record<string, string>;
+	}): Promise<{ text: string }>;
+};
+
+export async function getRemoteFileSize(
+	playground: PlaygroundFileSizeClient,
+	path: string
+): Promise<number> {
+	const response = await playground.run({
+		code: `<?php
+$path = getenv('PLAYGROUND_FILE_SIZE_PATH');
+clearstatcache(true, $path);
+$size = filesize($path);
+if ($size !== false) {
+	echo $size;
+}
+`,
+		env: {
+			PLAYGROUND_FILE_SIZE_PATH: path,
+		},
+	});
+	const sizeText = response.text.trim();
+	if (!/^\d+$/.test(sizeText)) {
+		throw new Error(`Could not read the size of ${path}.`);
+	}
+	const size = Number(sizeText);
+	if (!Number.isSafeInteger(size)) {
+		throw new Error(`Could not read the size of ${path}.`);
+	}
+	return size;
+}

--- a/packages/playground/components/src/index.ts
+++ b/packages/playground/components/src/index.ts
@@ -3,3 +3,11 @@ export * from './FilePickerTree/index';
 export * from './FilePickerControl/index';
 export * from './BinaryFilePreview';
 export * from './PlaygroundFileEditor/index';
+export {
+	getRemoteFileSize,
+	type PlaygroundFileSizeClient,
+} from './get-remote-file-size';
+export {
+	downloadDatabase,
+	type DatabaseDownloadPlayground,
+} from './download-database';

--- a/packages/playground/personal-wp/src/components/site-manager/site-database-panel/download-button.tsx
+++ b/packages/playground/personal-wp/src/components/site-manager/site-database-panel/download-button.tsx
@@ -1,47 +1,54 @@
+import { useRef, useState } from 'react';
 import { Button, Icon, Flex, FlexItem } from '@wordpress/components';
 import { download } from '@wordpress/icons';
 import type { PlaygroundClient } from '@wp-playground/client';
+import { downloadDatabase } from '@wp-playground/components';
+import { logger } from '@php-wasm/logger';
+import css from './style.module.css';
 
 const DATABASE_PATH = '/wordpress/wp-content/database/.ht.sqlite';
-
-async function downloadDatabase(playground: PlaygroundClient): Promise<void> {
-	const fileExists = await playground.fileExists(DATABASE_PATH);
-	if (!fileExists) {
-		throw new Error('Database file does not exist');
-	}
-
-	const buffer = await playground.readFileAsBuffer(DATABASE_PATH);
-	const blob = new Blob([new Uint8Array(buffer)], {
-		type: 'application/x-sqlite3',
-	});
-
-	const url = URL.createObjectURL(blob);
-	const link = document.createElement('a');
-	link.href = url;
-	link.download = 'database.sqlite';
-	link.click();
-	URL.revokeObjectURL(url);
-}
 
 export function DownloadButton({
 	playground,
 }: {
 	playground: PlaygroundClient | undefined;
 }) {
+	const isDownloadingRef = useRef(false);
+	const [downloadError, setDownloadError] = useState<string | null>(null);
+
+	const handleDownload = async () => {
+		if (!playground || isDownloadingRef.current) {
+			return;
+		}
+		isDownloadingRef.current = true;
+		setDownloadError(null);
+		try {
+			await downloadDatabase(playground, DATABASE_PATH);
+		} catch (error) {
+			logger.error('Failed to download database', error);
+			setDownloadError('Could not download the database. Try again.');
+		} finally {
+			isDownloadingRef.current = false;
+		}
+	};
+
 	return (
-		<Button
-			variant="secondary"
-			disabled={!playground}
-			onClick={
-				playground ? () => downloadDatabase(playground) : undefined
-			}
-		>
-			<Flex justify="space-between" gap={2} expanded={true}>
-				<FlexItem>Download database.sqlite</FlexItem>
-				<FlexItem>
-					<Icon icon={download} size={16} />
-				</FlexItem>
-			</Flex>
-		</Button>
+		<div>
+			<Button
+				variant="secondary"
+				disabled={!playground}
+				onClick={() => void handleDownload()}
+			>
+				<Flex justify="space-between" gap={2} expanded={true}>
+					<FlexItem>Download database.sqlite</FlexItem>
+					<FlexItem>
+						<Icon icon={download} size={16} />
+					</FlexItem>
+				</Flex>
+			</Button>
+			{downloadError ? (
+				<div className={css.error}>{downloadError}</div>
+			) : null}
+		</div>
 	);
 }

--- a/packages/playground/personal-wp/src/components/site-manager/site-database-panel/index.tsx
+++ b/packages/playground/personal-wp/src/components/site-manager/site-database-panel/index.tsx
@@ -4,6 +4,7 @@ import { Notice, __experimentalVStack as VStack } from '@wordpress/components';
 import { DownloadButton } from './download-button';
 import { AdminerButton } from './adminer-button';
 import { PhpMyAdminButton } from './phpmyadmin-button';
+import { getRemoteFileSize } from '@wp-playground/components';
 import css from './style.module.css';
 
 const DATABASE_PATH = '/wordpress/wp-content/database/.ht.sqlite';
@@ -27,9 +28,9 @@ export function SiteDatabasePanel({
 			try {
 				const fileExists = await playground.fileExists(DATABASE_PATH);
 				if (fileExists) {
-					const buffer =
-						await playground.readFileAsBuffer(DATABASE_PATH);
-					setDatabaseSize(buffer.byteLength);
+					setDatabaseSize(
+						await getRemoteFileSize(playground, DATABASE_PATH)
+					);
 				} else {
 					setDatabaseSize(null);
 				}

--- a/packages/playground/personal-wp/src/components/site-manager/site-file-browser/index.tsx
+++ b/packages/playground/personal-wp/src/components/site-manager/site-file-browser/index.tsx
@@ -7,7 +7,10 @@ import {
 	EventedFilesystem,
 } from '@wp-playground/storage';
 import type { PlaygroundClient } from '@wp-playground/remote';
-import { PlaygroundFileEditor } from '@wp-playground/components';
+import {
+	getRemoteFileSize,
+	PlaygroundFileEditor,
+} from '@wp-playground/components';
 import { logger } from '@php-wasm/logger';
 import { getDirectoryPathForSlug } from '../../../lib/state/opfs/opfs-site-storage';
 
@@ -99,10 +102,16 @@ class ClientFilesystemWrapper
 	fileExists(path: string) {
 		return this.client.fileExists(path);
 	}
-	async read(path: string): Promise<{ arrayBuffer(): Promise<ArrayBuffer> }> {
-		const buffer = await this.client.readFileAsBuffer(path);
+	async read(
+		path: string
+	): Promise<{ filesize: number; arrayBuffer(): Promise<ArrayBuffer> }> {
+		const filesize = await getRemoteFileSize(this.client, path);
 		return {
-			arrayBuffer: async () => buffer.buffer as ArrayBuffer,
+			filesize,
+			arrayBuffer: async () => {
+				const buffer = await this.client.readFileAsBuffer(path);
+				return toArrayBuffer(buffer);
+			},
 		};
 	}
 	readFileAsText(path: string) {
@@ -178,4 +187,8 @@ function useFilesystem(
 		// Fall back to direct OPFS access
 		return opfsFilesystem;
 	}, [client, opfsFilesystem]);
+}
+
+function toArrayBuffer(buffer: Uint8Array): ArrayBuffer {
+	return new Uint8Array(buffer).buffer;
 }

--- a/packages/playground/website/src/components/site-manager/site-database-panel/download-button.tsx
+++ b/packages/playground/website/src/components/site-manager/site-database-panel/download-button.tsx
@@ -1,47 +1,54 @@
+import { useRef, useState } from 'react';
 import { Button, Icon, Flex, FlexItem } from '@wordpress/components';
 import { download } from '@wordpress/icons';
 import type { PlaygroundClient } from '@wp-playground/client';
+import { downloadDatabase } from '@wp-playground/components';
+import { logger } from '@php-wasm/logger';
+import css from './style.module.css';
 
 const DATABASE_PATH = '/wordpress/wp-content/database/.ht.sqlite';
-
-async function downloadDatabase(playground: PlaygroundClient): Promise<void> {
-	const fileExists = await playground.fileExists(DATABASE_PATH);
-	if (!fileExists) {
-		throw new Error('Database file does not exist');
-	}
-
-	const buffer = await playground.readFileAsBuffer(DATABASE_PATH);
-	const blob = new Blob([new Uint8Array(buffer)], {
-		type: 'application/x-sqlite3',
-	});
-
-	const url = URL.createObjectURL(blob);
-	const link = document.createElement('a');
-	link.href = url;
-	link.download = 'database.sqlite';
-	link.click();
-	URL.revokeObjectURL(url);
-}
 
 export function DownloadButton({
 	playground,
 }: {
 	playground: PlaygroundClient | undefined;
 }) {
+	const isDownloadingRef = useRef(false);
+	const [downloadError, setDownloadError] = useState<string | null>(null);
+
+	const handleDownload = async () => {
+		if (!playground || isDownloadingRef.current) {
+			return;
+		}
+		isDownloadingRef.current = true;
+		setDownloadError(null);
+		try {
+			await downloadDatabase(playground, DATABASE_PATH);
+		} catch (error) {
+			logger.error('Failed to download database', error);
+			setDownloadError('Could not download the database. Try again.');
+		} finally {
+			isDownloadingRef.current = false;
+		}
+	};
+
 	return (
-		<Button
-			variant="secondary"
-			disabled={!playground}
-			onClick={
-				playground ? () => downloadDatabase(playground) : undefined
-			}
-		>
-			<Flex justify="space-between" gap={2} expanded={true}>
-				<FlexItem>Download database.sqlite</FlexItem>
-				<FlexItem>
-					<Icon icon={download} size={16} />
-				</FlexItem>
-			</Flex>
-		</Button>
+		<div>
+			<Button
+				variant="secondary"
+				disabled={!playground}
+				onClick={() => void handleDownload()}
+			>
+				<Flex justify="space-between" gap={2} expanded={true}>
+					<FlexItem>Download database.sqlite</FlexItem>
+					<FlexItem>
+						<Icon icon={download} size={16} />
+					</FlexItem>
+				</Flex>
+			</Button>
+			{downloadError ? (
+				<div className={css.error}>{downloadError}</div>
+			) : null}
+		</div>
 	);
 }

--- a/packages/playground/website/src/components/site-manager/site-database-panel/index.tsx
+++ b/packages/playground/website/src/components/site-manager/site-database-panel/index.tsx
@@ -4,6 +4,7 @@ import { Notice, __experimentalVStack as VStack } from '@wordpress/components';
 import { DownloadButton } from './download-button';
 import { AdminerButton } from './adminer-button';
 import { PhpMyAdminButton } from './phpmyadmin-button';
+import { getRemoteFileSize } from '@wp-playground/components';
 import css from './style.module.css';
 
 const DATABASE_PATH = '/wordpress/wp-content/database/.ht.sqlite';
@@ -27,9 +28,9 @@ export function SiteDatabasePanel({
 			try {
 				const fileExists = await playground.fileExists(DATABASE_PATH);
 				if (fileExists) {
-					const buffer =
-						await playground.readFileAsBuffer(DATABASE_PATH);
-					setDatabaseSize(buffer.byteLength);
+					setDatabaseSize(
+						await getRemoteFileSize(playground, DATABASE_PATH)
+					);
 				} else {
 					setDatabaseSize(null);
 				}

--- a/packages/playground/website/src/components/site-manager/site-file-browser/index.tsx
+++ b/packages/playground/website/src/components/site-manager/site-file-browser/index.tsx
@@ -3,7 +3,10 @@ import type { SiteInfo } from '../../../lib/state/redux/slice-sites';
 import { usePlaygroundClient } from '../../../lib/use-playground-client';
 import type { AsyncWritableFilesystem } from '@wp-playground/storage';
 import type { PlaygroundClient } from '@wp-playground/remote';
-import { PlaygroundFileEditor } from '@wp-playground/components';
+import {
+	getRemoteFileSize,
+	PlaygroundFileEditor,
+} from '@wp-playground/components';
 import { logger } from '@php-wasm/logger';
 
 export function SiteFileBrowser({
@@ -80,10 +83,16 @@ class ClientFilesystemWrapper
 	fileExists(path: string) {
 		return this.client.fileExists(path);
 	}
-	async read(path: string): Promise<{ arrayBuffer(): Promise<ArrayBuffer> }> {
-		const buffer = await this.client.readFileAsBuffer(path);
+	async read(
+		path: string
+	): Promise<{ filesize: number; arrayBuffer(): Promise<ArrayBuffer> }> {
+		const filesize = await getRemoteFileSize(this.client, path);
 		return {
-			arrayBuffer: async () => buffer.buffer as ArrayBuffer,
+			filesize,
+			arrayBuffer: async () => {
+				const buffer = await this.client.readFileAsBuffer(path);
+				return toArrayBuffer(buffer);
+			},
 		};
 	}
 	readFileAsText(path: string) {
@@ -118,4 +127,8 @@ function useFilesystem(
 		}
 		return new ClientFilesystemWrapper(client);
 	}, [client]);
+}
+
+function toArrayBuffer(buffer: Uint8Array): ArrayBuffer {
+	return new Uint8Array(buffer).buffer;
 }


### PR DESCRIPTION
## What it does

Bounds the site manager file browser/editor paths without adding shared file transfer helper modules:

- caps file picker uploads and downloads at 100 MB, sanitizes dropped filenames, and reports skipped/failed uploads
- avoids buffering known-oversized files before showing the inline editor
- streams database downloads through a short-lived, token-gated PHP script instead of reading the SQLite file into JavaScript
- reads remote file sizes through PHP `filesize()` for the browser and database size display
- flushes and remaps the open editor file when file tree entries are renamed, moved, or deleted so stale paths are not recreated

## Rationale

The previous PR2 shape included shared file-transfer helpers and stream-oriented abstractions that were not needed for the concrete site-manager flows. This keeps the change focused on safer upload/download/browse/edit behavior that users hit today.

## Implementation

The file picker keeps its upload/download guard helpers local to `FilePickerTree`. The file editor gets a small inline-preview read helper and path-change callbacks from the tree. Database download moves to the components package so website and personal-wp use the same non-buffering path.

## Testing instructions

- `npm exec vitest run -- --config packages/playground/components/vite.config.ts src/download-database.spec.ts src/get-remote-file-size.spec.ts src/PlaygroundFileEditor/file-utils.spec.ts src/PlaygroundFileEditor/playground-file-editor.spec.tsx`
- `npm exec tsc -- -p packages/playground/components/tsconfig.lib.json --noEmit`
- `npm exec tsc -- -p packages/playground/components/tsconfig.spec.json --noEmit`
- `npm exec tsc -- -p packages/playground/website/tsconfig.app.json --noEmit`
- `npm exec tsc -- -p packages/playground/personal-wp/tsconfig.app.json --noEmit`
- `git diff --check`
- `(git diff --name-only; git ls-files --others --exclude-standard) | grep -E '\.(ts|tsx)$' | grep -v '^\.context/' | sort -u | xargs env ESLINT_USE_FLAT_CONFIG=false npm exec eslint -- --plugin react-hooks --rule '@nx/enforce-module-boundaries: off'`
