### PR TITLE
[Website] Stream site manager database downloads

### DIFF
--- a/packages/playground/components/src/download-database.spec.ts
+++ b/packages/playground/components/src/download-database.spec.ts
@@ -1,0 +1,100 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+	createDatabaseDownloadScript,
+	downloadDatabase,
+} from './download-database';
+
+describe('downloadDatabase', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('downloads through a token-gated PHP script instead of buffering in JS', async () => {
+		const databasePath = '/wordpress/wp-content/database/.ht.sqlite';
+		const playground = createPlaygroundClient(databasePath);
+		const appendChildSpy = vi.spyOn(document.body, 'appendChild');
+
+		try {
+			await downloadDatabase(playground, databasePath);
+
+			expect(playground.readFileAsBuffer).not.toHaveBeenCalled();
+			expect(playground.writeFile).toHaveBeenCalledOnce();
+			const [scriptPath, script] = playground.writeFile.mock.calls[0];
+			expect(scriptPath).toMatch(
+				/^\/wordpress\/\.playground-database-download-[a-f0-9]{32}\.php$/
+			);
+			expect(script).toContain(
+				"$databasePath = '/wordpress/wp-content/database/.ht.sqlite';"
+			);
+			expect(script).toContain('fread($handle, 1048576)');
+
+			const frame = appendChildSpy.mock.calls[0][0] as HTMLIFrameElement;
+			expect(frame.src).toMatch(
+				/^https:\/\/example\.test\/scope:test\/\.playground-database-download-[a-f0-9]{32}\.php\?token=[a-f0-9]{32}$/
+			);
+			expect(frame.hidden).toBe(true);
+			expect(frame.getAttribute('aria-hidden')).toBe('true');
+			expect(playground.unlink).not.toHaveBeenCalled();
+
+			await vi.advanceTimersByTimeAsync(60_000);
+			expect(playground.unlink).toHaveBeenCalledWith(scriptPath);
+			expect(frame.isConnected).toBe(true);
+
+			await vi.advanceTimersByTimeAsync(9 * 60_000);
+			expect(frame.isConnected).toBe(false);
+		} finally {
+			appendChildSpy.mockRestore();
+		}
+	});
+});
+
+describe('createDatabaseDownloadScript', () => {
+	it('escapes PHP string literals and stays compatible with legacy PHP', () => {
+		const script = createDatabaseDownloadScript(
+			"/wordpress/wp-content/weird'\\db.sqlite",
+			'abcdef0123456789abcdef0123456789'
+		);
+
+		expect(script).toContain(
+			"$databasePath = '/wordpress/wp-content/weird\\'\\\\db.sqlite';"
+		);
+		expect(script).toContain(
+			"register_shutdown_function('playground_database_download_cleanup_abcdef0123456789abcdef0123456789')"
+		);
+		expect(script).toContain('$providedToken !== $expectedToken');
+		expect(script).toContain("is_string($_GET['token'])");
+		expect(script).toContain('fread($handle, 1048576)');
+		expect(script).not.toContain('function ()');
+		expect(script).not.toContain('=>');
+	});
+
+	it('rejects tokens that cannot be embedded in PHP function names', () => {
+		expect(() =>
+			createDatabaseDownloadScript(
+				'/wordpress/database.sqlite',
+				'bad-token'
+			)
+		).toThrow('Invalid database download token.');
+	});
+});
+
+function createPlaygroundClient(databasePath: string) {
+	return {
+		absoluteUrl: Promise.resolve('https://example.test/scope:test'),
+		documentRoot: Promise.resolve('/wordpress'),
+		fileExists: vi.fn(async (path: string) => path === databasePath),
+		readFileAsBuffer: vi.fn(),
+		unlink: vi.fn(async (path: string) => {
+			void path;
+		}),
+		writeFile: vi.fn(async (path: string, contents: string) => {
+			void path;
+			void contents;
+		}),
+	};
+}

--- a/packages/playground/components/src/download-database.ts
+++ b/packages/playground/components/src/download-database.ts
@@ -1,0 +1,190 @@
+import { logger } from '@php-wasm/logger';
+import { joinPaths } from '@php-wasm/util';
+
+const DATABASE_DOWNLOAD_FILENAME = 'database.sqlite';
+// The download request goes through the Playground service worker/PHP queue.
+// Keep the script around longer than the PHP request timeout so cleanup cannot
+// delete it before a queued download starts.
+const TEMPORARY_DOWNLOAD_SCRIPT_TTL = 60_000;
+// Keep the iframe around longer than the temporary PHP script. Removing the
+// frame can cancel a slow browser download even after the PHP script started.
+const DOWNLOAD_FRAME_TTL = 10 * TEMPORARY_DOWNLOAD_SCRIPT_TTL;
+
+export type DatabaseDownloadPlayground = {
+	absoluteUrl: Promise<string>;
+	documentRoot: Promise<string>;
+	fileExists(path: string): Promise<boolean>;
+	writeFile(path: string, contents: string): Promise<void>;
+	unlink(path: string): Promise<void>;
+};
+
+export async function downloadDatabase(
+	playground: DatabaseDownloadPlayground,
+	databasePath: string
+): Promise<void> {
+	const fileExists = await playground.fileExists(databasePath);
+	if (!fileExists) {
+		throw new Error('Database file does not exist');
+	}
+
+	const token = createDownloadToken();
+	const scriptFileName = `.playground-database-download-${token}.php`;
+	const documentRoot = await playground.documentRoot;
+	const scriptPath = joinPaths(documentRoot, scriptFileName);
+	let downloadStarted = false;
+
+	try {
+		await playground.writeFile(
+			scriptPath,
+			createDatabaseDownloadScript(databasePath, token)
+		);
+		const playgroundUrl = await playground.absoluteUrl;
+		startDownloadInHiddenFrame(
+			createDatabaseDownloadUrl(playgroundUrl, scriptFileName, token)
+		);
+		downloadStarted = true;
+	} finally {
+		if (downloadStarted) {
+			scheduleDownloadScriptCleanup(playground, scriptPath);
+		} else {
+			await removeDownloadScript(playground, scriptPath);
+		}
+	}
+}
+
+export function createDatabaseDownloadScript(
+	databasePath: string,
+	token: string
+): string {
+	assertValidDownloadToken(token);
+	const cleanupFunction = `playground_database_download_cleanup_${token}`;
+	const statusFunction = `playground_database_download_status_${token}`;
+	return `<?php
+$databasePath = ${phpSingleQuotedString(databasePath)};
+$expectedToken = ${phpSingleQuotedString(token)};
+
+function ${cleanupFunction}() {
+	@unlink(__FILE__);
+}
+
+function ${statusFunction}($code, $text) {
+	header('HTTP/1.1 ' . $code . ' ' . $text, true, $code);
+}
+
+$providedToken = isset($_GET['token']) && is_string($_GET['token'])
+	? $_GET['token']
+	: '';
+if ($providedToken !== $expectedToken) {
+	${statusFunction}(403, 'Forbidden');
+	exit;
+}
+
+register_shutdown_function('${cleanupFunction}');
+
+if (!is_file($databasePath)) {
+	${statusFunction}(404, 'Not Found');
+	exit;
+}
+
+$databaseSize = filesize($databasePath);
+if ($databaseSize === false) {
+	${statusFunction}(500, 'Internal Server Error');
+	exit;
+}
+
+$handle = fopen($databasePath, 'rb');
+if ($handle === false) {
+	${statusFunction}(500, 'Internal Server Error');
+	exit;
+}
+
+header('Content-Type: application/x-sqlite3');
+header('Content-Disposition: attachment; filename="${DATABASE_DOWNLOAD_FILENAME}"');
+header('Content-Length: ' . $databaseSize);
+
+while (!feof($handle)) {
+	$chunk = fread($handle, 1048576);
+	if ($chunk === false) {
+		fclose($handle);
+		exit;
+	}
+	if ($chunk === '') {
+		break;
+	}
+	echo $chunk;
+	flush();
+}
+
+fclose($handle);
+`;
+}
+
+function assertValidDownloadToken(token: string): void {
+	if (!/^[a-f0-9]{32}$/.test(token)) {
+		throw new Error('Invalid database download token.');
+	}
+}
+
+function createDownloadToken(): string {
+	const bytes = new Uint8Array(16);
+	globalThis.crypto.getRandomValues(bytes);
+	return Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join(
+		''
+	);
+}
+
+function createDatabaseDownloadUrl(
+	playgroundUrl: string,
+	scriptFileName: string,
+	token: string
+): string {
+	const baseUrl = playgroundUrl.endsWith('/')
+		? playgroundUrl
+		: `${playgroundUrl}/`;
+	const url = new URL(scriptFileName, baseUrl);
+	url.searchParams.set('token', token);
+	return url.toString();
+}
+
+function startDownloadInHiddenFrame(downloadUrl: string): void {
+	const frame = document.createElement('iframe');
+	frame.hidden = true;
+	frame.src = downloadUrl;
+	frame.title = '';
+	frame.setAttribute('aria-hidden', 'true');
+	document.body.appendChild(frame);
+	window.setTimeout(() => {
+		frame.remove();
+	}, DOWNLOAD_FRAME_TTL);
+}
+
+function scheduleDownloadScriptCleanup(
+	playground: DatabaseDownloadPlayground,
+	scriptPath: string
+): void {
+	window.setTimeout(() => {
+		void removeDownloadScript(playground, scriptPath).catch((error) => {
+			logger.error(
+				'Failed to remove temporary database download script',
+				error
+			);
+		});
+	}, TEMPORARY_DOWNLOAD_SCRIPT_TTL);
+}
+
+async function removeDownloadScript(
+	playground: DatabaseDownloadPlayground,
+	scriptPath: string
+): Promise<void> {
+	try {
+		await playground.unlink(scriptPath);
+	} catch (error) {
+		if (await playground.fileExists(scriptPath).catch(() => false)) {
+			throw error;
+		}
+	}
+}
+
+function phpSingleQuotedString(value: string): string {
+	return `'${value.replace(/['\\]/g, '\\$&')}'`;
+}

--- a/packages/playground/components/src/index.ts
+++ b/packages/playground/components/src/index.ts
@@ -7,3 +7,7 @@ export {
 	getPlaygroundFileSize,
 	type PlaygroundFileSizeClient,
 } from './get-playground-file-size';
+export {
+	downloadDatabase,
+	type DatabaseDownloadPlayground,
+} from './download-database';

--- a/packages/playground/personal-wp/src/components/site-manager/site-database-panel/download-button.tsx
+++ b/packages/playground/personal-wp/src/components/site-manager/site-database-panel/download-button.tsx
@@ -1,47 +1,54 @@
+import { useRef, useState } from 'react';
 import { Button, Icon, Flex, FlexItem } from '@wordpress/components';
 import { download } from '@wordpress/icons';
 import type { PlaygroundClient } from '@wp-playground/client';
+import { downloadDatabase } from '@wp-playground/components';
+import { logger } from '@php-wasm/logger';
+import css from './style.module.css';
 
 const DATABASE_PATH = '/wordpress/wp-content/database/.ht.sqlite';
-
-async function downloadDatabase(playground: PlaygroundClient): Promise<void> {
-	const fileExists = await playground.fileExists(DATABASE_PATH);
-	if (!fileExists) {
-		throw new Error('Database file does not exist');
-	}
-
-	const buffer = await playground.readFileAsBuffer(DATABASE_PATH);
-	const blob = new Blob([new Uint8Array(buffer)], {
-		type: 'application/x-sqlite3',
-	});
-
-	const url = URL.createObjectURL(blob);
-	const link = document.createElement('a');
-	link.href = url;
-	link.download = 'database.sqlite';
-	link.click();
-	URL.revokeObjectURL(url);
-}
 
 export function DownloadButton({
 	playground,
 }: {
 	playground: PlaygroundClient | undefined;
 }) {
+	const isDownloadingRef = useRef(false);
+	const [downloadError, setDownloadError] = useState<string | null>(null);
+
+	const handleDownload = async () => {
+		if (!playground || isDownloadingRef.current) {
+			return;
+		}
+		isDownloadingRef.current = true;
+		setDownloadError(null);
+		try {
+			await downloadDatabase(playground, DATABASE_PATH);
+		} catch (error) {
+			logger.error('Failed to download database', error);
+			setDownloadError('Could not download the database. Try again.');
+		} finally {
+			isDownloadingRef.current = false;
+		}
+	};
+
 	return (
-		<Button
-			variant="secondary"
-			disabled={!playground}
-			onClick={
-				playground ? () => downloadDatabase(playground) : undefined
-			}
-		>
-			<Flex justify="space-between" gap={2} expanded={true}>
-				<FlexItem>Download database.sqlite</FlexItem>
-				<FlexItem>
-					<Icon icon={download} size={16} />
-				</FlexItem>
-			</Flex>
-		</Button>
+		<div>
+			<Button
+				variant="secondary"
+				disabled={!playground}
+				onClick={() => void handleDownload()}
+			>
+				<Flex justify="space-between" gap={2} expanded={true}>
+					<FlexItem>Download database.sqlite</FlexItem>
+					<FlexItem>
+						<Icon icon={download} size={16} />
+					</FlexItem>
+				</Flex>
+			</Button>
+			{downloadError ? (
+				<div className={css.error}>{downloadError}</div>
+			) : null}
+		</div>
 	);
 }

--- a/packages/playground/website/src/components/site-manager/site-database-panel/download-button.tsx
+++ b/packages/playground/website/src/components/site-manager/site-database-panel/download-button.tsx
@@ -1,47 +1,54 @@
+import { useRef, useState } from 'react';
 import { Button, Icon, Flex, FlexItem } from '@wordpress/components';
 import { download } from '@wordpress/icons';
 import type { PlaygroundClient } from '@wp-playground/client';
+import { downloadDatabase } from '@wp-playground/components';
+import { logger } from '@php-wasm/logger';
+import css from './style.module.css';
 
 const DATABASE_PATH = '/wordpress/wp-content/database/.ht.sqlite';
-
-async function downloadDatabase(playground: PlaygroundClient): Promise<void> {
-	const fileExists = await playground.fileExists(DATABASE_PATH);
-	if (!fileExists) {
-		throw new Error('Database file does not exist');
-	}
-
-	const buffer = await playground.readFileAsBuffer(DATABASE_PATH);
-	const blob = new Blob([new Uint8Array(buffer)], {
-		type: 'application/x-sqlite3',
-	});
-
-	const url = URL.createObjectURL(blob);
-	const link = document.createElement('a');
-	link.href = url;
-	link.download = 'database.sqlite';
-	link.click();
-	URL.revokeObjectURL(url);
-}
 
 export function DownloadButton({
 	playground,
 }: {
 	playground: PlaygroundClient | undefined;
 }) {
+	const isDownloadingRef = useRef(false);
+	const [downloadError, setDownloadError] = useState<string | null>(null);
+
+	const handleDownload = async () => {
+		if (!playground || isDownloadingRef.current) {
+			return;
+		}
+		isDownloadingRef.current = true;
+		setDownloadError(null);
+		try {
+			await downloadDatabase(playground, DATABASE_PATH);
+		} catch (error) {
+			logger.error('Failed to download database', error);
+			setDownloadError('Could not download the database. Try again.');
+		} finally {
+			isDownloadingRef.current = false;
+		}
+	};
+
 	return (
-		<Button
-			variant="secondary"
-			disabled={!playground}
-			onClick={
-				playground ? () => downloadDatabase(playground) : undefined
-			}
-		>
-			<Flex justify="space-between" gap={2} expanded={true}>
-				<FlexItem>Download database.sqlite</FlexItem>
-				<FlexItem>
-					<Icon icon={download} size={16} />
-				</FlexItem>
-			</Flex>
-		</Button>
+		<div>
+			<Button
+				variant="secondary"
+				disabled={!playground}
+				onClick={() => void handleDownload()}
+			>
+				<Flex justify="space-between" gap={2} expanded={true}>
+					<FlexItem>Download database.sqlite</FlexItem>
+					<FlexItem>
+						<Icon icon={download} size={16} />
+					</FlexItem>
+				</Flex>
+			</Button>
+			{downloadError ? (
+				<div className={css.error}>{downloadError}</div>
+			) : null}
+		</div>
 	);
 }


### PR DESCRIPTION
## What it does

Streams site-manager database downloads through a temporary, token-gated PHP script instead of reading the SQLite database into JavaScript.

## Rationale

Database downloads can be large. The UI should start a browser download without buffering the entire SQLite file in the parent JavaScript context.

## Implementation

Adds a shared `downloadDatabase()` component helper used by website and personal-wp. The helper writes a short-lived PHP script into the Playground document root, opens it in a hidden iframe with a random token, and schedules cleanup after the download has had time to start.

This is PR 2 in the site-manager file transfer safety stack, stacked on PR 1.

## Testing instructions

- `npm exec vitest run -- --config packages/playground/components/vite.config.ts src/download-database.spec.ts src/get-remote-file-size.spec.ts`
- `npm exec tsc -- -p packages/playground/components/tsconfig.lib.json --noEmit`
- `npm exec tsc -- -p packages/playground/components/tsconfig.spec.json --noEmit`
- `npm exec tsc -- -p packages/playground/website/tsconfig.app.json --noEmit`
- `npm exec tsc -- -p packages/playground/personal-wp/tsconfig.app.json --noEmit`
- `git diff --check`
