### PR TITLE
[Website] Skip buffering oversized editor files

### DIFF
--- a/packages/playground/components/src/PlaygroundFileEditor/file-explorer-sidebar.tsx
+++ b/packages/playground/components/src/PlaygroundFileEditor/file-explorer-sidebar.tsx
@@ -17,11 +17,11 @@ import { logger } from '@php-wasm/logger';
 import { dirname, normalizePath } from '@php-wasm/util';
 import { BinaryFilePreview } from '@wp-playground/components';
 import {
-	MAX_INLINE_FILE_BYTES,
 	seemsLikeBinary,
 	createDownloadUrl,
 	getMimeType,
 	isPreviewableBinary,
+	readFileForInlinePreview,
 } from './file-utils';
 
 export type FileExplorerSidebarProps = {
@@ -71,29 +71,30 @@ export function FileExplorerSidebar({
 	const handleOpenFile = async (path: string, shouldFocus: boolean) => {
 		try {
 			const file = await filesystem.read(path);
-			const data = new Uint8Array(await file.arrayBuffer());
-			const size = data.byteLength;
+			const fileRead = await readFileForInlinePreview(file);
 			const filename = path.split('/').pop() || 'download';
-
-			if (size > MAX_INLINE_FILE_BYTES) {
-				const { url, filename: fname } = createDownloadUrl(
-					data,
-					filename
-				);
+			if (fileRead.type === 'too-large') {
 				await onShowMessage(
 					path,
 					<>
 						<p>File too large to open (&gt;1MB).</p>
 						<p>
-							<a href={url} download={fname}>
-								Download {fname}
-							</a>
+							{fileRead.downloadUrl ? (
+								<a
+									href={fileRead.downloadUrl}
+									download={filename}
+								>
+									Download {filename}
+								</a>
+							) : (
+								'Open or download it outside the in-browser editor.'
+							)}
 						</p>
 					</>
 				);
 				return;
 			}
-
+			const data = fileRead.data;
 			if (seemsLikeBinary(data)) {
 				const mimeType = getMimeType(filename);
 				const { url: downloadUrl, filename: fname } = createDownloadUrl(

--- a/packages/playground/components/src/PlaygroundFileEditor/file-utils.spec.ts
+++ b/packages/playground/components/src/PlaygroundFileEditor/file-utils.spec.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from 'vitest';
+import { readFileForInlinePreview } from './file-utils';
+
+describe('readFileForInlinePreview', () => {
+	it('reads files within the inline preview limit', async () => {
+		const file = {
+			size: 5,
+			arrayBuffer: vi.fn(
+				async () => new TextEncoder().encode('hello').buffer
+			),
+		};
+
+		const result = await readFileForInlinePreview(file, 10);
+
+		expect(result).toEqual({
+			type: 'inline',
+			data: new TextEncoder().encode('hello'),
+		});
+		expect(file.arrayBuffer).toHaveBeenCalledOnce();
+	});
+
+	it('rejects oversized files before buffering them', async () => {
+		const file = {
+			size: 11,
+			arrayBuffer: vi.fn(async () => new Uint8Array(11).buffer),
+		};
+
+		const result = await readFileForInlinePreview(file, 10);
+
+		expect(result).toEqual({ type: 'too-large', downloadUrl: undefined });
+		expect(file.arrayBuffer).not.toHaveBeenCalled();
+	});
+
+	it('falls back to measured bytes when the known size is invalid', async () => {
+		const file = {
+			filesize: Number.NaN,
+			arrayBuffer: vi.fn(async () => new Uint8Array(11).buffer),
+		};
+
+		const result = await readFileForInlinePreview(file, 10);
+
+		expect(result).toEqual({ type: 'too-large', downloadUrl: undefined });
+		expect(file.arrayBuffer).toHaveBeenCalledOnce();
+	});
+});

--- a/packages/playground/components/src/PlaygroundFileEditor/file-utils.ts
+++ b/packages/playground/components/src/PlaygroundFileEditor/file-utils.ts
@@ -39,6 +39,68 @@ export const createDownloadUrl = (
 	return { url, filename };
 };
 
+export type InlineFilePreviewReadResult =
+	| { type: 'inline'; data: Uint8Array }
+	| { type: 'too-large'; downloadUrl?: string };
+
+type BrowserReadableFile = {
+	arrayBuffer(): Promise<ArrayBuffer>;
+	size?: number;
+	filesize?: number;
+};
+
+/**
+ * Reads a file for inline editing without buffering files that already report
+ * they are larger than the editor limit.
+ */
+export async function readFileForInlinePreview(
+	file: BrowserReadableFile,
+	maxInlineBytes = MAX_INLINE_FILE_BYTES
+): Promise<InlineFilePreviewReadResult> {
+	const knownSize = getKnownFileSize(file);
+	if (knownSize !== undefined && knownSize > maxInlineBytes) {
+		return {
+			type: 'too-large',
+			downloadUrl: createObjectUrlForNativeBlob(file, knownSize),
+		};
+	}
+
+	const data = new Uint8Array(await file.arrayBuffer());
+	if (data.byteLength > maxInlineBytes) {
+		return {
+			type: 'too-large',
+			downloadUrl: createObjectUrlForNativeBlob(file, data.byteLength),
+		};
+	}
+	return { type: 'inline', data };
+}
+
+function getKnownFileSize(file: BrowserReadableFile): number | undefined {
+	if (isValidFileSize(file.filesize)) {
+		return file.filesize;
+	}
+	if (isValidFileSize(file.size)) {
+		return file.size;
+	}
+	return undefined;
+}
+
+function isValidFileSize(size: unknown): size is number {
+	return typeof size === 'number' && Number.isFinite(size) && size >= 0;
+}
+
+function createObjectUrlForNativeBlob(
+	file: BrowserReadableFile,
+	expectedSize: number
+): string | undefined {
+	if (file instanceof Blob && file.size === expectedSize) {
+		const url = URL.createObjectURL(file);
+		setTimeout(() => URL.revokeObjectURL(url), 60_000);
+		return url;
+	}
+	return undefined;
+}
+
 /**
  * Gets the MIME type for a filename based on its extension.
  */

--- a/packages/playground/personal-wp/src/components/site-manager/site-file-browser/index.tsx
+++ b/packages/playground/personal-wp/src/components/site-manager/site-file-browser/index.tsx
@@ -7,7 +7,10 @@ import {
 	EventedFilesystem,
 } from '@wp-playground/storage';
 import type { PlaygroundClient } from '@wp-playground/remote';
-import { PlaygroundFileEditor } from '@wp-playground/components';
+import {
+	getRemoteFileSize,
+	PlaygroundFileEditor,
+} from '@wp-playground/components';
 import { logger } from '@php-wasm/logger';
 import { getDirectoryPathForSlug } from '../../../lib/state/opfs/opfs-site-storage';
 
@@ -99,10 +102,16 @@ class ClientFilesystemWrapper
 	fileExists(path: string) {
 		return this.client.fileExists(path);
 	}
-	async read(path: string): Promise<{ arrayBuffer(): Promise<ArrayBuffer> }> {
-		const buffer = await this.client.readFileAsBuffer(path);
+	async read(
+		path: string
+	): Promise<{ filesize: number; arrayBuffer(): Promise<ArrayBuffer> }> {
+		const filesize = await getRemoteFileSize(this.client, path);
 		return {
-			arrayBuffer: async () => buffer.buffer as ArrayBuffer,
+			filesize,
+			arrayBuffer: async () => {
+				const buffer = await this.client.readFileAsBuffer(path);
+				return toArrayBuffer(buffer);
+			},
 		};
 	}
 	readFileAsText(path: string) {
@@ -178,4 +187,15 @@ function useFilesystem(
 		// Fall back to direct OPFS access
 		return opfsFilesystem;
 	}, [client, opfsFilesystem]);
+}
+
+function toArrayBuffer(buffer: Uint8Array): ArrayBuffer {
+	if (
+		buffer.buffer instanceof ArrayBuffer &&
+		buffer.byteOffset === 0 &&
+		buffer.byteLength === buffer.buffer.byteLength
+	) {
+		return buffer.buffer;
+	}
+	return new Uint8Array(buffer).buffer;
 }

--- a/packages/playground/personal-wp/src/components/site-manager/site-file-browser/index.tsx
+++ b/packages/playground/personal-wp/src/components/site-manager/site-file-browser/index.tsx
@@ -8,7 +8,7 @@ import {
 } from '@wp-playground/storage';
 import type { PlaygroundClient } from '@wp-playground/remote';
 import {
-	getRemoteFileSize,
+	getPlaygroundFileSize,
 	PlaygroundFileEditor,
 } from '@wp-playground/components';
 import { logger } from '@php-wasm/logger';
@@ -105,7 +105,7 @@ class ClientFilesystemWrapper
 	async read(
 		path: string
 	): Promise<{ filesize: number; arrayBuffer(): Promise<ArrayBuffer> }> {
-		const filesize = await getRemoteFileSize(this.client, path);
+		const filesize = await getPlaygroundFileSize(this.client, path);
 		return {
 			filesize,
 			arrayBuffer: async () => {

--- a/packages/playground/website/src/components/site-manager/site-file-browser/index.tsx
+++ b/packages/playground/website/src/components/site-manager/site-file-browser/index.tsx
@@ -3,7 +3,10 @@ import type { SiteInfo } from '../../../lib/state/redux/slice-sites';
 import { usePlaygroundClient } from '../../../lib/use-playground-client';
 import type { AsyncWritableFilesystem } from '@wp-playground/storage';
 import type { PlaygroundClient } from '@wp-playground/remote';
-import { PlaygroundFileEditor } from '@wp-playground/components';
+import {
+	getRemoteFileSize,
+	PlaygroundFileEditor,
+} from '@wp-playground/components';
 import { logger } from '@php-wasm/logger';
 
 export function SiteFileBrowser({
@@ -80,10 +83,16 @@ class ClientFilesystemWrapper
 	fileExists(path: string) {
 		return this.client.fileExists(path);
 	}
-	async read(path: string): Promise<{ arrayBuffer(): Promise<ArrayBuffer> }> {
-		const buffer = await this.client.readFileAsBuffer(path);
+	async read(
+		path: string
+	): Promise<{ filesize: number; arrayBuffer(): Promise<ArrayBuffer> }> {
+		const filesize = await getRemoteFileSize(this.client, path);
 		return {
-			arrayBuffer: async () => buffer.buffer as ArrayBuffer,
+			filesize,
+			arrayBuffer: async () => {
+				const buffer = await this.client.readFileAsBuffer(path);
+				return toArrayBuffer(buffer);
+			},
 		};
 	}
 	readFileAsText(path: string) {
@@ -118,4 +127,15 @@ function useFilesystem(
 		}
 		return new ClientFilesystemWrapper(client);
 	}, [client]);
+}
+
+function toArrayBuffer(buffer: Uint8Array): ArrayBuffer {
+	if (
+		buffer.buffer instanceof ArrayBuffer &&
+		buffer.byteOffset === 0 &&
+		buffer.byteLength === buffer.buffer.byteLength
+	) {
+		return buffer.buffer;
+	}
+	return new Uint8Array(buffer).buffer;
 }

--- a/packages/playground/website/src/components/site-manager/site-file-browser/index.tsx
+++ b/packages/playground/website/src/components/site-manager/site-file-browser/index.tsx
@@ -4,7 +4,7 @@ import { usePlaygroundClient } from '../../../lib/use-playground-client';
 import type { AsyncWritableFilesystem } from '@wp-playground/storage';
 import type { PlaygroundClient } from '@wp-playground/remote';
 import {
-	getRemoteFileSize,
+	getPlaygroundFileSize,
 	PlaygroundFileEditor,
 } from '@wp-playground/components';
 import { logger } from '@php-wasm/logger';
@@ -86,7 +86,7 @@ class ClientFilesystemWrapper
 	async read(
 		path: string
 	): Promise<{ filesize: number; arrayBuffer(): Promise<ArrayBuffer> }> {
-		const filesize = await getRemoteFileSize(this.client, path);
+		const filesize = await getPlaygroundFileSize(this.client, path);
 		return {
 			filesize,
 			arrayBuffer: async () => {


### PR DESCRIPTION
## What it does

Avoids buffering files that are already known to be too large for the in-browser editor.

## Rationale

The editor has a 1 MB inline limit. When the site-manager filesystem can provide the remote file size, the editor should reject oversized files before calling `arrayBuffer()`.

## Implementation

Adds `readFileForInlinePreview()` beside the editor file utilities. The site-manager client filesystem wrappers now expose `filesize` from `getRemoteFileSize()`, and the sidebar uses the helper before decoding text or binary previews.

This is PR 3 in the site-manager file transfer safety stack, stacked on PR 2.

## Testing instructions

- `npm exec vitest run -- --config packages/playground/components/vite.config.ts src/PlaygroundFileEditor/file-utils.spec.ts src/get-remote-file-size.spec.ts`
- `npm exec tsc -- -p packages/playground/components/tsconfig.lib.json --noEmit`
- `npm exec tsc -- -p packages/playground/components/tsconfig.spec.json --noEmit`
- `npm exec tsc -- -p packages/playground/website/tsconfig.app.json --noEmit`
- `npm exec tsc -- -p packages/playground/personal-wp/tsconfig.app.json --noEmit`
- `git diff --check`
