### PR TITLE
[Blueprints] Point unsupported v2 execution errors at declaration fields

### DIFF
--- a/packages/playground/blueprints/src/lib/v2/compile.ts
+++ b/packages/playground/blueprints/src/lib/v2/compile.ts
@@ -247,14 +247,28 @@ function createV1BlueprintForLoweredV2Steps(
 }
 
 function getUnsupportedPlanMessage(unsupportedPlan: BlueprintV2ExecutionPlan) {
-	const unsupportedTypes = Array.from(
-		new Set(unsupportedPlan.map((item) => item.type))
-	).join(', ');
+	const unsupportedItems = unsupportedPlan
+		.map(
+			(item) =>
+				`${getUnsupportedPlanItemPath(item)} (${getUnsupportedPlanItemName(item)})`
+		)
+		.join(', ');
 
 	return (
 		`Blueprint v2 execution plan contains unsupported items: ` +
-		`${unsupportedTypes}.`
+		`${unsupportedItems}.`
 	);
+}
+
+function getUnsupportedPlanItemName(item: BlueprintV2ExecutionPlanItem) {
+	if (item.type === 'runStep') {
+		return item.step.step;
+	}
+	return item.type;
+}
+
+function getUnsupportedPlanItemPath(item: BlueprintV2ExecutionPlanItem) {
+	return 'sourcePath' in item ? item.sourcePath : `/${item.type}`;
 }
 
 /**

--- a/packages/playground/blueprints/src/tests/compile.spec.ts
+++ b/packages/playground/blueprints/src/tests/compile.spec.ts
@@ -649,6 +649,10 @@ describe('compileBlueprintForExecution', () => {
 					step: 'mkdir',
 					path: 'site:wp-content/uploads/from-v2',
 				},
+				{
+					step: 'runSQL',
+					source: './dump.sql',
+				},
 			],
 		});
 		const playground = {
@@ -665,7 +669,12 @@ describe('compileBlueprintForExecution', () => {
 		expect(thrownError).toBeInstanceOf(UnsupportedBlueprintV2FeatureError);
 		expect(thrownError).toMatchObject({
 			featurePath: 'executionPlan',
-			message: expect.stringContaining('importMedia'),
+			message: expect.stringContaining('/media/0 (importMedia)'),
+		});
+		expect(thrownError).toMatchObject({
+			message: expect.stringContaining(
+				'/additionalStepsAfterExecution/1 (runSQL)'
+			),
 		});
 		expect(playground.mkdir).not.toHaveBeenCalled();
 	});


### PR DESCRIPTION
## What it does

Makes unsupported Blueprint v2 execution errors name the declaration fields that blocked execution. The v2 compiler already preserves `sourcePath` on plan items. The runtime error only listed plan item types, which made mixed plans harder to debug because callers could not tell which declaration entry was unsupported.

## Implementation

`getUnsupportedPlanMessage()` now renders each unsupported item as `sourcePath (feature)`. For unsupported `additionalStepsAfterExecution` entries, the feature name is the original step name, such as `runSQL`, instead of the generic `runStep` plan wrapper.

Example error detail:

```text
/media/0 (importMedia), /additionalStepsAfterExecution/1 (runSQL)
```

## Testing instructions

CI