### PR TITLE
[Blueprints] Ignore credential rewrites in git resource test

### DIFF
--- a/packages/playground/blueprints/src/tests/v1/resources.spec.ts
+++ b/packages/playground/blueprints/src/tests/v1/resources.spec.ts
@@ -139,7 +139,10 @@ describe('GitDirectoryResource', () => {
 				expect(currentCommit).toBe(commit);
 
 				// Verify the remote is configured correctly
-				const remoteUrl = execSync('git remote get-url origin', gitEnv)
+				const remoteUrl = execSync(
+					'git config --get remote.origin.url',
+					gitEnv
+				)
 					.toString()
 					.trim();
 				expect(remoteUrl).toBe(

--- a/packages/playground/blueprints/src/tests/v1/resources.spec.ts
+++ b/packages/playground/blueprints/src/tests/v1/resources.spec.ts
@@ -138,7 +138,8 @@ describe('GitDirectoryResource', () => {
 					.trim();
 				expect(currentCommit).toBe(commit);
 
-				// Verify the remote is configured correctly
+				// Verify the configured remote without applying global url.*.insteadOf
+				// rewrites, which may inject local credential helpers into the URL.
 				const remoteUrl = execSync(
 					'git config --get remote.origin.url',
 					gitEnv


### PR DESCRIPTION
## What it does

Updates the git directory resource test to read the generated remote URL directly from `.git/config` instead of asking `git remote get-url` to resolve it.

## Rationale

`git remote get-url` expands global `url.*.insteadOf` rewrites. In environments that rewrite GitHub HTTPS URLs to token-authenticated URLs, the test observes the rewritten credential URL instead of the remote URL generated by Playground.

## Implementation

The assertion still verifies the generated `.git/config` remote value, but now uses `git config --get remote.origin.url` so global credential rewrites do not affect the result. The nearby test comment documents this distinction so the command is not accidentally changed back.

## Testing instructions

```bash
npm exec nx test playground-blueprints -- --testFile=resources.spec.ts --outputStyle=stream
npm test -- --outputStyle=stream
```
