### PR TITLE
[Blueprints] Support Blueprint v2 runSQL steps

### DIFF
--- a/packages/playground/blueprints/src/lib/v2/compile.ts
+++ b/packages/playground/blueprints/src/lib/v2/compile.ts
@@ -75,6 +75,12 @@ type BlueprintV2DataReference =
 type BlueprintV2InlineDirectory = {
 	files: Record<string, string | BlueprintV2InlineDirectory>;
 };
+type BlueprintV2FileDataReference =
+	| string
+	| {
+			filename: string;
+			content: string;
+	  };
 type BlueprintV2InstallAssetDefinition = {
 	source: BlueprintV2DataReference;
 	active?: boolean;
@@ -549,6 +555,16 @@ function lowerAdditionalBlueprintV2Step(
 					path: toPlaygroundPath(step.path),
 				},
 			];
+		case 'runSQL':
+			return [
+				{
+					step: 'runSql',
+					sql: convertV2FileDataReferenceToV1(
+						step.source,
+						'runSQL.source'
+					),
+				},
+			];
 		case 'setSiteLanguage':
 			return [
 				{
@@ -764,6 +780,40 @@ function convertV2DataReferenceToV1(
 	throw new UnsupportedBlueprintV2FeatureError(
 		context,
 		'Unsupported Blueprint v2 data reference.'
+	);
+}
+
+function convertV2FileDataReferenceToV1(
+	reference: BlueprintV2FileDataReference,
+	featurePath: string
+): FileReference {
+	if (typeof reference === 'string') {
+		if (isHttpUrl(reference)) {
+			return { resource: 'url', url: reference };
+		}
+		if (isExecutionContextPath(reference)) {
+			return {
+				resource: 'bundled',
+				path: normalizeExecutionContextPath(reference),
+			};
+		}
+		throw new UnsupportedBlueprintV2FeatureError(
+			featurePath,
+			'Blueprint v2 file references must be URLs or execution-context paths.'
+		);
+	}
+
+	if (isInlineFile(reference)) {
+		return {
+			resource: 'literal',
+			name: reference.filename,
+			contents: reference.content,
+		};
+	}
+
+	throw new UnsupportedBlueprintV2FeatureError(
+		featurePath,
+		'Unsupported Blueprint v2 file reference.'
 	);
 }
 

--- a/packages/playground/blueprints/src/tests/compile.spec.ts
+++ b/packages/playground/blueprints/src/tests/compile.spec.ts
@@ -414,6 +414,7 @@ describe('compileBlueprintForExecution', () => {
 			'installPlugin',
 			'installTheme',
 			'wp-cli',
+			'runSql',
 		]);
 		expect(compiled.compiled.steps).toMatchObject([
 			{
@@ -514,10 +515,17 @@ describe('compileBlueprintForExecution', () => {
 				step: 'wp-cli',
 				command: 'plugin list',
 			},
+			{
+				step: 'runSql',
+				sql: {
+					resource: 'bundled',
+					path: 'dump.sql',
+				},
+			},
 		]);
 		expect(
 			compiled.compiled.unsupportedPlan.map((item) => item.type)
-		).toEqual(['importMedia', 'runStep']);
+		).toEqual(['importMedia']);
 	});
 
 	it('rejects empty Blueprint v2 target-site paths', async () => {
@@ -649,10 +657,6 @@ describe('compileBlueprintForExecution', () => {
 					step: 'mkdir',
 					path: 'site:wp-content/uploads/from-v2',
 				},
-				{
-					step: 'runSQL',
-					source: './dump.sql',
-				},
 			],
 		});
 		const playground = {
@@ -670,11 +674,6 @@ describe('compileBlueprintForExecution', () => {
 		expect(thrownError).toMatchObject({
 			featurePath: 'executionPlan',
 			message: expect.stringContaining('/media/0 (importMedia)'),
-		});
-		expect(thrownError).toMatchObject({
-			message: expect.stringContaining(
-				'/additionalStepsAfterExecution/1 (runSQL)'
-			),
 		});
 		expect(playground.mkdir).not.toHaveBeenCalled();
 	});


### PR DESCRIPTION
## What it does

Lowers Blueprint v2 `runSQL` entries from `additionalStepsAfterExecution` into the existing v1 `runSql` step shape.

Supersedes #3942, which GitHub closed when its stacked base branch was merged.

## Rationale

`runSQL` already has a v1 runner implementation and resource-resolution path. Mapping the v2 step to that shape moves another supported v2 field out of `unsupportedPlan` without adding new runtime behavior.

## Implementation

Adds `convertV2FileDataReferenceToV1()` for file-only v2 references:

- HTTP(S) strings become `resource: "url"`
- execution-context paths become `resource: "bundled"`
- inline files become `resource: "literal"`

The lowering maps:

```ts
{ step: "runSQL", source: "./dump.sql" }
```

to:

```ts
{ step: "runSql", sql: { resource: "bundled", path: "dump.sql" } }
```

## Testing instructions

```bash
npx vitest run src/tests/compile.spec.ts --config vite.config.ts
npx nx lint playground-blueprints
```