### PR TITLE
[Blueprints] Lower Blueprint v2 mysql-dump content to runSql

### DIFF
--- a/packages/playground/blueprints/src/lib/v2/compile.ts
+++ b/packages/playground/blueprints/src/lib/v2/compile.ts
@@ -463,6 +463,8 @@ function lowerBlueprintV2ExecutionPlanItem(
 			return [createInstallThemeStep(planItem.theme, planItem.active)];
 		case 'installPlugin':
 			return [createInstallPluginStep(planItem.plugin)];
+		case 'importContent':
+			return lowerBlueprintV2Content(planItem.content);
 		case 'setSiteLanguage':
 			return [
 				{
@@ -475,6 +477,19 @@ function lowerBlueprintV2ExecutionPlanItem(
 		default:
 			return undefined;
 	}
+}
+
+function lowerBlueprintV2Content(
+	content: BlueprintV2Content
+): StepDefinition[] | undefined {
+	if (content.type !== 'mysql-dump') {
+		return undefined;
+	}
+
+	return asArray(content.source).map((source, index) => ({
+		step: 'runSql',
+		sql: convertV2FileDataReferenceToV1(source, `content.source[${index}]`),
+	}));
 }
 
 /**
@@ -815,6 +830,10 @@ function convertV2FileDataReferenceToV1(
 		featurePath,
 		'Unsupported Blueprint v2 file reference.'
 	);
+}
+
+function asArray<T>(value: T | T[]): T[] {
+	return Array.isArray(value) ? value : [value];
 }
 
 /**

--- a/packages/playground/blueprints/src/tests/compile.spec.ts
+++ b/packages/playground/blueprints/src/tests/compile.spec.ts
@@ -528,6 +528,98 @@ describe('compileBlueprintForExecution', () => {
 		).toEqual(['importMedia']);
 	});
 
+	it('lowers Blueprint v2 mysql-dump content to runSql steps', async () => {
+		const compiled = await compileBlueprintForExecution({
+			version: 2,
+			content: [
+				{
+					type: 'mysql-dump',
+					source: [
+						'./dump.sql',
+						{
+							filename: 'inline.sql',
+							content: 'SELECT 1;',
+						},
+						'https://example.com/dump.sql',
+					],
+				},
+			],
+		});
+
+		expect(compiled.version).toBe(2);
+		if (compiled.version !== 2) {
+			throw new Error('Expected a compiled Blueprint v2 result.');
+		}
+		expect(compiled.compiled.steps).toEqual([
+			{
+				step: 'runSql',
+				sql: {
+					resource: 'bundled',
+					path: 'dump.sql',
+				},
+			},
+			{
+				step: 'runSql',
+				sql: {
+					resource: 'literal',
+					name: 'inline.sql',
+					contents: 'SELECT 1;',
+				},
+			},
+			{
+				step: 'runSql',
+				sql: {
+					resource: 'url',
+					url: 'https://example.com/dump.sql',
+				},
+			},
+		]);
+		expect(compiled.compiled.unsupportedPlan).toEqual([]);
+	});
+
+	it('lowers single-source Blueprint v2 mysql-dump content to a runSql step', async () => {
+		const compiled = await compileBlueprintForExecution({
+			version: 2,
+			content: [
+				{
+					type: 'mysql-dump',
+					source: './single-dump.sql',
+				},
+			],
+		});
+
+		expect(compiled.version).toBe(2);
+		if (compiled.version !== 2) {
+			throw new Error('Expected a compiled Blueprint v2 result.');
+		}
+		expect(compiled.compiled.steps).toEqual([
+			{
+				step: 'runSql',
+				sql: {
+					resource: 'bundled',
+					path: 'single-dump.sql',
+				},
+			},
+		]);
+		expect(compiled.compiled.unsupportedPlan).toEqual([]);
+	});
+
+	it('reports the source index for unsupported Blueprint v2 mysql-dump sources', async () => {
+		const declaration = {
+			version: 2,
+			content: [
+				{
+					type: 'mysql-dump',
+					source: ['./ok.sql', 'not-a-file-reference'],
+				},
+			],
+		} as unknown as BlueprintV2Declaration;
+
+		await expect(compileBlueprintForExecution(declaration)).rejects.toThrow(
+			'content.source[1]: Blueprint v2 file references must be URLs or execution-context paths.'
+		);
+	});
+
 	it('rejects empty Blueprint v2 target-site paths', async () => {
 		await expect(
 			compileBlueprintForExecution({


### PR DESCRIPTION
## What it does

Lowers Blueprint v2 `content` entries whose `type` is `mysql-dump` into existing v1 `runSql` steps, so SQL dump content can run through the TypeScript runner.

This PR does not lower `wxr` content. WXR content remains unsupported here and should map to the existing v1 `importWxr` step separately.

## Rationale

Blueprint v2 represents top-level content as `importContent` plan items, but `mysql-dump` content is a SQL file source rather than a WXR import. The v1 runner already has `runSql`, so mysql dumps can be supported by lowering each dump source to one ordered SQL step without adding new runtime behavior.

Keeping WXR out of this PR avoids mixing two content import paths: SQL dumps execute through `runSql`, while WXR files need the importer-specific options handled by `importWxr`.

## Implementation

`importContent` plan items now lower only when `content.type === 'mysql-dump'`. Single and multiple `source` values are normalized to an ordered list, then each source is converted with the existing Blueprint v2 file-reference converter:

- `./dump.sql` -> bundled resource
- inline file -> literal resource
- HTTP(S) URL -> URL resource

The source normalization intentionally treats a string as one file reference, not as an iterable of characters.

## Testing instructions

```bash
npx vitest run src/tests/compile.spec.ts --config vite.config.ts
npx nx lint playground-blueprints
```
