### PR TITLE
[Website] Parse GitHub inputs before import, export, and preview

### DIFF
--- a/packages/playground/website/src/github/analyze-github-url.spec.ts
+++ b/packages/playground/website/src/github/analyze-github-url.spec.ts
@@ -18,6 +18,16 @@ describe('staticAnalyzeGitHubURL', () => {
 		expect(staticAnalyzeGitHubURL(url)).toEqual(expected);
 	});
 
+	it('should accept www.github.com URLs', () => {
+		expect(
+			staticAnalyzeGitHubURL('https://www.github.com/owner/repo')
+		).toMatchObject({
+			owner: 'owner',
+			repo: 'repo',
+			type: 'repo',
+		});
+	});
+
 	it('should return correct GitHubURLInformation for a PR URL', () => {
 		const url = 'https://github.com/owner/repo/pull/123';
 		const expected: GitHubURLInformation = {

--- a/packages/playground/website/src/github/analyze-github-url.spec.ts
+++ b/packages/playground/website/src/github/analyze-github-url.spec.ts
@@ -1,5 +1,8 @@
 import type { GitHubURLInformation } from './analyze-github-url';
-import { staticAnalyzeGitHubURL } from './analyze-github-url';
+import {
+	resolveGitHubBranchPath,
+	staticAnalyzeGitHubURL,
+} from './analyze-github-url';
 
 describe('staticAnalyzeGitHubURL', () => {
 	it('should return correct GitHubURLInformation for a repo URL', () => {
@@ -28,11 +31,45 @@ describe('staticAnalyzeGitHubURL', () => {
 		expect(staticAnalyzeGitHubURL(url)).toEqual(expected);
 	});
 
-	it('should throw an error for an invalid PR URL', () => {
+	it('should reject an invalid PR URL', () => {
 		const url = 'https://github.com/owner/repo/pull/invalid';
-		expect(() => staticAnalyzeGitHubURL(url)).toThrowError(
-			'Invalid Pull Request  number NaN parsed from the following GitHub URL: https://github.com/owner/repo/pull/invalid'
-		);
+		expect(staticAnalyzeGitHubURL(url)).toEqual({
+			type: 'unknown',
+		});
+		expect(
+			staticAnalyzeGitHubURL('https://github.com/owner/repo/pull/123abc')
+		).toEqual({
+			type: 'unknown',
+		});
+		expect(
+			staticAnalyzeGitHubURL('https://github.com/owner/repo/pull/0')
+		).toEqual({
+			type: 'unknown',
+		});
+	});
+
+	it('should reject non-GitHub URLs', () => {
+		const url = 'https://example.com/owner/repo';
+		expect(staticAnalyzeGitHubURL(url)).toEqual({
+			type: 'unknown',
+		});
+	});
+
+	it('should reject non-web GitHub URLs', () => {
+		expect(staticAnalyzeGitHubURL('ftp://github.com/owner/repo')).toEqual({
+			type: 'unknown',
+		});
+	});
+
+	it('should reject incomplete GitHub URLs', () => {
+		expect(staticAnalyzeGitHubURL('https://github.com/owner')).toEqual({
+			type: 'unknown',
+		});
+		expect(
+			staticAnalyzeGitHubURL('https://github.com/owner/repo/tree')
+		).toEqual({
+			type: 'unknown',
+		});
 	});
 
 	it('should return correct GitHubURLInformation for a branch URL', () => {
@@ -44,6 +81,7 @@ describe('staticAnalyzeGitHubURL', () => {
 			ref: 'branch',
 			path: 'path/to/file',
 			pr: undefined,
+			branchPathSegments: ['branch', 'path', 'to', 'file'],
 		};
 		expect(staticAnalyzeGitHubURL(url)).toEqual(expected);
 	});
@@ -71,5 +109,46 @@ describe('staticAnalyzeGitHubURL', () => {
 			path: '',
 		};
 		expect(staticAnalyzeGitHubURL(url)).toEqual(expected);
+	});
+});
+
+describe('resolveGitHubBranchPath', () => {
+	it('uses the longest existing branch prefix for tree URLs', async () => {
+		const octokit = {
+			rest: {
+				repos: {
+					getBranch: async ({ branch }: { branch: string }) => {
+						if (branch === 'feature/foo') {
+							return {
+								data: {
+									commit: {
+										sha: 'abc123',
+									},
+								},
+							};
+						}
+						const error = new Error('Not found') as Error & {
+							status?: number;
+						};
+						error.status = 404;
+						throw error;
+					},
+				},
+			},
+		};
+
+		await expect(
+			resolveGitHubBranchPath(
+				octokit,
+				staticAnalyzeGitHubURL(
+					'https://github.com/owner/repo/tree/feature/foo/src'
+				)
+			)
+		).resolves.toMatchObject({
+			type: 'branch',
+			ref: 'feature/foo',
+			commitSha: 'abc123',
+			path: 'src',
+		});
 	});
 });

--- a/packages/playground/website/src/github/analyze-github-url.ts
+++ b/packages/playground/website/src/github/analyze-github-url.ts
@@ -87,7 +87,17 @@ export function staticAnalyzeGitHubURL(url: string): GitHubURLInformation {
 }
 
 /**
- * Resolves branch URLs whose branch names may contain slashes.
+ * Resolves the ambiguous branch-and-path suffix in GitHub tree/blob URLs.
+ *
+ * GitHub does not mark where the branch name ends:
+ * - `/tree/trunk/packages/playground` means branch `trunk`, path `packages/playground`.
+ * - `/tree/feature/export-form/packages/playground` may mean branch `feature`
+ *   plus path `export-form/packages/playground`, or branch `feature/export-form`
+ *   plus path `packages/playground`.
+ *
+ * Try the longest possible branch name first, matching GitHub's routing for
+ * branch names that contain `/`. If no candidate exists, keep the parser's
+ * original first-segment branch guess.
  */
 export async function resolveGitHubBranchPath(
 	octokit: GitHubBranchClient,

--- a/packages/playground/website/src/github/analyze-github-url.ts
+++ b/packages/playground/website/src/github/analyze-github-url.ts
@@ -50,7 +50,7 @@ export function staticAnalyzeGitHubURL(url: string): GitHubURLInformation {
 	if (hostname === 'raw.githubusercontent.com') {
 		type = 'rawfile';
 		path = urlObj.pathname.substring(1);
-	} else if (hostname !== 'github.com') {
+	} else if (hostname !== 'github.com' && hostname !== 'www.github.com') {
 		return {
 			type: 'unknown',
 		};

--- a/packages/playground/website/src/github/analyze-github-url.ts
+++ b/packages/playground/website/src/github/analyze-github-url.ts
@@ -3,14 +3,37 @@ export type GitHubURLInformation = {
 	repo?: string;
 	type: 'pr' | 'repo' | 'branch' | 'rawfile' | 'unknown';
 	ref?: string;
+	commitSha?: string;
 	path?: string;
 	pr?: number;
+	branchPathSegments?: string[];
 };
+
+type GitHubBranchClient = {
+	rest: {
+		repos: {
+			getBranch(args: {
+				owner: string;
+				repo: string;
+				branch: string;
+			}): Promise<{ data?: { commit?: { sha?: string } } }>;
+		};
+	};
+};
+
+/**
+ * Parses supported GitHub URLs without making network requests.
+ */
 export function staticAnalyzeGitHubURL(url: string): GitHubURLInformation {
 	let urlObj;
 	try {
 		urlObj = new URL(url);
 	} catch {
+		return {
+			type: 'unknown',
+		};
+	}
+	if (!['http:', 'https:'].includes(urlObj.protocol.toLowerCase())) {
 		return {
 			type: 'unknown',
 		};
@@ -23,24 +46,89 @@ export function staticAnalyzeGitHubURL(url: string): GitHubURLInformation {
 		ref,
 		type: GitHubURLInformation['type'] = 'unknown',
 		path = '';
-	if (urlObj.hostname === 'raw.githubusercontent.com') {
+	const hostname = urlObj.hostname.toLowerCase();
+	if (hostname === 'raw.githubusercontent.com') {
 		type = 'rawfile';
 		path = urlObj.pathname.substring(1);
+	} else if (hostname !== 'github.com') {
+		return {
+			type: 'unknown',
+		};
+	} else if (!owner || !repo) {
+		return {
+			type: 'unknown',
+		};
 	} else if (rest[0] === 'pull') {
 		type = 'pr';
-		pr = parseInt(rest[1]);
-		if (isNaN(pr) || !pr) {
-			throw new Error(
-				`Invalid Pull Request  number ${pr} parsed from the following GitHub URL: ${url}`
-			);
+		if (!/^[1-9]\d*$/.test(rest[1] ?? '')) {
+			return {
+				type: 'unknown',
+			};
 		}
+		pr = Number(rest[1]);
 	} else if (['blob', 'tree'].includes(rest[0])) {
+		if (!rest[1]) {
+			return {
+				type: 'unknown',
+			};
+		}
 		type = 'branch';
 		ref = rest[1];
 		path = rest.slice(2).join('/');
+		// GitHub tree/blob URLs do not delimit branch names, so
+		// `tree/feature/foo/src` may mean branch `feature/foo` plus path `src`.
+		const branchPathSegments = rest.slice(1);
+		return { owner, repo, type, ref, path, pr, branchPathSegments };
 	} else if (rest.length === 0) {
 		type = 'repo';
 	}
 
 	return { owner, repo, type, ref, path, pr };
+}
+
+/**
+ * Resolves branch URLs whose branch names may contain slashes.
+ */
+export async function resolveGitHubBranchPath(
+	octokit: GitHubBranchClient,
+	urlDetails: GitHubURLInformation
+): Promise<GitHubURLInformation> {
+	if (
+		urlDetails.type !== 'branch' ||
+		!urlDetails.owner ||
+		!urlDetails.repo ||
+		!urlDetails.branchPathSegments?.length
+	) {
+		return urlDetails;
+	}
+
+	// Try the longest possible branch name first so branch `feature/foo`
+	// wins over branch `feature` for URLs such as `tree/feature/foo/src`.
+	for (
+		let length = urlDetails.branchPathSegments.length;
+		length >= 1;
+		length--
+	) {
+		const ref = urlDetails.branchPathSegments.slice(0, length).join('/');
+		try {
+			const branch = await octokit.rest.repos.getBranch({
+				owner: urlDetails.owner,
+				repo: urlDetails.repo,
+				branch: ref,
+			});
+			return {
+				...urlDetails,
+				ref,
+				commitSha: branch.data?.commit?.sha,
+				path: urlDetails.branchPathSegments.slice(length).join('/'),
+			};
+		} catch (error) {
+			if ((error as any)?.status === 404) {
+				continue;
+			}
+			throw error;
+		}
+	}
+
+	return urlDetails;
 }

--- a/packages/playground/website/src/github/client.spec.ts
+++ b/packages/playground/website/src/github/client.spec.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+	getAuthenticatedGitHubClient,
+	resetAuthenticatedGitHubClient,
+} from './client';
+import { setOAuthToken } from './state';
+
+const createClientMock = vi.hoisted(() =>
+	vi.fn((token: string) => ({ token }))
+);
+
+vi.mock('@wp-playground/storage', () => ({
+	createClient: createClientMock,
+}));
+
+describe('getAuthenticatedGitHubClient', () => {
+	beforeEach(() => {
+		createClientMock.mockClear();
+		resetAuthenticatedGitHubClient();
+		setOAuthToken(undefined);
+	});
+
+	it('reuses the client while the OAuth token is unchanged', () => {
+		setOAuthToken('first-token');
+
+		const first = getAuthenticatedGitHubClient();
+		const second = getAuthenticatedGitHubClient();
+
+		expect(second).toBe(first);
+		expect(createClientMock).toHaveBeenCalledTimes(1);
+		expect(createClientMock).toHaveBeenCalledWith('first-token');
+	});
+
+	it('throws instead of creating a client without an OAuth token', () => {
+		expect(() => getAuthenticatedGitHubClient()).toThrow(
+			'GitHub authentication is required.'
+		);
+		expect(createClientMock).not.toHaveBeenCalled();
+	});
+
+	it('rebuilds the client after the OAuth token changes', () => {
+		setOAuthToken('first-token');
+		const first = getAuthenticatedGitHubClient();
+
+		setOAuthToken('second-token');
+		const second = getAuthenticatedGitHubClient();
+
+		expect(second).not.toBe(first);
+		expect(createClientMock).toHaveBeenCalledTimes(2);
+		expect(createClientMock).toHaveBeenLastCalledWith('second-token');
+	});
+
+	it('rebuilds the client after a reset', () => {
+		setOAuthToken('token');
+		const first = getAuthenticatedGitHubClient();
+
+		resetAuthenticatedGitHubClient();
+		const second = getAuthenticatedGitHubClient();
+
+		expect(second).not.toBe(first);
+		expect(createClientMock).toHaveBeenCalledTimes(2);
+	});
+});

--- a/packages/playground/website/src/github/client.ts
+++ b/packages/playground/website/src/github/client.ts
@@ -1,0 +1,32 @@
+import { createClient } from '@wp-playground/storage';
+import type { GithubClient } from '@wp-playground/storage';
+import { oAuthState } from './state';
+
+let octokitClient: GithubClient | undefined;
+let octokitClientToken: string | undefined;
+
+/**
+ * Returns an authenticated GitHub client for the current OAuth token.
+ */
+export function getAuthenticatedGitHubClient() {
+	const token = oAuthState.value.token;
+	if (!token) {
+		throw new Error('GitHub authentication is required.');
+	}
+	// OAuth can replace the token while this module stays loaded. Reusing a
+	// client across token changes would keep sending the stale Authorization
+	// header until the next hard refresh.
+	if (!octokitClient || octokitClientToken !== token) {
+		octokitClient = createClient(token!);
+		octokitClientToken = token;
+	}
+	return octokitClient;
+}
+
+/**
+ * Clears the cached GitHub client after auth failures or token changes.
+ */
+export function resetAuthenticatedGitHubClient() {
+	octokitClient = undefined;
+	octokitClientToken = undefined;
+}

--- a/packages/playground/website/src/github/github-export-form/form.tsx
+++ b/packages/playground/website/src/github/github-export-form/form.tsx
@@ -9,7 +9,10 @@ import {
 import css from './style.module.css';
 import forms from '../../forms.module.css';
 import Button from '../../components/button';
-import { staticAnalyzeGitHubURL } from '../analyze-github-url';
+import {
+	resolveGitHubBranchPath,
+	staticAnalyzeGitHubURL,
+} from '../analyze-github-url';
 import type {
 	Changeset,
 	FileEntry,
@@ -17,7 +20,6 @@ import type {
 } from '@wp-playground/storage';
 import {
 	changeset,
-	createClient,
 	createCommit,
 	createOrUpdateBranch,
 	createTree,
@@ -27,7 +29,11 @@ import {
 	iterateFiles,
 	mayPush,
 } from '@wp-playground/storage';
-import { oAuthState, setOAuthToken } from '../state';
+import { setOAuthToken } from '../state';
+import {
+	getAuthenticatedGitHubClient as getClient,
+	resetAuthenticatedGitHubClient as resetClient,
+} from '../client';
 import { Spinner } from '../../components/spinner';
 import GitHubOAuthGuard from '../github-oauth-guard';
 import type { ContentType } from '../import-from-github';
@@ -41,14 +47,6 @@ export interface GitHubExportFormProps {
 	allowZipExport?: boolean;
 	onExported?: (prURL: string, formValues: ExportFormValues) => void;
 	onClose: () => void;
-}
-
-let octokitClient: GithubClient;
-function getClient() {
-	if (!octokitClient) {
-		octokitClient = createClient(oAuthState.value.token!);
-	}
-	return octokitClient;
 }
 
 export type PullRequestAction = 'update' | 'create';
@@ -99,13 +97,11 @@ export default function GitHubExportForm({
 		repo: string;
 	}>(() => {
 		if (formValues.repoUrl) {
-			try {
-				const { owner, repo } = staticAnalyzeGitHubURL(
-					formValues.repoUrl
-				);
+			const { owner, repo, type } = staticAnalyzeGitHubURL(
+				formValues.repoUrl
+			);
+			if (type !== 'unknown' && owner && repo) {
 				return { owner: owner!, repo: repo! };
-			} catch {
-				// Ignore
 			}
 		}
 
@@ -210,12 +206,35 @@ export default function GitHubExportForm({
 			return;
 		}
 		if (URLNeedsAnalyzing) {
-			const { type, owner, repo, path, pr } = staticAnalyzeGitHubURL(
-				formValues.repoUrl
-			);
+			const analyzed = staticAnalyzeGitHubURL(formValues.repoUrl);
+			let { type, owner, repo, path, pr } = analyzed;
 			if (type === 'unknown') {
 				setError('repoUrl', 'This URL is not supported');
 				return;
+			}
+			if (!['pr', 'branch', 'repo'].includes(type)) {
+				setError('repoUrl', 'This URL is not supported');
+				return;
+			}
+			if (type === 'branch') {
+				try {
+					const resolved = await resolveGitHubBranchPath(
+						getClient(),
+						analyzed
+					);
+					({ type, owner, repo, path, pr } = resolved);
+				} catch (error: any) {
+					if (error?.status === 401) {
+						setOAuthToken(undefined);
+						resetClient();
+						return;
+					}
+					setError(
+						'repoUrl',
+						'Could not analyze this GitHub branch URL. Please paste the repository URL and enter the path manually.'
+					);
+					return;
+				}
 			}
 			setRepoDetails({
 				owner: owner || '',
@@ -417,7 +436,8 @@ export default function GitHubExportForm({
 			// Handle the "Bad Credentials" error
 			if (e && e.status === 401) {
 				setOAuthToken(undefined);
-				throw e;
+				resetClient();
+				return;
 			}
 
 			let eMessage = (e as any)?.message;

--- a/packages/playground/website/src/github/github-export-form/form.tsx
+++ b/packages/playground/website/src/github/github-export-form/form.tsx
@@ -208,10 +208,6 @@ export default function GitHubExportForm({
 		if (URLNeedsAnalyzing) {
 			const analyzed = staticAnalyzeGitHubURL(formValues.repoUrl);
 			let { type, owner, repo, path, pr } = analyzed;
-			if (type === 'unknown') {
-				setError('repoUrl', 'This URL is not supported');
-				return;
-			}
 			if (!['pr', 'branch', 'repo'].includes(type)) {
 				setError('repoUrl', 'This URL is not supported');
 				return;

--- a/packages/playground/website/src/github/github-import-form/form.tsx
+++ b/packages/playground/website/src/github/github-import-form/form.tsx
@@ -80,12 +80,6 @@ export default function GitHubImportForm({
 		}
 		if (!urlInformation) {
 			const info = staticAnalyzeGitHubURL(newUrl);
-			if (info.type === 'unknown') {
-				setErrors({
-					url: 'This URL is not supported',
-				});
-				return;
-			}
 			if (!['pr', 'branch', 'repo'].includes(info.type)) {
 				setErrors({
 					url: 'This URL is not supported',
@@ -93,6 +87,8 @@ export default function GitHubImportForm({
 				return;
 			}
 			const octokit = getClient();
+			// Only keep the most recent analysis run if the user triggers
+			// multiple analysis attempts.
 			const analysisRun = ++analysisRunRef.current;
 			setIsAnalyzing(true);
 			try {

--- a/packages/playground/website/src/github/github-import-form/form.tsx
+++ b/packages/playground/website/src/github/github-import-form/form.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { Notice, Button as WPButton } from '@wordpress/components';
 import type { PlaygroundClient } from '@wp-playground/client';
 
@@ -7,10 +7,17 @@ import css from './style.module.css';
 import forms from '../../forms.module.css';
 import Button from '../../components/button';
 import type { GitHubURLInformation } from '../analyze-github-url';
-import { staticAnalyzeGitHubURL } from '../analyze-github-url';
+import {
+	resolveGitHubBranchPath,
+	staticAnalyzeGitHubURL,
+} from '../analyze-github-url';
 import type { GetFilesProgress, GithubClient } from '@wp-playground/storage';
-import { createClient, getFilesFromDirectory } from '@wp-playground/storage';
-import { oAuthState, setOAuthToken } from '../state';
+import { getFilesFromDirectory } from '@wp-playground/storage';
+import { setOAuthToken } from '../state';
+import {
+	getAuthenticatedGitHubClient as getClient,
+	resetAuthenticatedGitHubClient as resetClient,
+} from '../client';
 import type { ContentType } from '../import-from-github';
 import { importFromGitHub } from '../import-from-github';
 import { Spinner } from '../../components/spinner';
@@ -33,14 +40,6 @@ export interface GitHubImportFormProps {
 	onClose: () => void;
 }
 
-let octokitClient: any;
-function getClient() {
-	if (!octokitClient) {
-		octokitClient = createClient(oAuthState.value.token!);
-	}
-	return octokitClient;
-}
-
 export default function GitHubImportForm({
 	playground,
 	getPlaygroundBeforeImport,
@@ -56,6 +55,8 @@ export default function GitHubImportForm({
 	const [showExample, setShowExample] = useState<boolean>(false);
 
 	const [url, setUrl] = useState<string>('');
+	const latestUrlRef = useRef(url);
+	const analysisRunRef = useRef(0);
 	const [urlInformation, setUrlInformation] = useState<
 		GitHubURLInformation | undefined
 	>();
@@ -69,6 +70,7 @@ export default function GitHubImportForm({
 		e.preventDefault();
 		const newUrl = url.trim();
 		setUrl(newUrl);
+		latestUrlRef.current = newUrl;
 		setErrors({});
 		if (!newUrl) {
 			setErrors({
@@ -82,28 +84,54 @@ export default function GitHubImportForm({
 				setErrors({
 					url: 'This URL is not supported',
 				});
+				return;
 			}
-			logger.log(info);
-			setUrlInformation(info);
+			if (!['pr', 'branch', 'repo'].includes(info.type)) {
+				setErrors({
+					url: 'This URL is not supported',
+				});
+				return;
+			}
 			const octokit = getClient();
+			const analysisRun = ++analysisRunRef.current;
 			setIsAnalyzing(true);
 			try {
-				if (!info.ref) {
-					info.ref = (await guessDefaultBranch(octokit, info))!;
+				const importSource = await resolveImportSource(octokit, info);
+				if (
+					analysisRunRef.current !== analysisRun ||
+					latestUrlRef.current.trim() !== newUrl
+				) {
+					return;
 				}
-				if (info.path) {
-					setPath(info.path);
+				const guessedContentType = await guessContentType(
+					octokit,
+					importSource
+				);
+				if (
+					analysisRunRef.current !== analysisRun ||
+					latestUrlRef.current.trim() !== newUrl
+				) {
+					return;
 				}
-				setBranch(info.ref);
-				setContentType(await guessContentType(octokit, info));
+				setUrlInformation(importSource);
+				setPath(importSource.path ?? '');
+				setBranch(importSource.ref ?? '');
+				setContentType(guessedContentType);
 				return;
 			} catch (e: any) {
+				if (
+					analysisRunRef.current !== analysisRun ||
+					latestUrlRef.current.trim() !== newUrl
+				) {
+					return;
+				}
 				logger.error(e);
 				// Handle the "Bad Credentials" error
 				if (e && e.status) {
 					switch (e.status) {
 						case 401:
 							setOAuthToken(undefined);
+							resetClient();
 							return;
 						case 404:
 							setErrors({
@@ -113,9 +141,11 @@ export default function GitHubImportForm({
 					}
 				}
 				setErrors({ url: e.message });
-				throw e;
+				return;
 			} finally {
-				setIsAnalyzing(false);
+				if (analysisRunRef.current === analysisRun) {
+					setIsAnalyzing(false);
+				}
 			}
 		}
 		if (!contentType) {
@@ -131,11 +161,13 @@ export default function GitHubImportForm({
 			const pluginOrThemeName = basename(path!) || urlInformation!.repo!;
 
 			const relativeRepoPath = path!.replace(/^\//g, '');
+			// Use the commit resolved during analysis so a branch moving
+			// mid-flow cannot change the files being imported.
 			const ghFiles = await getFilesFromDirectory(
 				octokit,
 				urlInformation!.owner!,
 				urlInformation!.repo!,
-				branch!,
+				urlInformation!.commitSha || branch!,
 				relativeRepoPath,
 				{
 					onProgress: (progress) =>
@@ -163,12 +195,17 @@ export default function GitHubImportForm({
 				files: ghFiles,
 			});
 		} catch (e) {
+			if ((e as any)?.status === 401) {
+				setOAuthToken(undefined);
+				resetClient();
+				return;
+			}
 			let eMessage = (e as any)?.message;
 			eMessage = eMessage ? `(${eMessage})` : '';
 			setErrors({
 				url: `There was an unexpected error ${eMessage}, please try again. If the problem persists, please report it at https://github.com/WordPress/wordpress-playground/issues.`,
 			});
-			throw e;
+			return;
 		} finally {
 			setIsImporting(false);
 		}
@@ -192,8 +229,15 @@ export default function GitHubImportForm({
 							onChange={(
 								e: React.ChangeEvent<HTMLInputElement>
 							) => {
-								setUrl(e.target.value);
+								const nextUrl = e.target.value;
+								latestUrlRef.current = nextUrl;
+								analysisRunRef.current++;
+								setUrl(nextUrl);
+								setIsAnalyzing(false);
 								setUrlInformation(undefined);
+								setContentType(undefined);
+								setPath('');
+								setBranch('');
 							}}
 							placeholder="https://github.com/my-org/my-repo/..."
 							autoFocus
@@ -361,17 +405,31 @@ export default function GitHubImportForm({
 	);
 }
 
-async function guessDefaultBranch(
+/**
+ * Resolves the exact repository ref that should be imported.
+ */
+async function resolveImportSource(
 	octokit: GithubClient,
 	urlDetails: GitHubURLInformation
-): Promise<string | undefined> {
+): Promise<GitHubURLInformation> {
 	if (urlDetails.type === 'pr') {
 		const prDetails = await octokit.rest.pulls.get({
 			owner: urlDetails.owner!,
 			repo: urlDetails.repo!,
 			pull_number: urlDetails.pr!,
 		});
-		return prDetails.data.head.ref;
+		if (!prDetails.data.head.repo) {
+			throw new Error(
+				'This pull request cannot be imported because its source repository is unavailable.'
+			);
+		}
+		return {
+			...urlDetails,
+			owner: prDetails.data.head.repo.owner.login,
+			repo: prDetails.data.head.repo.name,
+			ref: prDetails.data.head.ref,
+			commitSha: prDetails.data.head.sha,
+		};
 	}
 	if (urlDetails.type === 'repo') {
 		const {
@@ -380,20 +438,30 @@ async function guessDefaultBranch(
 			owner: urlDetails.owner!,
 			repo: urlDetails.repo!,
 		});
-		return default_branch;
+		const { data: branch } = await octokit.rest.repos.getBranch({
+			owner: urlDetails.owner!,
+			repo: urlDetails.repo!,
+			branch: default_branch,
+		});
+		return {
+			...urlDetails,
+			ref: default_branch,
+			commitSha: branch.commit.sha,
+		};
 	}
+	return resolveGitHubBranchPath(octokit, urlDetails);
 }
 
 async function guessContentType(
 	octokit: GithubClient,
-	{ owner, repo, path, ref }: GitHubURLInformation
+	{ owner, repo, path, ref, commitSha }: GitHubURLInformation
 ): Promise<ContentType | undefined> {
 	// Guess the content type
 	const { data: files } = await octokit.rest.repos.getContent({
 		owner: owner!,
 		repo: repo!,
 		path: path!,
-		ref,
+		ref: commitSha || ref,
 	});
 	if (Array.isArray(files)) {
 		if (files.some(({ name }) => name === 'theme.json')) {

--- a/packages/playground/website/src/github/preview-pr/form.tsx
+++ b/packages/playground/website/src/github/preview-pr/form.tsx
@@ -7,7 +7,6 @@ import ModalButtons from '../../components/modal/modal-buttons';
 import type { BlueprintV1Declaration } from '@wp-playground/blueprints';
 import type { ResolvedRef } from './resolve-pr-input';
 import {
-	getPreviewPrInputFromQuery,
 	isWordPressPrBeforePreviewer,
 	resolvePrInput,
 } from './resolve-pr-input';
@@ -45,10 +44,16 @@ export default function PreviewPRForm({
 	const [errorMsg, setError] = useState<string>('');
 
 	useEffect(() => {
-		const initialValue = getPreviewPrInputFromQuery(
-			new URLSearchParams(window.location.search),
-			target
-		);
+		const query = new URLSearchParams(window.location.search);
+		let initialValue = '';
+		if (target === 'wordpress') {
+			initialValue = query.get('core-pr') || '';
+		} else {
+			initialValue =
+				query.get('gutenberg-pr') ||
+				query.get('gutenberg-branch') ||
+				'';
+		}
 		if (initialValue) {
 			setValue(initialValue);
 		}

--- a/packages/playground/website/src/github/preview-pr/form.tsx
+++ b/packages/playground/website/src/github/preview-pr/form.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { useState } from 'react';
 import { Spinner, TextControl } from '@wordpress/components';
 import css from './style.module.css';
@@ -42,6 +42,7 @@ export default function PreviewPRForm({
 	const [value, setValue] = useState<string>('');
 	const [submitting, setSubmitting] = useState<boolean>(false);
 	const [errorMsg, setError] = useState<string>('');
+	const cleanupRetryRef = useRef<() => void>(() => {});
 
 	useEffect(() => {
 		const query = new URLSearchParams(window.location.search);
@@ -58,6 +59,10 @@ export default function PreviewPRForm({
 			setValue(initialValue);
 		}
 	}, [target]);
+
+	useEffect(() => {
+		return () => cleanupRetryRef.current();
+	}, []);
 
 	async function handleSubmit(e: React.FormEvent) {
 		e.preventDefault();
@@ -101,10 +106,8 @@ export default function PreviewPRForm({
 	}
 
 	async function previewPr(resolved: ResolvedRef) {
-		let cleanupRetry = () => {};
-		if (cleanupRetry) {
-			cleanupRetry();
-		}
+		cleanupRetryRef.current();
+		cleanupRetryRef.current = () => {};
 
 		const { target: repo, ref, isBranch } = resolved;
 		setSubmitting(true);
@@ -152,10 +155,10 @@ export default function PreviewPRForm({
 						const scheduledRetry = setTimeout(() => {
 							previewPr(resolved);
 						}, retryIn);
-						cleanupRetry = () => {
+						cleanupRetryRef.current = () => {
 							clearInterval(timerInterval);
 							clearTimeout(scheduledRetry);
-							cleanupRetry = () => {};
+							cleanupRetryRef.current = () => {};
 						};
 					}
 				} else if (error === 'artifact_invalid') {

--- a/packages/playground/website/src/github/preview-pr/form.tsx
+++ b/packages/playground/website/src/github/preview-pr/form.tsx
@@ -5,6 +5,12 @@ import css from './style.module.css';
 import { logger } from '@php-wasm/logger';
 import ModalButtons from '../../components/modal/modal-buttons';
 import type { BlueprintV1Declaration } from '@wp-playground/blueprints';
+import type { ResolvedRef } from './resolve-pr-input';
+import {
+	getPreviewPrInputFromQuery,
+	isWordPressPrBeforePreviewer,
+	resolvePrInput,
+} from './resolve-pr-input';
 
 interface PreviewPRFormProps {
 	onClose: () => void;
@@ -39,80 +45,69 @@ export default function PreviewPRForm({
 	const [errorMsg, setError] = useState<string>('');
 
 	useEffect(() => {
-		const query = new URLSearchParams(window.location.search);
-		if (query.has('core-pr')) {
-			const prNumber = query.get('core-pr');
-			prNumber && setValue(prNumber);
+		const initialValue = getPreviewPrInputFromQuery(
+			new URLSearchParams(window.location.search),
+			target
+		);
+		if (initialValue) {
+			setValue(initialValue);
 		}
-	}, []);
+	}, [target]);
 
 	async function handleSubmit(e: React.FormEvent) {
 		e.preventDefault();
 
-		if (!value) {
+		if (!value.trim()) {
 			return;
 		}
 
-		await previewPr(value);
+		const resolved = resolvePrInput(value, target);
+		if (!resolved.ok) {
+			setError(resolved.error);
+			return;
+		}
+
+		await previewPr(resolved.value);
 	}
 
-	function renderRetryIn(retryIn: number, isBranch: boolean) {
+	function renderRetryIn(retryIn: number, resolved: ResolvedRef) {
 		setError(
 			`Waiting for GitHub to finish building ${
-				isBranch ? 'branch' : 'PR'
-			} ${value}. This might take 15 minutes or more! Retrying in ${
+				resolved.isBranch ? 'branch' : 'PR'
+			} ${resolved.ref}. This might take 15 minutes or more! Retrying in ${
 				retryIn / 1000
 			}...`
 		);
 	}
 
-	function buildArtifactUrl(ref: string, isBranch: boolean): string {
+	function buildArtifactUrl(resolved: ResolvedRef): string {
+		const { target: repo, ref, isBranch } = resolved;
 		const refType = isBranch ? 'branch' : 'pr';
 		// For WordPress PRs: artifact name is wordpress-build-{PR_NUMBER}
 		// For Gutenberg PRs: artifact name is always gutenberg-plugin
 		// For Gutenberg branches: artifact name is always gutenberg-plugin
 		//   (we use prefix matching with trailing dash for branches)
 		let artifactSuffix = '';
-		if (target === 'wordpress') {
+		if (repo === 'wordpress') {
 			// WordPress only supports PRs, not branches
 			artifactSuffix = ref;
 		}
-		return `https://playground.wordpress.net/plugin-proxy.php?org=WordPress&repo=${targetParams[target].repo}&workflow=${targetParams[target].workflow}&artifact=${targetParams[target].artifact}${artifactSuffix}&${refType}=${ref}`;
+		return `https://playground.wordpress.net/plugin-proxy.php?org=WordPress&repo=${targetParams[repo].repo}&workflow=${targetParams[repo].workflow}&artifact=${targetParams[repo].artifact}${artifactSuffix}&${refType}=${encodeURIComponent(ref)}`;
 	}
 
-	async function previewPr(prValue: string) {
+	async function previewPr(resolved: ResolvedRef) {
 		let cleanupRetry = () => {};
 		if (cleanupRetry) {
 			cleanupRetry();
 		}
 
-		let prNumber: string = prValue;
-		let branchName: string | null = null;
+		const { target: repo, ref, isBranch } = resolved;
 		setSubmitting(true);
-
-		// Extract number from a GitHub URL
-		if (prNumber.toLowerCase().includes(targetParams[target].pull)) {
-			prNumber = prNumber.match(/\/pull\/(\d+)/)![1];
-		} else if (!/^\d+$/.test(prNumber)) {
-			// For WordPress core, only allow PR numbers/URLs, not branch names
-			if (target === 'wordpress') {
-				setError(
-					'Please enter a valid PR number or PR URL for WordPress Core.'
-				);
-				setSubmitting(false);
-				return;
-			}
-			// For Gutenberg, treat non-numeric input as a branch name
-			branchName = prNumber;
-		}
-
-		const ref = branchName || prNumber;
-		const isBranch = !!branchName;
 
 		// For branches, skip verification since we'll use the most recent artifact with prefix matching
 		// For PRs, verify that the specific PR build exists
 		if (!isBranch) {
-			const zipArtifactUrl = buildArtifactUrl(ref, isBranch);
+			const zipArtifactUrl = buildArtifactUrl(resolved);
 			const response = await fetch(zipArtifactUrl + '&verify_only=true');
 			if (response.status !== 200) {
 				let error = 'invalid_pr_number';
@@ -124,6 +119,7 @@ export default function PreviewPRForm({
 				} catch (e) {
 					logger.error(e);
 					setError('An unexpected error occurred. Please try again.');
+					setSubmitting(false);
 					return;
 				}
 
@@ -133,23 +129,23 @@ export default function PreviewPRForm({
 					error === 'artifact_not_found' ||
 					error === 'artifact_not_available'
 				) {
-					if (parseInt(ref) < 5749) {
+					if (isWordPressPrBeforePreviewer(resolved)) {
 						setError(
 							`The PR ${ref} predates the Pull Request previewer and requires a rebase before it can be previewed.`
 						);
 					} else {
 						// For PRs, retry since we expect a specific build to complete
 						let retryIn = 30000;
-						renderRetryIn(retryIn, false);
+						renderRetryIn(retryIn, resolved);
 						const timerInterval = setInterval(() => {
 							retryIn -= 1000;
 							if (retryIn <= 0) {
 								retryIn = 0;
 							}
-							renderRetryIn(retryIn, false);
+							renderRetryIn(retryIn, resolved);
 						}, 1000);
 						const scheduledRetry = setTimeout(() => {
-							previewPr(ref);
+							previewPr(resolved);
 						}, retryIn);
 						cleanupRetry = () => {
 							clearInterval(timerInterval);
@@ -188,14 +184,14 @@ export default function PreviewPRForm({
 		};
 
 		const refParam = isBranch
-			? `${target === 'wordpress' ? 'core' : 'gutenberg'}-branch`
-			: `${target === 'wordpress' ? 'core' : 'gutenberg'}-pr`;
+			? `${repo === 'wordpress' ? 'core' : 'gutenberg'}-branch`
+			: `${repo === 'wordpress' ? 'core' : 'gutenberg'}-pr`;
 		const urlWithPreview = new URL(
 			window.location.pathname,
 			window.location.href
 		);
 
-		if (target === 'wordpress') {
+		if (repo === 'wordpress') {
 			// [wordpress] Passthrough the mode query parameter if it exists
 			if (urlParams.has('mode')) {
 				urlWithPreview.searchParams.set(
@@ -204,7 +200,7 @@ export default function PreviewPRForm({
 				);
 			}
 			urlWithPreview.searchParams.set(refParam, ref);
-		} else if (target === 'gutenberg') {
+		} else if (repo === 'gutenberg') {
 			// [gutenberg] If there's a import-site query parameter, pass that to the blueprint
 			try {
 				const importSite = new URL(

--- a/packages/playground/website/src/github/preview-pr/resolve-pr-input.spec.ts
+++ b/packages/playground/website/src/github/preview-pr/resolve-pr-input.spec.ts
@@ -68,6 +68,18 @@ describe('resolvePrInput', () => {
 		});
 	});
 
+	it('accepts www.github.com URLs', () => {
+		expect(
+			resolvePrInput(
+				'https://www.github.com/WordPress/gutenberg/pull/789',
+				'wordpress'
+			)
+		).toEqual({
+			ok: true,
+			value: { target: 'gutenberg', ref: '789', isBranch: false },
+		});
+	});
+
 	it('resolves official Gutenberg branch URLs without including query parameters', () => {
 		expect(
 			resolvePrInput(

--- a/packages/playground/website/src/github/preview-pr/resolve-pr-input.spec.ts
+++ b/packages/playground/website/src/github/preview-pr/resolve-pr-input.spec.ts
@@ -1,5 +1,4 @@
 import {
-	getPreviewPrInputFromQuery,
 	isWordPressPrBeforePreviewer,
 	resolvePrInput,
 } from './resolve-pr-input';
@@ -128,29 +127,6 @@ describe('resolvePrInput', () => {
 			ok: true,
 			value: { target: 'gutenberg', ref: 'feature/foo', isBranch: true },
 		});
-	});
-});
-
-describe('getPreviewPrInputFromQuery', () => {
-	it('prefills the matching repository reference only', () => {
-		const query = new URLSearchParams({
-			'core-pr': '123',
-			'gutenberg-pr': '456',
-		});
-
-		expect(getPreviewPrInputFromQuery(query, 'wordpress')).toBe('123');
-		expect(getPreviewPrInputFromQuery(query, 'gutenberg')).toBe('456');
-	});
-
-	it('prefills Gutenberg branches', () => {
-		const query = new URLSearchParams({
-			'gutenberg-branch': 'feature/foo',
-		});
-
-		expect(getPreviewPrInputFromQuery(query, 'gutenberg')).toBe(
-			'feature/foo'
-		);
-		expect(getPreviewPrInputFromQuery(query, 'wordpress')).toBe('');
 	});
 });
 

--- a/packages/playground/website/src/github/preview-pr/resolve-pr-input.spec.ts
+++ b/packages/playground/website/src/github/preview-pr/resolve-pr-input.spec.ts
@@ -1,0 +1,188 @@
+import {
+	getPreviewPrInputFromQuery,
+	isWordPressPrBeforePreviewer,
+	resolvePrInput,
+} from './resolve-pr-input';
+
+describe('resolvePrInput', () => {
+	it('resolves bare numbers against the preferred repository', () => {
+		expect(resolvePrInput('123', 'wordpress')).toEqual({
+			ok: true,
+			value: { target: 'wordpress', ref: '123', isBranch: false },
+		});
+		expect(resolvePrInput('123', 'gutenberg')).toEqual({
+			ok: true,
+			value: { target: 'gutenberg', ref: '123', isBranch: false },
+		});
+	});
+
+	it('resolves official WordPress Core and Gutenberg pull request URLs', () => {
+		expect(
+			resolvePrInput(
+				'https://github.com/WordPress/wordpress-develop/pull/456',
+				'gutenberg'
+			)
+		).toEqual({
+			ok: true,
+			value: { target: 'wordpress', ref: '456', isBranch: false },
+		});
+		expect(
+			resolvePrInput(
+				'github.com/WordPress/gutenberg/pull/789',
+				'wordpress'
+			)
+		).toEqual({
+			ok: true,
+			value: { target: 'gutenberg', ref: '789', isBranch: false },
+		});
+	});
+
+	it('rejects zero as a pull request number', () => {
+		expect(resolvePrInput('0', 'wordpress')).toEqual({
+			ok: false,
+			error: 'Enter a valid pull request number.',
+		});
+		expect(resolvePrInput('0', 'gutenberg')).toEqual({
+			ok: false,
+			error: 'Enter a valid pull request number.',
+		});
+		expect(
+			resolvePrInput(
+				'https://github.com/WordPress/gutenberg/pull/0',
+				'gutenberg'
+			)
+		).toEqual({
+			ok: false,
+			error: expect.stringContaining('Paste a WordPress Core'),
+		});
+	});
+
+	it('accepts GitHub URL owner, repository, and route casing', () => {
+		expect(
+			resolvePrInput(
+				'https://github.com/wordpress/Gutenberg/PULL/789',
+				'wordpress'
+			)
+		).toEqual({
+			ok: true,
+			value: { target: 'gutenberg', ref: '789', isBranch: false },
+		});
+	});
+
+	it('resolves official Gutenberg branch URLs without including query parameters', () => {
+		expect(
+			resolvePrInput(
+				'https://github.com/WordPress/gutenberg/tree/feature/foo?plain=1',
+				'wordpress'
+			)
+		).toEqual({
+			ok: true,
+			value: { target: 'gutenberg', ref: 'feature/foo', isBranch: true },
+		});
+	});
+
+	it('rejects WordPress Core branch URLs', () => {
+		expect(
+			resolvePrInput(
+				'https://github.com/WordPress/wordpress-develop/tree/trunk',
+				'wordpress'
+			)
+		).toEqual({
+			ok: false,
+			error: expect.stringContaining("Branch names aren't supported"),
+		});
+	});
+
+	it('does not treat unsupported GitHub URLs as bare Gutenberg branch names', () => {
+		expect(
+			resolvePrInput(
+				'https://github.com/someone/gutenberg/pull/123',
+				'gutenberg'
+			)
+		).toEqual({
+			ok: false,
+			error: expect.stringContaining('Only WordPress'),
+		});
+	});
+
+	it('rejects malformed GitHub URLs instead of throwing', () => {
+		expect(() =>
+			resolvePrInput(
+				'https://github.com/WordPress/gutenberg/tree/%E0%A4%A',
+				'gutenberg'
+			)
+		).not.toThrow();
+		expect(
+			resolvePrInput(
+				'https://github.com/WordPress/gutenberg/tree/%E0%A4%A',
+				'gutenberg'
+			)
+		).toEqual({
+			ok: false,
+			error: expect.stringContaining('Paste a WordPress Core'),
+		});
+	});
+
+	it('still accepts bare Gutenberg branch names', () => {
+		expect(resolvePrInput('feature/foo', 'gutenberg')).toEqual({
+			ok: true,
+			value: { target: 'gutenberg', ref: 'feature/foo', isBranch: true },
+		});
+	});
+});
+
+describe('getPreviewPrInputFromQuery', () => {
+	it('prefills the matching repository reference only', () => {
+		const query = new URLSearchParams({
+			'core-pr': '123',
+			'gutenberg-pr': '456',
+		});
+
+		expect(getPreviewPrInputFromQuery(query, 'wordpress')).toBe('123');
+		expect(getPreviewPrInputFromQuery(query, 'gutenberg')).toBe('456');
+	});
+
+	it('prefills Gutenberg branches', () => {
+		const query = new URLSearchParams({
+			'gutenberg-branch': 'feature/foo',
+		});
+
+		expect(getPreviewPrInputFromQuery(query, 'gutenberg')).toBe(
+			'feature/foo'
+		);
+		expect(getPreviewPrInputFromQuery(query, 'wordpress')).toBe('');
+	});
+});
+
+describe('isWordPressPrBeforePreviewer', () => {
+	it('only applies the old-PR cutoff to WordPress Core PRs', () => {
+		expect(
+			isWordPressPrBeforePreviewer({
+				target: 'wordpress',
+				ref: '5748',
+				isBranch: false,
+			})
+		).toBe(true);
+		expect(
+			isWordPressPrBeforePreviewer({
+				target: 'wordpress',
+				ref: '5749',
+				isBranch: false,
+			})
+		).toBe(false);
+		expect(
+			isWordPressPrBeforePreviewer({
+				target: 'gutenberg',
+				ref: '100',
+				isBranch: false,
+			})
+		).toBe(false);
+		expect(
+			isWordPressPrBeforePreviewer({
+				target: 'wordpress',
+				ref: 'trunk',
+				isBranch: true,
+			})
+		).toBe(false);
+	});
+});

--- a/packages/playground/website/src/github/preview-pr/resolve-pr-input.ts
+++ b/packages/playground/website/src/github/preview-pr/resolve-pr-input.ts
@@ -33,9 +33,10 @@ export function resolvePrInput(
 	// repository even when the modal was opened for the other target.
 	const githubUrl = parseGitHubUrl(input);
 	if (githubUrl) {
+		const hostname = githubUrl.hostname.toLowerCase();
 		if (
 			!['http:', 'https:'].includes(githubUrl.protocol) ||
-			githubUrl.hostname.toLowerCase() !== 'github.com'
+			(hostname !== 'github.com' && hostname !== 'www.github.com')
 		) {
 			return {
 				ok: false,

--- a/packages/playground/website/src/github/preview-pr/resolve-pr-input.ts
+++ b/packages/playground/website/src/github/preview-pr/resolve-pr-input.ts
@@ -15,16 +15,6 @@ const WP_BRANCH_ERROR =
 const PULL_REQUEST_NUMBER = /^[1-9]\d*$/;
 const FIRST_WORDPRESS_PREVIEWABLE_PR = 5749;
 
-export function getPreviewPrInputFromQuery(
-	query: URLSearchParams,
-	target: 'wordpress' | 'gutenberg'
-): string {
-	if (target === 'wordpress') {
-		return query.get('core-pr') || '';
-	}
-	return query.get('gutenberg-pr') || query.get('gutenberg-branch') || '';
-}
-
 /**
  * Resolves free-form input into a repository + reference. A recognized GitHub
  * URL decides the repository; a bare number is a pull request on the preferred
@@ -52,8 +42,10 @@ export function resolvePrInput(
 				error: 'Paste a WordPress Core or Gutenberg pull request URL, or a Gutenberg branch URL.',
 			};
 		}
-		const githubPath = decodeGitHubPath(githubUrl.pathname);
-		if (!githubPath) {
+		let githubPath = undefined;
+		try {
+			githubPath = decodeURIComponent(githubUrl.pathname);
+		} catch {
 			return {
 				ok: false,
 				error: 'Paste a WordPress Core or Gutenberg pull request URL, or a Gutenberg branch URL.',
@@ -160,13 +152,5 @@ function parseGitHubUrl(input: string): URL | undefined {
 		} catch {
 			return undefined;
 		}
-	}
-}
-
-function decodeGitHubPath(pathname: string): string | undefined {
-	try {
-		return decodeURIComponent(pathname);
-	} catch {
-		return undefined;
 	}
 }

--- a/packages/playground/website/src/github/preview-pr/resolve-pr-input.ts
+++ b/packages/playground/website/src/github/preview-pr/resolve-pr-input.ts
@@ -1,0 +1,172 @@
+export type ResolvedRef = {
+	target: 'wordpress' | 'gutenberg';
+	ref: string;
+	isBranch: boolean;
+};
+
+export type ResolvePrInputResult =
+	| { ok: true; value: ResolvedRef }
+	| { ok: false; error: string };
+
+// WordPress Core builds artifacts per pull request, not per branch, so a branch
+// name (or branch URL) can't be previewed. Gutenberg branches still work.
+const WP_BRANCH_ERROR =
+	"Branch names aren't supported for WordPress Core — paste a pull request number or URL instead. (To preview a Gutenberg branch, paste its full GitHub branch URL.)";
+const PULL_REQUEST_NUMBER = /^[1-9]\d*$/;
+const FIRST_WORDPRESS_PREVIEWABLE_PR = 5749;
+
+export function getPreviewPrInputFromQuery(
+	query: URLSearchParams,
+	target: 'wordpress' | 'gutenberg'
+): string {
+	if (target === 'wordpress') {
+		return query.get('core-pr') || '';
+	}
+	return query.get('gutenberg-pr') || query.get('gutenberg-branch') || '';
+}
+
+/**
+ * Resolves free-form input into a repository + reference. A recognized GitHub
+ * URL decides the repository; a bare number is a pull request on the preferred
+ * repository; anything else is a branch name, which only Gutenberg supports.
+ */
+export function resolvePrInput(
+	raw: string,
+	preferredTarget: 'wordpress' | 'gutenberg'
+): ResolvePrInputResult {
+	const input = raw.trim();
+	if (!input) {
+		return { ok: false, error: 'Enter a pull request number or URL.' };
+	}
+
+	// Extract number from a GitHub URL. Recognized URLs decide the
+	// repository even when the modal was opened for the other target.
+	const githubUrl = parseGitHubUrl(input);
+	if (githubUrl) {
+		if (
+			!['http:', 'https:'].includes(githubUrl.protocol) ||
+			githubUrl.hostname.toLowerCase() !== 'github.com'
+		) {
+			return {
+				ok: false,
+				error: 'Paste a WordPress Core or Gutenberg pull request URL, or a Gutenberg branch URL.',
+			};
+		}
+		const githubPath = decodeGitHubPath(githubUrl.pathname);
+		if (!githubPath) {
+			return {
+				ok: false,
+				error: 'Paste a WordPress Core or Gutenberg pull request URL, or a Gutenberg branch URL.',
+			};
+		}
+		const [owner, repoRaw, kindRaw, ...rest] = githubPath
+			.split('/')
+			.filter(Boolean);
+		if (owner?.toLowerCase() !== 'wordpress') {
+			return {
+				ok: false,
+				error: 'Only WordPress/wordpress-develop and WordPress/gutenberg URLs are supported.',
+			};
+		}
+		const repo = repoRaw?.toLowerCase();
+		const kind = kindRaw?.toLowerCase();
+		if (
+			repo === 'gutenberg' &&
+			kind === 'pull' &&
+			PULL_REQUEST_NUMBER.test(rest[0])
+		) {
+			return {
+				ok: true,
+				value: {
+					target: 'gutenberg',
+					ref: rest[0],
+					isBranch: false,
+				},
+			};
+		}
+		if (repo === 'gutenberg' && kind === 'tree' && rest.length > 0) {
+			return {
+				ok: true,
+				value: {
+					target: 'gutenberg',
+					ref: rest.join('/').replace(/\/+$/, ''),
+					isBranch: true,
+				},
+			};
+		}
+		if (
+			repo === 'wordpress-develop' &&
+			kind === 'pull' &&
+			PULL_REQUEST_NUMBER.test(rest[0])
+		) {
+			return {
+				ok: true,
+				value: {
+					target: 'wordpress',
+					ref: rest[0],
+					isBranch: false,
+				},
+			};
+		}
+		if (repo === 'wordpress-develop' && kind === 'tree') {
+			return { ok: false, error: WP_BRANCH_ERROR };
+		}
+		return {
+			ok: false,
+			error: 'Paste a WordPress Core or Gutenberg pull request URL, or a Gutenberg branch URL.',
+		};
+	}
+
+	// Bare numbers are PR numbers for whichever repository the modal prefers.
+	if (PULL_REQUEST_NUMBER.test(input)) {
+		return {
+			ok: true,
+			value: { target: preferredTarget, ref: input, isBranch: false },
+		};
+	}
+	if (/^\d+$/.test(input)) {
+		return { ok: false, error: 'Enter a valid pull request number.' };
+	}
+
+	// Bare, non-numeric, no recognized URL: treat as a branch name. Gutenberg
+	// supports branches; WordPress Core does not.
+	if (preferredTarget === 'gutenberg') {
+		return {
+			ok: true,
+			value: { target: 'gutenberg', ref: input, isBranch: true },
+		};
+	}
+	return { ok: false, error: WP_BRANCH_ERROR };
+}
+
+export function isWordPressPrBeforePreviewer(resolved: ResolvedRef) {
+	return (
+		resolved.target === 'wordpress' &&
+		!resolved.isBranch &&
+		PULL_REQUEST_NUMBER.test(resolved.ref) &&
+		Number(resolved.ref) < FIRST_WORDPRESS_PREVIEWABLE_PR
+	);
+}
+
+function parseGitHubUrl(input: string): URL | undefined {
+	try {
+		return new URL(input);
+	} catch {
+		if (!/^github\.com\//i.test(input)) {
+			return undefined;
+		}
+		try {
+			return new URL(`https://${input}`);
+		} catch {
+			return undefined;
+		}
+	}
+}
+
+function decodeGitHubPath(pathname: string): string | undefined {
+	try {
+		return decodeURIComponent(pathname);
+	} catch {
+		return undefined;
+	}
+}


### PR DESCRIPTION
## What it does

Parses GitHub inputs before the import, export, and PR preview forms use them. Repository URLs, PR URLs, branch URLs, raw file URLs, PR numbers, and Gutenberg branch references now become structured repository/ref/path data instead of being re-parsed inside each form.

This PR keeps the follow-up export behavior out of scope: updating an existing PR by pushing to its head branch remains in the next stacked PR.

## Rationale

The GitHub forms accepted several user-facing input shapes, but each form interpreted those strings differently. That made branch, PR, and preview flows depend on local parsing guesses instead of one tested source of truth.

GitHub tree/blob URLs are especially ambiguous because the URL does not mark where a slash-containing branch name ends:

- `/tree/trunk/packages/playground` means branch `trunk`, path `packages/playground`.
- `/tree/feature/export-form/packages/playground` may mean branch `feature/export-form`, path `packages/playground`.

Resolving those inputs before the form action lets import/export use the same owner, repo, ref, path, and commit data that the UI displayed during analysis. The shared authenticated client is part of that flow because branch and PR resolution now make GitHub API requests before the final import/export action; it avoids reusing an Octokit instance after OAuth replaces the token.

## Implementation

- Extends GitHub URL parsing to return structured data without throwing on unsupported URLs.
- Resolves slash-containing branch URLs by checking the longest possible branch name first.
- Resolves import sources to the PR head, default branch, or branch commit before importing files.
- Extracts PR preview input parsing for WordPress Core and Gutenberg into a tested helper.
- Shares the authenticated GitHub client across forms and clears it after auth failures.

## Testing instructions

Run:

```bash
npx vitest run --config packages/playground/website/vite.config.ts \
  src/github/analyze-github-url.spec.ts \
  src/github/client.spec.ts \
  src/github/git-auth-helpers.spec.ts \
  src/github/oauth-popup.spec.ts \
  src/github/preview-pr/resolve-pr-input.spec.ts

ESLINT_USE_FLAT_CONFIG=false npx eslint \
  packages/playground/website/src/github/analyze-github-url.ts \
  packages/playground/website/src/github/analyze-github-url.spec.ts \
  packages/playground/website/src/github/client.ts \
  packages/playground/website/src/github/client.spec.ts \
  packages/playground/website/src/github/github-export-form/form.tsx \
  packages/playground/website/src/github/github-import-form/form.tsx \
  packages/playground/website/src/github/preview-pr/form.tsx \
  packages/playground/website/src/github/preview-pr/resolve-pr-input.ts \
  packages/playground/website/src/github/preview-pr/resolve-pr-input.spec.ts

git diff --check
```

Note: `npx nx test playground-website ...` is currently blocked in this workspace because `.context` contains copied worktrees with duplicate Nx project names.
