### PR TITLE
[Website] Derive GitHub import folder names from safe basenames

### DIFF
--- a/packages/playground/website/src/github/github-import-form/form.tsx
+++ b/packages/playground/website/src/github/github-import-form/form.tsx
@@ -22,8 +22,9 @@ import type { ContentType } from '../import-from-github';
 import { importFromGitHub } from '../import-from-github';
 import { Spinner } from '../../components/spinner';
 import GitHubOAuthGuard from '../github-oauth-guard';
-import { basename, normalizePath } from '@php-wasm/util';
+import { normalizePath } from '@php-wasm/util';
 import { logger } from '@php-wasm/logger';
+import { getGitHubImportDirectoryName } from './import-directory-name';
 
 export interface GitHubImportFormProps {
 	playground: PlaygroundClient;
@@ -92,10 +93,10 @@ export default function GitHubImportForm({
 				});
 				return;
 			}
-			const octokit = getClient();
 			const analysisRun = ++analysisRunRef.current;
 			setIsAnalyzing(true);
 			try {
+				const octokit = getClient();
 				const importSource = await resolveImportSource(octokit, info);
 				if (
 					analysisRunRef.current !== analysisRun ||
@@ -158,7 +159,10 @@ export default function GitHubImportForm({
 		setImportProgress({ downloadedFiles: 0, foundFiles: 0 });
 		try {
 			const octokit = getClient();
-			const pluginOrThemeName = basename(path!) || urlInformation!.repo!;
+			const pluginOrThemeName = getGitHubImportDirectoryName(
+				path!,
+				urlInformation!.repo!
+			);
 
 			const relativeRepoPath = path!.replace(/^\//g, '');
 			// Use the commit resolved during analysis so a branch moving

--- a/packages/playground/website/src/github/github-import-form/import-directory-name.spec.ts
+++ b/packages/playground/website/src/github/github-import-form/import-directory-name.spec.ts
@@ -1,0 +1,39 @@
+import { getGitHubImportDirectoryName } from './import-directory-name';
+
+describe('getGitHubImportDirectoryName', () => {
+	it('uses the last repository path segment', () => {
+		expect(getGitHubImportDirectoryName('plugins/my-plugin', 'repo')).toBe(
+			'my-plugin'
+		);
+	});
+
+	it('falls back to the repository name for root imports', () => {
+		expect(getGitHubImportDirectoryName('', 'repo-name')).toBe('repo-name');
+	});
+
+	it('does not use dot segments as directory names', () => {
+		expect(getGitHubImportDirectoryName('..', 'repo-name')).toBe(
+			'repo-name'
+		);
+		expect(getGitHubImportDirectoryName('.', 'repo-name')).toBe(
+			'repo-name'
+		);
+	});
+
+	it('does not use backslash-separated paths as directory names', () => {
+		expect(getGitHubImportDirectoryName('plugins\\my-plugin', 'repo')).toBe(
+			'repo'
+		);
+	});
+
+	it('falls back to a stable name when both inputs are unsafe', () => {
+		expect(getGitHubImportDirectoryName('..', '..')).toBe('github-import');
+		expect(getGitHubImportDirectoryName('\0', '')).toBe('github-import');
+	});
+
+	it('uses only the last segment of fallback repository names', () => {
+		expect(getGitHubImportDirectoryName('', 'owner\\repo-name')).toBe(
+			'repo-name'
+		);
+	});
+});

--- a/packages/playground/website/src/github/github-import-form/import-directory-name.ts
+++ b/packages/playground/website/src/github/github-import-form/import-directory-name.ts
@@ -1,0 +1,37 @@
+import { basename } from '@php-wasm/util';
+
+const FALLBACK_IMPORT_DIRECTORY = 'github-import';
+
+/**
+ * Returns a safe plugin/theme folder name for files imported from GitHub.
+ *
+ * The repository path itself is left unchanged for fetching; this only chooses
+ * the local WordPress directory name used after the files are downloaded.
+ */
+export function getGitHubImportDirectoryName(
+	repoPath: string,
+	fallbackRepoName: string
+): string {
+	const pathName = basename(repoPath);
+	if (isSafeDirectoryName(pathName)) {
+		return pathName;
+	}
+
+	const fallbackName = basename(fallbackRepoName.replace(/\\/g, '/'));
+	if (isSafeDirectoryName(fallbackName)) {
+		return fallbackName;
+	}
+
+	return FALLBACK_IMPORT_DIRECTORY;
+}
+
+function isSafeDirectoryName(name: string) {
+	return (
+		!!name &&
+		name !== '.' &&
+		name !== '..' &&
+		!name.includes('/') &&
+		!name.includes('\\') &&
+		!name.includes('\0')
+	);
+}


### PR DESCRIPTION
## What it does

Adds a small GitHub import helper that chooses a safe folder name for imported plugins and themes.

## Rationale

The import form used the raw basename of the selected repository path as the plugin/theme folder name. Root imports or dot-like path values could produce an empty or invalid folder name before falling back inconsistently.

## Implementation

- Derives the import folder from the selected repository path basename when it is safe.
- Falls back to the repository name, then to `github-import`, when the basename is empty or dot-like.
- Leaves the GitHub repository path itself untouched; this PR intentionally does not add import path normalization or rewrite the path used for fetching files.

## Testing instructions

Run:

```bash
npx vitest run --config packages/playground/website/vite.config.ts \
  src/github/github-import-form/import-directory-name.spec.ts \
  src/github/analyze-github-url.spec.ts \
  src/github/client.spec.ts

ESLINT_USE_FLAT_CONFIG=false npx eslint \
  packages/playground/website/src/github/github-import-form/form.tsx \
  packages/playground/website/src/github/github-import-form/import-directory-name.ts \
  packages/playground/website/src/github/github-import-form/import-directory-name.spec.ts

git diff --check
```

Note: this PR is stacked on #3945.
