### PR TITLE
[Website] Push GitHub export updates to pull request head branches

### DIFF
--- a/packages/playground/website/src/github/github-export-form/form.spec.tsx
+++ b/packages/playground/website/src/github/github-export-form/form.spec.tsx
@@ -36,6 +36,12 @@ vi.mock('../state', () => ({
 
 describe('pushToGithub', () => {
 	beforeEach(() => {
+		vi.stubGlobal('document', {
+			location: {
+				origin: 'https://playground.test',
+				pathname: '/website-server/',
+			},
+		});
 		for (const mock of Object.values(storageMocks)) {
 			mock.mockReset();
 		}
@@ -112,6 +118,45 @@ describe('pushToGithub', () => {
 		});
 	});
 
+	it('adds zip preview links that use the PR head before merge', async () => {
+		storageMocks.mayPush.mockResolvedValue(true);
+		const octokit = createOctokit({
+			pullRequest: createPullRequest({
+				headOwner: 'contributor',
+				headRepo: 'wordpress-playground-fork',
+				headRef: 'feature/export',
+				htmlUrl:
+					'https://github.com/WordPress/wordpress-playground/pull/12',
+			}),
+		});
+
+		await pushToGithub(octokit as any, {
+			owner: 'WordPress',
+			repo: 'wordpress-playground',
+			commitMessage: 'Changes from Playground',
+			changeset: createChangeset(),
+			zipPathForPreview: 'wp-content/plugins/demo/playground.zip',
+			shouldCreateNewPR: false,
+			create: {
+				againstBranch: 'unused',
+				branchName: 'unused',
+				title: 'Update plugin',
+			},
+			update: {
+				prNumber: 12,
+			},
+		});
+
+		const commitMessage = storageMocks.createCommit.mock.calls[0][3];
+		expect(commitMessage).toContain('Also exported as a zip file.');
+		expect(commitMessage).toContain(
+			'raw.githubusercontent.com%2Fcontributor%2Fwordpress-playground-fork%2Frefs%2Fheads%2Ffeature%2Fexport%2Fwp-content%2Fplugins%2Fdemo%2Fplayground.zip'
+		);
+		expect(commitMessage).toContain(
+			'raw.githubusercontent.com%2FWordPress%2Fwordpress-playground%2Frefs%2Fheads%2Ftrunk%2Fwp-content%2Fplugins%2Fdemo%2Fplayground.zip'
+		);
+	});
+
 	it('creates a fork branch when the target repository cannot be pushed', async () => {
 		storageMocks.mayPush.mockResolvedValue(false);
 		const changeset = createChangeset();
@@ -157,6 +202,36 @@ describe('pushToGithub', () => {
 			url: 'https://github.com/WordPress/wordpress-playground/pull/1',
 			forked: true,
 		});
+	});
+
+	it('does not push a commit when there are no changes to export', async () => {
+		storageMocks.mayPush.mockResolvedValue(true);
+		storageMocks.createTree.mockResolvedValue(null);
+		const octokit = createOctokit();
+
+		await expect(
+			pushToGithub(octokit as any, {
+				owner: 'WordPress',
+				repo: 'wordpress-playground',
+				commitMessage: 'Changes from Playground',
+				changeset: createChangeset(),
+				shouldCreateNewPR: true,
+				create: {
+					againstBranch: 'trunk',
+					branchName: 'playground-changes',
+					title: 'Update plugin',
+				},
+				update: {
+					prNumber: 0,
+				},
+			})
+		).rejects.toThrow(
+			'There are no changes to export. Make an edit in the Playground before exporting to GitHub.'
+		);
+
+		expect(storageMocks.createCommit).not.toHaveBeenCalled();
+		expect(octokit.rest.git.createRef).not.toHaveBeenCalled();
+		expect(storageMocks.createOrUpdateBranch).not.toHaveBeenCalled();
 	});
 });
 

--- a/packages/playground/website/src/github/github-export-form/form.spec.tsx
+++ b/packages/playground/website/src/github/github-export-form/form.spec.tsx
@@ -1,0 +1,237 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ReactNode } from 'react';
+import { pushToGithub } from './form';
+
+const storageMocks = vi.hoisted(() => ({
+	changeset: vi.fn(),
+	createCommit: vi.fn(),
+	createOrUpdateBranch: vi.fn(),
+	createTree: vi.fn(),
+	filesListToObject: vi.fn(),
+	fork: vi.fn(),
+	getFilesFromDirectory: vi.fn(),
+	iterateFiles: vi.fn(),
+	mayPush: vi.fn(),
+}));
+
+vi.mock('@wp-playground/client', () => ({
+	wpContentFilesExcludedFromExport: [],
+	zipWpContent: vi.fn(),
+}));
+
+vi.mock('@wp-playground/storage', () => storageMocks);
+
+vi.mock('../client', () => ({
+	getAuthenticatedGitHubClient: vi.fn(),
+	resetAuthenticatedGitHubClient: vi.fn(),
+}));
+
+vi.mock('../github-oauth-guard', () => ({
+	default: ({ children }: { children: ReactNode }) => children,
+}));
+
+vi.mock('../state', () => ({
+	setOAuthToken: vi.fn(),
+}));
+
+describe('pushToGithub', () => {
+	beforeEach(() => {
+		for (const mock of Object.values(storageMocks)) {
+			mock.mockReset();
+		}
+		storageMocks.createTree.mockResolvedValue('tree-sha');
+		storageMocks.createCommit.mockResolvedValue('commit-sha');
+		storageMocks.createOrUpdateBranch.mockResolvedValue(undefined);
+		storageMocks.fork.mockResolvedValue('playground-user');
+	});
+
+	it('updates an existing PR by pushing to the PR head repository', async () => {
+		storageMocks.mayPush.mockResolvedValue(true);
+		const changeset = createChangeset();
+		const octokit = createOctokit({
+			pullRequest: createPullRequest({
+				headOwner: 'contributor',
+				headRepo: 'wordpress-playground-fork',
+				headSha: 'head-sha',
+				headRef: 'playground-export',
+				htmlUrl:
+					'https://github.com/WordPress/wordpress-playground/pull/12',
+			}),
+		});
+
+		const result = await pushToGithub(octokit as any, {
+			owner: 'WordPress',
+			repo: 'wordpress-playground',
+			commitMessage: 'Changes from Playground',
+			changeset,
+			shouldCreateNewPR: false,
+			create: {
+				againstBranch: 'trunk',
+				branchName: 'unused',
+				title: 'Update plugin',
+			},
+			update: {
+				prNumber: 12,
+			},
+		});
+
+		expect(storageMocks.fork).not.toHaveBeenCalled();
+		expect(octokit.rest.repos.getBranch).not.toHaveBeenCalled();
+		expect(storageMocks.mayPush).toHaveBeenCalledWith(
+			octokit,
+			'contributor',
+			'wordpress-playground-fork'
+		);
+		expect(storageMocks.createTree).toHaveBeenCalledWith(
+			octokit,
+			'contributor',
+			'wordpress-playground-fork',
+			'head-sha',
+			changeset
+		);
+		expect(storageMocks.createCommit).toHaveBeenCalledWith(
+			octokit,
+			'contributor',
+			'wordpress-playground-fork',
+			'Changes from Playground',
+			'head-sha',
+			'tree-sha'
+		);
+		expect(storageMocks.createOrUpdateBranch).toHaveBeenCalledWith(
+			octokit,
+			'contributor',
+			'wordpress-playground-fork',
+			'playground-export',
+			'commit-sha'
+		);
+		expect(octokit.rest.git.createRef).not.toHaveBeenCalled();
+		expect(octokit.rest.pulls.create).not.toHaveBeenCalled();
+		expect(result).toEqual({
+			url: 'https://github.com/WordPress/wordpress-playground/pull/12',
+			forked: false,
+		});
+	});
+
+	it('creates a fork branch when the target repository cannot be pushed', async () => {
+		storageMocks.mayPush.mockResolvedValue(false);
+		const changeset = createChangeset();
+		const octokit = createOctokit({
+			branchSha: 'base-sha',
+		});
+
+		const result = await pushToGithub(octokit as any, {
+			owner: 'WordPress',
+			repo: 'wordpress-playground',
+			commitMessage: 'Changes from Playground',
+			changeset,
+			shouldCreateNewPR: true,
+			create: {
+				againstBranch: 'trunk',
+				branchName: 'playground-changes',
+				title: 'Update plugin',
+			},
+			update: {
+				prNumber: 0,
+			},
+		});
+
+		expect(octokit.rest.repos.getBranch).toHaveBeenCalledWith({
+			owner: 'WordPress',
+			repo: 'wordpress-playground',
+			branch: 'trunk',
+		});
+		expect(storageMocks.createTree).toHaveBeenCalledWith(
+			octokit,
+			'playground-user',
+			'wordpress-playground',
+			'base-sha',
+			changeset
+		);
+		expect(octokit.rest.git.createRef).toHaveBeenCalledWith({
+			owner: 'playground-user',
+			repo: 'wordpress-playground',
+			sha: 'commit-sha',
+			ref: 'refs/heads/playground-changes',
+		});
+		expect(result).toEqual({
+			url: 'https://github.com/WordPress/wordpress-playground/pull/1',
+			forked: true,
+		});
+	});
+});
+
+function createChangeset() {
+	return {
+		create: new Map([
+			['wp-content/plugins/demo/demo.php', new Uint8Array()],
+		]),
+		update: new Map(),
+		delete: new Set<string>(),
+	};
+}
+
+function createOctokit({
+	branchSha = 'base-sha',
+	pullRequest = createPullRequest({}),
+} = {}) {
+	return {
+		rest: {
+			repos: {
+				getBranch: vi.fn(async () => ({
+					data: {
+						commit: {
+							sha: branchSha,
+						},
+					},
+				})),
+			},
+			git: {
+				createRef: vi.fn(async () => ({})),
+			},
+			pulls: {
+				create: vi.fn(async () => ({
+					data: {
+						html_url:
+							'https://github.com/WordPress/wordpress-playground/pull/1',
+					},
+				})),
+				get: vi.fn(async () => ({
+					data: pullRequest,
+				})),
+			},
+		},
+	};
+}
+
+function createPullRequest({
+	headOwner = 'WordPress',
+	headRepo = 'wordpress-playground',
+	headSha = 'head-sha',
+	headRef = 'playground-changes',
+	baseRef = 'trunk',
+	htmlUrl = 'https://github.com/WordPress/wordpress-playground/pull/1',
+}: {
+	headOwner?: string;
+	headRepo?: string;
+	headSha?: string;
+	headRef?: string;
+	baseRef?: string;
+	htmlUrl?: string;
+}) {
+	return {
+		html_url: htmlUrl,
+		head: {
+			sha: headSha,
+			ref: headRef,
+			repo: {
+				name: headRepo,
+				owner: {
+					login: headOwner,
+				},
+			},
+		},
+		base: {
+			ref: baseRef,
+		},
+	};
+}

--- a/packages/playground/website/src/github/github-export-form/form.tsx
+++ b/packages/playground/website/src/github/github-export-form/form.tsx
@@ -61,6 +61,13 @@ export function asPullRequestAction(value: any): PullRequestAction | undefined {
 const NO_CHANGES_TO_EXPORT_MESSAGE =
 	'There are no changes to export. Make an edit in the Playground before exporting to GitHub.';
 
+class NoChangesToExportError extends Error {
+	constructor() {
+		super(NO_CHANGES_TO_EXPORT_MESSAGE);
+		this.name = 'NoChangesToExportError';
+	}
+}
+
 export interface ExportFormValues {
 	repoUrl: string;
 	prAction?: PullRequestAction;
@@ -433,7 +440,7 @@ export default function GitHubExportForm({
 				return;
 			}
 
-			if (e?.message === NO_CHANGES_TO_EXPORT_MESSAGE) {
+			if (e instanceof NoChangesToExportError) {
 				setError('repoUrl', e.message);
 				return;
 			}
@@ -940,7 +947,7 @@ export async function pushToGithub(
 			changeset
 		);
 		if (!newTreeSha) {
-			throw new Error(NO_CHANGES_TO_EXPORT_MESSAGE);
+			throw new NoChangesToExportError();
 		}
 		const commitSha = await createCommit(
 			octokit,
@@ -1031,10 +1038,10 @@ function appendZipPreviewLinks(
 	// The pre-merge preview reads from the commit we just pushed, while the
 	// post-merge preview reads from the branch the pull request targets.
 	const branchPreviewUrl = (owner: string, repo: string, branch: string) => {
-		const zipballURL = buildGitHubRawUrl(owner, repo, branch, zipPath);
+		const rawZipUrl = buildGitHubRawUrl(owner, repo, branch, zipPath);
 		const url = new URL(document.location.origin);
 		url.pathname = document.location.pathname;
-		url.searchParams.set('import-site', zipballURL);
+		url.searchParams.set('import-site', rawZipUrl);
 		return url.toString();
 	};
 

--- a/packages/playground/website/src/github/github-export-form/form.tsx
+++ b/packages/playground/website/src/github/github-export-form/form.tsx
@@ -58,6 +58,9 @@ export function asPullRequestAction(value: any): PullRequestAction | undefined {
 	return 'create';
 }
 
+const NO_CHANGES_TO_EXPORT_MESSAGE =
+	'There are no changes to export. Make an edit in the Playground before exporting to GitHub.';
+
 export interface ExportFormValues {
 	repoUrl: string;
 	prAction?: PullRequestAction;
@@ -285,17 +288,39 @@ export default function GitHubExportForm({
 			});
 			const defaultBranch = ghRepo.default_branch;
 
+			let comparisonOwner = repoDetails.owner;
+			let comparisonRepo = repoDetails.repo;
+			let comparisonRef = defaultBranch;
+			if (formValues.prAction === 'update') {
+				const { data: pullRequest } = await octokit.rest.pulls.get({
+					owner: repoDetails.owner,
+					repo: repoDetails.repo,
+					pull_number: parseInt(formValues.prNumber),
+				});
+				if (!pullRequest.head.repo) {
+					throw new Error(
+						'Cannot update this pull request because its source repository is unavailable.'
+					);
+				}
+				// Updating a PR must diff against its head, not the target branch.
+				// Otherwise files added only in the PR are invisible to deletions.
+				comparisonOwner = pullRequest.head.repo.owner.login;
+				comparisonRepo = pullRequest.head.repo.name;
+				comparisonRef = pullRequest.head.sha;
+			}
+
 			let ghRawFiles: any[] = [];
 			try {
 				ghRawFiles =
-					filesBeforeChanges ||
-					(await getFilesFromDirectory(
-						octokit,
-						repoDetails.owner,
-						repoDetails.repo,
-						defaultBranch,
-						toPathInRepo
-					));
+					filesBeforeChanges && formValues.prAction === 'create'
+						? filesBeforeChanges
+						: await getFilesFromDirectory(
+								octokit,
+								comparisonOwner,
+								comparisonRepo,
+								comparisonRef,
+								toPathInRepo
+							);
 			} catch {
 				// ignore
 			}
@@ -335,7 +360,8 @@ export default function GitHubExportForm({
 
 			const isoDateSlug = new Date().toISOString().replace(/[:.]/g, '-');
 			const newBranchName = `playground-changes-${isoDateSlug}`;
-			let commitMessage = formValues.commitMessage;
+			const commitMessage = formValues.commitMessage;
+			let zipPathForPreview: string | undefined;
 
 			if (allowZipExport && formValues.includeZip) {
 				const zipFilename = `playground.zip`;
@@ -346,42 +372,12 @@ export default function GitHubExportForm({
 				}
 				const zipContents = await zipWpContent(playground);
 				await playground.writeFile(zipPath, zipContents);
-
-				const branchPreviewUrl = (branchName: string) => {
-					const zipPath = [toPathInRepo, zipFilename]
-						.filter(Boolean)
-						.join('/');
-					const zipballURL = `https://raw.githubusercontent.com/${repoDetails.owner}/${repoDetails.repo}/${branchName}/${zipPath}`;
-					const url = new URL(document.location.origin);
-					url.pathname = document.location.pathname;
-					url.searchParams.set('import-site', zipballURL);
-					return url.toString();
-				};
-
-				let targetBranchName = '';
-				if (parseInt(formValues.prNumber, 10)) {
-					const { data } = await octokit.rest.pulls.get({
-						owner: repoDetails.owner,
-						repo: repoDetails.repo,
-						pull_number: parseInt(formValues.prNumber),
-					});
-					targetBranchName = data.head.ref;
-				} else {
-					targetBranchName = newBranchName;
-				}
-
-				commitMessage +=
-					'\n\n' +
-					[
-						'Also exported as a zip file.',
-						'',
-						`* [Preview loaded from this PR – available **before** this PR is merged](${branchPreviewUrl(
-							targetBranchName
-						)})`,
-						`* [Preview loaded from the main branch – available **after** this PR is merged](${branchPreviewUrl(
-							defaultBranch
-						)})`,
-					].join('\n');
+				zipPathForPreview = [
+					toPathInRepo === '.' ? '' : toPathInRepo,
+					zipFilename,
+				]
+					.filter(Boolean)
+					.join('/');
 			}
 
 			const allPlaygroundFiles: FileEntry[] = [];
@@ -413,6 +409,7 @@ export default function GitHubExportForm({
 				repo: repoDetails.repo,
 				commitMessage,
 				changeset: changes,
+				zipPathForPreview,
 
 				shouldCreateNewPR: formValues.prAction === 'create',
 				create: {
@@ -433,6 +430,11 @@ export default function GitHubExportForm({
 			if (e && e.status === 401) {
 				setOAuthToken(undefined);
 				resetClient();
+				return;
+			}
+
+			if (e?.message === NO_CHANGES_TO_EXPORT_MESSAGE) {
+				setError('repoUrl', e.message);
 				return;
 			}
 
@@ -839,6 +841,7 @@ type PushToGitHubOptions = {
 	repo: string;
 	commitMessage: string;
 	changeset: Changeset;
+	zipPathForPreview?: string;
 	shouldCreateNewPR: boolean;
 	create: CreatePROptions;
 	update: UpdatePROptions;
@@ -850,7 +853,14 @@ interface PushResult {
 	forked: boolean;
 }
 
-async function pushToGithub(
+/**
+ * Pushes a Playground export to GitHub and returns the pull request URL.
+ *
+ * New pull requests branch from the target repository and may fall back to the
+ * user's fork. Existing pull requests are updated through their head
+ * repository, which may be a fork of the target repository.
+ */
+export async function pushToGithub(
 	octokit: GithubClient,
 	options: PushToGitHubOptions
 ): Promise<PushResult> {
@@ -860,36 +870,32 @@ async function pushToGithub(
 		shouldCreateNewPR,
 		commitMessage,
 		changeset,
+		zipPathForPreview,
 		shouldFork,
 		create: { againstBranch, branchName: branchToCreate, title: prTitle },
 		update: { prNumber },
 	} = options;
 
-	let pushToOwner = owner;
-	if (shouldFork || !(await mayPush(octokit, owner, repo))) {
-		pushToOwner = await fork(octokit, owner, repo);
-	}
 	try {
 		let parentSha: string;
 		let pushToBranch: string;
+		let pushToOwner = owner;
+		let pushToRepo = repo;
 		let PR: Awaited<
 			ReturnType<GithubClient['rest']['pulls']['create']>
 		>['data'];
 		if (shouldCreateNewPR) {
+			if (shouldFork || !(await mayPush(octokit, owner, repo))) {
+				pushToOwner = await fork(octokit, owner, repo);
+			}
 			const { data: branch } = await octokit.rest.repos.getBranch({
-				owner: pushToOwner,
+				owner,
 				repo,
 				branch: againstBranch,
 			});
 
 			parentSha = branch.commit.sha;
 			pushToBranch = branchToCreate!;
-			await octokit.rest.git.createRef({
-				owner: pushToOwner,
-				repo,
-				sha: parentSha,
-				ref: `refs/heads/${pushToBranch}`,
-			});
 		} else {
 			const { data } = await octokit.rest.pulls.get({
 				owner,
@@ -897,44 +903,76 @@ async function pushToGithub(
 				pull_number: prNumber!,
 			});
 			PR = data;
+			if (!PR.head.repo) {
+				throw new Error(
+					'Cannot update this pull request because its source repository is unavailable.'
+				);
+			}
+			pushToOwner = PR.head.repo.owner.login;
+			pushToRepo = PR.head.repo.name;
 			parentSha = PR.head.sha;
 			pushToBranch = PR.head.ref;
+			if (!(await mayPush(octokit, pushToOwner, pushToRepo))) {
+				throw new Error(
+					"Cannot update this pull request because you don't have permission to push to its source branch. Create a new pull request instead."
+				);
+			}
 		}
 
+		const finalCommitMessage = zipPathForPreview
+			? appendZipPreviewLinks(commitMessage, {
+					sourceOwner: pushToOwner,
+					sourceRepo: pushToRepo,
+					sourceBranch: pushToBranch,
+					targetOwner: owner,
+					targetRepo: repo,
+					targetBranch: shouldCreateNewPR
+						? againstBranch
+						: PR!.base.ref,
+					zipPath: zipPathForPreview,
+				})
+			: commitMessage;
 		const newTreeSha = await createTree(
 			octokit,
 			pushToOwner,
-			repo,
+			pushToRepo,
 			parentSha,
 			changeset
 		);
 		if (!newTreeSha) {
-			throw new Error(
-				'No changes were detected so there is nothing to commit.'
-			);
+			throw new Error(NO_CHANGES_TO_EXPORT_MESSAGE);
 		}
 		const commitSha = await createCommit(
 			octokit,
 			pushToOwner,
-			repo,
-			commitMessage,
+			pushToRepo,
+			finalCommitMessage,
 			parentSha,
-			newTreeSha || parentSha
+			newTreeSha
 		);
-		await createOrUpdateBranch(
-			octokit,
-			pushToOwner,
-			repo,
-			pushToBranch,
-			commitSha
-		);
+		if (shouldCreateNewPR) {
+			await octokit.rest.git.createRef({
+				owner: pushToOwner,
+				repo: pushToRepo,
+				sha: commitSha,
+				ref: `refs/heads/${pushToBranch}`,
+			});
+		} else {
+			await createOrUpdateBranch(
+				octokit,
+				pushToOwner,
+				pushToRepo,
+				pushToBranch,
+				commitSha
+			);
+		}
 
 		if (shouldCreateNewPR) {
 			const { data } = await octokit.rest.pulls.create({
 				owner,
 				repo,
 				title: prTitle || commitMessage,
-				body: commitMessage,
+				body: finalCommitMessage,
 				head: `${pushToOwner}:${pushToBranch}`,
 				base: againstBranch,
 			});
@@ -943,10 +981,11 @@ async function pushToGithub(
 
 		return {
 			url: PR!.html_url,
-			forked: pushToOwner !== owner,
+			forked: shouldCreateNewPR && pushToOwner !== owner,
 		};
 	} catch (e: any) {
 		if (
+			shouldCreateNewPR &&
 			e.status === 403 &&
 			e.message?.includes(
 				'organization has enabled OAuth App access restrictions'
@@ -960,4 +999,76 @@ async function pushToGithub(
 		}
 		throw e;
 	}
+}
+
+function appendZipPreviewLinks(
+	commitMessage: string,
+	{
+		sourceOwner,
+		sourceRepo,
+		sourceBranch,
+		targetOwner,
+		targetRepo,
+		targetBranch,
+		zipPath,
+	}: {
+		sourceOwner: string;
+		sourceRepo: string;
+		sourceBranch: string;
+		targetOwner: string;
+		targetRepo: string;
+		targetBranch: string;
+		zipPath: string;
+	}
+) {
+	// The pre-merge preview reads from the commit we just pushed, while the
+	// post-merge preview reads from the branch the pull request targets.
+	const branchPreviewUrl = (owner: string, repo: string, branch: string) => {
+		const zipballURL = buildGitHubRawUrl(owner, repo, branch, zipPath);
+		const url = new URL(document.location.origin);
+		url.pathname = document.location.pathname;
+		url.searchParams.set('import-site', zipballURL);
+		return url.toString();
+	};
+
+	return (
+		commitMessage +
+		'\n\n' +
+		[
+			'Also exported as a zip file.',
+			'',
+			`* [Preview loaded from this PR – available **before** this PR is merged](${branchPreviewUrl(
+				sourceOwner,
+				sourceRepo,
+				sourceBranch
+			)})`,
+			`* [Preview loaded from the target branch – available **after** this PR is merged](${branchPreviewUrl(
+				targetOwner,
+				targetRepo,
+				targetBranch
+			)})`,
+		].join('\n')
+	);
+}
+
+function buildGitHubRawUrl(
+	owner: string,
+	repo: string,
+	branchName: string,
+	filePath: string
+) {
+	// Use refs/heads so branch names with slashes do not compete with file paths.
+	return `https://raw.githubusercontent.com/${encodeURIComponent(
+		owner
+	)}/${encodeURIComponent(repo)}/refs/heads/${encodePathSegments(
+		branchName
+	)}/${encodePathSegments(filePath)}`;
+}
+
+function encodePathSegments(path: string) {
+	return path
+		.split('/')
+		.filter(Boolean)
+		.map((segment) => encodeURIComponent(segment))
+		.join('/');
 }

--- a/packages/playground/website/src/github/github-export-form/form.tsx
+++ b/packages/playground/website/src/github/github-export-form/form.tsx
@@ -1001,6 +1001,13 @@ export async function pushToGithub(
 	}
 }
 
+/**
+ * Adds before-merge and after-merge zip preview links to the commit message.
+ *
+ * The before-merge link must read from the branch that receives the export
+ * commit. The after-merge link must read from the target branch, because that
+ * is where the zip file becomes available after the pull request is merged.
+ */
 function appendZipPreviewLinks(
 	commitMessage: string,
 	{


### PR DESCRIPTION
## What it does

Make the "Export as GitHub PR" feature push to the PR head branch. Before this PR, the push could target the wrong branch.

The failure looked like this:

1. The PR points to `adam:feature/export`.
2. The export reads that PR and gets `feature/export`.
3. The export picks a repo separately — for example `WordPress/wordpress-playground`.
4. It pushes to `WordPress:feature/export`.
5. But the PR still points to `adam:feature/export`, so the PR was not actually updated.

## Implementation

New exports still branch from the selected target repository and fall back to the user's fork when they cannot push there. Zip preview links now point to the pushed PR branch before merge and the target branch after merge. No-change exports show a direct message instead of continuing into commit/PR creation.

## Testing instructions

This is a GitHub integration code, you'll need to export a PR using Playground running in the local dev server.
