### PR TITLE
[Blueprints] Lower more Blueprint v2 declarations to v1 steps

### DIFF
--- a/packages/playground/blueprints/src/lib/v2/compile.ts
+++ b/packages/playground/blueprints/src/lib/v2/compile.ts
@@ -515,7 +515,7 @@ function lowerBlueprintV2WxrContent(
 ): StepDefinition[] | undefined {
 	if (
 		content.urlsMap ||
-		content.importUsers ||
+		content.importUsers !== undefined ||
 		content.authorsMode !== 'default-author' ||
 		content.authorsMap
 	) {

--- a/packages/playground/blueprints/src/lib/v2/compile.ts
+++ b/packages/playground/blueprints/src/lib/v2/compile.ts
@@ -56,6 +56,16 @@ type BlueprintV2Content = NonNullable<
 type BlueprintV2Step = NonNullable<
 	BlueprintV2Declaration['additionalStepsAfterExecution']
 >[number];
+type BlueprintV2ImportContentStep = Extract<
+	BlueprintV2Step,
+	{ step: 'importContent' }
+>;
+type BlueprintV2RunPHPStep = Extract<BlueprintV2Step, { step: 'runPHP' }>;
+type BlueprintV2WriteFilesStep = Extract<
+	BlueprintV2Step,
+	{ step: 'writeFiles' }
+>;
+type BlueprintV2WxrContent = Extract<BlueprintV2Content, { type: 'wxr' }>;
 type BlueprintV2DataReference =
 	| string
 	| {
@@ -464,7 +474,7 @@ function lowerBlueprintV2ExecutionPlanItem(
 		case 'installPlugin':
 			return [createInstallPluginStep(planItem.plugin)];
 		case 'importContent':
-			return lowerBlueprintV2Content(planItem.content);
+			return lowerBlueprintV2Content(planItem.content, 'content');
 		case 'setSiteLanguage':
 			return [
 				{
@@ -480,16 +490,54 @@ function lowerBlueprintV2ExecutionPlanItem(
 }
 
 function lowerBlueprintV2Content(
-	content: BlueprintV2Content
+	content: BlueprintV2Content,
+	featurePath: string
 ): StepDefinition[] | undefined {
-	if (content.type !== 'mysql-dump') {
+	switch (content.type) {
+		case 'mysql-dump':
+			return asArray(content.source).map((source, index) => ({
+				step: 'runSql',
+				sql: convertV2FileDataReferenceToV1(
+					source,
+					`${featurePath}.source[${index}]`
+				),
+			}));
+		case 'wxr':
+			return lowerBlueprintV2WxrContent(content, featurePath);
+		default:
+			return undefined;
+	}
+}
+
+function lowerBlueprintV2WxrContent(
+	content: BlueprintV2WxrContent,
+	featurePath: string
+): StepDefinition[] | undefined {
+	if (
+		content.urlsMap ||
+		content.importUsers ||
+		content.authorsMode !== 'default-author' ||
+		content.authorsMap
+	) {
 		return undefined;
 	}
 
-	return asArray(content.source).map((source, index) => ({
-		step: 'runSql',
-		sql: convertV2FileDataReferenceToV1(source, `content.source[${index}]`),
-	}));
+	return asArray(content.source).map((source, index) => {
+		const step: StepDefinition = {
+			step: 'importWxr',
+			file: convertV2FileDataReferenceToV1(
+				source,
+				`${featurePath}.source[${index}]`
+			),
+			fetchAttachments: content.staticAssets !== 'hotlink',
+			rewriteUrls: content.urlsMode !== 'preserve',
+			importComments: content.importComments ?? false,
+		};
+		if (content.defaultAuthorUsername !== undefined) {
+			step.defaultAuthorUsername = content.defaultAuthorUsername;
+		}
+		return step;
+	});
 }
 
 /**
@@ -530,6 +578,8 @@ function lowerAdditionalBlueprintV2Step(
 					consts: step.constants,
 				},
 			];
+		case 'importContent':
+			return lowerImportContentStep(step);
 		case 'importThemeStarterContent':
 			return [
 				{
@@ -570,6 +620,8 @@ function lowerAdditionalBlueprintV2Step(
 					path: toPlaygroundPath(step.path),
 				},
 			];
+		case 'runPHP':
+			return lowerRunPHPStep(step);
 		case 'runSQL':
 			return [
 				{
@@ -602,9 +654,91 @@ function lowerAdditionalBlueprintV2Step(
 					wpCliPath: step.wpCliPath,
 				},
 			];
+		case 'unzip':
+			return [
+				{
+					step: 'unzip',
+					zipFile: convertV2FileDataReferenceToV1(
+						step.zipFile,
+						'unzip.zipFile'
+					),
+					extractToPath: toPlaygroundPath(step.extractToPath),
+				},
+			];
+		case 'writeFiles':
+			return lowerWriteFilesStep(step);
 		default:
 			return undefined;
 	}
+}
+
+function lowerImportContentStep(
+	step: BlueprintV2ImportContentStep
+): StepDefinition[] | undefined {
+	const steps: StepDefinition[] = [];
+	for (const [index, content] of step.content.entries()) {
+		const loweredSteps = lowerBlueprintV2Content(
+			content,
+			`importContent.content[${index}]`
+		);
+		if (!loweredSteps) {
+			return undefined;
+		}
+		steps.push(...loweredSteps);
+	}
+	return steps;
+}
+
+function lowerRunPHPStep(
+	step: BlueprintV2RunPHPStep
+): StepDefinition[] | undefined {
+	if (!isInlineFile(step.code)) {
+		return undefined;
+	}
+	if (step.env) {
+		return [
+			{
+				step: 'runPHPWithOptions',
+				options: {
+					code: step.code.content,
+					env: step.env,
+				},
+			},
+		];
+	}
+	return [
+		{
+			step: 'runPHP',
+			code: step.code,
+		},
+	];
+}
+
+function lowerWriteFilesStep(
+	step: BlueprintV2WriteFilesStep
+): StepDefinition[] {
+	const steps: StepDefinition[] = [];
+	for (const [path, dataReference] of Object.entries(step.files)) {
+		const writeToPath = toPlaygroundPath(path);
+		const resource = convertV2WritableDataReferenceToV1(
+			dataReference,
+			`writeFiles.files[${JSON.stringify(path)}]`
+		);
+		if (isDirectoryReference(resource)) {
+			steps.push({
+				step: 'writeFiles',
+				writeToPath,
+				filesTree: resource,
+			});
+		} else {
+			steps.push({
+				step: 'writeFile',
+				path: writeToPath,
+				data: resource,
+			});
+		}
+	}
+	return steps;
 }
 
 /**
@@ -829,6 +963,66 @@ function convertV2FileDataReferenceToV1(
 	throw new UnsupportedBlueprintV2FeatureError(
 		featurePath,
 		'Unsupported Blueprint v2 file reference.'
+	);
+}
+
+function convertV2WritableDataReferenceToV1(
+	reference: BlueprintV2DataReference,
+	featurePath: string
+): FileReference | DirectoryReference {
+	if (typeof reference === 'string') {
+		if (isHttpUrl(reference)) {
+			return { resource: 'url', url: reference };
+		}
+		if (isExecutionContextPath(reference)) {
+			return {
+				resource: 'bundled',
+				path: normalizeExecutionContextPath(reference),
+			};
+		}
+		throw new UnsupportedBlueprintV2FeatureError(
+			featurePath,
+			'Blueprint v2 writable data references must be URLs or execution-context paths.'
+		);
+	}
+
+	if (isInlineFile(reference)) {
+		return {
+			resource: 'literal',
+			name: reference.filename,
+			contents: reference.content,
+		};
+	}
+
+	if (isInlineDirectory(reference)) {
+		return {
+			resource: 'literal:directory',
+			name: reference.directoryName,
+			files: inlineDirectoryFilesToFileTree(reference.files),
+		};
+	}
+
+	if (isGitPath(reference)) {
+		return {
+			resource: 'git:directory',
+			url: reference.gitRepository,
+			ref: reference.ref || 'HEAD',
+			path: reference.pathInRepository || reference.path || '',
+		};
+	}
+
+	throw new UnsupportedBlueprintV2FeatureError(
+		featurePath,
+		'Unsupported Blueprint v2 writable data reference.'
+	);
+}
+
+function isDirectoryReference(
+	resource: FileReference | DirectoryReference
+): resource is DirectoryReference {
+	return (
+		resource.resource === 'literal:directory' ||
+		resource.resource === 'git:directory'
 	);
 }
 

--- a/packages/playground/blueprints/src/tests/compile.spec.ts
+++ b/packages/playground/blueprints/src/tests/compile.spec.ts
@@ -620,6 +620,262 @@ describe('compileBlueprintForExecution', () => {
 		);
 	});
 
+	it('lowers Blueprint v2 WXR content to importWxr steps', async () => {
+		const compiled = await compileBlueprintForExecution({
+			version: 2,
+			content: [
+				{
+					type: 'wxr',
+					source: [
+						'./content.wxr',
+						{
+							filename: 'inline.wxr',
+							content: '<rss />',
+						},
+					],
+					staticAssets: 'hotlink',
+					urlsMode: 'preserve',
+					authorsMode: 'default-author',
+					defaultAuthorUsername: 'editor',
+					importUsers: false,
+					importComments: true,
+				},
+			],
+		});
+
+		expect(compiled.version).toBe(2);
+		if (compiled.version !== 2) {
+			throw new Error('Expected a compiled Blueprint v2 result.');
+		}
+		expect(compiled.compiled.steps).toEqual([
+			{
+				step: 'importWxr',
+				file: {
+					resource: 'bundled',
+					path: 'content.wxr',
+				},
+				fetchAttachments: false,
+				rewriteUrls: false,
+				importComments: true,
+				defaultAuthorUsername: 'editor',
+			},
+			{
+				step: 'importWxr',
+				file: {
+					resource: 'literal',
+					name: 'inline.wxr',
+					contents: '<rss />',
+				},
+				fetchAttachments: false,
+				rewriteUrls: false,
+				importComments: true,
+				defaultAuthorUsername: 'editor',
+			},
+		]);
+		expect(compiled.compiled.unsupportedPlan).toEqual([]);
+	});
+
+	it('keeps WXR content with unsupported author behavior in the unsupported plan', async () => {
+		const compiled = await compileBlueprintForExecution({
+			version: 2,
+			content: [
+				{
+					type: 'wxr',
+					source: './content.wxr',
+					authorsMode: 'map',
+					authorsMap: {
+						remote: 'admin',
+					},
+				},
+			],
+		});
+
+		expect(compiled.version).toBe(2);
+		if (compiled.version !== 2) {
+			throw new Error('Expected a compiled Blueprint v2 result.');
+		}
+		expect(compiled.compiled.steps).toEqual([]);
+		expect(
+			compiled.compiled.unsupportedPlan.map((item) => item.type)
+		).toEqual(['importContent']);
+	});
+
+	it('lowers Blueprint v2 importContent steps through content lowering', async () => {
+		const compiled = await compileBlueprintForExecution({
+			version: 2,
+			additionalStepsAfterExecution: [
+				{
+					step: 'importContent',
+					content: [
+						{
+							type: 'mysql-dump',
+							source: './dump.sql',
+						},
+						{
+							type: 'wxr',
+							source: 'https://example.com/content.wxr',
+							authorsMode: 'default-author',
+						},
+					],
+				},
+			],
+		});
+
+		expect(compiled.version).toBe(2);
+		if (compiled.version !== 2) {
+			throw new Error('Expected a compiled Blueprint v2 result.');
+		}
+		expect(compiled.compiled.steps).toEqual([
+			{
+				step: 'runSql',
+				sql: {
+					resource: 'bundled',
+					path: 'dump.sql',
+				},
+			},
+			{
+				step: 'importWxr',
+				file: {
+					resource: 'url',
+					url: 'https://example.com/content.wxr',
+				},
+				fetchAttachments: true,
+				rewriteUrls: true,
+				importComments: false,
+			},
+		]);
+		expect(compiled.compiled.unsupportedPlan).toEqual([]);
+	});
+
+	it('lowers Blueprint v2 writeFiles steps to writeFile and writeFiles steps', async () => {
+		const compiled = await compileBlueprintForExecution({
+			version: 2,
+			additionalStepsAfterExecution: [
+				{
+					step: 'writeFiles',
+					files: {
+						'site:wp-content/uploads/readme.txt': {
+							filename: 'readme.txt',
+							content: 'Hello',
+						},
+						'site:wp-content/plugins/inline-plugin': {
+							directoryName: 'inline-plugin',
+							files: {
+								'index.php': '<?php',
+							},
+						},
+						'site:wp-content/plugins/git-plugin': {
+							gitRepository:
+								'https://github.com/example/plugin.git',
+							ref: 'main',
+							pathInRepository: 'plugin',
+						},
+					},
+				},
+			],
+		});
+
+		expect(compiled.version).toBe(2);
+		if (compiled.version !== 2) {
+			throw new Error('Expected a compiled Blueprint v2 result.');
+		}
+		expect(compiled.compiled.steps).toEqual([
+			{
+				step: 'writeFile',
+				path: '/wordpress/wp-content/uploads/readme.txt',
+				data: {
+					resource: 'literal',
+					name: 'readme.txt',
+					contents: 'Hello',
+				},
+			},
+			{
+				step: 'writeFiles',
+				writeToPath: '/wordpress/wp-content/plugins/inline-plugin',
+				filesTree: {
+					resource: 'literal:directory',
+					name: 'inline-plugin',
+					files: {
+						'index.php': '<?php',
+					},
+				},
+			},
+			{
+				step: 'writeFiles',
+				writeToPath: '/wordpress/wp-content/plugins/git-plugin',
+				filesTree: {
+					resource: 'git:directory',
+					url: 'https://github.com/example/plugin.git',
+					ref: 'main',
+					path: 'plugin',
+				},
+			},
+		]);
+		expect(compiled.compiled.unsupportedPlan).toEqual([]);
+	});
+
+	it('lowers Blueprint v2 unzip and inline runPHP steps', async () => {
+		const compiled = await compileBlueprintForExecution({
+			version: 2,
+			additionalStepsAfterExecution: [
+				{
+					step: 'unzip',
+					zipFile: './archive.zip',
+					extractToPath: 'site:wp-content/uploads/imported',
+				},
+				{
+					step: 'runPHP',
+					code: {
+						filename: 'script.php',
+						content: '<?php echo "Hello";',
+					},
+				},
+				{
+					step: 'runPHP',
+					code: {
+						filename: 'script-with-env.php',
+						content: '<?php echo getenv("MODE");',
+					},
+					env: {
+						MODE: 'test',
+					},
+				},
+			],
+		});
+
+		expect(compiled.version).toBe(2);
+		if (compiled.version !== 2) {
+			throw new Error('Expected a compiled Blueprint v2 result.');
+		}
+		expect(compiled.compiled.steps).toEqual([
+			{
+				step: 'unzip',
+				zipFile: {
+					resource: 'bundled',
+					path: 'archive.zip',
+				},
+				extractToPath: '/wordpress/wp-content/uploads/imported',
+			},
+			{
+				step: 'runPHP',
+				code: {
+					filename: 'script.php',
+					content: '<?php echo "Hello";',
+				},
+			},
+			{
+				step: 'runPHPWithOptions',
+				options: {
+					code: '<?php echo getenv("MODE");',
+					env: {
+						MODE: 'test',
+					},
+				},
+			},
+		]);
+		expect(compiled.compiled.unsupportedPlan).toEqual([]);
+	});
+
 	it('rejects empty Blueprint v2 target-site paths', async () => {
 		await expect(
 			compileBlueprintForExecution({

--- a/packages/playground/blueprints/src/tests/compile.spec.ts
+++ b/packages/playground/blueprints/src/tests/compile.spec.ts
@@ -637,7 +637,6 @@ describe('compileBlueprintForExecution', () => {
 					urlsMode: 'preserve',
 					authorsMode: 'default-author',
 					defaultAuthorUsername: 'editor',
-					importUsers: false,
 					importComments: true,
 				},
 			],
@@ -686,6 +685,29 @@ describe('compileBlueprintForExecution', () => {
 					authorsMap: {
 						remote: 'admin',
 					},
+				},
+			],
+		});
+
+		expect(compiled.version).toBe(2);
+		if (compiled.version !== 2) {
+			throw new Error('Expected a compiled Blueprint v2 result.');
+		}
+		expect(compiled.compiled.steps).toEqual([]);
+		expect(
+			compiled.compiled.unsupportedPlan.map((item) => item.type)
+		).toEqual(['importContent']);
+	});
+
+	it('keeps WXR content with unsupported importer behavior in the unsupported plan', async () => {
+		const compiled = await compileBlueprintForExecution({
+			version: 2,
+			content: [
+				{
+					type: 'wxr',
+					source: './content.wxr',
+					authorsMode: 'default-author',
+					importUsers: false,
 				},
 			],
 		});


### PR DESCRIPTION
## What it does

Lowers more Blueprint v2 declarations into existing v1 step records:

- WXR `content` entries with `authorsMode: 'default-author'` become `importWxr` steps.
- `importContent` steps reuse the same content lowering as top-level `content`.
- `writeFiles` becomes `writeFile` or `writeFiles`, depending on whether the source is a file or directory reference.
- `unzip` becomes the existing v1 `unzip` step.
- Inline `runPHP` file objects become `runPHP`, or `runPHPWithOptions` when `env` is provided.

## Rationale

This keeps moving the TypeScript Blueprint v2 compiler forward without touching CLI, browser, or v1 runtime behavior. These lowerings all map onto step handlers that already exist today.

WXR options that need importer behavior not exposed by the current v1 `importWxr` step still stay unsupported: `authorsMode: 'create'`, `authorsMode: 'map'`, `authorsMap`, `importUsers`, and `urlsMap`.

## Implementation

Adds focused lowering helpers in the v2 compiler:

- `lowerBlueprintV2WxrContent()` for the supported WXR subset.
- `lowerImportContentStep()` to flatten supported nested content entries.
- `lowerRunPHPStep()` for inline PHP file objects.
- `lowerWriteFilesStep()` for v2 writable data references.

Unsupported content inside a single `importContent` step leaves the whole step unsupported, so the compiler does not partially apply one declarative step.

## Testing instructions

```bash
npx vitest run src/tests/compile.spec.ts --config vite.config.ts
npx nx lint playground-blueprints
npx nx typecheck playground-blueprints
```
