### PR TITLE
[Website] Add bottom dock shortcuts for site tools

### DIFF
--- a/packages/playground/website/src/components/browser-chrome/index.tsx
+++ b/packages/playground/website/src/components/browser-chrome/index.tsx
@@ -2,27 +2,17 @@ import React from 'react';
 import css from './style.module.css';
 import AddressBar from '../address-bar';
 import classNames from 'classnames';
-import { useMediaQuery } from '@wordpress/compose';
 import {
 	useAppSelector,
 	getActiveClientInfo,
-	useActiveSite,
-	useAppDispatch,
 } from '../../lib/state/redux/store';
-import { SyncLocalFilesButton } from '../sync-local-files-button';
-import { Dropdown, Icon } from '@wordpress/components';
-import { Modal } from '../../components/modal';
-import { cog, category } from '@wordpress/icons';
-import Button from '../button';
-import { ActiveSiteSettingsForm } from '../site-manager/site-settings-form';
-import { setSiteManagerOpen } from '../../lib/state/redux/slice-ui';
-import { SiteManagerIcon } from '@wp-playground/components';
 import {
 	SavedPlaygroundsOverlay,
 	type OverlayViewMode,
 } from '../saved-playgrounds-overlay';
 import { SaveStatusIndicator } from './save-status-indicator';
 import { isSiteSavingDisabled } from '../../lib/state/url/router';
+import { Dock } from '../dock';
 
 const query = new URL(document.location.href).searchParams;
 const overlayParam = query.get('overlay');
@@ -39,13 +29,8 @@ export default function BrowserChrome({
 	className,
 }: BrowserChromeProps) {
 	const clientInfo = useAppSelector(getActiveClientInfo);
-	const activeSite = useActiveSite();
 	const showAddressBar = !!clientInfo;
 	const url = clientInfo?.url;
-	const dispatch = useAppDispatch();
-	const siteManagerIsOpen = useAppSelector(
-		(state) => state.ui.siteManagerIsOpen
-	);
 	const addressBarClass = classNames(css.addressBarSlot, {
 		[css.isHidden]: !showAddressBar,
 	});
@@ -54,16 +39,12 @@ export default function BrowserChrome({
 		css.hasFullSizeWindow,
 		className
 	);
-	const isMobileUi = useMediaQuery('(max-width: 875px)');
-	const [isSettingsModalOpen, setIsSettingsModalOpen] = React.useState(false);
 	const [isPlaygroundsOverlayOpen, setIsPlaygroundsOverlayOpen] =
 		React.useState(shouldOpenOverlay);
 	const [overlayInitialViewMode, setOverlayInitialViewMode] =
 		React.useState<OverlayViewMode>(
 			overlayParam === 'blueprints' ? 'blueprints' : 'main'
 		);
-	const onSettingsToggle = () => setIsSettingsModalOpen(!isSettingsModalOpen);
-	const closeSettingsModal = () => setIsSettingsModalOpen(false);
 	const closePlaygroundsOverlay = () => {
 		setIsPlaygroundsOverlayOpen(false);
 		setOverlayInitialViewMode('main'); // Reset for next manual open
@@ -79,12 +60,7 @@ export default function BrowserChrome({
 	return (
 		<div className={wrapperClass} data-cy="simulated-browser">
 			<div className={`${css.window} browser-chrome-window`}>
-				<header
-					className={classNames(css.toolbar, {
-						[css.withSidebarOpen]: siteManagerIsOpen,
-					})}
-					aria-label="Playground toolbar"
-				>
+				<header className={css.toolbar} aria-label="Playground toolbar">
 					<div className={addressBarClass}>
 						<AddressBar
 							url={url}
@@ -95,114 +71,18 @@ export default function BrowserChrome({
 					</div>
 
 					{!isSavingDisabled && <SaveStatusIndicator />}
-
-					<div className={css.toolbarButtons}>
-						<Button
-							variant="browser-chrome"
-							aria-label="Your Playgrounds"
-							onClick={() => setIsPlaygroundsOverlayOpen(true)}
-							aria-expanded={isPlaygroundsOverlayOpen}
-							className={css.savedPlaygroundsButton}
-						>
-							<Icon icon={category} size={20} />
-						</Button>
-
-						<Button
-							variant="browser-chrome"
-							aria-label={
-								siteManagerIsOpen
-									? 'Close Site Manager'
-									: 'Open Site Manager'
-							}
-							aria-pressed={siteManagerIsOpen}
-							className={classNames(css.openSiteManagerButton, {
-								[css.openSiteManagerButtonActive]:
-									siteManagerIsOpen,
-							})}
-							onClick={() => {
-								dispatch(
-									setSiteManagerOpen(!siteManagerIsOpen)
-								);
-							}}
-						>
-							<SiteManagerIcon
-								sidebarActive={siteManagerIsOpen}
-							/>
-						</Button>
-
-						{isMobileUi ? (
-							<>
-								<Button
-									variant="browser-chrome"
-									aria-label="Edit Playground settings"
-									onClick={onSettingsToggle}
-									aria-expanded={isSettingsModalOpen}
-									style={{
-										fill: '#FFF',
-										alignItems: 'center',
-										display: 'flex',
-									}}
-								>
-									<Icon icon={cog} size={28} />
-								</Button>
-								{isSettingsModalOpen && (
-									<Modal
-										isFullScreen={true}
-										title="Playground settings"
-										onRequestClose={closeSettingsModal}
-									>
-										<ActiveSiteSettingsForm
-											onSubmit={closeSettingsModal}
-										/>
-									</Modal>
-								)}
-							</>
-						) : (
-							<Dropdown
-								className="my-container-class-name"
-								contentClassName="my-dropdown-content-classname"
-								popoverProps={{ placement: 'bottom-start' }}
-								renderToggle={({ isOpen, onToggle }) => (
-									<Button
-										variant="browser-chrome"
-										aria-label="Edit Playground settings"
-										onClick={onToggle}
-										aria-expanded={isOpen}
-										style={{
-											fill: '#FFF',
-											alignItems: 'center',
-											display: 'flex',
-										}}
-									>
-										<Icon icon={cog} size={28} />
-									</Button>
-								)}
-								renderContent={({ onClose }) => (
-									<div
-										style={{
-											width: 400,
-											maxWidth: '100vw',
-											padding: 0,
-										}}
-									>
-										<div className={css.headerSection}>
-											<h2 style={{ margin: 0 }}>
-												Playground settings
-											</h2>
-										</div>
-										<ActiveSiteSettingsForm
-											onSubmit={onClose}
-										/>
-									</div>
-								)}
-							/>
-						)}
-						{activeSite?.metadata?.storage === 'local-fs' ? (
-							<SyncLocalFilesButton />
-						) : null}
-					</div>
 				</header>
 				<div className={css.content}>{children}</div>
+				<Dock
+					onOpenPlaygrounds={() => {
+						setOverlayInitialViewMode('main');
+						setIsPlaygroundsOverlayOpen(true);
+					}}
+					onOpenBlueprints={() => {
+						setOverlayInitialViewMode('blueprints');
+						setIsPlaygroundsOverlayOpen(true);
+					}}
+				/>
 			</div>
 			{isPlaygroundsOverlayOpen && (
 				<SavedPlaygroundsOverlay

--- a/packages/playground/website/src/components/browser-chrome/style.module.css
+++ b/packages/playground/website/src/components/browser-chrome/style.module.css
@@ -27,6 +27,7 @@ body.is-embedded .fake-window-wrapper {
 }
 
 .window {
+	position: relative;
 	display: flex;
 	flex-direction: column;
 	margin: 0 auto;

--- a/packages/playground/website/src/components/dock/index.tsx
+++ b/packages/playground/website/src/components/dock/index.tsx
@@ -1,0 +1,93 @@
+import classNames from 'classnames';
+import { SyncLocalFilesButton } from '../sync-local-files-button';
+import {
+	setSiteManagerOpen,
+	setSiteManagerSection,
+	type SiteManagerSection,
+} from '../../lib/state/redux/slice-ui';
+import {
+	useActiveSite,
+	useAppDispatch,
+	useAppSelector,
+} from '../../lib/state/redux/store';
+import css from './style.module.css';
+
+type DockSection = Extract<
+	SiteManagerSection,
+	'settings' | 'files' | 'blueprint' | 'database' | 'logs'
+>;
+
+const SITE_MANAGER_TOOLS: Array<{
+	section: DockSection;
+	label: string;
+}> = [
+	{ section: 'settings', label: 'Settings' },
+	{ section: 'files', label: 'Files' },
+	{ section: 'blueprint', label: 'Blueprint' },
+	{ section: 'database', label: 'Database' },
+	{ section: 'logs', label: 'Logs' },
+];
+
+export function Dock({
+	onOpenPlaygrounds,
+	onOpenBlueprints,
+}: {
+	onOpenPlaygrounds: () => void;
+	onOpenBlueprints: () => void;
+}) {
+	const dispatch = useAppDispatch();
+	const activeSite = useActiveSite();
+	const siteManagerIsOpen = useAppSelector(
+		(state) => state.ui.siteManagerIsOpen
+	);
+	const activeSection = useAppSelector(
+		(state) => state.ui.siteManagerSection
+	);
+
+	function openSiteManagerSection(section: DockSection) {
+		dispatch(setSiteManagerSection(section));
+		dispatch(setSiteManagerOpen(true));
+	}
+
+	return (
+		<nav className={css.dock} aria-label="Playground tools">
+			<div className={css.tools}>
+				<button
+					type="button"
+					className={css.tool}
+					onClick={onOpenPlaygrounds}
+				>
+					Playgrounds
+				</button>
+				<button
+					type="button"
+					className={css.tool}
+					onClick={onOpenBlueprints}
+				>
+					New
+				</button>
+				{SITE_MANAGER_TOOLS.map(({ section, label }) => (
+					<button
+						key={section}
+						type="button"
+						className={classNames(css.tool, {
+							[css.active]:
+								siteManagerIsOpen && activeSection === section,
+						})}
+						aria-pressed={
+							siteManagerIsOpen && activeSection === section
+						}
+						onClick={() => openSiteManagerSection(section)}
+					>
+						{label}
+					</button>
+				))}
+				{activeSite?.metadata.storage === 'local-fs' ? (
+					<div className={css.syncButton}>
+						<SyncLocalFilesButton />
+					</div>
+				) : null}
+			</div>
+		</nav>
+	);
+}

--- a/packages/playground/website/src/components/dock/style.module.css
+++ b/packages/playground/website/src/components/dock/style.module.css
@@ -1,0 +1,52 @@
+.dock {
+	position: absolute;
+	left: 50%;
+	bottom: 16px;
+	z-index: 6;
+	max-width: calc(100% - 32px);
+	transform: translateX(-50%);
+	padding: 6px;
+	border: 1px solid rgba(255, 255, 255, 0.14);
+	border-radius: 999px;
+	background: rgba(30, 35, 39, 0.96);
+	box-shadow: 0 12px 40px rgba(0, 0, 0, 0.24);
+}
+
+.tools {
+	display: flex;
+	align-items: center;
+	gap: 4px;
+	overflow-x: auto;
+	scrollbar-width: none;
+}
+
+.tools::-webkit-scrollbar {
+	display: none;
+}
+
+.tool {
+	padding: 8px 12px;
+	border: 0;
+	border-radius: 999px;
+	background: transparent;
+	color: #fff;
+	font: inherit;
+	font-size: 13px;
+	line-height: 16px;
+	white-space: nowrap;
+	cursor: pointer;
+}
+
+.tool:hover,
+.tool:focus-visible,
+.tool.active {
+	background: rgba(255, 255, 255, 0.14);
+}
+
+.syncButton :global(button) {
+	min-height: 32px;
+	padding: 8px 12px;
+	border-radius: 999px;
+	color: #fff;
+	font-size: 13px;
+}

--- a/packages/playground/website/src/components/site-manager/index.tsx
+++ b/packages/playground/website/src/components/site-manager/index.tsx
@@ -1,4 +1,5 @@
 import { useMediaQuery } from '@wordpress/compose';
+import type { SiteManagerSection } from '../../lib/state/redux/slice-ui';
 import { useActiveSite, useAppSelector } from '../../lib/state/redux/store';
 
 import css from './style.module.css';
@@ -60,6 +61,7 @@ export const SiteManager = forwardRef<
 	};
 
 	let activePanel;
+	const initialTabName = getSiteInfoInitialTabName(activeSiteManagerSection);
 	switch (activeSiteManagerSection) {
 		case 'blueprints':
 			activePanel = (
@@ -71,17 +73,23 @@ export const SiteManager = forwardRef<
 			break;
 		default:
 		case 'site-details':
+		case 'settings':
+		case 'files':
+		case 'blueprint':
+		case 'database':
+		case 'logs':
 			activePanel = activeSite ? (
 				fullScreenSections ? (
 					<SiteInfoPanel
-						key={activeSite?.slug}
+						key={`${activeSite?.slug}-${initialTabName ?? 'last'}`}
 						className={css.siteManagerSiteInfo}
 						site={activeSite}
 						mobileUi={fullScreenSections}
+						initialTabName={initialTabName}
 					/>
 				) : (
 					<ResizableBox
-						key={activeSite?.slug}
+						key={`${activeSite?.slug}-${initialTabName ?? 'last'}`}
 						className={css.siteInfoResizable}
 						minWidth={SITE_INFO_MIN_WIDTH}
 						size={{
@@ -104,6 +112,7 @@ export const SiteManager = forwardRef<
 							className={css.siteManagerSiteInfo}
 							site={activeSite}
 							mobileUi={fullScreenSections}
+							initialTabName={initialTabName}
 						/>
 					</ResizableBox>
 				)
@@ -123,3 +132,9 @@ export const SiteManager = forwardRef<
 		</div>
 	);
 });
+
+function getSiteInfoInitialTabName(section: SiteManagerSection) {
+	return section === 'site-details' || section === 'sidebar'
+		? undefined
+		: section;
+}

--- a/packages/playground/website/src/components/site-manager/site-info-panel/index.tsx
+++ b/packages/playground/website/src/components/site-manager/site-info-panel/index.tsx
@@ -80,16 +80,18 @@ export function SiteInfoPanel({
 	site,
 	mobileUi,
 	siteViewHidden,
+	initialTabName,
 }: {
 	className: string;
 	site: SiteInfo;
 	mobileUi?: boolean;
 	siteViewHidden?: boolean;
+	initialTabName?: string;
 }) {
 	const offline = useAppSelector((state) => state.ui.offline);
 	const dispatch = useAppDispatch();
 	// Load the last active tab for this site
-	const [initialTabName] = useState(() => {
+	const [storedInitialTabName] = useState(() => {
 		const lastTab = getSiteLastTab(site.slug);
 		return lastTab || 'settings';
 	});
@@ -390,7 +392,7 @@ export function SiteInfoPanel({
 				<FlexItem style={{ flexGrow: 1 }}>
 					<TabPanel
 						className={css.tabs}
-						initialTabName={initialTabName}
+						initialTabName={initialTabName ?? storedInitialTabName}
 						onSelect={handleTabSelect}
 						tabs={[
 							{

--- a/packages/playground/website/src/lib/state/redux/slice-ui.ts
+++ b/packages/playground/website/src/lib/state/redux/slice-ui.ts
@@ -18,7 +18,15 @@ export type SiteError =
 	| 'network-firewall-interference'
 	| 'resource-download-failed';
 
-export type SiteManagerSection = 'sidebar' | 'site-details' | 'blueprints';
+export type SiteManagerSection =
+	| 'sidebar'
+	| 'site-details'
+	| 'settings'
+	| 'files'
+	| 'blueprint'
+	| 'database'
+	| 'logs'
+	| 'blueprints';
 
 export const modalSlugs = {
 	LOG: 'log',


### PR DESCRIPTION
## What it does
Adds a small bottom dock for common Playground tools without changing the underlying storage, GitHub, Blueprint, or file-editor behavior.

## Rationale
This replaces the closed oversized dock draft with the smallest reviewable UI slice. It intentionally leaves the OPFS save lifecycle, GitHub import/export flows, Blueprint bundle import hardening, autosave nudge, and file-editor hardening out of this PR.

## Implementation
- Adds a bottom dock component with Playgrounds/New shortcuts and Site Manager tab shortcuts.
- Moves the existing Playgrounds entry point and local file sync button out of the browser toolbar into the dock.
- Lets dock buttons open the existing Site Manager settings, files, Blueprint, database, and logs tabs.
- Reuses the existing Saved Playgrounds overlay, Site Manager panels, database panel, file browser, Blueprint editor, and logs UI.

## Testing instructions
- `npm exec nx run playground-website:typecheck`
- `npm exec nx lint playground-website`
- `npm exec nx test playground-website -- --testFiles=src/lib/state/redux/site-lifecycle.spec.ts --testFiles=src/lib/state/url/router.spec.ts`
- `npm exec nx run playground-website:build:standalone:development`
- `npm run dev`, then `curl -I --max-time 10 http://127.0.0.1:5400/website-server/`
