### PR TITLE
Add util process stdin helpers

### DIFF
--- a/packages/php-wasm/util/src/lib/concat-bytes.ts
+++ b/packages/php-wasm/util/src/lib/concat-bytes.ts
@@ -1,0 +1,22 @@
+/**
+ * Concatenates multiple byte arrays into a single `Uint8Array`.
+ */
+export function concatUint8Arrays(arrays: Uint8Array[]): Uint8Array {
+	let totalLength = 0;
+	arrays.forEach((a) => (totalLength += a.length));
+	const result = new Uint8Array(totalLength);
+	let offset = 0;
+	arrays.forEach((a) => {
+		result.set(a, offset);
+		offset += a.length;
+	});
+	return result;
+}
+
+/**
+ * Concatenates multiple array buffers into a single `ArrayBuffer`.
+ */
+export function concatArrayBuffers(buffers: ArrayBuffer[]): ArrayBuffer {
+	return concatUint8Arrays(buffers.map((b) => new Uint8Array(b)))
+		.buffer as ArrayBuffer;
+}

--- a/packages/php-wasm/util/src/lib/create-spawn-handler.ts
+++ b/packages/php-wasm/util/src/lib/create-spawn-handler.ts
@@ -1,8 +1,18 @@
 import { EventEmitterPolyfill } from './event-emitter-polyfill';
+import { concatUint8Arrays } from './concat-bytes';
 import { splitShellCommand } from './split-shell-command';
 import { WritablePolyfill, type WriteCallback } from './writable-polyfill';
 
 type Listener = (...args: any[]) => any;
+
+export type StdinBytesReadResult = {
+	bytes: Uint8Array;
+	exceededMaxSize: boolean;
+};
+
+export type ReadStdinOptions = {
+	maxSize?: number;
+};
 
 export interface ProcessOptions {
 	cwd?: string;
@@ -13,8 +23,9 @@ export interface ProcessOptions {
  * Usage:
  * ```ts
  * php.setSpawnHandler(
- *   createSpawnHandler(function (command, processApi) {
- *     console.log(processApi.flushStdin());
+ *   createSpawnHandler(async function (command, processApi) {
+ *     const stdin = await processApi.readStdin();
+ *     console.log(new TextDecoder().decode(stdin.bytes));
  *     processApi.stdout('/\n/tmp\n/home');
  *	   processApi.exit(0);
  *   })
@@ -114,6 +125,56 @@ export class ProcessApi extends EventEmitterPolyfill {
 		if (!this.childProcess.stdin.ended) {
 			this.childProcess.stdin.end();
 		}
+	}
+	/**
+	 * Reads all stdin bytes written to this process.
+	 * Uses the existing `stdin` listener flow so bytes buffered before the
+	 * listener is attached are replayed before waiting for stdin to finish.
+	 *
+	 * If `maxSize` is exceeded, the remaining stdin is still drained so the
+	 * process can exit cleanly, but buffered bytes are discarded.
+	 */
+	async readStdin({
+		maxSize = Infinity,
+	}: ReadStdinOptions = {}): Promise<StdinBytesReadResult> {
+		const chunks: Uint8Array[] = [];
+		let totalLength = 0;
+		let exceededMaxSize = false;
+
+		const stdinDone = this.childProcess.stdin.ended
+			? Promise.resolve()
+			: new Promise<void>((resolve) => {
+					this.childProcess.stdin.on('finish', resolve);
+				});
+
+		this.on('stdin', (data: Uint8Array) => {
+			if (exceededMaxSize) {
+				return;
+			}
+			totalLength += data.length;
+			if (totalLength > maxSize) {
+				exceededMaxSize = true;
+				chunks.length = 0;
+				return;
+			}
+			// Need to clone the data buffer as it's reused by PHP and the next
+			// data chunk will overwrite the previous one.
+			chunks.push(data.slice());
+		});
+
+		await stdinDone;
+
+		if (exceededMaxSize) {
+			return {
+				bytes: new Uint8Array(),
+				exceededMaxSize,
+			};
+		}
+
+		return {
+			bytes: concatUint8Arrays(chunks),
+			exceededMaxSize,
+		};
 	}
 	stdout(data: string | ArrayBuffer) {
 		this.childProcess.stdout.write(data);

--- a/packages/php-wasm/util/src/lib/index.ts
+++ b/packages/php-wasm/util/src/lib/index.ts
@@ -16,25 +16,9 @@ export { createSpawnHandler } from './create-spawn-handler';
 export { randomString } from './random-string';
 export { randomFilename } from './random-filename';
 export { splitShellCommand } from './split-shell-command';
+export { concatArrayBuffers, concatUint8Arrays } from './concat-bytes';
 export { WritablePolyfill, type WritableOptions } from './writable-polyfill';
 export { EventEmitterPolyfill } from './event-emitter-polyfill';
 export * from './php-vars';
 
 export * from './sprintf';
-
-export function concatUint8Arrays(arrays: Uint8Array[]): Uint8Array {
-	let totalLength = 0;
-	arrays.forEach((a) => (totalLength += a.length));
-	const result = new Uint8Array(totalLength);
-	let offset = 0;
-	arrays.forEach((a) => {
-		result.set(a, offset);
-		offset += a.length;
-	});
-	return result;
-}
-
-export function concatArrayBuffers(buffers: ArrayBuffer[]): ArrayBuffer {
-	return concatUint8Arrays(buffers.map((b) => new Uint8Array(b)))
-		.buffer as ArrayBuffer;
-}

--- a/packages/php-wasm/util/src/lib/split-shell-command.ts
+++ b/packages/php-wasm/util/src/lib/split-shell-command.ts
@@ -3,6 +3,8 @@
  * Ensures that commands like `wp option set blogname "My blog name"` are split
  * into `['wp', 'option', 'set', 'blogname', 'My blog name']` instead of
  * `['wp', 'option', 'set', 'blogname', 'My', 'blog', 'name']`.
+ * Also preserves empty quoted arguments, which sendmail uses for values such
+ * as `-f ""`.
  *
  * @param command
  * @returns
@@ -12,48 +14,55 @@ export function splitShellCommand(command: string) {
 	const MODE_IN_QUOTE = 1;
 
 	let mode = MODE_UNQUOTED;
-	let quote = '';
+	let quote: '"' | "'" | undefined;
 
 	const parts: string[] = [];
-	let currentPart = '';
+	// `null` means no argument is active. `''` means an active empty argument,
+	// which preserves quoted values such as `sendmail -f "" -t`.
+	let currentPart: string | null = null;
+
 	for (let i = 0; i < command.length; i++) {
 		const char = command[i];
 		if (char === '\\') {
-			// Escaped quotes are treated as normal characters
+			// Escaped quotes are treated as normal characters.
 			// This is a very naive approach to escaping, but it's good enough for
-			// now. @TODO: Iterate on this later, perhaps using bun shell. @see https://github.com/WordPress/wordpress-playground/issues/1062
+			// now. @TODO: Iterate on this later, perhaps using bun shell.
+			// @see https://github.com/WordPress/wordpress-playground/issues/1062
 			if (command[i + 1] === '"' || command[i + 1] === "'") {
 				i++;
 			}
-			currentPart += command[i];
+			currentPart = (currentPart ?? '') + command[i];
 		} else if (mode === MODE_UNQUOTED) {
 			if (char === '"' || char === "'") {
 				mode = MODE_IN_QUOTE;
 				quote = char;
-			} else if (char.match(/\s/)) {
-				if (currentPart.trim().length) {
-					parts.push(currentPart.trim());
+				// Starting a quote opens an argument even if the quote is empty.
+				currentPart ??= '';
+			} else if (/\s/.test(char)) {
+				// Whitespace only ends an active argument. Repeated whitespace
+				// outside quotes is ignored.
+				if (currentPart !== null) {
+					parts.push(currentPart);
 				}
-				currentPart = char;
-			} else if (parts.length && !currentPart) {
-				// We just closed a quote to continue the same
-				// argument with different escaping style, e.g.:
-				// php -r 'require '\''vendor/autoload.php'\''
-				currentPart = parts.pop()! + char;
+				currentPart = null;
 			} else {
-				currentPart += char;
+				currentPart = (currentPart ?? '') + char;
 			}
 		} else if (mode === MODE_IN_QUOTE) {
 			if (char === quote) {
 				mode = MODE_UNQUOTED;
-				quote = '';
+				quote = undefined;
+				// Keep the current argument open after a closing quote. The next
+				// unquoted or quoted segment may continue the same shell argument,
+				// e.g. `php -r 'require '\''vendor/autoload.php'\''`.
 			} else {
-				currentPart += char;
+				currentPart = (currentPart ?? '') + char;
 			}
 		}
 	}
-	if (currentPart) {
-		parts.push(currentPart.trim());
+
+	if (currentPart !== null) {
+		parts.push(currentPart);
 	}
 	return parts;
 }

--- a/packages/php-wasm/util/src/test/create-spawn-handler.spec.ts
+++ b/packages/php-wasm/util/src/test/create-spawn-handler.spec.ts
@@ -2,6 +2,9 @@ import type { ProcessApi } from '../lib/create-spawn-handler';
 import { createSpawnHandler } from '../lib/create-spawn-handler';
 
 describe('createSpawnHandler', () => {
+	const encoder = new TextEncoder();
+	const decoder = new TextDecoder();
+
 	it('should create and execute a spawn handler', async () => {
 		const command = 'testCommand';
 		const testOut = 'testOut';
@@ -56,5 +59,54 @@ describe('createSpawnHandler', () => {
 			});
 		});
 		expect(errorfn).toHaveBeenCalledWith(new Error('Program crash'));
+	});
+
+	it('reads all stdin bytes', async () => {
+		const program = vitest.fn(
+			async (_cmd: string[], processApi: ProcessApi) => {
+				const stdin = await processApi.readStdin();
+				processApi.stdout(decoder.decode(stdin.bytes));
+				processApi.exit(0);
+			}
+		);
+
+		const spawnHandler = createSpawnHandler(program);
+		const childProcess = spawnHandler('testCommand');
+		const stdout: string[] = [];
+		childProcess.stdin.write(encoder.encode('first '));
+		childProcess.stdin.write(encoder.encode('second'));
+		childProcess.stdin.end();
+
+		const exitCode = await new Promise<number>((resolve) => {
+			childProcess.stdout.on('data', (data: ArrayBuffer) => {
+				stdout.push(decoder.decode(data));
+			});
+			childProcess.on('exit', resolve);
+		});
+
+		expect(exitCode).toBe(0);
+		expect(stdout.join('')).toBe('first second');
+	});
+
+	it('drains stdin and reports when maxSize is exceeded', async () => {
+		const program = vitest.fn(
+			async (_cmd: string[], processApi: ProcessApi) => {
+				const stdin = await processApi.readStdin({ maxSize: 5 });
+				expect(stdin.exceededMaxSize).toBe(true);
+				expect(stdin.bytes.length).toBe(0);
+				processApi.exit(1);
+			}
+		);
+
+		const spawnHandler = createSpawnHandler(program);
+		const childProcess = spawnHandler('testCommand');
+		childProcess.stdin.write(encoder.encode('123456'));
+		childProcess.stdin.end();
+
+		const exitCode = await new Promise<number>((resolve) => {
+			childProcess.on('exit', resolve);
+		});
+
+		expect(exitCode).toBe(1);
 	});
 });

--- a/packages/php-wasm/util/src/test/split-shell-command.spec.ts
+++ b/packages/php-wasm/util/src/test/split-shell-command.spec.ts
@@ -79,4 +79,22 @@ describe('splitShellCommand', () => {
 			'args',
 		]);
 	});
+
+	it('Should preserve empty quoted arguments', () => {
+		const command = 'mail "" --';
+		const result = splitShellCommand(command);
+		expect(result).toEqual(['mail', '', '--']);
+	});
+
+	it('Should preserve an empty argument between options', () => {
+		const command = 'sendmail -f "" -t';
+		const result = splitShellCommand(command);
+		expect(result).toEqual(['sendmail', '-f', '', '-t']);
+	});
+
+	it('Should preserve whitespace inside quoted arguments', () => {
+		const command = 'printf " leading and trailing "';
+		const result = splitShellCommand(command);
+		expect(result).toEqual(['printf', ' leading and trailing ']);
+	});
 });


### PR DESCRIPTION
## Summary

Adds utility foundations needed by later SMTP integration: safer shell command splitting, bounded stdin reads for spawn handlers, and a standalone byte concatenation helper.

## Motivation for the change, related issues

The SMTP sendmail adapter needs to parse commands like `sendmail -f "" -t` without losing the empty envelope sender argument. It also needs to read piped message bytes from process stdin while enforcing a maximum message size. Keeping these changes separate makes the behavior changes easier to review because `splitShellCommand` and spawn handlers are shared utilities.

## Implementation details

- Reworks `splitShellCommand` so it preserves empty quoted arguments and whitespace inside quoted arguments while still ignoring repeated whitespace between arguments.
- Adds `ProcessApi.readStdin({ maxSize })`, which replays already-buffered stdin, drains the stream before resolving, and reports when the configured size limit is exceeded.
- Moves the existing byte concatenation helpers from `index.ts` into `concat-bytes.ts` while preserving the public exports.

## Testing Instructions

Run the utility package test suite:

```bash
npm exec nx test php-wasm-util
```
