### PR TITLE
Add SMTP sink protocol engine

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43167,6 +43167,12 @@
 				"node": ">= 0.4"
 			}
 		},
+		"node_modules/postal-mime": {
+			"version": "2.7.5",
+			"resolved": "https://registry.npmjs.org/postal-mime/-/postal-mime-2.7.5.tgz",
+			"integrity": "sha512-GNEXKvWFQnbgO5NlrGzVa0FmWzBZ24PersAWErttSg1Hjpf0ATxTwS5DOMGaOpTG6bUh5cTr7xi0jAD942wCJA==",
+			"license": "MIT-0"
+		},
 		"node_modules/postcss": {
 			"version": "8.5.9",
 			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
@@ -53976,6 +53982,9 @@
 		"packages/php-wasm/util": {
 			"name": "@php-wasm/util",
 			"version": "3.1.44",
+			"dependencies": {
+				"postal-mime": "2.7.5"
+			},
 			"engines": {
 				"node": ">=20.10.0",
 				"npm": ">=10.2.3"

--- a/packages/php-wasm/node/project.json
+++ b/packages/php-wasm/node/project.json
@@ -170,6 +170,7 @@
 					"php-imagick.spec.ts",
 					"php-soap.spec.ts",
 					"php-image-extensions.spec.ts",
+					"php-mail-capture.spec.ts",
 					"php-fsockopen.spec.ts",
 					"php-socket-timeouts.spec.ts"
 				]
@@ -185,6 +186,7 @@
 					"php-imagick.spec.ts",
 					"php-soap.spec.ts",
 					"php-image-extensions.spec.ts",
+					"php-mail-capture.spec.ts",
 					"php-fsockopen.spec.ts",
 					"php-socket-timeouts.spec.ts"
 				]

--- a/packages/php-wasm/node/src/lib/load-runtime.ts
+++ b/packages/php-wasm/node/src/lib/load-runtime.ts
@@ -10,6 +10,8 @@ import {
 	createLegacyPhpIniPreRunStep,
 	isLegacyPHPVersion,
 	ProcessIdAllocator,
+	withMailCapture,
+	type WithMailCaptureOptions,
 } from '@php-wasm/universal';
 import type { WasmUserSpaceAPI, WasmUserSpaceContext } from './wasm-user-space';
 import { bindUserSpace } from './wasm-user-space';
@@ -53,6 +55,10 @@ export interface PHPLoaderOptions {
 	 * @deprecated Use `extensions: ['memcached']` instead.
 	 */
 	withMemcached?: boolean;
+	/**
+	 * Capture raw bytes written to sendmail stdin.
+	 */
+	withMailCapture?: WithMailCaptureOptions;
 }
 
 export type PHPLoaderOptionsForNode = PHPLoaderOptions & {
@@ -376,6 +382,12 @@ export async function loadNodeRuntime(
 	}
 
 	emscriptenOptions = await withNetworking(emscriptenOptions);
+	if (options?.withMailCapture) {
+		emscriptenOptions = withMailCapture(
+			options.withMailCapture,
+			emscriptenOptions
+		);
+	}
 
 	const phpLoaderModule = await getPHPLoaderModule(phpVersion);
 

--- a/packages/php-wasm/node/src/test/php-mail-capture.spec.ts
+++ b/packages/php-wasm/node/src/test/php-mail-capture.spec.ts
@@ -1,0 +1,84 @@
+import { PHP, setPhpIniEntries } from '@php-wasm/universal';
+import type { RawSendmailMessage } from '@php-wasm/util';
+import { loadNodeRuntime } from '../lib';
+
+const phpVersions = ['8.4'];
+
+describe.each(phpVersions)('PHP %s - raw mail capture', (phpVersion) => {
+	let php: PHP;
+	let messages: RawSendmailMessage[];
+
+	beforeEach(async () => {
+		messages = [];
+		php = new PHP(
+			await loadNodeRuntime(phpVersion as any, {
+				withMailCapture: {
+					onSendmail: (message) => messages.push(message),
+				},
+			})
+		);
+		await setPhpIniEntries(php, {
+			disable_functions: '',
+		});
+	}, 30_000);
+
+	afterEach(() => {
+		php?.exit();
+	});
+
+	it('captures raw bytes sent via mail()', async () => {
+		const result = await php.run({
+			code: `<?php
+				error_reporting(E_ALL);
+				$result = mail(
+					'recipient@test.com',
+					'Raw subject',
+					'Raw body.',
+					'From: sender@test.com'
+				);
+				echo $result ? 'SENT' : 'FAILED';
+			`,
+		});
+
+		expect(result.text).toBe('SENT');
+		expect(messages).toHaveLength(1);
+		expect(messages[0].text).toContain('From: sender@test.com');
+		expect(messages[0].text).toContain('To: recipient@test.com');
+		expect(messages[0].text).toContain('Subject: Raw subject');
+		expect(messages[0].text).toContain('Raw body.');
+		expect(messages[0].rawSize).toBe(messages[0].bytes.byteLength);
+	});
+
+	it('captures raw bytes sent to sendmail stdin', async () => {
+		const result = await php.run({
+			code: `<?php
+				error_reporting(E_ALL);
+				$email = "From: sender@test.com\\r\\n"
+					. "To: recipient@test.com\\r\\n"
+					. "Subject: Raw proc_open\\r\\n"
+					. "\\r\\n"
+					. "Raw proc_open body.";
+				$proc = proc_open(
+					'/usr/sbin/sendmail -t -i -fsender@test.com',
+					[['pipe', 'r'], ['pipe', 'w'], ['pipe', 'w']],
+					$pipes
+				);
+				if (!is_resource($proc)) {
+					echo 'PROC_OPEN_FAILED';
+					exit;
+				}
+				fwrite($pipes[0], $email);
+				fclose($pipes[0]);
+				$exit = proc_close($proc);
+				echo $exit === 0 ? 'SENT' : 'EXIT_' . $exit;
+			`,
+		});
+
+		expect(result.text).toBe('SENT');
+		expect(messages).toHaveLength(1);
+		expect(messages[0].command).toContain('-fsender@test.com');
+		expect(messages[0].envelopeSender).toBe('sender@test.com');
+		expect(messages[0].text).toContain('Subject: Raw proc_open');
+		expect(messages[0].text).toContain('Raw proc_open body.');
+	});
+});

--- a/packages/php-wasm/universal/src/lib/index.ts
+++ b/packages/php-wasm/universal/src/lib/index.ts
@@ -69,6 +69,8 @@ export {
 export { PHP, __private__dont__use, PHPExecutionFailureError } from './php';
 export type { MountHandler, UnmountFunction } from './php';
 export { loadPHPRuntime, popLoadedRuntime } from './load-php-runtime';
+export { withMailCapture } from './with-mail-capture';
+export type { WithMailCaptureOptions } from './with-mail-capture';
 export type { Emscripten } from './emscripten-types';
 export type {
 	DataModule,

--- a/packages/php-wasm/universal/src/lib/with-mail-capture.ts
+++ b/packages/php-wasm/universal/src/lib/with-mail-capture.ts
@@ -1,0 +1,36 @@
+import type { EmscriptenOptions } from './load-php-runtime';
+import {
+	createSendmailCaptureSpawnHandler,
+	type RawSendmailMessage,
+} from '@php-wasm/util';
+
+export type WithMailCaptureOptions = {
+	/**
+	 * Called with raw bytes written to sendmail stdin.
+	 */
+	onSendmail: (message: RawSendmailMessage) => void | Promise<void>;
+	/**
+	 * Maximum accepted raw message size in bytes.
+	 */
+	maxSize?: number;
+};
+
+/**
+ * Adds raw sendmail capture to Emscripten options.
+ *
+ * This is plumbing only: it captures the byte stream PHP writes to sendmail,
+ * without parsing headers, MIME bodies, attachments, or SMTP socket sessions.
+ */
+export function withMailCapture(
+	{ onSendmail, maxSize }: WithMailCaptureOptions,
+	emscriptenOptions: EmscriptenOptions = {}
+): EmscriptenOptions {
+	return {
+		...emscriptenOptions,
+		spawnProcess: createSendmailCaptureSpawnHandler(
+			onSendmail,
+			emscriptenOptions['spawnProcess'],
+			{ maxSize }
+		),
+	};
+}

--- a/packages/php-wasm/util/package.json
+++ b/packages/php-wasm/util/package.json
@@ -31,5 +31,8 @@
 	"engines": {
 		"node": ">=20.10.0",
 		"npm": ">=10.2.3"
+	},
+	"dependencies": {
+		"postal-mime": "2.7.5"
 	}
 }

--- a/packages/php-wasm/util/src/lib/base64.spec.ts
+++ b/packages/php-wasm/util/src/lib/base64.spec.ts
@@ -1,0 +1,40 @@
+import {
+	decodeBase64ToString,
+	decodeBase64ToUint8Array,
+	encodeStringAsBase64,
+	encodeUint8ArrayAsBase64,
+} from './base64';
+
+describe('base64', () => {
+	// RFC 4648 §10 vectors pin the exact wire format and padding so the
+	// encoding stays interoperable with PHP's base64_decode(), which is how
+	// these helpers are consumed across the JS/PHP boundary (see php-vars.ts).
+	// https://datatracker.ietf.org/doc/html/rfc4648#section-10
+	it.each([
+		['', ''],
+		['f', 'Zg=='],
+		['fo', 'Zm8='],
+		['foo', 'Zm9v'],
+		['foob', 'Zm9vYg=='],
+		['fooba', 'Zm9vYmE='],
+		['foobar', 'Zm9vYmFy'],
+	])('encodes %j as %j and decodes it back (RFC 4648)', (text, base64) => {
+		expect(encodeStringAsBase64(text)).toBe(base64);
+		expect(decodeBase64ToString(base64)).toBe(text);
+	});
+
+	it('round-trips UTF-8 beyond the Basic Multilingual Plane', () => {
+		const text = 'Hello \u{1f680} café \u{2603} \u{10ffff}';
+
+		expect(decodeBase64ToString(encodeStringAsBase64(text))).toBe(text);
+	});
+
+	it('encodes large inputs without overflowing the call stack', () => {
+		// Create a 131072 byte array of 'A's (0x41)
+		const bytes = new Uint8Array(0x20000).fill(0x41);
+
+		expect(
+			decodeBase64ToUint8Array(encodeUint8ArrayAsBase64(bytes))
+		).toEqual(bytes);
+	});
+});

--- a/packages/php-wasm/util/src/lib/base64.ts
+++ b/packages/php-wasm/util/src/lib/base64.ts
@@ -3,7 +3,7 @@ export function decodeBase64ToString(base64: string) {
 }
 
 export function decodeBase64ToUint8Array(base64: string) {
-	const binaryString = window.atob(base64); // This will convert base64 to binary string
+	const binaryString = atob(base64);
 	const len = binaryString.length;
 	const bytes = new Uint8Array(len);
 	for (let i = 0; i < len; i++) {
@@ -17,6 +17,15 @@ export function encodeStringAsBase64(str: string) {
 }
 
 export function encodeUint8ArrayAsBase64(bytes: Uint8Array) {
-	const binString = String.fromCodePoint(...bytes);
-	return btoa(binString);
+	/**
+	 * String.fromCharCode can only take up to 65536 arguments,
+	 * so we need to chunk the input into smaller pieces before converting it to a string.
+	 * Reference: https://bugs.webkit.org/show_bug.cgi?id=80797
+	 */
+	const chunkSize = 65536;
+	const chunks = [];
+	for (let i = 0; i < bytes.length; i += chunkSize) {
+		chunks.push(String.fromCharCode(...bytes.subarray(i, i + chunkSize)));
+	}
+	return btoa(chunks.join(''));
 }

--- a/packages/php-wasm/util/src/lib/concat-bytes.ts
+++ b/packages/php-wasm/util/src/lib/concat-bytes.ts
@@ -1,0 +1,22 @@
+/**
+ * Concatenates multiple byte arrays into a single `Uint8Array`.
+ */
+export function concatUint8Arrays(arrays: Uint8Array[]): Uint8Array {
+	let totalLength = 0;
+	arrays.forEach((a) => (totalLength += a.length));
+	const result = new Uint8Array(totalLength);
+	let offset = 0;
+	arrays.forEach((a) => {
+		result.set(a, offset);
+		offset += a.length;
+	});
+	return result;
+}
+
+/**
+ * Concatenates multiple array buffers into a single `ArrayBuffer`.
+ */
+export function concatArrayBuffers(buffers: ArrayBuffer[]): ArrayBuffer {
+	return concatUint8Arrays(buffers.map((b) => new Uint8Array(b)))
+		.buffer as ArrayBuffer;
+}

--- a/packages/php-wasm/util/src/lib/create-sendmail-capture-handler.ts
+++ b/packages/php-wasm/util/src/lib/create-sendmail-capture-handler.ts
@@ -1,0 +1,98 @@
+import { createSpawnHandler } from './create-spawn-handler';
+import { basename } from './paths';
+import { splitShellCommand } from './split-shell-command';
+
+export const DEFAULT_SENDMAIL_CAPTURE_MAX_SIZE = 10 * 1024 * 1024;
+
+export type RawSendmailMessage = {
+	receivedAt: string;
+	command: string[];
+	envelopeSender: string;
+	bytes: Uint8Array;
+	text: string;
+	rawSize: number;
+};
+
+/**
+ * Intercepts sendmail-style process calls and captures their raw stdin bytes.
+ *
+ * This is intentionally a transport-level helper. It does not parse message
+ * headers, MIME parts, or SMTP sessions; higher layers can interpret `bytes`
+ * once the raw stream has been captured.
+ */
+export function createSendmailCaptureSpawnHandler(
+	onSendmail: (message: RawSendmailMessage) => void | Promise<void>,
+	fallbackSpawnHandler?: (
+		command: any,
+		argsArray?: any,
+		options?: any
+	) => any,
+	{ maxSize = DEFAULT_SENDMAIL_CAPTURE_MAX_SIZE }: { maxSize?: number } = {}
+) {
+	const sendmailHandler = createSpawnHandler(
+		async function (command, processApi) {
+			const envelopeSender = getEnvelopeSender(command);
+			const stdin = await processApi.readStdin({ maxSize });
+			if (stdin.exceededMaxSize) {
+				processApi.stderr(
+					`sendmail: message exceeds maximum size (${maxSize} bytes)\n`
+				);
+				processApi.exit(1);
+				return;
+			}
+
+			if (stdin.bytes.length > 0) {
+				await onSendmail({
+					receivedAt: new Date().toISOString(),
+					command,
+					envelopeSender,
+					bytes: stdin.bytes,
+					text: new TextDecoder().decode(stdin.bytes),
+					rawSize: stdin.bytes.byteLength,
+				});
+			}
+
+			processApi.exit(0);
+		}
+	);
+
+	return function (
+		command: string | string[],
+		argsArray: string[] = [],
+		options: any = {}
+	) {
+		const cmdStr = argsArray.length
+			? (command as string)
+			: Array.isArray(command)
+				? command[0]
+				: typeof command === 'string'
+					? (splitShellCommand(command)[0] ?? '')
+					: '';
+		const bin = basename(cmdStr);
+		if (bin !== 'sendmail') {
+			if (fallbackSpawnHandler) {
+				return fallbackSpawnHandler(command, argsArray, options);
+			}
+			throw new Error(
+				`createSendmailCaptureSpawnHandler: not a sendmail command: ${cmdStr}`
+			);
+		}
+		return sendmailHandler(command, argsArray, options);
+	};
+}
+
+function getEnvelopeSender(command: string[]) {
+	for (let commandIndex = 1; commandIndex < command.length; commandIndex++) {
+		const argument = command[commandIndex];
+		if (argument === '--') {
+			break;
+		}
+		if (argument === '-f' && commandIndex + 1 < command.length) {
+			return command[++commandIndex];
+		}
+		if (argument.startsWith('-f') && argument.length > 2) {
+			return argument.slice(2);
+		}
+	}
+	return '';
+}

--- a/packages/php-wasm/util/src/lib/create-spawn-handler.ts
+++ b/packages/php-wasm/util/src/lib/create-spawn-handler.ts
@@ -1,8 +1,18 @@
 import { EventEmitterPolyfill } from './event-emitter-polyfill';
+import { concatUint8Arrays } from './concat-bytes';
 import { splitShellCommand } from './split-shell-command';
 import { WritablePolyfill, type WriteCallback } from './writable-polyfill';
 
 type Listener = (...args: any[]) => any;
+
+export type StdinBytesReadResult = {
+	bytes: Uint8Array;
+	exceededMaxSize: boolean;
+};
+
+export type ReadStdinOptions = {
+	maxSize?: number;
+};
 
 export interface ProcessOptions {
 	cwd?: string;
@@ -13,8 +23,9 @@ export interface ProcessOptions {
  * Usage:
  * ```ts
  * php.setSpawnHandler(
- *   createSpawnHandler(function (command, processApi) {
- *     console.log(processApi.flushStdin());
+ *   createSpawnHandler(async function (command, processApi) {
+ *     const stdin = await processApi.readStdin();
+ *     console.log(new TextDecoder().decode(stdin.bytes));
  *     processApi.stdout('/\n/tmp\n/home');
  *	   processApi.exit(0);
  *   })
@@ -114,6 +125,56 @@ export class ProcessApi extends EventEmitterPolyfill {
 		if (!this.childProcess.stdin.ended) {
 			this.childProcess.stdin.end();
 		}
+	}
+	/**
+	 * Reads all stdin bytes written to this process.
+	 * Uses the existing `stdin` listener flow so bytes buffered before the
+	 * listener is attached are replayed before waiting for stdin to finish.
+	 *
+	 * If `maxSize` is exceeded, the remaining stdin is still drained so the
+	 * process can exit cleanly, but buffered bytes are discarded.
+	 */
+	async readStdin({
+		maxSize = Infinity,
+	}: ReadStdinOptions = {}): Promise<StdinBytesReadResult> {
+		const chunks: Uint8Array[] = [];
+		let totalLength = 0;
+		let exceededMaxSize = false;
+
+		const stdinDone = this.childProcess.stdin.ended
+			? Promise.resolve()
+			: new Promise<void>((resolve) => {
+					this.childProcess.stdin.on('finish', resolve);
+				});
+
+		this.on('stdin', (data: Uint8Array) => {
+			if (exceededMaxSize) {
+				return;
+			}
+			totalLength += data.length;
+			if (totalLength > maxSize) {
+				exceededMaxSize = true;
+				chunks.length = 0;
+				return;
+			}
+			// Need to clone the data buffer as it's reused by PHP and the next
+			// data chunk will overwrite the previous one.
+			chunks.push(data.slice());
+		});
+
+		await stdinDone;
+
+		if (exceededMaxSize) {
+			return {
+				bytes: new Uint8Array(),
+				exceededMaxSize,
+			};
+		}
+
+		return {
+			bytes: concatUint8Arrays(chunks),
+			exceededMaxSize,
+		};
 	}
 	stdout(data: string | ArrayBuffer) {
 		this.childProcess.stdout.write(data);

--- a/packages/php-wasm/util/src/lib/index.ts
+++ b/packages/php-wasm/util/src/lib/index.ts
@@ -22,6 +22,12 @@ export { randomString } from './random-string';
 export { randomFilename } from './random-filename';
 export { splitShellCommand } from './split-shell-command';
 export { concatArrayBuffers, concatUint8Arrays } from './concat-bytes';
+export {
+	decodeBase64ToString,
+	decodeBase64ToUint8Array,
+	encodeStringAsBase64,
+	encodeUint8ArrayAsBase64,
+} from './base64';
 export { WritablePolyfill, type WritableOptions } from './writable-polyfill';
 export { EventEmitterPolyfill } from './event-emitter-polyfill';
 export * from './php-vars';

--- a/packages/php-wasm/util/src/lib/index.ts
+++ b/packages/php-wasm/util/src/lib/index.ts
@@ -31,5 +31,16 @@ export {
 export { WritablePolyfill, type WritableOptions } from './writable-polyfill';
 export { EventEmitterPolyfill } from './event-emitter-polyfill';
 export * from './php-vars';
+export {
+	DEFAULT_SMTP_MAX_SIZE,
+	SmtpSink,
+	makeLoopbackPair,
+	type AuthValidator,
+	type ByteDuplex,
+	type CaughtAttachment,
+	type CaughtMessage,
+	type SaslMechanism,
+	type SmtpSinkOptions,
+} from './smtp';
 
 export * from './sprintf';

--- a/packages/php-wasm/util/src/lib/index.ts
+++ b/packages/php-wasm/util/src/lib/index.ts
@@ -13,28 +13,17 @@ export {
 	toPosixPath,
 } from './paths';
 export { createSpawnHandler } from './create-spawn-handler';
+export {
+	DEFAULT_SENDMAIL_CAPTURE_MAX_SIZE,
+	createSendmailCaptureSpawnHandler,
+} from './create-sendmail-capture-handler';
+export type { RawSendmailMessage } from './create-sendmail-capture-handler';
 export { randomString } from './random-string';
 export { randomFilename } from './random-filename';
 export { splitShellCommand } from './split-shell-command';
+export { concatArrayBuffers, concatUint8Arrays } from './concat-bytes';
 export { WritablePolyfill, type WritableOptions } from './writable-polyfill';
 export { EventEmitterPolyfill } from './event-emitter-polyfill';
 export * from './php-vars';
 
 export * from './sprintf';
-
-export function concatUint8Arrays(arrays: Uint8Array[]): Uint8Array {
-	let totalLength = 0;
-	arrays.forEach((a) => (totalLength += a.length));
-	const result = new Uint8Array(totalLength);
-	let offset = 0;
-	arrays.forEach((a) => {
-		result.set(a, offset);
-		offset += a.length;
-	});
-	return result;
-}
-
-export function concatArrayBuffers(buffers: ArrayBuffer[]): ArrayBuffer {
-	return concatUint8Arrays(buffers.map((b) => new Uint8Array(b)))
-		.buffer as ArrayBuffer;
-}

--- a/packages/php-wasm/util/src/lib/php-vars.ts
+++ b/packages/php-wasm/util/src/lib/php-vars.ts
@@ -1,5 +1,7 @@
+import { encodeStringAsBase64 } from './base64';
+
 export function phpVar(value: unknown): string {
-	return `json_decode(base64_decode('${stringToBase64(
+	return `json_decode(base64_decode('${encodeStringAsBase64(
 		JSON.stringify(value)
 	)}'), true)`;
 }
@@ -12,13 +14,4 @@ export function phpVars<T extends Record<string, unknown>>(
 		result[key] = phpVar(vars[key]);
 	}
 	return result as Record<keyof T, string>;
-}
-
-function stringToBase64(str: string) {
-	return bytesToBase64(new TextEncoder().encode(str));
-}
-
-function bytesToBase64(bytes: Uint8Array) {
-	const binString = String.fromCodePoint(...bytes);
-	return btoa(binString);
 }

--- a/packages/php-wasm/util/src/lib/smtp.test.ts
+++ b/packages/php-wasm/util/src/lib/smtp.test.ts
@@ -1,0 +1,1344 @@
+import { describe, it, expect } from 'vitest';
+import {
+	SmtpSink,
+	makeLoopbackPair,
+	parseMessage,
+	type CaughtMessage,
+	type SmtpSinkOptions,
+} from './smtp';
+import { encodeUint8ArrayAsBase64 } from './base64';
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+/**
+ * Spins up a fake SMTP server (the "sink") connected to an in-memory
+ * client via a loopback byte stream. Returns helpers that let tests
+ * act as an SMTP client: send commands, read responses, and inspect
+ * captured emails.
+ *
+ * - `messages` collects every email the sink accepted.
+ * - The sink starts listening immediately.
+ */
+function createClient(options?: SmtpSinkOptions) {
+	const [duplexClient, duplexServer] = makeLoopbackPair();
+	const messages: CaughtMessage[] = [];
+	const sink = new SmtpSink(
+		duplexServer,
+		(message: CaughtMessage) => messages.push(message),
+		options
+	);
+	void sink.start();
+	const writer = duplexClient.writable.getWriter();
+	const reader = duplexClient.readable.getReader();
+
+	/** Read the next chunk the server sent (e.g. a response line). */
+	async function read(): Promise<string> {
+		const { value } = await reader.read();
+		return value ? decoder.decode(value) : '';
+	}
+
+	/** Send raw bytes to the server (no CRLF added). */
+	async function write(s: string) {
+		await writer.write(encoder.encode(s));
+	}
+
+	return {
+		read,
+		write,
+		messages,
+		sink,
+	};
+}
+
+/** Run a full EHLO handshake, consuming multi-line responses. */
+async function ehlo(
+	client: ReturnType<typeof createClient>,
+	hostname = 'localhost'
+): Promise<string[]> {
+	await client.write(`EHLO ${hostname}\r\n`);
+	const lines: string[] = [];
+	while (true) {
+		const resp = await client.read();
+		lines.push(resp);
+		if (/^250 /m.test(resp)) break;
+		if (!/^250-/m.test(resp))
+			throw new Error(`Unexpected EHLO response: ${resp}`);
+	}
+	return lines;
+}
+
+function getServerDomainFromGreeting(greeting: string): string {
+	const match = greeting.match(/^220 ([^\s]+)(?:\s|\r\n|$)/);
+	if (!match) {
+		throw new Error(`Unexpected SMTP greeting: ${greeting}`);
+	}
+	return match[1];
+}
+
+function escapeForRegExp(text: string): string {
+	return text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+describe('SmtpSink – happy path', () => {
+	it('captures an email through a full SMTP transaction', async () => {
+		// Walks the canonical SMTP transaction from RFC 5321 §3.3:
+		// 220 greeting → HELO → MAIL FROM → RCPT TO → DATA (354) →
+		// body terminated by ".<CRLF>" (250 queued) → QUIT (221).
+		// Reference: https://www.rfc-editor.org/rfc/rfc5321.html#section-3.3
+		const client = createClient();
+		const greeting = await client.read();
+		expect(greeting).toMatch(/^220 /);
+
+		await client.write('HELO localhost\r\n');
+		let helo = await client.read();
+		while (/^250-/.test(helo)) helo = await client.read();
+		expect(helo).toMatch(/^250 /);
+
+		await client.write('MAIL FROM:<test@localhost>\r\n');
+		expect(await client.read()).toMatch(/^250 /);
+
+		await client.write('RCPT TO:<test2@localhost>\r\n');
+		expect(await client.read()).toMatch(/^250 /);
+
+		await client.write('DATA\r\n');
+		expect(await client.read()).toBe(
+			'354 Start mail input; end with <CRLF>.<CRLF>\r\n'
+		);
+
+		await client.write('Subject: Test Email\r\n');
+		await client.write('From: test@localhost\r\n');
+		await client.write('To: test2@localhost\r\n');
+		await client.write('\r\n');
+		await client.write('This is the email body content.\r\n');
+		await client.write('.\r\n');
+		expect(await client.read()).toMatch(/^250 /);
+
+		await client.write('QUIT\r\n');
+		expect(await client.read()).toMatch(/^221 /);
+
+		expect(client.messages).toHaveLength(1);
+		const msg = client.messages[0];
+		expect(msg.subject).toBe('Test Email');
+		expect(msg.from).toContain('test@localhost');
+		expect(msg.to).toContain('test2@localhost');
+		expect((msg.text ?? '').trim()).toBe('This is the email body content.');
+	});
+});
+
+describe('SmtpSink – EHLO', () => {
+	it('advertises SIZE and PIPELINING', async () => {
+		// RFC 1870 §3 (SIZE) and RFC 2920 §3 (PIPELINING) ESMTP keywords.
+		// References:
+		// - https://www.rfc-editor.org/rfc/rfc1870.html#section-3
+		// - https://www.rfc-editor.org/rfc/rfc2920.html#section-3
+		const client = createClient();
+		await client.read();
+		const lines = await ehlo(client);
+		const joined = lines.join('\n');
+		expect(joined).toMatch(/SIZE/);
+		expect(joined).toMatch(/PIPELINING/);
+	});
+
+	it('advertises AUTH when mechanisms are configured', async () => {
+		// RFC 4954 §3: the AUTH EHLO keyword is advertised with a
+		// space-separated list of available SASL mechanism names as
+		// its parameter.
+		// Reference: https://www.rfc-editor.org/rfc/rfc4954.html#section-3
+		const client = createClient({
+			auth: { mechanisms: ['PLAIN', 'LOGIN'] },
+		});
+		await client.read();
+		const lines = await ehlo(client);
+		const joined = lines.join('\n');
+		expect(joined).toMatch(/AUTH PLAIN LOGIN/);
+	});
+
+	it('does not advertise STARTTLS', async () => {
+		// The sink runs over an in-process loopback duplex with
+		// nothing to encrypt, so STARTTLS is never offered. Clients
+		// that need TLS must be configured for plain SMTP.
+		const client = createClient();
+		await client.read();
+		const lines = await ehlo(client);
+		const joined = lines.join('\n');
+		expect(joined).not.toMatch(/STARTTLS/);
+	});
+
+	it('HELO returns a single-line greeting with no extension lines', async () => {
+		// RFC 5321 §4.1.1.1: HELO is the legacy non-extended greeting,
+		// so it must NOT advertise ESMTP extensions.
+		// Reference: https://www.rfc-editor.org/rfc/rfc5321.html#section-4.1.1.1
+		const client = createClient({
+			auth: { mechanisms: ['PLAIN'] },
+		});
+		await client.read();
+		await client.write('HELO localhost\r\n');
+		const resp = await client.read();
+		expect(resp).toMatch(/^250 /);
+		expect(resp).not.toMatch(/^250-/m);
+		expect(resp).not.toMatch(/AUTH/);
+		expect(resp).not.toMatch(/SIZE/);
+		expect(resp).not.toMatch(/PIPELINING/);
+	});
+
+	it('rejects EHLO with no domain argument', async () => {
+		// RFC 5321 §4.1.1.1 ABNF:
+		//   ehlo = "EHLO" SP ( Domain / address-literal ) CRLF
+		// The Domain (or address-literal) is a required production,
+		// so a bare "EHLO\r\n" is a syntax error.
+		// Reference: https://www.rfc-editor.org/rfc/rfc5321.html#section-4.1.1.1
+		const client = createClient();
+		await client.read();
+		await client.write('EHLO\r\n');
+		expect(await client.read()).toMatch(/^501 /);
+	});
+
+	it('rejects HELO with no domain argument', async () => {
+		// RFC 5321 §4.1.1.1 ABNF:
+		//   helo = "HELO" SP Domain CRLF
+		// Domain is mandatory; a bare "HELO\r\n" is a syntax error.
+		// Reference: https://www.rfc-editor.org/rfc/rfc5321.html#section-4.1.1.1
+		const client = createClient();
+		await client.read();
+		await client.write('HELO\r\n');
+		expect(await client.read()).toMatch(/^501 /);
+	});
+
+	it('EHLO greeting line starts with the server domain, not free-form text', async () => {
+		// RFC 5321 §4.1.1.1 ABNF:
+		//   ehlo-ok-rsp = "250-" Domain [ SP ehlo-greet ] CRLF
+		//                 *( "250-" ehlo-line CRLF )
+		//                 "250" SP ehlo-line CRLF
+		// The first token after "250-" MUST be the server's Domain;
+		// any free-form `ehlo-greet` follows after a single SP.
+		// Reference: https://www.rfc-editor.org/rfc/rfc5321.html#section-4.1.1.1
+		const client = createClient();
+		const greeting = await client.read();
+		const serverDomain = getServerDomainFromGreeting(greeting);
+		await client.write('EHLO client.example.com\r\n');
+		const first = await client.read();
+		// The first reply line is "250-<Domain>[ SP ehlo-greet]".
+		// The domain token should match the 220 banner, not free-form text.
+		expect(first).toMatch(
+			new RegExp(`^250-${escapeForRegExp(serverDomain)}(\\s|\\r\\n)`)
+		);
+	});
+
+	it('HELO greeting line starts with the server domain', async () => {
+		// RFC 5321 §4.1.1.1 ABNF for HELO uses the same single-line
+		// `"250" SP Domain [ SP ehlo-greet ]` shape.
+		// Reference: https://www.rfc-editor.org/rfc/rfc5321.html#section-4.1.1.1
+		const client = createClient();
+		const greeting = await client.read();
+		const serverDomain = getServerDomainFromGreeting(greeting);
+		await client.write('HELO client.example.com\r\n');
+		const resp = await client.read();
+		expect(resp).toMatch(
+			new RegExp(`^250 ${escapeForRegExp(serverDomain)}(\\s|\\r\\n)`)
+		);
+	});
+});
+
+describe('SmtpSink – STARTTLS', () => {
+	it('refuses STARTTLS with 502', async () => {
+		// RFC 5321 §4.2.4: an unimplemented command is answered with
+		// 502. The sink never advertises STARTTLS in EHLO, so a
+		// client that issues it anyway gets the unimplemented response.
+		// Reference: https://www.rfc-editor.org/rfc/rfc5321.html#section-4.2.4
+		const client = createClient();
+		await client.read();
+		await ehlo(client);
+		await client.write('STARTTLS\r\n');
+		const resp = await client.read();
+		expect(resp).toBe('502 Command not implemented\r\n');
+	});
+});
+
+describe('SmtpSink – AUTH PLAIN', () => {
+	it('accepts valid credentials inline', async () => {
+		// RFC 4954 §4 (initial-response form) + RFC 4616 §2 (PLAIN
+		// SASL message: [authzid] UTF8NUL authcid UTF8NUL passwd).
+		// Success returns 235.
+		// References:
+		// - https://www.rfc-editor.org/rfc/rfc4954.html#section-4
+		// - https://www.rfc-editor.org/rfc/rfc4616.html#section-2
+		const client = createClient({
+			auth: { mechanisms: ['PLAIN'] },
+		});
+		await client.read();
+		await ehlo(client);
+		// PLAIN: \0username\0password in base64
+		const credentials = btoa('\0user\0pass');
+		await client.write(`AUTH PLAIN ${credentials}\r\n`);
+		const resp = await client.read();
+		expect(resp).toBe('235 2.7.0 Authentication Succeeded\r\n');
+	});
+
+	it('accepts valid credentials via challenge-response', async () => {
+		// RFC 4954 §4: when no initial response is supplied, the server
+		// issues "334 " with an empty challenge and the client follows
+		// up with the SASL response on its own line.
+		// Reference: https://www.rfc-editor.org/rfc/rfc4954.html#section-4
+		const client = createClient({
+			auth: { mechanisms: ['PLAIN'] },
+		});
+		await client.read();
+		await ehlo(client);
+		await client.write('AUTH PLAIN\r\n');
+		const challenge = await client.read();
+		expect(challenge).toMatch(/^334 /);
+		const credentials = btoa('\0user\0pass');
+		await client.write(`${credentials}\r\n`);
+		const resp = await client.read();
+		expect(resp).toBe('235 2.7.0 Authentication Succeeded\r\n');
+	});
+
+	it('accepts AUTH responses close to the 12288-octet limit', async () => {
+		// RFC 4954 §4 allows AUTH client response lines up to 12288 octets,
+		// including CRLF.
+		// https://www.rfc-editor.org/rfc/rfc4954.html#section-4
+		const authResponseLineLimit = 12288;
+		const client = createClient({
+			auth: { mechanisms: ['PLAIN'] },
+		});
+		await client.read();
+		await ehlo(client);
+		await client.write('AUTH PLAIN\r\n');
+		expect(await client.read()).toMatch(/^334 /);
+		const credentials = btoa(`\0${'u'.repeat(9207)}\0pass`);
+		expect(credentials.length + 2).toBeLessThanOrEqual(
+			authResponseLineLimit
+		);
+		expect(credentials.length + 2).toBeGreaterThan(
+			authResponseLineLimit - 8
+		);
+		expect(credentials.length + 2).toBeGreaterThan(512);
+		await client.write(`${credentials}\r\n`);
+		const resp = await client.read();
+		expect(resp).toBe('235 2.7.0 Authentication Succeeded\r\n');
+	});
+
+	it('rejects invalid PLAIN base64 with syntax error', async () => {
+		// RFC 4954 §4: undecodable client responses reject AUTH with 501.
+		const client = createClient({
+			auth: { mechanisms: ['PLAIN'] },
+		});
+		await client.read();
+		await ehlo(client);
+		await client.write('AUTH PLAIN\r\n');
+		await client.read();
+		await client.write('!!!!\r\n');
+		const resp = await client.read();
+		expect(resp).toBe('501 Syntax error in parameters or arguments\r\n');
+	});
+
+	it('treats = as an empty initial response', async () => {
+		// RFC 4954 §4: "=" is a zero-length initial response, not a
+		// request for another 334 challenge. Empty PLAIN credentials are
+		// invalid for this sink and should fail immediately.
+		// Reference: https://www.rfc-editor.org/rfc/rfc4954.html#section-4
+		const client = createClient({
+			auth: { mechanisms: ['PLAIN'] },
+		});
+		await client.read();
+		await ehlo(client);
+		await client.write('AUTH PLAIN =\r\n');
+		const resp = await client.read();
+		expect(resp).toBe('535 5.7.8 Authentication credentials invalid\r\n');
+	});
+
+	it('rejects invalid credentials', async () => {
+		// RFC 4954 §6: bad credentials produce "535 5.7.8
+		// Authentication credentials invalid".
+		// Reference: https://www.rfc-editor.org/rfc/rfc4954.html#section-6
+		const client = createClient({
+			auth: {
+				mechanisms: ['PLAIN'],
+				validator: async (_mechanism, { username, password }) =>
+					username === 'admin' && password === 'secret',
+			},
+		});
+		await client.read();
+		await ehlo(client);
+		const credentials = btoa('\0wrong\0creds');
+		await client.write(`AUTH PLAIN ${credentials}\r\n`);
+		const resp = await client.read();
+		expect(resp).toBe('535 5.7.8 Authentication credentials invalid\r\n');
+	});
+
+	it('allows cancellation with *', async () => {
+		// RFC 4954 §4: a single "*" sent in place of a SASL response
+		// cancels the AUTH exchange; the server returns 501.
+		// Reference: https://www.rfc-editor.org/rfc/rfc4954.html#section-4
+		const client = createClient({
+			auth: { mechanisms: ['PLAIN'] },
+		});
+		await client.read();
+		await ehlo(client);
+		await client.write('AUTH PLAIN\r\n');
+		await client.read();
+		await client.write('*\r\n');
+		const resp = await client.read();
+		expect(resp).toBe('501 5.7.0 Authentication canceled\r\n');
+	});
+});
+
+describe('SmtpSink – AUTH LOGIN', () => {
+	it('completes multi-step LOGIN flow', async () => {
+		// LOGIN SASL is non-standard (draft-murchison-sasl-login) but
+		// universally deployed: server prompts with base64("Username:")
+		// then base64("Password:") via 334 challenges, then 235 on
+		// success per RFC 4954 §4.
+		// Reference: https://www.rfc-editor.org/rfc/rfc4954.html#section-4
+		const client = createClient({
+			auth: { mechanisms: ['LOGIN'] },
+		});
+		await client.read();
+		await ehlo(client);
+		await client.write('AUTH LOGIN\r\n');
+		const usernameChallenge = await client.read();
+		expect(usernameChallenge).toMatch(/^334 /);
+		await client.write(`${btoa('myuser')}\r\n`);
+		const passwordChallenge = await client.read();
+		expect(passwordChallenge).toMatch(/^334 /);
+		await client.write(`${btoa('mypass')}\r\n`);
+		const resp = await client.read();
+		expect(resp).toBe('235 2.7.0 Authentication Succeeded\r\n');
+	});
+
+	it('accepts initial-response as username', async () => {
+		// RFC 4954 §4: clients may bundle the first SASL response onto
+		// the AUTH command line. For LOGIN that response is the
+		// username, so the server skips straight to the password
+		// challenge.
+		// Reference: https://www.rfc-editor.org/rfc/rfc4954.html#section-4
+		const client = createClient({
+			auth: { mechanisms: ['LOGIN'] },
+		});
+		await client.read();
+		await ehlo(client);
+		await client.write(`AUTH LOGIN ${btoa('myuser')}\r\n`);
+		const passwordChallenge = await client.read();
+		expect(passwordChallenge).toMatch(/^334 /);
+		await client.write(`${btoa('mypass')}\r\n`);
+		const resp = await client.read();
+		expect(resp).toBe('235 2.7.0 Authentication Succeeded\r\n');
+	});
+
+	it('rejects invalid LOGIN credentials', async () => {
+		// RFC 4954 §6: failed authentication exchange returns 535.
+		// Reference: https://www.rfc-editor.org/rfc/rfc4954.html#section-6
+		const client = createClient({
+			auth: {
+				mechanisms: ['LOGIN'],
+				validator: async () => false,
+			},
+		});
+		await client.read();
+		await ehlo(client);
+		await client.write('AUTH LOGIN\r\n');
+		await client.read();
+		await client.write(`${btoa('user')}\r\n`);
+		await client.read();
+		await client.write(`${btoa('wrong')}\r\n`);
+		const resp = await client.read();
+		expect(resp).toBe('535 5.7.8 Authentication credentials invalid\r\n');
+	});
+
+	it('rejects invalid LOGIN base64 without hanging the session', async () => {
+		// RFC 4954 §4: undecodable client responses reject AUTH with 501.
+		const client = createClient({
+			auth: { mechanisms: ['LOGIN'] },
+		});
+		await client.read();
+		await ehlo(client);
+		await client.write('AUTH LOGIN\r\n');
+		await client.read();
+		await client.write('!!!!\r\n');
+		const resp = await client.read();
+		expect(resp).toBe('501 Syntax error in parameters or arguments\r\n');
+	});
+});
+
+describe('SmtpSink – AUTH edge cases', () => {
+	it('rejects AUTH with no mechanism', async () => {
+		// RFC 4954 §4: AUTH command requires a mechanism argument;
+		// the server replies 501 on syntax errors.
+		// Reference: https://www.rfc-editor.org/rfc/rfc4954.html#section-4
+		const client = createClient({
+			auth: { mechanisms: ['PLAIN'] },
+		});
+		await client.read();
+		await ehlo(client);
+		await client.write('AUTH\r\n');
+		const resp = await client.read();
+		expect(resp).toMatch(/^501 /);
+	});
+
+	it('rejects quoted AUTH mechanism tokens', async () => {
+		// AUTH arguments follow SMTP ABNF, not shell argv quoting.
+		// A quoted mechanism token is therefore a syntax error.
+		const client = createClient({
+			auth: { mechanisms: ['PLAIN'] },
+		});
+		await client.read();
+		await ehlo(client);
+		await client.write('AUTH "PLAIN"\r\n');
+		const resp = await client.read();
+		expect(resp).toMatch(/^501 /);
+	});
+
+	it('rejects AUTH with trailing extra tokens', async () => {
+		// RFC 4954 §4 allows only `AUTH mechanism [initial-response]`.
+		// Anything after the optional initial response is a syntax error.
+		// Reference: https://www.rfc-editor.org/rfc/rfc4954.html#section-4
+		const client = createClient({
+			auth: { mechanisms: ['PLAIN'] },
+		});
+		await client.read();
+		await ehlo(client);
+		const credentials = btoa('\0user\0pass');
+		await client.write(`AUTH PLAIN ${credentials} extra\r\n`);
+		const resp = await client.read();
+		expect(resp).toMatch(/^501 /);
+	});
+
+	it('rejects AUTH initial responses split across whitespace', async () => {
+		// RFC 4954 §4 allows one optional initial-response token. Whitespace
+		// inside the base64 data creates an extra token and is a syntax error.
+		const client = createClient({
+			auth: { mechanisms: ['PLAIN'] },
+		});
+		await client.read();
+		await ehlo(client);
+		const credentials = btoa('\0user\0pass');
+		const splitCredentials = `${credentials.slice(0, 8)} ${credentials.slice(
+			8
+		)}`;
+		await client.write(`AUTH PLAIN ${splitCredentials}\r\n`);
+		const resp = await client.read();
+		expect(resp).toBe('501 Syntax error in parameters or arguments\r\n');
+	});
+
+	it('rejects already-authenticated client', async () => {
+		// RFC 4954 §4: after a successful AUTH, further AUTH commands
+		// in the same session must be rejected with 503.
+		// Reference: https://www.rfc-editor.org/rfc/rfc4954.html#section-4
+		const client = createClient({
+			auth: { mechanisms: ['PLAIN'] },
+		});
+		await client.read();
+		await ehlo(client);
+		const credentials = btoa('\0u\0p');
+		await client.write(`AUTH PLAIN ${credentials}\r\n`);
+		await client.read();
+		await client.write(`AUTH PLAIN ${credentials}\r\n`);
+		const resp = await client.read();
+		expect(resp).toMatch(/^503 /);
+	});
+
+	it('rejects unrecognized auth mechanism', async () => {
+		// RFC 4954 §4: a SASL mechanism the server doesn't support
+		// produces "504 5.5.4 Unrecognized authentication type".
+		// Reference: https://www.rfc-editor.org/rfc/rfc4954.html#section-4
+		const client = createClient({
+			auth: { mechanisms: ['PLAIN'] },
+		});
+		await client.read();
+		await ehlo(client);
+		await client.write('AUTH CRAM-MD5\r\n');
+		const resp = await client.read();
+		expect(resp).toBe('504 5.5.4 Unrecognized authentication type\r\n');
+	});
+
+	it('rejects MAIL/RCPT when requireAuth and not authenticated', async () => {
+		// RFC 4954 §6: "530 5.7.0 Authentication required" SHOULD be
+		// returned by any command other than AUTH/EHLO/HELO/NOOP/RSET/
+		// QUIT when server policy requires authentication and the
+		// session is not yet authenticated.
+		// Reference: https://www.rfc-editor.org/rfc/rfc4954.html#section-6
+		const client = createClient({
+			auth: { mechanisms: ['PLAIN'], requireAuth: true },
+		});
+		await client.read();
+		await ehlo(client);
+		await client.write('MAIL FROM:<a@b.com>\r\n');
+		const mailResp = await client.read();
+		expect(mailResp).toBe('530 5.7.0 Authentication required\r\n');
+		await client.write('RCPT TO:<c@d.com>\r\n');
+		const rcptResp = await client.read();
+		expect(rcptResp).toBe('530 5.7.0 Authentication required\r\n');
+	});
+
+	it('rejects AUTH during an active mail transaction', async () => {
+		// RFC 4954 §4: AUTH is not permitted during a mail transaction.
+		// Reference: https://www.rfc-editor.org/rfc/rfc4954.html#section-4
+		const client = createClient({
+			auth: { mechanisms: ['PLAIN'] },
+		});
+		await client.read();
+		await ehlo(client);
+		await client.write('MAIL FROM:<a@b.com>\r\n');
+		await client.read();
+		await client.write(`AUTH PLAIN ${btoa('\0u\0p')}\r\n`);
+		const resp = await client.read();
+		expect(resp).toBe('503 Bad sequence of commands\r\n');
+	});
+});
+
+describe('SmtpSink – command edge cases', () => {
+	it('RSET clears the envelope', async () => {
+		// RFC 5321 §4.1.1.5: RSET aborts the current mail transaction
+		// and clears reverse-path / forward-paths / mail data buffers,
+		// then the server replies 250.
+		// Reference: https://www.rfc-editor.org/rfc/rfc5321.html#section-4.1.1.5
+		const client = createClient();
+		await client.read();
+		await ehlo(client);
+		await client.write('MAIL FROM:<a@b.com>\r\n');
+		await client.read();
+		await client.write('RSET\r\n');
+		const rsetResp = await client.read();
+		expect(rsetResp).toBe('250 OK\r\n');
+		await client.write('RCPT TO:<c@d.com>\r\n');
+		const rcptResp = await client.read();
+		expect(rcptResp).toBe('503 Bad sequence of commands\r\n');
+	});
+
+	it('mid-session EHLO clears the envelope (RFC 5321 §4.1.4)', async () => {
+		// RFC 5321 §4.1.4: EHLO starts an SMTP session and resets the
+		// server's understanding of the client and advertised extensions.
+		// Regression: previously EHLO only set state='idle' without
+		// clearing buffers, leaking mailFrom/recipientPaths across sessions.
+		// Reference: https://www.rfc-editor.org/rfc/rfc5321.html#section-4.1.4
+		const client = createClient();
+		await client.read();
+		await ehlo(client);
+		await client.write('MAIL FROM:<a@b.com>\r\n');
+		await client.read();
+		await client.write('RCPT TO:<c@d.com>\r\n');
+		await client.read();
+		await ehlo(client);
+		await client.write('RCPT TO:<e@f.com>\r\n');
+		expect(await client.read()).toBe('503 Bad sequence of commands\r\n');
+		await client.write('DATA\r\n');
+		expect(await client.read()).toBe('503 Bad sequence of commands\r\n');
+	});
+
+	it('drops the connection with 500 when a command line exceeds 512 octets', async () => {
+		// RFC 5321 §4.5.3.1.4: "The maximum total length of a command
+		// line including the command word and the <CRLF> is 512
+		// octets." Outside of DATA mode the sink must refuse an
+		// un-terminated tail that has already exceeded that limit
+		// instead of growing lineBuffer without bound.
+		// Reference: https://www.rfc-editor.org/rfc/rfc5321.html#section-4.5.3.1.4
+		const client = createClient();
+		await client.read();
+		// 600 bytes of garbage with no CRLF — comfortably over 512
+		// but under the 1000-octet text-line limit, proving the sink
+		// uses the *command* limit when not in DATA mode.
+		await client.write('A'.repeat(600));
+		const resp = await client.read();
+		expect(resp).toBe('500 Syntax error, command unrecognized\r\n');
+		await expect(client.read()).resolves.toBe('');
+	});
+
+	it('drops the connection when a complete command line exceeds 512 octets', async () => {
+		// "NOOP " (5) + 506 chars + "\r\n" (2) = 513 octets total,
+		// one octet over the RFC 5321 §4.5.3.1.4 command-line limit.
+		const client = createClient();
+		await client.read();
+		await ehlo(client);
+		await client.write('NOOP ' + 'A'.repeat(506) + '\r\n');
+		const resp = await client.read();
+		expect(resp).toBe('500 Syntax error, command unrecognized\r\n');
+		await expect(client.read()).resolves.toBe('');
+	});
+
+	it('drops the connection with 500 when a DATA text line exceeds 1000 octets', async () => {
+		// RFC 5321 §4.5.3.1.6: "The maximum total length of a text
+		// line including the <CRLF> is 1000 octets." Inside DATA mode
+		// the sink applies the larger text-line limit; an
+		// un-terminated 1500-byte tail crosses it and must be
+		// refused.
+		// Reference: https://www.rfc-editor.org/rfc/rfc5321.html#section-4.5.3.1.6
+		const client = createClient();
+		await client.read();
+		await ehlo(client);
+		await client.write('MAIL FROM:<a@b.com>\r\n');
+		expect(await client.read()).toMatch(/^250 /);
+		await client.write('RCPT TO:<c@d.com>\r\n');
+		expect(await client.read()).toMatch(/^250 /);
+		await client.write('DATA\r\n');
+		expect(await client.read()).toBe(
+			'354 Start mail input; end with <CRLF>.<CRLF>\r\n'
+		);
+		await client.write('Subject: Big\r\n\r\n');
+		// 1500 bytes of body with no CRLF — over the 1000-octet
+		// text-line limit.
+		await client.write('A'.repeat(1500));
+		const resp = await client.read();
+		expect(resp).toBe('500 Syntax error, command unrecognized\r\n');
+		await expect(client.read()).resolves.toBe('');
+	});
+
+	it('drops the connection when a complete DATA line exceeds 1000 octets', async () => {
+		// 999 body octets + "\r\n" = 1001 octets total, one over
+		// the RFC 5321 §4.5.3.1.6 text-line limit.
+		const client = createClient();
+		await client.read();
+		await ehlo(client);
+		await client.write('MAIL FROM:<a@b.com>\r\n');
+		expect(await client.read()).toMatch(/^250 /);
+		await client.write('RCPT TO:<c@d.com>\r\n');
+		expect(await client.read()).toMatch(/^250 /);
+		await client.write('DATA\r\n');
+		expect(await client.read()).toBe(
+			'354 Start mail input; end with <CRLF>.<CRLF>\r\n'
+		);
+		await client.write('A'.repeat(999) + '\r\n');
+		const resp = await client.read();
+		expect(resp).toBe('500 Syntax error, command unrecognized\r\n');
+		await expect(client.read()).resolves.toBe('');
+	});
+
+	it('accepts a command line just under the 512-octet limit', async () => {
+		// RFC 5321 §4.5.3.1.4 caps command lines at 512 octets
+		// *including the CRLF*, so any compliant command can carry
+		// up to 510 octets of payload. NOOP accepts an arbitrary
+		// trailing string per §4.1.1.9, which gives us a clean way
+		// to test the upper bound without invoking another command's
+		// argument validation.
+		// References:
+		// - https://www.rfc-editor.org/rfc/rfc5321.html#section-4.5.3.1.4
+		// - https://www.rfc-editor.org/rfc/rfc5321.html#section-4.1.1.9
+		const client = createClient();
+		await client.read();
+		await ehlo(client);
+		// "NOOP " (5) + 505 chars + "\r\n" (2) = 512 octets total.
+		await client.write('NOOP ' + 'A'.repeat(505) + '\r\n');
+		expect(await client.read()).toMatch(/^250 /);
+	});
+
+	it('NOOP returns 250', async () => {
+		// RFC 5321 §4.1.1.9: NOOP has no effect on parameters or
+		// previously entered commands and always succeeds with 250.
+		// Reference: https://www.rfc-editor.org/rfc/rfc5321.html#section-4.1.1.9
+		const client = createClient();
+		await client.read();
+		await ehlo(client);
+		await client.write('NOOP\r\n');
+		expect(await client.read()).toBe('250 OK\r\n');
+	});
+
+	it('VRFY returns 252', async () => {
+		// RFC 5321 §3.5.3 / §4.1.1.6: a server that does not verify
+		// addresses but is willing to accept the message answers VRFY
+		// with "252 Cannot VRFY user, but will accept message and
+		// attempt delivery".
+		// References:
+		// - https://www.rfc-editor.org/rfc/rfc5321.html#section-3.5.3
+		// - https://www.rfc-editor.org/rfc/rfc5321.html#section-4.1.1.6
+		const client = createClient();
+		await client.read();
+		await ehlo(client);
+		await client.write('VRFY user\r\n');
+		expect(await client.read()).toBe(
+			'252 Cannot VRFY user, but will accept message and attempt delivery\r\n'
+		);
+	});
+
+	it('unknown command returns 500', async () => {
+		// RFC 5321 §4.2.4: an unrecognized command produces 500
+		// "Syntax error, command unrecognized".
+		// Reference: https://www.rfc-editor.org/rfc/rfc5321.html#section-4.2.4
+		const client = createClient();
+		await client.read();
+		await ehlo(client);
+		await client.write('XYZZY\r\n');
+		expect(await client.read()).toBe(
+			'500 Syntax error, command unrecognized\r\n'
+		);
+	});
+
+	it.each(['EXPN', 'HELP', 'TURN'])(
+		'recognized but unimplemented command %s returns 502',
+		async (command) => {
+			// RFC 5321 §4.2.4: a recognized but unimplemented command
+			// produces 502 "Command not implemented". EXPN and HELP
+			// are optional per §4.1.1.7 / §4.1.1.8; TURN is the
+			// historical RFC 821 §3.8 role-reversal command, listed
+			// among RFC 821 features deprecated in RFC 5321 Appendix
+			// F.1.
+			// References:
+			// - https://www.rfc-editor.org/rfc/rfc5321.html#section-4.2.4
+			// - https://www.rfc-editor.org/rfc/rfc5321.html#section-4.1.1.7
+			// - https://www.rfc-editor.org/rfc/rfc5321.html#section-4.1.1.8
+			// - https://www.rfc-editor.org/rfc/rfc821.html#page-18 (§3.8)
+			// - https://www.rfc-editor.org/rfc/rfc5321.html#appendix-F.1
+			const client = createClient();
+			await client.read();
+			await ehlo(client);
+			await client.write(`${command}\r\n`);
+			expect(await client.read()).toBe('502 Command not implemented\r\n');
+		}
+	);
+
+	it('rejects MAIL FROM with bad syntax', async () => {
+		// RFC 5321 §4.1.1.2: the MAIL command requires "FROM:" and a
+		// reverse-path; malformed input yields 501.
+		// Reference: https://www.rfc-editor.org/rfc/rfc5321.html#section-4.1.1.2
+		const client = createClient();
+		await client.read();
+		await ehlo(client);
+		await client.write('MAIL TO:<a@b.com>\r\n');
+		const resp = await client.read();
+		expect(resp).toMatch(/^501 /);
+	});
+
+	it('rejects RCPT TO with bad syntax', async () => {
+		// RFC 5321 §4.1.1.3: the RCPT command requires "TO:" and a
+		// forward-path; malformed input yields 501.
+		// Reference: https://www.rfc-editor.org/rfc/rfc5321.html#section-4.1.1.3
+		const client = createClient();
+		await client.read();
+		await ehlo(client);
+		await client.write('RCPT FROM:<a@b.com>\r\n');
+		const resp = await client.read();
+		expect(resp).toMatch(/^501 /);
+	});
+
+	it('rejects MAIL FROM with a space after the colon', async () => {
+		// RFC 5321 §3.3: "spaces are not permitted on either side of
+		// the colon following FROM in the MAIL command or TO in the
+		// RCPT command. The syntax is exactly as given above." This
+		// is called out explicitly because it has been "a common
+		// source of errors".
+		// Reference: https://www.rfc-editor.org/rfc/rfc5321.html#section-3.3
+		const client = createClient();
+		await client.read();
+		await ehlo(client);
+		await client.write('MAIL FROM: <a@b.com>\r\n');
+		expect(await client.read()).toMatch(/^501 /);
+	});
+
+	it('rejects RCPT TO with a space after the colon', async () => {
+		// RFC 5321 §3.3: same no-space rule as MAIL FROM. The session
+		// must be in the mail state for the rejection to be a syntax
+		// error rather than a sequence error, so set up MAIL first.
+		// Reference: https://www.rfc-editor.org/rfc/rfc5321.html#section-3.3
+		const client = createClient();
+		await client.read();
+		await ehlo(client);
+		await client.write('MAIL FROM:<a@b.com>\r\n');
+		expect(await client.read()).toMatch(/^250 /);
+		await client.write('RCPT TO: <c@d.com>\r\n');
+		expect(await client.read()).toMatch(/^501 /);
+	});
+
+	it('rejects MAIL FROM without angle brackets', async () => {
+		// RFC 5321 §4.1.2 ABNF: Reverse-path is `Path / "<>"` and
+		// `Path = "<" [ A-d-l ":" ] Mailbox ">"`. The angle brackets
+		// are mandatory; a bare addr-spec is a syntax error.
+		// Reference: https://www.rfc-editor.org/rfc/rfc5321.html#section-4.1.2
+		const client = createClient();
+		await client.read();
+		await ehlo(client);
+		await client.write('MAIL FROM:a@b.com\r\n');
+		expect(await client.read()).toMatch(/^501 /);
+	});
+
+	it('rejects RCPT TO without angle brackets', async () => {
+		// RFC 5321 §4.1.2: Forward-path uses the same `Path`
+		// production as Reverse-path, so the brackets are required
+		// here too.
+		// Reference: https://www.rfc-editor.org/rfc/rfc5321.html#section-4.1.2
+		const client = createClient();
+		await client.read();
+		await ehlo(client);
+		await client.write('MAIL FROM:<a@b.com>\r\n');
+		expect(await client.read()).toMatch(/^250 /);
+		await client.write('RCPT TO:c@d.com\r\n');
+		expect(await client.read()).toMatch(/^501 /);
+	});
+
+	it('rejects the null reverse-path form for RCPT TO', async () => {
+		// RFC 5321 §4.5.5 reserves <> for MAIL FROM bounce senders.
+		// Forward-path recipients still need a non-empty path.
+		// Reference: https://www.rfc-editor.org/rfc/rfc5321.html#section-4.5.5
+		const client = createClient();
+		await client.read();
+		await ehlo(client);
+		await client.write('MAIL FROM:<a@b.com>\r\n');
+		expect(await client.read()).toMatch(/^250 /);
+		await client.write('RCPT TO:<>\r\n');
+		expect(await client.read()).toMatch(/^501 /);
+	});
+
+	it('accepts MAIL FROM with trailing ESMTP parameters', async () => {
+		// RFC 5321 §4.1.1.2 ABNF:
+		//   mail = "MAIL FROM:" Reverse-path
+		//          [SP Mail-parameters] CRLF
+		// A single SP separates the closing `>` of the path from the
+		// optional ESMTP parameter list (e.g. RFC 1870 §6 SIZE=N). The
+		// sink must accept the path and ignore the parameters.
+		// References:
+		// - https://www.rfc-editor.org/rfc/rfc5321.html#section-4.1.1.2
+		// - https://www.rfc-editor.org/rfc/rfc1870.html#section-6
+		const client = createClient();
+		await client.read();
+		await ehlo(client);
+		await client.write('MAIL FROM:<a@b.com> SIZE=42\r\n');
+		expect(await client.read()).toMatch(/^250 /);
+	});
+
+	it('rejects MAIL FROM declaring SIZE above the fixed maximum', async () => {
+		// RFC 1870 §6.1: when the SIZE parameter exceeds the fixed
+		// maximum message size the server advertised, the server
+		// responds with 552 and the transaction does not start.
+		// Reference: https://www.rfc-editor.org/rfc/rfc1870.html#section-6.1
+		const client = createClient({ maxSize: 100 });
+		await client.read();
+		await ehlo(client);
+		await client.write('MAIL FROM:<a@b.com> SIZE=101\r\n');
+		expect(await client.read()).toBe(
+			'552 Message size exceeds fixed maximum message size\r\n'
+		);
+		// The envelope must not have started: RCPT is out of sequence.
+		await client.write('RCPT TO:<c@d.com>\r\n');
+		expect(await client.read()).toMatch(/^503 /);
+	});
+
+	it('accepts MAIL FROM declaring SIZE equal to the fixed maximum', async () => {
+		// RFC 1870 §6.1 rejects only sizes *exceeding* the fixed
+		// maximum; a declaration equal to it is acceptable.
+		// Reference: https://www.rfc-editor.org/rfc/rfc1870.html#section-6.1
+		const client = createClient({ maxSize: 100 });
+		await client.read();
+		await ehlo(client);
+		await client.write('MAIL FROM:<a@b.com> SIZE=100\r\n');
+		expect(await client.read()).toMatch(/^250 /);
+	});
+
+	it('matches the SIZE parameter keyword case-insensitively', async () => {
+		// RFC 5321 §2.4: ESMTP parameter keywords are case-insensitive.
+		// Reference: https://www.rfc-editor.org/rfc/rfc5321.html#section-2.4
+		const client = createClient({ maxSize: 100 });
+		await client.read();
+		await ehlo(client);
+		await client.write('MAIL FROM:<a@b.com> size=101\r\n');
+		expect(await client.read()).toBe(
+			'552 Message size exceeds fixed maximum message size\r\n'
+		);
+	});
+
+	it('rejects MAIL FROM with a malformed SIZE value', async () => {
+		// RFC 1870 §4 ABNF: size-value ::= 1*20DIGIT. A non-numeric
+		// value is a parameter syntax error (501).
+		// Reference: https://www.rfc-editor.org/rfc/rfc1870.html#section-4
+		const client = createClient({ maxSize: 100 });
+		await client.read();
+		await ehlo(client);
+		await client.write('MAIL FROM:<a@b.com> SIZE=12x\r\n');
+		expect(await client.read()).toMatch(/^501 /);
+	});
+
+	it('aborts a previous transaction when a new MAIL FROM is rejected', async () => {
+		// RFC 1870 §6.1: after a 552 SIZE rejection "the transaction
+		// never starts" — including any transaction left over from an
+		// earlier MAIL command. Without this, DATA could flush an
+		// envelope the client believes was rejected.
+		// Reference: https://www.rfc-editor.org/rfc/rfc1870.html#section-6.1
+		const client = createClient({ maxSize: 100 });
+		await client.read();
+		await ehlo(client);
+		await client.write('MAIL FROM:<a@b.com>\r\n');
+		expect(await client.read()).toMatch(/^250 /);
+		await client.write('RCPT TO:<c@d.com>\r\n');
+		expect(await client.read()).toMatch(/^250 /);
+		await client.write('MAIL FROM:<e@f.com> SIZE=101\r\n');
+		expect(await client.read()).toMatch(/^552 /);
+		await client.write('DATA\r\n');
+		expect(await client.read()).toMatch(/^503 /);
+		expect(client.messages).toHaveLength(0);
+	});
+
+	it('rejects MAIL FROM with a malformed ESMTP parameter token', async () => {
+		// RFC 5321 §4.1.1.2 ABNF: esmtp-keyword starts with ALPHA or
+		// DIGIT. The sink ignores unrecognized keywords, but a token
+		// that violates the grammar is a 501 syntax error.
+		// Reference: https://www.rfc-editor.org/rfc/rfc5321.html#section-4.1.1.2
+		const client = createClient();
+		await client.read();
+		await ehlo(client);
+		await client.write('MAIL FROM:<a@b.com> !!garbage\r\n');
+		expect(await client.read()).toMatch(/^501 /);
+	});
+
+	it('validates RCPT TO ESMTP parameters with the same grammar', async () => {
+		// RFC 5321 §4.1.1.3: Rcpt-parameters share the esmtp-param
+		// grammar. Well-formed keywords are ignored; malformed tokens
+		// are a 501 syntax error.
+		// Reference: https://www.rfc-editor.org/rfc/rfc5321.html#section-4.1.1.3
+		const client = createClient();
+		await client.read();
+		await ehlo(client);
+		await client.write('MAIL FROM:<a@b.com>\r\n');
+		expect(await client.read()).toMatch(/^250 /);
+		await client.write('RCPT TO:<c@d.com> NOTIFY=SUCCESS\r\n');
+		expect(await client.read()).toMatch(/^250 /);
+		await client.write('RCPT TO:<c@d.com> =broken\r\n');
+		expect(await client.read()).toMatch(/^501 /);
+	});
+
+	it('rejects RCPT before MAIL', async () => {
+		// RFC 5321 §3.3 + §4.1.1.3: RCPT TO can only follow a MAIL
+		// FROM in the current transaction; otherwise the server
+		// answers 503 "Bad sequence of commands".
+		// References:
+		// - https://www.rfc-editor.org/rfc/rfc5321.html#section-3.3
+		// - https://www.rfc-editor.org/rfc/rfc5321.html#section-4.1.1.3
+		const client = createClient();
+		await client.read();
+		await ehlo(client);
+		await client.write('RCPT TO:<a@b.com>\r\n');
+		const resp = await client.read();
+		expect(resp).toBe('503 Bad sequence of commands\r\n');
+	});
+
+	it('rejects DATA before MAIL/RCPT', async () => {
+		// RFC 5321 §3.3 + §4.1.1.4: DATA requires at least one
+		// successful RCPT (which itself requires a MAIL FROM); else
+		// the server answers 503 "Bad sequence of commands".
+		// References:
+		// - https://www.rfc-editor.org/rfc/rfc5321.html#section-3.3
+		// - https://www.rfc-editor.org/rfc/rfc5321.html#section-4.1.1.4
+		const client = createClient();
+		await client.read();
+		await ehlo(client);
+		await client.write('DATA\r\n');
+		const resp = await client.read();
+		expect(resp).toBe('503 Bad sequence of commands\r\n');
+	});
+
+	it('QUIT returns 221 and closes', async () => {
+		// RFC 5321 §4.1.1.10: the receiver MUST send "221 <domain>
+		// Service closing transmission channel" and then close the
+		// transmission channel.
+		// Reference: https://www.rfc-editor.org/rfc/rfc5321.html#section-4.1.1.10
+		const client = createClient();
+		const greeting = await client.read();
+		const serverDomain = getServerDomainFromGreeting(greeting);
+		await ehlo(client);
+		await client.write('QUIT\r\n');
+		const resp = await client.read();
+		expect(resp).toBe(
+			`221 ${serverDomain} Service closing transmission channel\r\n`
+		);
+	});
+});
+
+describe('SmtpSink – data handling', () => {
+	it('handles dot-stuffing (lines starting with ..)', async () => {
+		// RFC 5321 §4.5.2 (transparency): a leading "." on a body line
+		// is doubled by the sender and stripped by the receiver so the
+		// end-of-data marker (a bare "." line) cannot be confused with
+		// content.
+		// Reference: https://www.rfc-editor.org/rfc/rfc5321.html#section-4.5.2
+		const client = createClient();
+		await client.read();
+		await ehlo(client);
+		await client.write('MAIL FROM:<a@b.com>\r\n');
+		await client.read();
+		await client.write('RCPT TO:<c@d.com>\r\n');
+		await client.read();
+		await client.write('DATA\r\n');
+		await client.read();
+		await client.write('Subject: Dots\r\n');
+		await client.write('\r\n');
+		// A line that starts with a dot must be dot-stuffed by the client
+		await client.write('..This line started with a dot.\r\n');
+		await client.write('Normal line.\r\n');
+		await client.write('.\r\n');
+		await client.read(); // 250 Queued
+
+		expect(client.messages).toHaveLength(1);
+		expect(client.messages[0].text).toContain(
+			'.This line started with a dot.'
+		);
+		expect(client.messages[0].text).toContain('Normal line.');
+	});
+
+	it('rejects message exceeding maxSize', async () => {
+		// RFC 1870 §6.3: when the message exceeds the declared SIZE, the
+		// server returns 552 after the end-of-data marker.
+		// Reference: https://www.rfc-editor.org/rfc/rfc1870.html#section-6.3
+		const client = createClient({ maxSize: 100 });
+		await client.read();
+		await ehlo(client);
+		await client.write('MAIL FROM:<a@b.com>\r\n');
+		await client.read();
+		await client.write('RCPT TO:<c@d.com>\r\n');
+		await client.read();
+		await client.write('DATA\r\n');
+		await client.read();
+		await client.write('Subject: Big\r\n');
+		await client.write('\r\n');
+		await client.write('X'.repeat(200) + '\r\n');
+		await client.write('.\r\n');
+		const resp = await client.read();
+		expect(resp).toBe(
+			'552 Message size exceeds fixed maximum message size\r\n'
+		);
+		expect(client.messages).toHaveLength(0);
+	});
+
+	it('drains DATA after maxSize overflow and keeps session usable', async () => {
+		// Regression: issuing 552 before end-of-data flips out of
+		// dataMode, so remaining body lines are parsed as SMTP commands
+		// and the session is poisoned. RFC 1870 §6.3 requires the 552
+		// to come *after* the end-of-data marker.
+		// Reference: https://www.rfc-editor.org/rfc/rfc1870.html#section-6.3
+		const client = createClient({ maxSize: 100 });
+		await client.read();
+		await ehlo(client);
+		await client.write('MAIL FROM:<a@b.com>\r\n');
+		await client.read();
+		await client.write('RCPT TO:<c@d.com>\r\n');
+		await client.read();
+		await client.write('DATA\r\n');
+		await client.read();
+
+		let body = 'Subject: Big\r\n\r\n';
+		for (let i = 0; i < 200; i++) body += `line${i}\r\n`;
+		body += '.\r\n';
+		await client.write(body);
+
+		expect(await client.read()).toBe(
+			'552 Message size exceeds fixed maximum message size\r\n'
+		);
+		expect(client.messages).toHaveLength(0);
+
+		await client.write('MAIL FROM:<a@b.com>\r\n');
+		expect(await client.read()).toMatch(/^250 /);
+		await client.write('RCPT TO:<c@d.com>\r\n');
+		expect(await client.read()).toMatch(/^250 /);
+		await client.write('DATA\r\n');
+		expect(await client.read()).toMatch(/^354 /);
+		await client.write('Subject: Small\r\n\r\nbody\r\n.\r\n');
+		expect(await client.read()).toMatch(/^250 /);
+
+		expect(client.messages).toHaveLength(1);
+		expect(client.messages[0].subject).toBe('Small');
+	});
+
+	it('accepts the null reverse-path MAIL FROM:<> for bounce messages', async () => {
+		// RFC 5321 §4.5.5: bounce messages use a null reverse-path,
+		// `MAIL FROM:<>`. extractPath previously rejected `<>` and
+		// `mailFrom` was left in an undefined state that broke RCPT.
+		// Reference: https://www.rfc-editor.org/rfc/rfc5321.html#section-4.5.5
+		const client = createClient();
+		await client.read();
+		await ehlo(client);
+		await client.write('MAIL FROM:<>\r\n');
+		expect(await client.read()).toMatch(/^250 /);
+		await client.write('RCPT TO:<postmaster@local>\r\n');
+		expect(await client.read()).toMatch(/^250 /);
+		await client.write('DATA\r\n');
+		expect(await client.read()).toMatch(/^354 /);
+		await client.write('Subject: Bounce\r\n\r\nDelivery failed.\r\n.\r\n');
+		expect(await client.read()).toMatch(/^250 /);
+		expect(client.messages).toHaveLength(1);
+		// Empty envelope-from is preserved (not the literal string "<>").
+		// The parsed `from` falls back to the envelope value when no
+		// From: header is present, so it should be empty here.
+		expect(client.messages[0].from).toBe('');
+	});
+
+	it('sends multiple emails in one session', async () => {
+		// RFC 5321 §3.3: a transaction starts with MAIL, accepts one
+		// or more RCPTs, and is committed by DATA followed by the
+		// end-of-data marker. A session may carry further transactions
+		// without re-issuing HELO/EHLO; the spec contemplates this
+		// when it lets a new MAIL command (or RSET) reset all state
+		// tables and buffers.
+		// Reference: https://www.rfc-editor.org/rfc/rfc5321.html#section-3.3
+		const client = createClient();
+		await client.read();
+		await ehlo(client);
+
+		await client.write('MAIL FROM:<s@test.com>\r\n');
+		expect(await client.read()).toMatch(/^250 /);
+		await client.write('RCPT TO:<a@test.com>\r\n');
+		expect(await client.read()).toMatch(/^250 /);
+		await client.write('DATA\r\n');
+		expect(await client.read()).toMatch(/^354 /);
+		await client.write('Subject: First\r\n\r\nBody 1\r\n.\r\n');
+		expect(await client.read()).toMatch(/^250 /);
+
+		await client.write('MAIL FROM:<s@test.com>\r\n');
+		expect(await client.read()).toMatch(/^250 /);
+		await client.write('RCPT TO:<b@test.com>\r\n');
+		expect(await client.read()).toMatch(/^250 /);
+		await client.write('DATA\r\n');
+		expect(await client.read()).toMatch(/^354 /);
+		await client.write('Subject: Second\r\n\r\nBody 2\r\n.\r\n');
+		expect(await client.read()).toMatch(/^250 /);
+
+		expect(client.messages).toHaveLength(2);
+		expect(client.messages[0].subject).toBe('First');
+		expect(client.messages[1].subject).toBe('Second');
+	});
+});
+
+describe('parseMessage', () => {
+	const PDF_BYTES = encoder.encode('%PDF-fake');
+
+	it('parses a simple text/plain email', async () => {
+		const raw =
+			'Subject: Hello\r\n' +
+			'From: Sender <a@b.com>\r\n' +
+			'To: Recipient <c@d.com>\r\n' +
+			'X-Test: one\r\n' +
+			'X-Test: two\r\n' +
+			'\r\n' +
+			'Body text here.\r\n';
+		const result = await parseMessage(raw, 'fallback@x.com', ['fb@y.com']);
+		expect(result.subject).toBe('Hello');
+		expect(result.from).toBe('Sender <a@b.com>');
+		expect(result.to).toBe('Recipient <c@d.com>');
+		expect(result.headers['x-test']).toBe('one, two');
+		expect(result.text?.trim()).toBe('Body text here.');
+		expect(result.attachments).toEqual([]);
+	});
+
+	it('falls back to the SMTP envelope when message headers are missing', async () => {
+		const result = await parseMessage(
+			'Subject: No addrs\r\n\r\nBody.\r\n',
+			'env@from.com',
+			['a@b.com', 'c@d.com']
+		);
+
+		expect(result.from).toBe('env@from.com');
+		expect(result.to).toBe('a@b.com, c@d.com');
+	});
+
+	it('shows (no subject) when Subject header is missing', async () => {
+		const result = await parseMessage(
+			'From: a@b.com\r\n\r\nBody.\r\n',
+			'',
+			[]
+		);
+
+		expect(result.subject).toBe('(no subject)');
+	});
+
+	it('decodes RFC 2047 encoded headers', async () => {
+		const raw =
+			'From: =?utf-8?Q?J=C3=B6rg?= <sender@example.com>\r\n' +
+			'To: recipient@example.com\r\n' +
+			'Subject: =?utf-8?B?w5xuw69jw7ZkZQ==?=\r\n' +
+			'\r\n' +
+			'Body.\r\n';
+		const result = await parseMessage(raw, '', []);
+
+		expect(result.from).toBe('Jörg <sender@example.com>');
+		expect(result.subject).toBe('Ünïcöde');
+	});
+
+	it('decodes quoted-printable and base64 body parts', async () => {
+		const boundary = 'ALT';
+		const raw =
+			`Subject: Both\r\n` +
+			`Content-Type: multipart/alternative; boundary="${boundary}"\r\n` +
+			`\r\n` +
+			`--${boundary}\r\n` +
+			`Content-Type: text/plain; charset=utf-8\r\n` +
+			`Content-Transfer-Encoding: quoted-printable\r\n` +
+			`\r\n` +
+			`Caf=C3=A9\r\n` +
+			`--${boundary}\r\n` +
+			`Content-Type: text/html; charset=utf-8\r\n` +
+			`Content-Transfer-Encoding: base64\r\n` +
+			`\r\n` +
+			encodeUint8ArrayAsBase64(encoder.encode('<p>Café</p>')) +
+			`\r\n--${boundary}--\r\n`;
+		const result = await parseMessage(raw, '', []);
+
+		expect(result.text?.trim()).toBe('Café');
+		expect(result.html?.trim()).toBe('<p>Café</p>');
+	});
+
+	it('decodes attachments from nested multipart messages', async () => {
+		const outer = 'OUTER';
+		const inner = 'INNER';
+		const raw =
+			`Subject: Nested\r\n` +
+			`Content-Type: multipart/mixed; boundary="${outer}"\r\n` +
+			`\r\n` +
+			`--${outer}\r\n` +
+			`Content-Type: multipart/alternative; boundary="${inner}"\r\n` +
+			`\r\n` +
+			`--${inner}\r\n` +
+			`Content-Type: text/plain; charset=utf-8\r\n\r\nPlain body.\r\n` +
+			`--${inner}\r\n` +
+			`Content-Type: text/html; charset=utf-8\r\n\r\n<p>HTML body.</p>\r\n` +
+			`--${inner}--\r\n` +
+			`--${outer}\r\n` +
+			`Content-Type: application/pdf; name="invoice.pdf"\r\n` +
+			`Content-Transfer-Encoding: base64\r\n` +
+			`Content-Disposition: attachment; filename="invoice.pdf"\r\n` +
+			`\r\n` +
+			encodeUint8ArrayAsBase64(PDF_BYTES) +
+			`\r\n--${outer}--\r\n`;
+		const result = await parseMessage(raw, '', []);
+
+		expect(result.text?.trim()).toBe('Plain body.');
+		expect(result.html?.trim()).toBe('<p>HTML body.</p>');
+		expect(result.attachments).toHaveLength(1);
+		const attachment = result.attachments[0];
+		expect(attachment.filename).toBe('invoice.pdf');
+		expect(attachment.contentType).toBe('application/pdf');
+		expect(attachment.contentDisposition).toBe('attachment');
+		expect(attachment.content).toEqual(PDF_BYTES);
+		expect(attachment.size).toBe(PDF_BYTES.byteLength);
+	});
+
+	it('collects inline related resources as attachments', async () => {
+		const boundary = 'REL';
+		const pngBytes = encoder.encode('PNGDATA');
+		const raw =
+			`Subject: Inline image\r\n` +
+			`Content-Type: multipart/related; boundary="${boundary}"\r\n` +
+			`\r\n` +
+			`--${boundary}\r\n` +
+			`Content-Type: text/html; charset=utf-8\r\n\r\n<img src="cid:logo">\r\n` +
+			`--${boundary}\r\n` +
+			`Content-Type: image/png; name="logo.png"\r\n` +
+			`Content-Transfer-Encoding: base64\r\n` +
+			`Content-Disposition: inline; filename="logo.png"\r\n` +
+			`Content-ID: <logo>\r\n` +
+			`\r\n` +
+			encodeUint8ArrayAsBase64(pngBytes) +
+			`\r\n--${boundary}--\r\n`;
+		const result = await parseMessage(raw, '', []);
+
+		expect(result.html?.trim()).toBe('<img src="cid:logo">');
+		expect(result.attachments).toHaveLength(1);
+		expect(result.attachments[0].filename).toBe('logo.png');
+		expect(result.attachments[0].contentDisposition).toBe('inline');
+		expect(result.attachments[0].contentId).toBe('logo');
+		expect(result.attachments[0].content).toEqual(pngBytes);
+	});
+
+	it('parses Uint8Array raw email input', async () => {
+		const raw = encoder.encode(
+			'Subject: Bytes\r\n\r\nBody from bytes.\r\n'
+		);
+		const result = await parseMessage(raw, '', []);
+
+		expect(result.subject).toBe('Bytes');
+		expect(result.text?.trim()).toBe('Body from bytes.');
+	});
+});

--- a/packages/php-wasm/util/src/lib/smtp.ts
+++ b/packages/php-wasm/util/src/lib/smtp.ts
@@ -1,0 +1,1007 @@
+import PostalMime from 'postal-mime';
+import type {
+	Address as PostalAddress,
+	Attachment as PostalAttachment,
+	Email as PostalEmail,
+	RawEmail as PostalRawEmail,
+} from 'postal-mime';
+import { decodeBase64ToString, encodeStringAsBase64 } from './base64';
+
+/**
+ * A pair of byte streams representing one endpoint of a bidirectional
+ * connection.
+ *
+ * Data flow is intentionally from the endpoint owner's point of view:
+ *
+ * - bytes read from `readable` were written by the peer
+ * - bytes written to `writable` become readable by the peer
+ *
+ * `makeLoopbackPair()` returns two connected endpoints with opposite flow.
+ */
+export type ByteDuplex = {
+	readable: ReadableStream<Uint8Array>;
+	writable: WritableStream<Uint8Array>;
+};
+
+/**
+ * A non-body MIME part captured from a message: a regular attachment or an
+ * inline resource such as a `cid:` image.
+ */
+export type CaughtAttachment = {
+	/** Decoded filename from the parsed MIME part metadata. */
+	filename?: string;
+	/** Lower-cased media type without parameters, e.g. `application/pdf`. */
+	contentType: string;
+	/**
+	 * Lower-cased `Content-Disposition` type token with parameters stripped,
+	 * or `''` when the header is absent or carries no parseable token.
+	 */
+	contentDisposition: string;
+	/**
+	 * `Content-ID` value with one pair of surrounding angle brackets
+	 * stripped, so `<logo>` matches `cid:logo` references. Absent when the
+	 * header is missing.
+	 */
+	contentId?: string;
+	/** Parsed part headers as a lower-cased name/value map, when available. */
+	headers: Record<string, string>;
+	/**
+	 * Decoded bytes. Survives structured clone (postMessage/comlink) but not
+	 * `JSON.stringify` — JSON consumers must base64-encode it themselves.
+	 */
+	content: Uint8Array;
+	/** Decoded byte length, so serialized views can report sizes. */
+	size: number;
+};
+
+/**
+ * Message captured by `SmtpSink` after a complete SMTP DATA transaction.
+ */
+export type CaughtMessage = {
+	receivedAt: string;
+	from: string;
+	to: string;
+	subject: string;
+	headers: Record<string, string>;
+	/**
+	 * Decoded text/plain body part. In multipart/alternative messages this is
+	 * separate from the richer text/html alternative.
+	 */
+	text?: string;
+	/**
+	 * Decoded text/html body part. Mail clients typically render this when
+	 * available and fall back to text/plain.
+	 */
+	html?: string;
+	/**
+	 * Non-body MIME parts in message order. Empty when the message carries
+	 * no attachments.
+	 */
+	attachments: CaughtAttachment[];
+	raw: string;
+	rawSize: number;
+};
+
+/**
+ * SASL authentication mechanisms implemented by this test SMTP sink.
+ */
+export type SaslMechanism = 'PLAIN' | 'LOGIN';
+
+// Server identifier used in the 220 greeting and as the Domain token in the
+// EHLO/HELO 250 response. RFC 5321 §4.1.1.1 requires that token to be a Domain:
+// https://www.rfc-editor.org/rfc/rfc5321.html#section-4.1.1.1
+//
+// Use a stable Domain token for test-only SMTP sessions. It is emitted in the
+// 220/250 greeting only; this sink still runs over an in-process loopback
+// duplex and does not provide DNS or TLS identity.
+const SERVER_NAME = 'playground.wordpress.net';
+
+// RFC 5321 defines reply *codes* as protocol semantics and reply text as
+// human-readable context. Use RFC 5321/1870/4954 text where available, and
+// the generic code text where a command-specific phrase is unnecessary.
+const SMTP_REPLY_TEXT = {
+	serviceReady: `${SERVER_NAME} ESMTP Service Ready`,
+	ok: 'OK',
+	syntaxError: 'Syntax error in parameters or arguments',
+	commandUnrecognized: 'Syntax error, command unrecognized',
+	commandNotImplemented: 'Command not implemented',
+	badSequence: 'Bad sequence of commands',
+	startMailInput: 'Start mail input; end with <CRLF>.<CRLF>',
+	cannotVrfyUser:
+		'Cannot VRFY user, but will accept message and attempt delivery',
+	messageSizeExceeded: 'Message size exceeds fixed maximum message size',
+	authSucceeded: '2.7.0 Authentication Succeeded',
+	authCredentialsInvalid: '5.7.8 Authentication credentials invalid',
+	authRequired: '5.7.0 Authentication required',
+	authCanceled: '5.7.0 Authentication canceled',
+	authTypeUnrecognized: '5.5.4 Unrecognized authentication type',
+} as const;
+
+/**
+ * Validates credentials provided through SMTP AUTH.
+ */
+export type AuthValidator = (
+	mechanism: SaslMechanism,
+	credentials: { username: string; password: string }
+) => boolean | Promise<boolean>;
+
+export const DEFAULT_SMTP_MAX_SIZE = 10 * 1024 * 1024;
+
+/**
+ * Configuration for `SmtpSink`.
+ */
+export type SmtpSinkOptions = {
+	/**
+	 * Maximum accepted message size in octets. Advertised as the RFC 1870
+	 * SIZE fixed maximum, not as the current message's actual size.
+	 *
+	 * https://www.rfc-editor.org/rfc/rfc1870.html#section-3
+	 */
+	maxSize?: number;
+	auth?: {
+		/** SASL mechanisms to offer. */
+		mechanisms?: SaslMechanism[];
+		/** Whether to show AUTH in the EHLO extension list. */
+		advertise?: boolean;
+		/** Whether MAIL/RCPT require successful AUTH first. */
+		requireAuth?: boolean;
+		/** Credential validator. The default accepts any credentials. */
+		validator?: AuthValidator;
+	};
+};
+
+/**
+ * SMTP server sink that receives emails and invokes a callback for
+ * each fully-received message.
+ */
+export class SmtpSink {
+	private encoder = new TextEncoder();
+	private decoder = new TextDecoder();
+	private lineBuffer = '';
+	private dataMode = false;
+	private dataLines: string[] = [];
+	private dataBytes = 0;
+	private mailFrom: string | null = null;
+	private recipientPaths: string[] = [];
+	private writer: WritableStreamDefaultWriter<Uint8Array>;
+	private reader: ReadableStreamDefaultReader<Uint8Array>;
+	private closed = false;
+	private readonly maxSize: number;
+
+	// Commands may trigger async AUTH validators. Queue handlers so SMTP replies
+	// are written in the same order as the CRLF-terminated commands arrived.
+	private writeQueue: Promise<void> = Promise.resolve();
+
+	// AUTH policy
+	private authAdvertise: boolean;
+	private authMechanisms: SaslMechanism[];
+	private authRequire: boolean;
+	private authValidator: AuthValidator;
+	private authenticated = false;
+	private authPending = false;
+	private authState:
+		| { mechanism: 'PLAIN'; stage: 'waitInitial' }
+		| {
+				mechanism: 'LOGIN';
+				stage: 'username' | 'password';
+				username?: string;
+		  }
+		| null = null;
+
+	private onEmail: (message: CaughtMessage) => void;
+
+	constructor(
+		duplex: ByteDuplex,
+		onEmail: (message: CaughtMessage) => void,
+		options: SmtpSinkOptions = {}
+	) {
+		this.onEmail = onEmail;
+		this.writer = duplex.writable.getWriter();
+		this.reader = duplex.readable.getReader();
+		this.maxSize = options.maxSize ?? DEFAULT_SMTP_MAX_SIZE;
+
+		this.authMechanisms = options.auth?.mechanisms ?? [];
+		this.authAdvertise =
+			options.auth?.advertise ?? this.authMechanisms.length > 0;
+		this.authRequire = options.auth?.requireAuth ?? false;
+		this.authValidator = options.auth?.validator ?? (async () => true);
+	}
+
+	/**
+	 * Starts reading SMTP commands from the duplex until QUIT, stream close,
+	 * or protocol rejection closes the sink.
+	 */
+	async start(): Promise<void> {
+		// RFC 5321 §4.3.2: the server sends 220 before accepting commands.
+		// https://www.rfc-editor.org/rfc/rfc5321.html#section-4.3.2
+		await this.reply(220, SMTP_REPLY_TEXT.serviceReady);
+		while (true) {
+			const readResult = await this.reader.read();
+			if (readResult.done) break;
+			this.consumeChunk(readResult.value);
+			if (this.closed) break;
+		}
+		// Wait for all enqueued handlers to finish before closing
+		// the writer. When the client closes the connection, the
+		// reader gets done immediately, but enqueued handlers
+		// (like handleDataLine(".") which delivers the email) may
+		// still be pending in the promise chain.
+		await this.writeQueue;
+		await this.close();
+	}
+
+	private async close(): Promise<void> {
+		if (this.closed) return;
+		this.closed = true;
+		await Promise.allSettled([this.writer.close(), this.reader.cancel()]);
+	}
+
+	private consumeChunk(chunk: Uint8Array) {
+		if (this.closed) return;
+		const text = this.decoder.decode(chunk, { stream: true });
+		this.lineBuffer += text;
+
+		while (true) {
+			// SMTP is line-oriented and commands/data lines are terminated with
+			// CRLF, not bare LF:
+			// https://www.rfc-editor.org/rfc/rfc5321.html#section-2.3.8
+			const crlfIndex = this.lineBuffer.indexOf('\r\n');
+			if (crlfIndex < 0) break;
+			const line = this.lineBuffer.slice(0, crlfIndex);
+			this.lineBuffer = this.lineBuffer.slice(crlfIndex + 2);
+
+			this.queueHandler(async () => {
+				if (this.closed) return;
+				if (
+					this.encoder.encode(line).byteLength + 2 >
+					this.currentLineLimit()
+				) {
+					await this.reply(500, SMTP_REPLY_TEXT.commandUnrecognized);
+					await this.close();
+					return;
+				}
+				if (this.dataMode) {
+					await this.handleDataLine(line);
+				} else if (this.authPending) {
+					await this.handleAuthLine(line);
+				} else {
+					await this.handleCommand(line);
+				}
+			});
+			if (this.closed) return;
+		}
+
+		// RFC 5321 caps command lines at 512 octets and DATA text lines at
+		// 1000 octets, both including CRLF. RFC 4954 allows AUTH responses
+		// up to 12288 octets including CRLF.
+		// https://www.rfc-editor.org/rfc/rfc5321.html#section-4.5.3.1.4
+		// https://www.rfc-editor.org/rfc/rfc5321.html#section-4.5.3.1.6
+		// https://www.rfc-editor.org/rfc/rfc4954.html#section-4
+		if (
+			this.encoder.encode(this.lineBuffer).byteLength + 2 >
+			this.currentLineLimit()
+		) {
+			this.lineBuffer = '';
+			this.queueHandler(async () => {
+				await this.reply(500, SMTP_REPLY_TEXT.commandUnrecognized);
+				await this.close();
+			});
+		}
+	}
+
+	private currentLineLimit(): number {
+		if (this.dataMode) return 1000;
+		if (this.authPending) return 12288;
+		return 512;
+	}
+
+	private queueHandler(handler: () => Promise<void>) {
+		this.writeQueue = this.writeQueue.then(handler);
+	}
+
+	private async handleCommand(rawLine: string) {
+		const line = rawLine.trimEnd();
+		// SMTP command lines use protocol ABNF, not shell quoting. Splitting at
+		// the first space preserves the rest for command-specific RFC parsing.
+		const commandSeparator = line.indexOf(' ');
+		const command = (
+			commandSeparator < 0 ? line : line.slice(0, commandSeparator)
+		).toUpperCase();
+		const commandArgument =
+			commandSeparator < 0 ? '' : line.slice(commandSeparator + 1);
+
+		switch (command) {
+			case 'EHLO':
+			case 'HELO': {
+				// RFC 5321 §4.1.1.1 ABNF: both `helo` and `ehlo`
+				// require a Domain (or address-literal for EHLO)
+				// argument; an empty argument is a syntax error.
+				// https://www.rfc-editor.org/rfc/rfc5321.html#section-4.1.1.1
+				if (!commandArgument.trim()) {
+					await this.reply(501, SMTP_REPLY_TEXT.syntaxError);
+					break;
+				}
+				// RFC 5321 §4.1.4: a successful EHLO/HELO issued mid-
+				// session MUST clear all buffers and reset state exactly
+				// as RSET would. Auth state is preserved (RFC 4954 §4).
+				// https://www.rfc-editor.org/rfc/rfc5321.html#section-4.1.4
+				this.resetEnvelope();
+				if (command === 'HELO') {
+					// RFC 5321 §4.1.1.1 ABNF:
+					//   ehlo-ok-rsp = "250" SP Domain [ SP ehlo-greet ]
+					// HELO uses the same single-line form. The first
+					// token after the reply code MUST be the server's
+					// Domain, optionally followed by free-form text.
+					await this.reply(
+						250,
+						`${SERVER_NAME} Hello ${commandArgument}`
+					);
+					break;
+				}
+				// RFC 5321 §4.1.1.1 ABNF for the multi-line response:
+				//   "250-" Domain [ SP ehlo-greet ] CRLF
+				//   *( "250-" ehlo-line CRLF )
+				//   "250" SP ehlo-line CRLF
+				// The first line therefore starts with the server's
+				// Domain, never with free-form text.
+				const extensions: string[] = [];
+				if (this.authAdvertise && this.authMechanisms.length) {
+					const authMechanismList = this.authMechanisms.join(' ');
+					extensions.push(
+						`AUTH ${authMechanismList}`,
+						`AUTH=${authMechanismList}`
+					);
+				}
+				// RFC 1870 §3: SIZE parameter is the maximum message size the
+				// server will accept.
+				// https://www.rfc-editor.org/rfc/rfc1870.html#section-3
+				extensions.push(`SIZE ${this.maxSize}`, 'PIPELINING');
+				await this.replyMulti(250, [
+					`${SERVER_NAME} Hello ${commandArgument}`,
+					...extensions,
+				]);
+				break;
+			}
+
+			case 'STARTTLS': {
+				// The loopback duplex carries no real network traffic, so
+				// there is nothing to encrypt. STARTTLS is never advertised
+				// in EHLO and is always refused with 502 "Command not
+				// implemented" if a client tries it anyway:
+				// https://www.rfc-editor.org/rfc/rfc5321.html#section-4.2.4
+				// Clients with strict STARTTLS settings, such as PHPMailer
+				// SMTPSecure=ENCRYPTION_STARTTLS, must be configured for plain
+				// SMTP when talking to this sink. Opportunistic STARTTLS
+				// clients should not try STARTTLS because EHLO omits it.
+				// RFC 3207 §4 defines the STARTTLS command:
+				// https://www.rfc-editor.org/rfc/rfc3207.html#section-4
+				await this.reply(502, SMTP_REPLY_TEXT.commandNotImplemented);
+				break;
+			}
+
+			case 'AUTH': {
+				// RFC 4954 §4 forbids AUTH during an active mail transaction.
+				// https://www.rfc-editor.org/rfc/rfc4954.html#section-4
+				if (this.mailFrom !== null || this.recipientPaths.length > 0) {
+					await this.reply(503, SMTP_REPLY_TEXT.badSequence);
+					break;
+				}
+				// RFC 4954 §4: `AUTH <mechanism> [<initial-response>]`. Match
+				// group 1 = mechanism (1-20 of letter/digit/-/_); group 2 =
+				// one optional non-whitespace token. base64 is validated on
+				// decode below, so we don't check it here. `=` means empty.
+				// https://www.rfc-editor.org/rfc/rfc4954.html#section-4
+				const authMatch = commandArgument.match(
+					/^([A-Za-z0-9_-]{1,20})(?: (\S*))?$/
+				);
+				if (!authMatch) {
+					await this.reply(501, SMTP_REPLY_TEXT.syntaxError);
+					break;
+				}
+				const mechanism = authMatch[1].toUpperCase() as SaslMechanism;
+				const arg = authMatch[2];
+				const initialResponse =
+					arg === undefined ? null : arg === '=' ? '' : arg || null;
+
+				if (this.authenticated) {
+					await this.reply(503, SMTP_REPLY_TEXT.badSequence);
+					break;
+				}
+
+				if (!this.authMechanisms.includes(mechanism)) {
+					await this.reply(504, SMTP_REPLY_TEXT.authTypeUnrecognized);
+					break;
+				}
+
+				if (mechanism === 'PLAIN') {
+					if (initialResponse == null) {
+						this.authPending = true;
+						this.authState = {
+							mechanism: 'PLAIN',
+							stage: 'waitInitial',
+						};
+						await this.reply(334, ''); // empty challenge
+					} else {
+						const isValid =
+							await this.handleAuthPlain(initialResponse);
+						if (isValid === null) {
+							await this.rejectAuthSyntax();
+						} else {
+							await this.finishAuth(isValid);
+						}
+					}
+					break;
+				}
+
+				if (mechanism === 'LOGIN') {
+					if (initialResponse != null) {
+						// The initial response is the username for AUTH LOGIN.
+						let username: string;
+						try {
+							username = decodeBase64ToString(initialResponse);
+						} catch {
+							await this.rejectAuthSyntax();
+							break;
+						}
+						this.authPending = true;
+						this.authState = {
+							mechanism: 'LOGIN',
+							stage: 'password',
+							username,
+						};
+						await this.reply(
+							334,
+							encodeStringAsBase64('Password:')
+						);
+					} else {
+						this.authPending = true;
+						this.authState = {
+							mechanism: 'LOGIN',
+							stage: 'username',
+						};
+						await this.reply(
+							334,
+							encodeStringAsBase64('Username:')
+						);
+					}
+					break;
+				}
+				break;
+			}
+
+			case 'MAIL': {
+				if (this.authRequire && !this.authenticated) {
+					await this.reply(530, SMTP_REPLY_TEXT.authRequired);
+					break;
+				}
+				// RFC 5321 §3.3 + §4.1.1.2: the syntax is exactly
+				// `MAIL FROM:<reverse-path>`. §3.3 explicitly forbids
+				// "spaces on either side of the colon", and the
+				// reverse-path MUST be enclosed in angle brackets (or
+				// be the literal `<>` for the null reverse-path,
+				// §4.5.5).
+				// https://www.rfc-editor.org/rfc/rfc5321.html#section-3.3
+				const envelope = parseEnvelopeArg(commandArgument, 'FROM');
+				if (envelope === null) {
+					await this.reply(501, SMTP_REPLY_TEXT.syntaxError);
+					break;
+				}
+				// RFC 5321 §4.1.1.2: Mail-parameters must match the
+				// esmtp-param grammar. Unknown keywords are ignored, but
+				// a malformed parameter list is still a syntax error.
+				const parameters = parseEsmtpParameters(envelope.parameters);
+				if (parameters === null) {
+					// The client tried to start a new transaction and
+					// failed; do not leave a previous envelope around for
+					// DATA to flush.
+					this.resetEnvelope();
+					await this.reply(501, SMTP_REPLY_TEXT.syntaxError);
+					break;
+				}
+				// RFC 1870 §6.1: the EHLO response advertises a fixed
+				// maximum message size, so a MAIL command declaring a
+				// larger SIZE is rejected up front with 552 and the
+				// transaction never starts — including any transaction
+				// left over from a previous MAIL command.
+				// https://www.rfc-editor.org/rfc/rfc1870.html#section-6.1
+				if ('SIZE' in parameters) {
+					const declaredSize = parameters['SIZE'];
+					// RFC 1870 §4: size-value ::= 1*20DIGIT.
+					// https://www.rfc-editor.org/rfc/rfc1870.html#section-4
+					// Use the exact grammar instead of number parsing, which
+					// would accept SMTP-invalid forms like `1e2` or `+12`.
+					if (!/^[0-9]{1,20}$/.test(declaredSize)) {
+						this.resetEnvelope();
+						await this.reply(501, SMTP_REPLY_TEXT.syntaxError);
+						break;
+					}
+					if (Number(declaredSize) > this.maxSize) {
+						this.resetEnvelope();
+						await this.reply(
+							552,
+							SMTP_REPLY_TEXT.messageSizeExceeded
+						);
+						break;
+					}
+				}
+				this.mailFrom = envelope.path;
+				this.recipientPaths = [];
+				await this.reply(250, SMTP_REPLY_TEXT.ok);
+				break;
+			}
+
+			case 'RCPT': {
+				if (this.authRequire && !this.authenticated) {
+					await this.reply(530, SMTP_REPLY_TEXT.authRequired);
+					break;
+				}
+				// RFC 5321 §3.3 + §4.1.1.3: the syntax is exactly
+				// `RCPT TO:<forward-path>`. Same no-space, mandatory-
+				// brackets rule as MAIL FROM.
+				// https://www.rfc-editor.org/rfc/rfc5321.html#section-4.1.1.3
+				const envelope = parseEnvelopeArg(commandArgument, 'TO');
+				if (envelope === null || envelope.path === '') {
+					await this.reply(501, SMTP_REPLY_TEXT.syntaxError);
+					break;
+				}
+				// RFC 5321 §4.1.1.3: Rcpt-parameters share the esmtp-param
+				// grammar. Keywords are ignored (this sink implements none),
+				// but a malformed parameter list is still a syntax error.
+				if (parseEsmtpParameters(envelope.parameters) === null) {
+					await this.reply(501, SMTP_REPLY_TEXT.syntaxError);
+					break;
+				}
+				// Explicit null check (not falsy): an empty string is a
+				// valid null reverse-path (`MAIL FROM:<>`, RFC 5321
+				// §4.5.5) and must not gate RCPT.
+				if (this.mailFrom === null) {
+					await this.reply(503, SMTP_REPLY_TEXT.badSequence);
+					break;
+				}
+				this.recipientPaths.push(envelope.path);
+				await this.reply(250, SMTP_REPLY_TEXT.ok);
+				break;
+			}
+
+			case 'DATA': {
+				// RFC 5321 §3.3: DATA begins mail content after a valid
+				// MAIL/RCPT envelope and is terminated by <CRLF>.<CRLF>.
+				// https://www.rfc-editor.org/rfc/rfc5321.html#section-3.3
+				if (
+					this.mailFrom === null ||
+					this.recipientPaths.length === 0
+				) {
+					await this.reply(503, SMTP_REPLY_TEXT.badSequence);
+					break;
+				}
+				await this.reply(354, SMTP_REPLY_TEXT.startMailInput);
+				this.dataMode = true;
+				this.dataLines = [];
+				this.dataBytes = 0;
+				break;
+			}
+
+			case 'RSET':
+				// RFC 5321 §4.1.1.5: abort the current mail transaction.
+				// https://www.rfc-editor.org/rfc/rfc5321.html#section-4.1.1.5
+				this.resetEnvelope();
+				await this.reply(250, SMTP_REPLY_TEXT.ok);
+				break;
+
+			case 'NOOP':
+				// RFC 5321 §4.1.1.9: NOOP has no effect except returning OK.
+				// https://www.rfc-editor.org/rfc/rfc5321.html#section-4.1.1.9
+				await this.reply(250, SMTP_REPLY_TEXT.ok);
+				break;
+
+			case 'VRFY':
+				// RFC 5321 §3.5.3: 252 means we cannot verify, but will accept mail.
+				// https://www.rfc-editor.org/rfc/rfc5321.html#section-3.5.3
+				await this.reply(252, SMTP_REPLY_TEXT.cannotVrfyUser);
+				break;
+
+			case 'QUIT':
+				// RFC 5321 §4.1.1.10: successful QUIT returns 221, then closes.
+				// https://www.rfc-editor.org/rfc/rfc5321.html#section-4.1.1.10
+				await this.reply(
+					221,
+					`${SERVER_NAME} Service closing transmission channel`
+				);
+				await this.close();
+				break;
+
+			case 'EXPN':
+			case 'HELP':
+			case 'TURN':
+				// RFC 5321 §4.2.4: 502 means recognized but not implemented.
+				// https://www.rfc-editor.org/rfc/rfc5321.html#section-4.2.4
+				await this.reply(502, SMTP_REPLY_TEXT.commandNotImplemented);
+				break;
+
+			default:
+				// RFC 5321 §4.2.4: 500 means the command was not recognized.
+				// https://www.rfc-editor.org/rfc/rfc5321.html#section-4.2.4
+				await this.reply(500, SMTP_REPLY_TEXT.commandUnrecognized);
+				break;
+		}
+	}
+
+	private async handleDataLine(line: string) {
+		if (line === '.') {
+			this.dataMode = false;
+			if (this.dataBytes > this.maxSize) {
+				// RFC 1870 §6.3: when the size overflow is discovered
+				// mid-stream, the 552 reply must come *after* the
+				// end-of-data marker. Anything else desyncs the session.
+				// https://www.rfc-editor.org/rfc/rfc1870.html#section-6.3
+				await this.reply(552, SMTP_REPLY_TEXT.messageSizeExceeded);
+				this.resetEnvelope();
+				return;
+			}
+			// Reassemble the on-wire payload: reader stripped the CRLF
+			// terminators when splitting lines, so re-join with CRLF (the
+			// SMTP line ending) and append one for the final line.
+			// https://www.rfc-editor.org/rfc/rfc5321.html#section-2.3.8
+			const raw = this.dataLines.join('\r\n') + '\r\n';
+			let message: CaughtMessage;
+			try {
+				message = {
+					receivedAt: new Date().toISOString(),
+					...(await parseMessage(
+						raw,
+						this.mailFrom ?? '',
+						this.recipientPaths
+					)),
+					raw,
+					rawSize: this.dataBytes,
+				};
+			} catch {
+				// A parser exception here would reject the writeQueue chain
+				// and silently drop every later command, desyncing the SMTP
+				// session. Deliver the unparsed message instead.
+				message = {
+					receivedAt: new Date().toISOString(),
+					from: this.mailFrom ?? '',
+					to: this.recipientPaths.join(', '),
+					subject: '(no subject)',
+					headers: {},
+					attachments: [],
+					raw,
+					rawSize: this.dataBytes,
+				};
+			}
+
+			this.onEmail(message);
+
+			await this.reply(250, SMTP_REPLY_TEXT.ok);
+			this.resetEnvelope();
+			return;
+		}
+
+		const actual = line.startsWith('..') ? line.slice(1) : line;
+		// RFC 5321 §4.5.2 transparency: clients dot-stuff body lines that
+		// start with "." so they cannot be mistaken for end-of-data.
+		// https://www.rfc-editor.org/rfc/rfc5321.html#section-4.5.2
+		this.dataBytes += this.encoder.encode(actual).byteLength + 2;
+		if (this.dataBytes <= this.maxSize) {
+			this.dataLines.push(actual);
+		}
+	}
+
+	private async handleAuthLine(line: string) {
+		if (!this.authState) {
+			this.authPending = false;
+			return;
+		}
+		// RFC 4954 §4: during a SASL exchange the client may send a
+		// single "*" to abort the authentication; the server must then
+		// reject it with a 501 rather than continuing the challenge.
+		// https://www.rfc-editor.org/rfc/rfc4954.html#section-4
+		if (line === '*') {
+			this.authPending = false;
+			this.authState = null;
+			await this.reply(501, SMTP_REPLY_TEXT.authCanceled);
+			return;
+		}
+
+		if (this.authState.mechanism === 'PLAIN') {
+			const isValid = await this.handleAuthPlain(line.trim());
+			if (isValid === null) {
+				await this.rejectAuthSyntax();
+			} else {
+				await this.finishAuth(isValid);
+			}
+			return;
+		}
+
+		if (this.authState.mechanism === 'LOGIN') {
+			if (this.authState.stage === 'username') {
+				let username: string;
+				try {
+					username = decodeBase64ToString(line.trim());
+				} catch {
+					await this.rejectAuthSyntax();
+					return;
+				}
+				this.authState = {
+					mechanism: 'LOGIN',
+					stage: 'password',
+					username,
+				};
+				await this.reply(334, encodeStringAsBase64('Password:'));
+				return;
+			}
+			if (this.authState.stage === 'password') {
+				let password: string;
+				try {
+					password = decodeBase64ToString(line.trim());
+				} catch {
+					await this.rejectAuthSyntax();
+					return;
+				}
+				const isValid = await this.authValidator('LOGIN', {
+					username: this.authState.username || '',
+					password,
+				});
+				await this.finishAuth(isValid);
+				return;
+			}
+		}
+	}
+
+	private async handleAuthPlain(
+		initialBase64: string
+	): Promise<boolean | null> {
+		let decoded: string;
+		try {
+			decoded = decodeBase64ToString(initialBase64);
+		} catch {
+			return null;
+		}
+		// formats: authzid\0authcid\0passwd  OR  \0authcid\0passwd
+		const parts = decoded.split('\u0000');
+		let username = '';
+		let password = '';
+		if (parts.length >= 3) {
+			username = parts[1] || '';
+			password = parts[2] || '';
+		} else if (parts.length === 2) {
+			username = parts[0] || '';
+			password = parts[1] || '';
+		} else {
+			return false;
+		}
+		return await this.authValidator('PLAIN', { username, password });
+	}
+
+	private async finishAuth(isValid: boolean) {
+		this.authPending = false;
+		this.authState = null;
+		if (isValid) {
+			this.authenticated = true;
+			await this.reply(235, SMTP_REPLY_TEXT.authSucceeded);
+		} else {
+			await this.reply(535, SMTP_REPLY_TEXT.authCredentialsInvalid);
+		}
+	}
+
+	private async rejectAuthSyntax() {
+		this.authPending = false;
+		this.authState = null;
+		await this.reply(501, SMTP_REPLY_TEXT.syntaxError);
+	}
+
+	private resetEnvelope() {
+		this.mailFrom = null;
+		this.recipientPaths = [];
+		this.dataMode = false;
+		this.dataLines = [];
+		this.dataBytes = 0;
+	}
+
+	private async reply(code: number, text: string) {
+		// RFC 5321 §4.2: a single-line reply is "<code> <text><CRLF>".
+		// https://www.rfc-editor.org/rfc/rfc5321.html#section-4.2
+		await this.writer.write(this.encoder.encode(`${code} ${text}\r\n`));
+	}
+	private async replyMulti(code: number, lines: string[]) {
+		// RFC 5321 §4.2: multi-line replies use "-" until the final SP line.
+		// https://www.rfc-editor.org/rfc/rfc5321.html#section-4.2
+		for (let i = 0; i < lines.length - 1; i++) {
+			await this.writer.write(
+				this.encoder.encode(`${code}-${lines[i]}\r\n`)
+			);
+		}
+		await this.writer.write(
+			this.encoder.encode(`${code} ${lines[lines.length - 1]}\r\n`)
+		);
+	}
+}
+
+/**
+ * Parses the argument of a MAIL or RCPT command into the envelope
+ * path and the trailing ESMTP parameter list. Returns `null` if the
+ * syntax does not match RFC 5321.
+ *
+ * RFC 5321 §3.3 + §4.1.1.2/3 require:
+ *   - the keyword (`FROM` or `TO`) is followed immediately by a
+ *     colon, with NO whitespace on either side ("a common source
+ *     of errors", §3.3)
+ *   - the path is enclosed in angle brackets, or is the literal
+ *     `<>` for the null reverse-path (§4.5.5)
+ *   - any ESMTP Mail-parameters that follow MUST be separated
+ *     from the closing `>` by a single space (RFC 1870, RFC 4954)
+ *
+ * https://www.rfc-editor.org/rfc/rfc5321.html#section-3.3
+ * https://www.rfc-editor.org/rfc/rfc5321.html#section-4.1.1.2
+ * https://www.rfc-editor.org/rfc/rfc5321.html#section-4.1.1.3
+ * https://www.rfc-editor.org/rfc/rfc5321.html#section-4.5.5
+ * https://www.rfc-editor.org/rfc/rfc1870.html#section-5
+ * https://www.rfc-editor.org/rfc/rfc4954.html#section-5
+ */
+export function parseEnvelopeArg(
+	commandArgument: string,
+	keyword: 'FROM' | 'TO'
+): { path: string; parameters: string } | null {
+	const prefix = `${keyword}:<`;
+	if (commandArgument.length < prefix.length + 1) return null;
+	if (commandArgument.slice(0, prefix.length).toUpperCase() !== prefix) {
+		return null;
+	}
+	const close = commandArgument.indexOf('>', prefix.length);
+	if (close < 0) return null;
+	// Anything past the closing bracket must either be empty or
+	// begin with a single space introducing ESMTP parameters.
+	const tail = commandArgument.slice(close + 1);
+	if (tail !== '' && !tail.startsWith(' ')) return null;
+	return {
+		path: commandArgument.slice(prefix.length, close),
+		parameters: tail.slice(1),
+	};
+}
+
+/**
+ * Parses a space-separated ESMTP command parameter list into an
+ * upper-cased keyword → value record, or `null` when any token violates
+ * the RFC 5321 §4.1.1.2 grammar:
+ *
+ *   esmtp-param   = esmtp-keyword ["=" esmtp-value]
+ *   esmtp-keyword = (ALPHA / DIGIT) *(ALPHA / DIGIT / "-")
+ *   esmtp-value   = 1*(%d33-60 / %d62-126) ; printable except "="
+ *
+ * A keyword without "=" maps to the empty string. This intentionally does
+ * not use `getHeaderParameter()` below: MIME headers use semicolon-separated
+ * parameters, while SMTP commands do not.
+ *
+ * https://www.rfc-editor.org/rfc/rfc5321.html#section-4.1.1.2
+ */
+function parseEsmtpParameters(
+	parameters: string
+): Record<string, string> | null {
+	const parsed: Record<string, string> = {};
+	if (parameters === '') return parsed;
+	for (const parameter of parameters.split(' ')) {
+		const match = parameter.match(
+			/^([A-Za-z0-9][A-Za-z0-9-]*)(?:=([\x21-\x3C\x3E-\x7E]+))?$/
+		);
+		if (!match) return null;
+		parsed[match[1].toUpperCase()] = match[2] ?? '';
+	}
+	return parsed;
+}
+
+/**
+ * Parses the message content received after SMTP DATA into convenient fields.
+ *
+ * The SMTP sink owns the transport protocol. RFC 5322/MIME interpretation is
+ * delegated to `postal-mime`, which supports browser and Node.js runtimes.
+ */
+export async function parseMessage(
+	raw: PostalRawEmail,
+	fallbackFrom: string,
+	fallbackRecipients: string[]
+): Promise<{
+	headers: Record<string, string>;
+	subject: string;
+	text?: string;
+	html?: string;
+	attachments: CaughtAttachment[];
+	from: string;
+	to: string;
+}> {
+	const parsed = await PostalMime.parse(raw, {
+		attachmentEncoding: 'arraybuffer',
+	});
+	const headers = mapHeaders(parsed);
+	const from = formatAddress(parsed.from) || fallbackFrom;
+	const to = formatRecipients(parsed) || fallbackRecipients.join(', ');
+	const subject = parsed.subject || '(no subject)';
+	const attachments = parsed.attachments.map(mapAttachment);
+	const text = parsed.text;
+	const html = parsed.html;
+	return { headers, subject, text, html, attachments, from, to };
+}
+
+function mapHeaders(parsed: PostalEmail): Record<string, string> {
+	const headers: Record<string, string> = {};
+	for (const header of parsed.headers) {
+		headers[header.key] = headers[header.key]
+			? `${headers[header.key]}, ${header.value}`
+			: header.value;
+	}
+	return headers;
+}
+
+function formatRecipients(parsed: PostalEmail): string {
+	const recipients = [
+		...(parsed.to || []),
+		...(parsed.cc || []),
+		...(parsed.bcc || []),
+	];
+	return formatAddresses(recipients);
+}
+
+function formatAddresses(addresses: PostalAddress[]): string {
+	return addresses.map(formatAddress).filter(Boolean).join(', ');
+}
+
+function formatAddress(address: PostalAddress | undefined): string {
+	if (!address) return '';
+	if ('group' in address && Array.isArray(address.group)) {
+		return formatAddresses(address.group);
+	}
+	if (!('address' in address) || !address.address) {
+		return '';
+	}
+	return address.name
+		? `${address.name} <${address.address}>`
+		: address.address;
+}
+
+function mapAttachment(attachment: PostalAttachment): CaughtAttachment {
+	const content = attachmentContentToUint8Array(attachment.content);
+	const contentId = attachment.contentId
+		? attachment.contentId.replace(/^<(.*)>$/, '$1')
+		: undefined;
+	return {
+		filename: attachment.filename || undefined,
+		contentType: attachment.mimeType.toLowerCase(),
+		contentDisposition: attachment.disposition || '',
+		contentId,
+		headers: {},
+		content,
+		size: content.byteLength,
+	};
+}
+
+function attachmentContentToUint8Array(
+	content: PostalAttachment['content']
+): Uint8Array {
+	if (content instanceof Uint8Array) {
+		return content;
+	}
+	if (content instanceof ArrayBuffer) {
+		return new Uint8Array(content);
+	}
+	return new TextEncoder().encode(content);
+}
+
+/**
+ * Creates two connected in-memory `ByteDuplex` endpoints.
+ *
+ * Bytes written to the first endpoint's `writable` are read from the second
+ * endpoint's `readable`, and vice versa.
+ */
+export function makeLoopbackPair(): [ByteDuplex, ByteDuplex] {
+	const firstToSecond = new TransformStream<Uint8Array, Uint8Array>();
+	const secondToFirst = new TransformStream<Uint8Array, Uint8Array>();
+	const first: ByteDuplex = {
+		readable: secondToFirst.readable,
+		writable: firstToSecond.writable,
+	};
+	const second: ByteDuplex = {
+		readable: firstToSecond.readable,
+		writable: secondToFirst.writable,
+	};
+	return [first, second];
+}

--- a/packages/php-wasm/web/src/lib/load-runtime.ts
+++ b/packages/php-wasm/web/src/lib/load-runtime.ts
@@ -7,6 +7,8 @@ import {
 	createLegacyPhpIniPreRunStep,
 	isLegacyPHPVersion,
 	loadPHPRuntime,
+	withMailCapture,
+	type WithMailCaptureOptions,
 } from '@php-wasm/universal';
 import { getPHPLoaderModule } from './get-php-loader-module';
 import type { TCPOverFetchOptions } from './tcp-over-fetch-websocket';
@@ -32,6 +34,10 @@ export interface LoaderOptions {
 	 * @deprecated Use `extensions: ['intl']` instead.
 	 */
 	withIntl?: boolean;
+	/**
+	 * Capture raw bytes written to sendmail stdin.
+	 */
+	withMailCapture?: WithMailCaptureOptions;
 }
 
 /**
@@ -93,6 +99,13 @@ export async function loadWebRuntime(
 		emscriptenOptions = tcpOverFetchWebsocket(
 			emscriptenOptions,
 			loaderOptions.tcpOverFetch
+		);
+	}
+
+	if (loaderOptions.withMailCapture) {
+		emscriptenOptions = withMailCapture(
+			loaderOptions.withMailCapture,
+			await emscriptenOptions
 		);
 	}
 

--- a/packages/php-wasm/web/src/lib/tls/certificates.ts
+++ b/packages/php-wasm/web/src/lib/tls/certificates.ts
@@ -1,4 +1,4 @@
-import { concatUint8Arrays } from '@php-wasm/util';
+import { concatUint8Arrays, encodeUint8ArrayAsBase64 } from '@php-wasm/util';
 
 /**
  * Generates an X.509 certificate from the given description.
@@ -24,14 +24,14 @@ export function generateCertificate(
 
 export function certificateToPEM(certificate: Uint8Array): string {
 	return `-----BEGIN CERTIFICATE-----\n${formatPEM(
-		encodeUint8ArrayAsBase64(certificate.buffer)
+		encodeUint8ArrayAsBase64(certificate)
 	)}\n-----END CERTIFICATE-----`;
 }
 
 export async function privateKeyToPEM(privateKey: CryptoKey): Promise<string> {
 	const pkcs8 = await crypto.subtle.exportKey('pkcs8', privateKey);
 	return `-----BEGIN PRIVATE KEY-----\n${formatPEM(
-		encodeUint8ArrayAsBase64(pkcs8)
+		encodeUint8ArrayAsBase64(new Uint8Array(pkcs8))
 	)}\n-----END PRIVATE KEY-----`;
 }
 
@@ -708,11 +708,6 @@ export type GeneratedCertificate = {
 	tbsDescription: TBSCertificateDescription;
 	tbsCertificate: TBSCertificate;
 };
-
-// Helper functions
-function encodeUint8ArrayAsBase64(bytes: ArrayBuffer) {
-	return btoa(String.fromCodePoint(...new Uint8Array(bytes)));
-}
 
 function formatPEM(pemString: string): string {
 	return pemString.match(/.{1,64}/g)?.join('\n') || pemString;

--- a/packages/playground/personal-wp/src/lib/personalwp/my-apps.ts
+++ b/packages/playground/personal-wp/src/lib/personalwp/my-apps.ts
@@ -1,5 +1,5 @@
 import type { PlaygroundClient } from '@wp-playground/remote';
-import { encodeStringAsBase64 } from '../base64';
+import { encodeStringAsBase64 } from '@php-wasm/util';
 
 export const MY_APPS_PLUGIN_FILE =
 	'/wordpress/wp-content/plugins/my-apps/my-apps.php';

--- a/packages/playground/personal-wp/src/lib/state/url/router.ts
+++ b/packages/playground/personal-wp/src/lib/state/url/router.ts
@@ -1,6 +1,6 @@
 import type { SiteInfo } from '../redux/slice-sites';
 import { updateUrl } from './router-hooks';
-import { decodeBase64ToString } from '../../base64';
+import { decodeBase64ToString } from '@php-wasm/util';
 import { personalWPSiteSlug } from 'virtual:website-defaults';
 import { isAppBasePath } from './app-base-url';
 import { HEALTH_CHECK_RECOVERY_MODE_QUERY_PARAM } from '../../health-check-recovery';

--- a/packages/playground/storage/src/lib/github.ts
+++ b/packages/playground/storage/src/lib/github.ts
@@ -1,4 +1,4 @@
-import { Semaphore } from '@php-wasm/util';
+import { decodeBase64ToUint8Array, Semaphore } from '@php-wasm/util';
 import { Octokit } from 'octokit';
 import type { Changeset } from './changeset';
 
@@ -118,21 +118,11 @@ async function getFileContent(
 		return {
 			name: item.name,
 			path: item.path,
-			content: base64ToUint8Array(fileContent.content),
+			content: decodeBase64ToUint8Array(fileContent.content),
 		};
 	} finally {
 		release();
 	}
-}
-
-function base64ToUint8Array(base64: string) {
-	const binaryString = window.atob(base64); // This will convert base64 to binary string
-	const len = binaryString.length;
-	const bytes = new Uint8Array(len);
-	for (let i = 0; i < len; i++) {
-		bytes[i] = binaryString.charCodeAt(i);
-	}
-	return bytes;
 }
 
 /**

--- a/packages/playground/website/playwright/e2e/blueprints.spec.ts
+++ b/packages/playground/website/playwright/e2e/blueprints.spec.ts
@@ -460,6 +460,36 @@ test('CURLFile uploads via curl_exec() should work', async ({
 			'but the issue does not occur in local testing or on https://playground.wordpress.net/. ' +
 			'Perhaps it is something highly specific to the CI runtime.'
 	);
+	const uploadUrl = 'https://curlfile-upload.test/post';
+	await website.page.route(uploadUrl, async (route) => {
+		const request = route.request();
+		if (request.method() === 'OPTIONS') {
+			await route.fulfill({
+				status: 204,
+				headers: {
+					'Access-Control-Allow-Origin': '*',
+					'Access-Control-Allow-Methods': 'POST, OPTIONS',
+					'Access-Control-Allow-Headers': '*',
+				},
+			});
+			return;
+		}
+
+		await route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			headers: {
+				'Access-Control-Allow-Origin': '*',
+			},
+			body: JSON.stringify({
+				method: request.method(),
+				isMultipartUpload: (
+					request.headers()['content-type'] ?? ''
+				).startsWith('multipart/form-data; boundary='),
+			}),
+		});
+	});
+
 	const blueprint: Blueprint = {
 		landingPage: '/curlfile-test.php',
 		features: { networking: true },
@@ -468,21 +498,28 @@ test('CURLFile uploads via curl_exec() should work', async ({
 				step: 'writeFile',
 				path: '/wordpress/curlfile-test.php',
 				/**
-				 * Test CURLFile upload: creates a temp file > 1024 bytes
-				 * (triggering Expect: 100-continue), uploads it via curl
-				 * to a known endpoint, and verifies it succeeds.
+				 * Test CURLFile upload: creates a temp file, uploads it via
+				 * curl to a Playwright-routed endpoint, and verifies curl
+				 * emits a multipart upload request.
 				 *
-				 * The URL:
+				 * Playwright routes streaming uploads, but does not expose
+				 * their bodies via request.postData(). This test still keeps
+				 * the network observable in-process and independent from
+				 * third-party availability.
 				 *
-				 * * Is served over HTTPS.
-				 * * Echoes back the uploaded file contents.
-				 * * The response is proxied through the CORS proxy.
+				 * Keep this endpoint controlled by the test. Using public echo
+				 * services such as httpbin.org made this test depend on
+				 * third-party availability and rate limits, which showed up in
+				 * CI as intermittent 503s.
+				 *
+				 * Keep this payload small. The CORS proxy-specific test below
+				 * covers larger uploads that trigger Expect: 100-continue.
 				 */
 				data: `<?php
 					$tmpFile = tempnam(sys_get_temp_dir(), 'curltest');
-					file_put_contents($tmpFile, str_repeat('PLAYGROUND_TEST_CONTENT ', 100));
+					file_put_contents($tmpFile, 'PLAYGROUND_TEST_CONTENT');
 					$ch = curl_init();
-					curl_setopt($ch, CURLOPT_URL, "https://httpbin.org/post");
+					curl_setopt($ch, CURLOPT_URL, '${uploadUrl}');
 					curl_setopt($ch, CURLOPT_POST, true);
 					curl_setopt($ch, CURLOPT_POSTFIELDS, [
 						'file' => new CURLFile($tmpFile, 'text/plain', 'test-upload.txt'),
@@ -498,11 +535,11 @@ test('CURLFile uploads via curl_exec() should work', async ({
 					} else {
 						echo "HTTP_CODE:" . $httpCode;
 						$decoded = json_decode($result, true);
-						if (isset($decoded['files']['file'])) {
-							echo " FILE_RECEIVED:YES";
-							echo " CONTENT_MATCH:" . (strpos($decoded['files']['file'], 'PLAYGROUND_TEST_CONTENT') !== false ? 'YES' : 'NO');
+						if (isset($decoded['isMultipartUpload'])) {
+							echo " POST_RECEIVED:" . ($decoded['method'] === 'POST' ? 'YES' : 'NO');
+							echo " MULTIPART_UPLOAD:" . ($decoded['isMultipartUpload'] ? 'YES' : 'NO');
 						} else {
-							echo " FILE_RECEIVED:NO";
+							echo " MULTIPART_UPLOAD:NO";
 							echo " BODY:" . substr($result, 0, 500);
 						}
 					}
@@ -512,8 +549,8 @@ test('CURLFile uploads via curl_exec() should work', async ({
 	};
 	await website.goto(`/#${JSON.stringify(blueprint)}`);
 	await expect(wordpress.locator('body')).toContainText('HTTP_CODE:200');
-	await expect(wordpress.locator('body')).toContainText('FILE_RECEIVED:YES');
-	await expect(wordpress.locator('body')).toContainText('CONTENT_MATCH:YES');
+	await expect(wordpress.locator('body')).toContainText('POST_RECEIVED:YES');
+	await expect(wordpress.locator('body')).toContainText('MULTIPART_UPLOAD:YES');
 });
 
 /**

--- a/packages/playground/website/playwright/e2e/blueprints.spec.ts
+++ b/packages/playground/website/playwright/e2e/blueprints.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '../playground-fixtures';
 import type { Blueprint } from '@wp-playground/blueprints';
-import { encodeStringAsBase64 } from '../../src/lib/base64';
+import { encodeStringAsBase64 } from '@php-wasm/util';
 
 // We can't import the SupportedPHPVersions versions directly from the remote package
 // because of ESModules vs CommonJS incompatibilities. Let's just import the
@@ -460,36 +460,6 @@ test('CURLFile uploads via curl_exec() should work', async ({
 			'but the issue does not occur in local testing or on https://playground.wordpress.net/. ' +
 			'Perhaps it is something highly specific to the CI runtime.'
 	);
-	const uploadUrl = 'https://curlfile-upload.test/post';
-	await website.page.route(uploadUrl, async (route) => {
-		const request = route.request();
-		if (request.method() === 'OPTIONS') {
-			await route.fulfill({
-				status: 204,
-				headers: {
-					'Access-Control-Allow-Origin': '*',
-					'Access-Control-Allow-Methods': 'POST, OPTIONS',
-					'Access-Control-Allow-Headers': '*',
-				},
-			});
-			return;
-		}
-
-		await route.fulfill({
-			status: 200,
-			contentType: 'application/json',
-			headers: {
-				'Access-Control-Allow-Origin': '*',
-			},
-			body: JSON.stringify({
-				method: request.method(),
-				isMultipartUpload: (
-					request.headers()['content-type'] ?? ''
-				).startsWith('multipart/form-data; boundary='),
-			}),
-		});
-	});
-
 	const blueprint: Blueprint = {
 		landingPage: '/curlfile-test.php',
 		features: { networking: true },
@@ -498,28 +468,21 @@ test('CURLFile uploads via curl_exec() should work', async ({
 				step: 'writeFile',
 				path: '/wordpress/curlfile-test.php',
 				/**
-				 * Test CURLFile upload: creates a temp file, uploads it via
-				 * curl to a Playwright-routed endpoint, and verifies curl
-				 * emits a multipart upload request.
+				 * Test CURLFile upload: creates a temp file > 1024 bytes
+				 * (triggering Expect: 100-continue), uploads it via curl
+				 * to a known endpoint, and verifies it succeeds.
 				 *
-				 * Playwright routes streaming uploads, but does not expose
-				 * their bodies via request.postData(). This test still keeps
-				 * the network observable in-process and independent from
-				 * third-party availability.
+				 * The URL:
 				 *
-				 * Keep this endpoint controlled by the test. Using public echo
-				 * services such as httpbin.org made this test depend on
-				 * third-party availability and rate limits, which showed up in
-				 * CI as intermittent 503s.
-				 *
-				 * Keep this payload small. The CORS proxy-specific test below
-				 * covers larger uploads that trigger Expect: 100-continue.
+				 * * Is served over HTTPS.
+				 * * Echoes back the uploaded file contents.
+				 * * The response is proxied through the CORS proxy.
 				 */
 				data: `<?php
 					$tmpFile = tempnam(sys_get_temp_dir(), 'curltest');
-					file_put_contents($tmpFile, 'PLAYGROUND_TEST_CONTENT');
+					file_put_contents($tmpFile, str_repeat('PLAYGROUND_TEST_CONTENT ', 100));
 					$ch = curl_init();
-					curl_setopt($ch, CURLOPT_URL, '${uploadUrl}');
+					curl_setopt($ch, CURLOPT_URL, "https://httpbin.org/post");
 					curl_setopt($ch, CURLOPT_POST, true);
 					curl_setopt($ch, CURLOPT_POSTFIELDS, [
 						'file' => new CURLFile($tmpFile, 'text/plain', 'test-upload.txt'),
@@ -535,11 +498,11 @@ test('CURLFile uploads via curl_exec() should work', async ({
 					} else {
 						echo "HTTP_CODE:" . $httpCode;
 						$decoded = json_decode($result, true);
-						if (isset($decoded['isMultipartUpload'])) {
-							echo " POST_RECEIVED:" . ($decoded['method'] === 'POST' ? 'YES' : 'NO');
-							echo " MULTIPART_UPLOAD:" . ($decoded['isMultipartUpload'] ? 'YES' : 'NO');
+						if (isset($decoded['files']['file'])) {
+							echo " FILE_RECEIVED:YES";
+							echo " CONTENT_MATCH:" . (strpos($decoded['files']['file'], 'PLAYGROUND_TEST_CONTENT') !== false ? 'YES' : 'NO');
 						} else {
-							echo " MULTIPART_UPLOAD:NO";
+							echo " FILE_RECEIVED:NO";
 							echo " BODY:" . substr($result, 0, 500);
 						}
 					}
@@ -549,8 +512,8 @@ test('CURLFile uploads via curl_exec() should work', async ({
 	};
 	await website.goto(`/#${JSON.stringify(blueprint)}`);
 	await expect(wordpress.locator('body')).toContainText('HTTP_CODE:200');
-	await expect(wordpress.locator('body')).toContainText('POST_RECEIVED:YES');
-	await expect(wordpress.locator('body')).toContainText('MULTIPART_UPLOAD:YES');
+	await expect(wordpress.locator('body')).toContainText('FILE_RECEIVED:YES');
+	await expect(wordpress.locator('body')).toContainText('CONTENT_MATCH:YES');
 });
 
 /**

--- a/packages/playground/website/playwright/e2e/query-api.spec.ts
+++ b/packages/playground/website/playwright/e2e/query-api.spec.ts
@@ -3,7 +3,7 @@ import { test, expect } from '../playground-fixtures';
 import type { BrowserContext, Page } from '@playwright/test';
 import type { Blueprint } from '@wp-playground/blueprints';
 import { resolve } from 'node:path';
-import { encodeStringAsBase64 } from '../../src/lib/base64';
+import { encodeStringAsBase64 } from '@php-wasm/util';
 
 // We can't import the WordPress versions directly from the remote package
 // because of ESModules vs CommonJS incompatibilities. Let's just import the

--- a/packages/playground/website/src/github/git-auth-helpers.ts
+++ b/packages/playground/website/src/github/git-auth-helpers.ts
@@ -1,5 +1,5 @@
 import { oAuthState } from './state';
-import { encodeStringAsBase64 } from '../lib/base64';
+import { encodeStringAsBase64 } from '@php-wasm/util';
 
 function isGitHubUrl(url: string): boolean {
 	try {

--- a/packages/playground/website/src/lib/hooks/use-blueprint-url-hash.ts
+++ b/packages/playground/website/src/lib/hooks/use-blueprint-url-hash.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import type { EventedFilesystem } from '@wp-playground/storage';
-import { encodeStringAsBase64 } from '../base64';
+import { encodeStringAsBase64 } from '@php-wasm/util';
 import { useDebouncedCallback } from './use-debounced-callback';
 
 export interface UseBlueprintUrlHashResult {

--- a/packages/playground/website/src/lib/state/url/router.ts
+++ b/packages/playground/website/src/lib/state/url/router.ts
@@ -1,6 +1,6 @@
 import type { SiteInfo } from '../redux/slice-sites';
 import { updateUrl } from './router-hooks';
-import { decodeBase64ToString } from '../../base64';
+import { decodeBase64ToString } from '@php-wasm/util';
 
 export function redirectTo(url: string) {
 	window.history.pushState({}, '', url);


### PR DESCRIPTION
## Summary

Adds the core `SmtpSink` protocol engine and delegates RFC 5322/MIME parsing to `postal-mime`.

## Motivation for the change, related issues

The earlier plumbing PRs make PHP's outbound mail bytes observable, but they intentionally do not interpret SMTP socket traffic or MIME content. This PR adds the SMTP protocol layer while avoiding a hand-rolled email parser.

This sits after #3956 and #3726 in the stack: first capture raw sendmail streams, then add shared Base64 helpers, then accept SMTP sessions and parse completed message data.

## Implementation details

- Adds a stream-based SMTP state machine with support for `EHLO` / `HELO`, `AUTH PLAIN`, `AUTH LOGIN`, `MAIL FROM`, `RCPT TO`, `DATA`, `RSET`, `NOOP`, `VRFY`, and `QUIT`.
- Enforces SMTP command and DATA line limits, message size limits, transaction ordering, `SIZE` declarations, and envelope reset behavior.
- Uses `postal-mime` to parse each complete RFC 5322 message after SMTP `DATA` finishes.
- Maps `postal-mime` output into Playground's `CaughtMessage` / `CaughtAttachment` shape, with SMTP envelope fallback for missing From/To headers.
- Keeps parser failure isolated from SMTP session handling by delivering an unparsed fallback message when parsing throws.
- Exports the core sink APIs and types from `@php-wasm/util`.
- Leaves sendmail/WebSocket adapters and final runtime integration to #3954.

## Testing Instructions

Run the utility package tests and build:

```bash
npm exec nx test php-wasm-util -- --runInBand
npm exec nx build php-wasm-util
```
