### PR TITLE
Add parsed SMTP sink adapters

### DIFF
--- a/packages/php-wasm/node/project.json
+++ b/packages/php-wasm/node/project.json
@@ -172,6 +172,7 @@
 					"php-image-extensions.spec.ts",
 					"php-mail-capture.spec.ts",
 					"php-fsockopen.spec.ts",
+					"php-smtp.spec.ts",
 					"php-socket-timeouts.spec.ts"
 				]
 			}
@@ -188,6 +189,7 @@
 					"php-image-extensions.spec.ts",
 					"php-mail-capture.spec.ts",
 					"php-fsockopen.spec.ts",
+					"php-smtp.spec.ts",
 					"php-socket-timeouts.spec.ts"
 				]
 			}

--- a/packages/php-wasm/node/src/lib/load-runtime.ts
+++ b/packages/php-wasm/node/src/lib/load-runtime.ts
@@ -12,6 +12,8 @@ import {
 	ProcessIdAllocator,
 	withMailCapture,
 	type WithMailCaptureOptions,
+	withSMTPSink,
+	type WithSmtpSinkOptions,
 } from '@php-wasm/universal';
 import type { WasmUserSpaceAPI, WasmUserSpaceContext } from './wasm-user-space';
 import { bindUserSpace } from './wasm-user-space';
@@ -59,6 +61,7 @@ export interface PHPLoaderOptions {
 	 * Capture raw bytes written to sendmail stdin.
 	 */
 	withMailCapture?: WithMailCaptureOptions;
+	withSMTPSink?: WithSmtpSinkOptions;
 }
 
 export type PHPLoaderOptionsForNode = PHPLoaderOptions & {
@@ -385,6 +388,12 @@ export async function loadNodeRuntime(
 	if (options?.withMailCapture) {
 		emscriptenOptions = withMailCapture(
 			options.withMailCapture,
+			emscriptenOptions
+		);
+	}
+	if (options?.withSMTPSink) {
+		emscriptenOptions = withSMTPSink(
+			options.withSMTPSink,
 			emscriptenOptions
 		);
 	}

--- a/packages/php-wasm/node/src/test/php-smtp.spec.ts
+++ b/packages/php-wasm/node/src/test/php-smtp.spec.ts
@@ -1,0 +1,253 @@
+import { PHP, setPhpIniEntries } from '@php-wasm/universal';
+import { joinPaths } from '@php-wasm/util';
+import type { CaughtMessage } from '@php-wasm/util';
+import { readFileSync } from 'fs';
+import { loadNodeRuntime } from '../lib';
+
+const phpVersions = ['8.4'];
+const attachmentFilename = 'image.jpg';
+const attachmentPath = `/tmp/${attachmentFilename}`;
+const attachmentContent = readFileSync(
+	joinPaths(__dirname, 'test-data', attachmentFilename)
+);
+// TODO re-enable testing on all versions before merging
+// 'PHP' in process.env
+// 	? [process.env['PHP']! as SupportedPHPVersion]
+// 	: SupportedPHPVersions;
+
+describe.each(phpVersions)('PHP %s – SMTP sink', (phpVersion) => {
+	let php: PHP;
+	let emails: CaughtMessage[];
+
+	beforeEach(async () => {
+		emails = [];
+		php = new PHP(
+			await loadNodeRuntime(phpVersion as any, {
+				withSMTPSink: {
+					smtpPort: 25,
+					onEmail: (m: CaughtMessage) => emails.push(m),
+				},
+			})
+		);
+		await setPhpIniEntries(php, {
+			disable_functions: '',
+			allow_url_fopen: 1,
+		});
+		php.writeFile(attachmentPath, attachmentContent);
+	}, 30_000);
+
+	afterEach(() => {
+		php?.exit();
+	});
+
+	it('captures an email piped via proc_open to sendmail', async () => {
+		const result = await php.run({
+			code: `<?php
+				error_reporting(E_ALL);
+				$email = "From: sender@test.com\r\nTo: recipient@test.com\r\nSubject: Hello from PHP\r\n\r\nThis is the body.";
+				$proc = proc_open(
+					'/usr/sbin/sendmail -t -i',
+					[['pipe', 'r'], ['pipe', 'w'], ['pipe', 'w']],
+					$pipes
+				);
+				if (!is_resource($proc)) {
+					echo 'PROC_OPEN_FAILED';
+					exit;
+				}
+				fwrite($pipes[0], $email);
+				fclose($pipes[0]);
+				$exit = proc_close($proc);
+				echo $exit === 0 ? 'SENT' : 'EXIT_' . $exit;
+			`,
+		});
+
+		expect(result.text).toBe('SENT');
+		expect(emails).toHaveLength(1);
+		expect(emails[0].from).toContain('sender@test.com');
+		expect(emails[0].to).toContain('recipient@test.com');
+		expect(emails[0].subject).toBe('Hello from PHP');
+		expect(emails[0].text?.trim()).toBe('This is the body.');
+	});
+
+	it('captures an email sent via fsockopen SMTP', async () => {
+		const result = await php.run({
+			code: `<?php
+				error_reporting(E_ALL);
+
+				function smtp_read_reply($fp) {
+					$lines = '';
+					while (($line = fgets($fp)) !== false) {
+						$lines .= $line;
+						if (preg_match('/^\\d{3} /', $line)) break;
+					}
+					return $lines;
+				}
+
+				$smtp = fsockopen('localhost', 25, $errno, $errstr, 5);
+				if (!$smtp) { echo "CONNECT_FAILED: $errstr ($errno)"; exit; }
+
+				smtp_read_reply($smtp);
+				fwrite($smtp, "EHLO localhost\\r\\n");
+				smtp_read_reply($smtp);
+				fwrite($smtp, "MAIL FROM:<sender@test.com>\\r\\n");
+				smtp_read_reply($smtp);
+				fwrite($smtp, "RCPT TO:<recipient@test.com>\\r\\n");
+				smtp_read_reply($smtp);
+				fwrite($smtp, "DATA\\r\\n");
+				smtp_read_reply($smtp);
+				fwrite($smtp, "From: sender@test.com\\r\\n");
+				fwrite($smtp, "To: recipient@test.com\\r\\n");
+				fwrite($smtp, "Subject: Hello via SMTP\\r\\n");
+				fwrite($smtp, "\\r\\n");
+				fwrite($smtp, "This is the body.\\r\\n");
+				fwrite($smtp, ".\\r\\n");
+				smtp_read_reply($smtp);
+				fwrite($smtp, "QUIT\\r\\n");
+				fclose($smtp);
+				echo 'SENT';
+			`,
+		});
+
+		expect(result.text).toBe('SENT');
+		expect(emails).toHaveLength(1);
+		expect(emails[0].from).toContain('sender@test.com');
+		expect(emails[0].to).toContain('recipient@test.com');
+		expect(emails[0].subject).toBe('Hello via SMTP');
+		expect(emails[0].text?.trim()).toBe('This is the body.');
+	});
+
+	it('captures an attachment from a MIME message sent via mail()', async () => {
+		const result = await php.run({
+			code: `<?php
+				error_reporting(E_ALL);
+				$attachment = file_get_contents('${attachmentPath}');
+				if ($attachment === false) {
+					echo 'ATTACHMENT_READ_FAILED';
+					exit;
+				}
+				$body = "--MIXBOUND\r\n"
+					. "Content-Type: text/plain; charset=utf-8\r\n"
+					. "\r\n"
+					. "Body text.\r\n"
+					. "--MIXBOUND\r\n"
+					. "Content-Type: image/jpeg; name=\\"${attachmentFilename}\\"\r\n"
+					. "Content-Transfer-Encoding: base64\r\n"
+					. "Content-Disposition: attachment; filename=\\"${attachmentFilename}\\"\r\n"
+					. "\r\n"
+					. chunk_split(base64_encode($attachment), 76, "\r\n")
+					. "--MIXBOUND--\r\n";
+				$headers = "From: sender@test.com\r\n"
+					. "MIME-Version: 1.0\r\n"
+					. "Content-Type: multipart/mixed; boundary=\\"MIXBOUND\\"";
+				$result = mail(
+					'recipient@test.com',
+					'With attachment',
+					$body,
+					$headers
+				);
+				echo $result ? 'SENT' : 'FAILED';
+			`,
+		});
+
+		expect(result.text).toBe('SENT');
+		expect(emails).toHaveLength(1);
+		expect(emails[0].text?.trim()).toBe('Body text.');
+		expect(emails[0].attachments).toHaveLength(1);
+		const attachment = emails[0].attachments[0];
+		expect(attachment.filename).toBe(attachmentFilename);
+		expect(attachment.contentType).toBe('image/jpeg');
+		expect(attachment.contentDisposition).toBe('attachment');
+		expect(attachment.content).toEqual(new Uint8Array(attachmentContent));
+		expect(attachment.size).toBe(attachmentContent.length);
+	});
+
+	it('captures an attachment from a MIME message sent via fsockopen SMTP', async () => {
+		const result = await php.run({
+			code: `<?php
+				error_reporting(E_ALL);
+				$attachment = file_get_contents('${attachmentPath}');
+				if ($attachment === false) {
+					echo 'ATTACHMENT_READ_FAILED';
+					exit;
+				}
+
+				function smtp_read_reply($fp) {
+					$lines = '';
+					while (($line = fgets($fp)) !== false) {
+						$lines .= $line;
+						if (preg_match('/^\\d{3} /', $line)) break;
+					}
+					return $lines;
+				}
+
+				$smtp = fsockopen('localhost', 25, $errno, $errstr, 5);
+				if (!$smtp) { echo "CONNECT_FAILED: $errstr ($errno)"; exit; }
+
+				smtp_read_reply($smtp);
+				fwrite($smtp, "EHLO localhost\\r\\n");
+				smtp_read_reply($smtp);
+				fwrite($smtp, "MAIL FROM:<sender@test.com>\\r\\n");
+				smtp_read_reply($smtp);
+				fwrite($smtp, "RCPT TO:<recipient@test.com>\\r\\n");
+				smtp_read_reply($smtp);
+				fwrite($smtp, "DATA\\r\\n");
+				smtp_read_reply($smtp);
+				fwrite($smtp, "From: sender@test.com\\r\\n");
+				fwrite($smtp, "To: recipient@test.com\\r\\n");
+				fwrite($smtp, "Subject: With attachment\\r\\n");
+				fwrite($smtp, "MIME-Version: 1.0\\r\\n");
+				fwrite($smtp, "Content-Type: multipart/mixed; boundary=\\"MIXBOUND\\"\\r\\n");
+				fwrite($smtp, "\\r\\n");
+				fwrite($smtp, "--MIXBOUND\\r\\n");
+				fwrite($smtp, "Content-Type: text/plain; charset=utf-8\\r\\n");
+				fwrite($smtp, "\\r\\n");
+				fwrite($smtp, "Body text.\\r\\n");
+				fwrite($smtp, "--MIXBOUND\\r\\n");
+				fwrite($smtp, "Content-Type: image/jpeg; name=\\"${attachmentFilename}\\"\\r\\n");
+				fwrite($smtp, "Content-Transfer-Encoding: base64\\r\\n");
+				fwrite($smtp, "Content-Disposition: attachment; filename=\\"${attachmentFilename}\\"\\r\\n");
+				fwrite($smtp, "\\r\\n");
+				fwrite($smtp, chunk_split(base64_encode($attachment), 76, "\\r\\n"));
+				fwrite($smtp, "--MIXBOUND--\\r\\n");
+				fwrite($smtp, ".\\r\\n");
+				smtp_read_reply($smtp);
+				fwrite($smtp, "QUIT\\r\\n");
+				fclose($smtp);
+				echo 'SENT';
+			`,
+		});
+
+		expect(result.text).toBe('SENT');
+		expect(emails).toHaveLength(1);
+		expect(emails[0].text?.trim()).toBe('Body text.');
+		expect(emails[0].attachments).toHaveLength(1);
+		const attachment = emails[0].attachments[0];
+		expect(attachment.filename).toBe(attachmentFilename);
+		expect(attachment.contentType).toBe('image/jpeg');
+		expect(attachment.contentDisposition).toBe('attachment');
+		expect(attachment.content).toEqual(new Uint8Array(attachmentContent));
+		expect(attachment.size).toBe(attachmentContent.length);
+	});
+
+	it('captures an email sent via mail()', async () => {
+		const result = await php.run({
+			code: `<?php
+				error_reporting(E_ALL);
+				$result = mail(
+					'recipient@test.com',
+					'Hello from PHP',
+					'This is the body.',
+					'From: sender@test.com'
+				);
+				echo $result ? 'SENT' : 'FAILED';
+			`,
+		});
+
+		expect(result.text).toBe('SENT');
+		expect(emails).toHaveLength(1);
+		expect(emails[0].from).toContain('sender@test.com');
+		expect(emails[0].to).toContain('recipient@test.com');
+		expect(emails[0].subject).toBe('Hello from PHP');
+		expect(emails[0].text?.trim()).toBe('This is the body.');
+	});
+});

--- a/packages/php-wasm/universal/src/lib/index.ts
+++ b/packages/php-wasm/universal/src/lib/index.ts
@@ -128,6 +128,7 @@ export {
 export { isExitCode } from './is-exit-code';
 export { proxyFileSystem, isPathToSharedFS } from './proxy-file-system';
 export { sandboxedSpawnHandlerFactory } from './sandboxed-spawn-handler-factory';
+export { withSMTPSink, type WithSmtpSinkOptions } from './with-smtp-sink';
 
 export * from './api';
 export type { WithAPIState as WithIsReady } from './api';

--- a/packages/php-wasm/universal/src/lib/with-smtp-sink.ts
+++ b/packages/php-wasm/universal/src/lib/with-smtp-sink.ts
@@ -1,0 +1,90 @@
+import type { EmscriptenOptions } from './load-php-runtime';
+import {
+	SmtpSinkWebSocket,
+	createSendmailSpawnHandler,
+	type CaughtMessage,
+} from '@php-wasm/util';
+
+export type WithSmtpSinkOptions = {
+	/**
+	 * The TCP destination port PHP connects to for SMTP (e.g. 25). Connections
+	 * to this port are intercepted and routed to the in-process SMTP sink
+	 * instead of going out over the network.
+	 */
+	smtpPort: number;
+	/**
+	 * Callback invoked with each captured email message.
+	 */
+	onEmail: (message: CaughtMessage) => void;
+};
+
+/**
+ * Adds an in-process SMTP sink to Emscripten options.
+ *
+ * Use this when a PHP runtime should capture outgoing mail instead of sending
+ * it. Messages are reported through `onEmail` for both `mail()` calls that
+ * invoke sendmail and SMTP socket connections whose TCP destination port
+ * matches `smtpPort`.
+ *
+ * Existing `spawnProcess` and `websocket.decorator` handlers are preserved for
+ * non-sendmail commands and non-SMTP WebSocket connections.
+ */
+export function withSMTPSink(
+	{ smtpPort, onEmail }: WithSmtpSinkOptions,
+	emscriptenOptions: EmscriptenOptions = {}
+): EmscriptenOptions {
+	// TODO: Provide a way for the Playground website to read received messages.
+	const previousWebSocketOptions = emscriptenOptions['websocket'] || {};
+	const previousDecorator = previousWebSocketOptions.decorator as
+		| ((Base: any) => any)
+		| undefined;
+
+	const smtpDecorator = (BaseWebSocketConstructor: any) => {
+		return class SMTPDecoratedWebSocket extends BaseWebSocketConstructor {
+			constructor(url: string, webSocketOptions?: any) {
+				let requestedTcpDestinationPort = -1;
+				try {
+					const websocketUrl = new URL(url);
+					// Runtime URL factories encode PHP's TCP destination port
+					// in the WebSocket URL so decorators can route it. See
+					// `@php-wasm/web`'s `tcp-over-fetch-websocket.ts` and
+					// `@php-wasm/node`'s `networking/with-networking.ts`.
+					requestedTcpDestinationPort = parseInt(
+						websocketUrl.searchParams.get('port') || '-1',
+						10
+					);
+				} catch {
+					// Ignore URL parse errors
+				}
+
+				if (requestedTcpDestinationPort === smtpPort) {
+					// Returning an object from a constructor
+					// bypasses `this`, avoiding a super() call
+					// that would open a real connection to the
+					// SMTP port.
+					return new SmtpSinkWebSocket(url, onEmail) as any;
+				}
+
+				super(url, webSocketOptions);
+			}
+		};
+	};
+
+	return {
+		...emscriptenOptions,
+		spawnProcess: createSendmailSpawnHandler(
+			onEmail,
+			emscriptenOptions['spawnProcess']
+		),
+		websocket: {
+			...previousWebSocketOptions,
+			decorator: (BaseWebSocketConstructor: any) => {
+				const WebSocketConstructorWithPreviousDecorator =
+					previousDecorator
+						? previousDecorator(BaseWebSocketConstructor)
+						: BaseWebSocketConstructor;
+				return smtpDecorator(WebSocketConstructorWithPreviousDecorator);
+			},
+		},
+	};
+}

--- a/packages/php-wasm/util/src/lib/create-sendmail-handler.ts
+++ b/packages/php-wasm/util/src/lib/create-sendmail-handler.ts
@@ -1,0 +1,78 @@
+import { createSendmailCaptureSpawnHandler } from './create-sendmail-capture-handler';
+import { DEFAULT_SMTP_MAX_SIZE, parseMessage } from './smtp';
+import type { CaughtMessage } from './smtp';
+
+/**
+ * Intercepts PHP's mail() function and routes the outgoing message to
+ * `onEmail`.
+ *
+ * PHP's mail() pipes a fully-formed message to the program in php.ini's
+ * `sendmail_path`, which defaults to `/usr/sbin/sendmail -t -i`. The `-t`
+ * means a real sendmail would read recipients from the To/Cc/Bcc headers,
+ * and this handler relies on that — it always extracts recipients from the
+ * headers rather than from command-line arguments.
+ *
+ * The envelope sender is read from sendmail's `-f` flag. Both forms are
+ * supported: `-f sender@example.com` and `-fsender@example.com`.
+ *
+ * The full message is buffered in memory before parsing so headers, MIME
+ * boundaries, and text encodings can be inspected together. Messages larger
+ * than `maxSize`, including large attachments, are rejected.
+ *
+ * Any command whose binary basename is `sendmail` is matched. Other
+ * commands are forwarded to `fallbackSpawnHandler` if provided, otherwise
+ * they throw. The fallback lets callers combine this mail interceptor with
+ * their existing spawn handler for unrelated commands.
+ *
+ * @param onEmail - Called once per successfully parsed message.
+ * @param fallbackSpawnHandler - Receives any non-sendmail command. Omit to
+ *   throw on unrecognized commands instead.
+ * @param options.maxSize - Maximum accepted message size in bytes.
+ *   Defaults to `DEFAULT_SMTP_MAX_SIZE`. Messages exceeding this limit are
+ *   rejected with exit code 1 and a diagnostic written to stderr.
+ */
+export function createSendmailSpawnHandler(
+	onEmail: (message: CaughtMessage) => void,
+	fallbackSpawnHandler?: (
+		command: any,
+		argsArray?: any,
+		options?: any
+	) => any,
+	{ maxSize = DEFAULT_SMTP_MAX_SIZE }: { maxSize?: number } = {}
+) {
+	return createSendmailCaptureSpawnHandler(
+		(captured) => {
+			// PHP 7 pipes LF-only to sendmail. PHP 8 changed the default to
+			// CRLF even on Unix to fix RFC non-compliance:
+			// https://bugs.php.net/47983
+			// Since Playground supports PHP 7.4–8.5, both line endings can
+			// arrive here. Our parseMessage helpers expect RFC 5322 canonical
+			// CRLF, so normalize before parsing:
+			// https://www.rfc-editor.org/rfc/rfc5322.html#section-2.1
+			const raw = captured.text.replace(/\r?\n/g, '\r\n');
+
+			// Parse folded headers, MIME boundaries, and transfer encodings only
+			// after sendmail has received the complete stdin payload.
+			const parsed = parseMessage(raw, captured.envelopeSender, []);
+
+			const message: CaughtMessage = {
+				receivedAt: captured.receivedAt,
+				from: parsed.from,
+				to: parsed.to,
+				subject: parsed.subject,
+				headers: parsed.headers,
+				text: parsed.text,
+				html: parsed.html,
+				attachments: parsed.attachments,
+				raw,
+				// RFC 1870 SIZE values are measured in octets.
+				// https://www.rfc-editor.org/rfc/rfc1870.html#section-3
+				rawSize: new TextEncoder().encode(raw).byteLength,
+			};
+
+			onEmail(message);
+		},
+		fallbackSpawnHandler,
+		{ maxSize }
+	);
+}

--- a/packages/php-wasm/util/src/lib/create-sendmail-handler.ts
+++ b/packages/php-wasm/util/src/lib/create-sendmail-handler.ts
@@ -41,7 +41,7 @@ export function createSendmailSpawnHandler(
 	{ maxSize = DEFAULT_SMTP_MAX_SIZE }: { maxSize?: number } = {}
 ) {
 	return createSendmailCaptureSpawnHandler(
-		(captured) => {
+		async (captured) => {
 			// PHP 7 pipes LF-only to sendmail. PHP 8 changed the default to
 			// CRLF even on Unix to fix RFC non-compliance:
 			// https://bugs.php.net/47983
@@ -53,26 +53,51 @@ export function createSendmailSpawnHandler(
 
 			// Parse folded headers, MIME boundaries, and transfer encodings only
 			// after sendmail has received the complete stdin payload.
-			const parsed = parseMessage(raw, captured.envelopeSender, []);
-
-			const message: CaughtMessage = {
-				receivedAt: captured.receivedAt,
-				from: parsed.from,
-				to: parsed.to,
-				subject: parsed.subject,
-				headers: parsed.headers,
-				text: parsed.text,
-				html: parsed.html,
-				attachments: parsed.attachments,
-				raw,
-				// RFC 1870 SIZE values are measured in octets.
-				// https://www.rfc-editor.org/rfc/rfc1870.html#section-3
-				rawSize: new TextEncoder().encode(raw).byteLength,
-			};
-
-			onEmail(message);
+			onEmail(
+				await parseCapturedSendmailMessage(
+					captured.receivedAt,
+					raw,
+					captured.envelopeSender
+				)
+			);
 		},
 		fallbackSpawnHandler,
 		{ maxSize }
 	);
+}
+
+async function parseCapturedSendmailMessage(
+	receivedAt: string,
+	raw: string,
+	envelopeSender: string
+): Promise<CaughtMessage> {
+	const rawSize = new TextEncoder().encode(raw).byteLength;
+	try {
+		const parsed = await parseMessage(raw, envelopeSender, []);
+		return {
+			receivedAt,
+			from: parsed.from,
+			to: parsed.to,
+			subject: parsed.subject,
+			headers: parsed.headers,
+			text: parsed.text,
+			html: parsed.html,
+			attachments: parsed.attachments,
+			raw,
+			// RFC 1870 SIZE values are measured in octets.
+			// https://www.rfc-editor.org/rfc/rfc1870.html#section-3
+			rawSize,
+		};
+	} catch {
+		return {
+			receivedAt,
+			from: envelopeSender,
+			to: '',
+			subject: '(no subject)',
+			headers: {},
+			attachments: [],
+			raw,
+			rawSize,
+		};
+	}
 }

--- a/packages/php-wasm/util/src/lib/index.ts
+++ b/packages/php-wasm/util/src/lib/index.ts
@@ -18,6 +18,7 @@ export {
 	createSendmailCaptureSpawnHandler,
 } from './create-sendmail-capture-handler';
 export type { RawSendmailMessage } from './create-sendmail-capture-handler';
+export { createSendmailSpawnHandler } from './create-sendmail-handler';
 export { randomString } from './random-string';
 export { randomFilename } from './random-filename';
 export { splitShellCommand } from './split-shell-command';
@@ -30,6 +31,7 @@ export {
 } from './base64';
 export { WritablePolyfill, type WritableOptions } from './writable-polyfill';
 export { EventEmitterPolyfill } from './event-emitter-polyfill';
+export { SmtpSinkWebSocket } from './smtp-sink-websocket';
 export * from './php-vars';
 export {
 	DEFAULT_SMTP_MAX_SIZE,

--- a/packages/php-wasm/util/src/lib/smtp-sink-websocket.spec.ts
+++ b/packages/php-wasm/util/src/lib/smtp-sink-websocket.spec.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { SmtpSinkWebSocket } from './smtp-sink-websocket';
+
+const decoder = new TextDecoder();
+
+describe('SmtpSinkWebSocket', () => {
+	it('emits open asynchronously and flushes sends buffered while connecting', async () => {
+		const socket = new SmtpSinkWebSocket(
+			'ws://localhost?port=25',
+			() => {}
+		);
+		const messages: string[] = [];
+		const open = new Promise<void>((resolve) => {
+			socket.onopen = () => resolve();
+		});
+
+		socket.onmessage = ({ data }) => {
+			messages.push(
+				data instanceof Uint8Array ? decoder.decode(data) : data
+			);
+		};
+
+		expect(socket.readyState).toBe(socket.CONNECTING);
+
+		socket.send('NOOP\r\n');
+		expect(socket.readyState).toBe(socket.CONNECTING);
+
+		await open;
+		expect(socket.readyState).toBe(socket.OPEN);
+		await waitFor(() => messages.join('').includes('250 OK'));
+
+		expect(messages.join('')).toMatch(/^220 /);
+
+		const close = new Promise<void>((resolve) => {
+			socket.onclose = () => resolve();
+		});
+		socket.close();
+		await close;
+	});
+});
+
+async function waitFor(predicate: () => boolean) {
+	const deadline = Date.now() + 500;
+	while (Date.now() < deadline) {
+		if (predicate()) return;
+		await new Promise((resolve) => setTimeout(resolve, 0));
+	}
+	expect(predicate()).toBe(true);
+}

--- a/packages/php-wasm/util/src/lib/smtp-sink-websocket.ts
+++ b/packages/php-wasm/util/src/lib/smtp-sink-websocket.ts
@@ -1,0 +1,180 @@
+import { SmtpSink, makeLoopbackPair, type CaughtMessage } from './smtp';
+
+/**
+ * A WebSocket-shaped class that pipes outbound bytes through an in-process
+ * SmtpSink instead of opening a real network connection. Used to intercept
+ * Emscripten's SMTP-bound TCP traffic.
+ */
+export class SmtpSinkWebSocket {
+	readonly CONNECTING = 0;
+	readonly OPEN = 1;
+	readonly CLOSING = 2;
+	readonly CLOSED = 3;
+
+	readyState = this.CONNECTING;
+
+	url: string;
+
+	onopen: ((event: any) => void) | null = null;
+	onmessage: ((event: any) => void) | null = null;
+	onclose: ((event: any) => void) | null = null;
+	onerror: ((event: any) => void) | null = null;
+
+	private eventListeners = new Map<string, Set<(...args: any[]) => void>>();
+	private nodeListeners = new Map<string, Set<(...args: any[]) => void>>();
+	private writer: WritableStreamDefaultWriter<Uint8Array>;
+	private pendingWrites: Uint8Array[] | null = [];
+
+	constructor(url: string, onEmail: (message: CaughtMessage) => void) {
+		this.url = url;
+
+		const [client, server] = makeLoopbackPair();
+		void new SmtpSink(server, onEmail)
+			.start()
+			.catch((error) => this.emitError(error));
+		this.writer = client.writable.getWriter();
+
+		client.readable
+			.pipeTo(
+				new WritableStream({
+					write: (chunk) => this.emitMessage(chunk),
+				})
+			)
+			.catch((error) => this.emitError(error))
+			.finally(() => {
+				if (this.readyState !== this.CLOSED) this.emitClose();
+			});
+		queueMicrotask(() => {
+			if (this.readyState === this.CONNECTING) this.emitOpen();
+		});
+	}
+
+	addEventListener(eventName: string, callback: (...args: any[]) => void) {
+		this.addListener(this.eventListeners, eventName, callback);
+	}
+
+	removeEventListener(eventName: string, callback: (...args: any[]) => void) {
+		this.eventListeners.get(eventName)?.delete(callback);
+	}
+
+	on(eventName: string, callback: (...args: any[]) => void) {
+		this.addListener(this.nodeListeners, eventName, callback);
+	}
+
+	once(eventName: string, callback: (...args: any[]) => void) {
+		const wrapped = (...args: any[]) => {
+			this.removeListener(eventName, wrapped);
+			callback(...args);
+		};
+		this.on(eventName, wrapped);
+	}
+
+	removeListener(eventName: string, callback: (...args: any[]) => void) {
+		this.nodeListeners.get(eventName)?.delete(callback);
+	}
+
+	send(data: ArrayBuffer | Uint8Array | string) {
+		// WebSocket send(string) always delivers a complete JS string, never a
+		// partial surrogate pair. Binary chunks pass through as-is; multibyte
+		// splits across writes are handled by SmtpSink.consumeChunk().
+		const bytes =
+			typeof data === 'string'
+				? new TextEncoder().encode(data)
+				: data instanceof ArrayBuffer
+					? new Uint8Array(data)
+					: data;
+
+		if (this.readyState === this.CONNECTING) {
+			this.pendingWrites!.push(bytes);
+			return;
+		}
+		if (this.readyState !== this.OPEN) {
+			this.emitError(
+				new Error(
+					`SmtpSinkWebSocket: send() called in state ${this.readyState}`
+				)
+			);
+			return;
+		}
+		this.writeToStream(bytes);
+	}
+
+	close() {
+		if (
+			this.readyState === this.CLOSING ||
+			this.readyState === this.CLOSED
+		) {
+			return;
+		}
+		this.pendingWrites = null;
+		this.readyState = this.CLOSING;
+		void this.writer.close();
+	}
+
+	private addListener(
+		listeners: Map<string, Set<(...args: any[]) => void>>,
+		eventName: string,
+		callback: (...args: any[]) => void
+	) {
+		let callbacks = listeners.get(eventName);
+		if (!callbacks) {
+			callbacks = new Set();
+			listeners.set(eventName, callbacks);
+		}
+		callbacks.add(callback);
+	}
+
+	private emitOpen() {
+		this.readyState = this.OPEN;
+		this.onopen?.({});
+		this.emitBrowserEvent('open', {});
+		this.emitNodeEvent('open', {});
+		const buffered = this.pendingWrites;
+		this.pendingWrites = null;
+		if (buffered) {
+			for (const bytes of buffered) {
+				this.writeToStream(bytes);
+			}
+		}
+	}
+
+	private emitMessage(data: Uint8Array | ArrayBuffer | string) {
+		const event = { data };
+		this.onmessage?.(event);
+		this.emitBrowserEvent('message', event);
+		this.emitNodeEvent('message', data, typeof data !== 'string');
+	}
+
+	private emitClose() {
+		this.readyState = this.CLOSED;
+		this.onclose?.({});
+		this.emitBrowserEvent('close', {});
+		this.emitNodeEvent('close', {});
+	}
+
+	private emitError(error: any) {
+		this.onerror?.(error);
+		this.emitBrowserEvent('error', error);
+		this.emitNodeEvent('error', error);
+	}
+
+	private emitBrowserEvent(eventName: string, event: any) {
+		const callbacks = this.eventListeners.get(eventName);
+		if (!callbacks) return;
+		for (const callback of callbacks) {
+			callback(event);
+		}
+	}
+
+	private emitNodeEvent(eventName: string, ...args: any[]) {
+		const callbacks = this.nodeListeners.get(eventName);
+		if (!callbacks) return;
+		for (const callback of callbacks) {
+			callback(...args);
+		}
+	}
+
+	private writeToStream(bytes: Uint8Array) {
+		void this.writer.write(bytes);
+	}
+}

--- a/packages/php-wasm/util/src/test/create-sendmail-handler.spec.ts
+++ b/packages/php-wasm/util/src/test/create-sendmail-handler.spec.ts
@@ -1,0 +1,172 @@
+import { createSendmailSpawnHandler } from '../lib/create-sendmail-handler';
+import type { CaughtMessage } from '../lib/smtp';
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+describe('createSendmailSpawnHandler', () => {
+	it('parses a quoted sendmail command string', async () => {
+		const result = await sendMail(
+			'"/usr/sbin/sendmail" -t -i -f "sender@example.com"',
+			[
+				'To: recipient@example.com',
+				'Subject: Quoted command',
+				'',
+				'Body',
+			].join('\n')
+		);
+
+		expect(result.exitCode).toBe(0);
+		expect(result.message).toMatchObject({
+			from: 'sender@example.com',
+			to: 'recipient@example.com',
+			subject: 'Quoted command',
+		});
+	});
+
+	it('supports a separate -f envelope sender argument', async () => {
+		const result = await sendMail(
+			'/usr/sbin/sendmail -f sender@example.com',
+			[
+				'To: recipient@example.com',
+				'Subject: Separate sender',
+				'',
+				'Body',
+			].join('\n')
+		);
+
+		expect(result.exitCode).toBe(0);
+		expect(result.message?.from).toBe('sender@example.com');
+	});
+
+	it('supports an attached -f envelope sender argument', async () => {
+		const result = await sendMail(
+			'/usr/sbin/sendmail -fsender@example.com',
+			[
+				'To: recipient@example.com',
+				'Subject: Attached sender',
+				'',
+				'Body',
+			].join('\n')
+		);
+
+		expect(result.exitCode).toBe(0);
+		expect(result.message?.from).toBe('sender@example.com');
+	});
+
+	it('preserves an empty -f argument passed in argsArray', async () => {
+		const result = await sendMail(
+			'/usr/sbin/sendmail',
+			[
+				'To: recipient@example.com',
+				'Subject: Empty envelope sender from argsArray',
+				'',
+				'Body',
+			].join('\n'),
+			{ argsArray: ['-f', '', '-t'] }
+		);
+
+		expect(result.exitCode).toBe(0);
+		expect(result.message?.from).toBe('');
+	});
+
+	it('stops parsing envelope sender options after --', async () => {
+		const result = await sendMail(
+			'/usr/sbin/sendmail -f sender@example.com -- -fignored@example.com',
+			[
+				'To: recipient@example.com',
+				'Subject: End of options',
+				'',
+				'Body',
+			].join('\n')
+		);
+
+		expect(result.exitCode).toBe(0);
+		expect(result.message?.from).toBe('sender@example.com');
+	});
+
+	it('captures attachments from a MIME message with LF-only line endings', async () => {
+		// PHP 7 pipes LF-only messages to sendmail; the handler
+		// normalizes them to CRLF before parsing.
+		const result = await sendMail(
+			'/usr/sbin/sendmail -t -i',
+			[
+				'To: recipient@example.com',
+				'Subject: With attachment',
+				'MIME-Version: 1.0',
+				'Content-Type: multipart/mixed; boundary="MIX"',
+				'',
+				'--MIX',
+				'Content-Type: text/plain; charset=utf-8',
+				'',
+				'Body text.',
+				'--MIX',
+				'Content-Type: application/pdf; name="invoice.pdf"',
+				'Content-Transfer-Encoding: base64',
+				'Content-Disposition: attachment; filename="invoice.pdf"',
+				'',
+				btoa('%PDF-fake'),
+				'--MIX--',
+			].join('\n')
+		);
+
+		expect(result.exitCode).toBe(0);
+		expect(result.message?.text?.trim()).toBe('Body text.');
+		expect(result.message?.attachments).toHaveLength(1);
+		const attachment = result.message!.attachments[0];
+		expect(attachment.filename).toBe('invoice.pdf');
+		expect(attachment.contentType).toBe('application/pdf');
+		expect(attachment.contentDisposition).toBe('attachment');
+		expect(decoder.decode(attachment.content)).toBe('%PDF-fake');
+		expect(attachment.size).toBe('%PDF-fake'.length);
+	});
+
+	it('rejects messages that exceed maxSize', async () => {
+		const result = await sendMail('/usr/sbin/sendmail -t', '123456', {
+			maxSize: 5,
+		});
+
+		expect(result.exitCode).toBe(1);
+		expect(result.message).toBeUndefined();
+		expect(result.stderr).toContain('message exceeds maximum size');
+	});
+});
+
+async function sendMail(
+	command: string | string[],
+	rawMessage: string,
+	{ argsArray = [], maxSize }: { argsArray?: string[]; maxSize?: number } = {}
+): Promise<{
+	exitCode: number;
+	message?: CaughtMessage;
+	stderr: string;
+}> {
+	let caughtMessage: CaughtMessage | undefined;
+	const spawnHandler = createSendmailSpawnHandler(
+		(message) => {
+			caughtMessage = message;
+		},
+		undefined,
+		{ maxSize }
+	);
+	const childProcess = spawnHandler(command, argsArray);
+	const stderr: string[] = [];
+
+	childProcess.stderr.on('data', (data: ArrayBuffer) => {
+		stderr.push(decoder.decode(data));
+	});
+
+	const exitCode = await new Promise<number>((resolve) => {
+		childProcess.on('spawn', () => {
+			childProcess.stdin.write(encoder.encode(rawMessage));
+			childProcess.stdin.end();
+		});
+		childProcess.on('exit', resolve);
+	});
+
+	return {
+		exitCode,
+		message: caughtMessage,
+		stderr: stderr.join(''),
+	};
+}

--- a/packages/php-wasm/web/src/lib/load-runtime.ts
+++ b/packages/php-wasm/web/src/lib/load-runtime.ts
@@ -9,6 +9,8 @@ import {
 	loadPHPRuntime,
 	withMailCapture,
 	type WithMailCaptureOptions,
+	withSMTPSink,
+	type WithSmtpSinkOptions,
 } from '@php-wasm/universal';
 import { getPHPLoaderModule } from './get-php-loader-module';
 import type { TCPOverFetchOptions } from './tcp-over-fetch-websocket';
@@ -38,6 +40,7 @@ export interface LoaderOptions {
 	 * Capture raw bytes written to sendmail stdin.
 	 */
 	withMailCapture?: WithMailCaptureOptions;
+	withSMTPSink?: WithSmtpSinkOptions;
 }
 
 /**
@@ -105,6 +108,13 @@ export async function loadWebRuntime(
 	if (loaderOptions.withMailCapture) {
 		emscriptenOptions = withMailCapture(
 			loaderOptions.withMailCapture,
+			await emscriptenOptions
+		);
+	}
+
+	if (loaderOptions.withSMTPSink) {
+		emscriptenOptions = withSMTPSink(
+			loaderOptions.withSMTPSink,
 			await emscriptenOptions
 		);
 	}

--- a/packages/php-wasm/web/src/lib/tcp-over-fetch-websocket.ts
+++ b/packages/php-wasm/web/src/lib/tcp-over-fetch-websocket.ts
@@ -238,7 +238,7 @@ export class TCPOverFetchWebsocket {
 	 * Emscripten calls this method whenever the WASM module
 	 * writes bytes to the TCP socket.
 	 */
-	send(data: ArrayBuffer) {
+	send(data: ArrayBuffer | Uint8Array | string) {
 		if (
 			this.readyState === this.CLOSING ||
 			this.readyState === this.CLOSED
@@ -246,7 +246,14 @@ export class TCPOverFetchWebsocket {
 			return;
 		}
 
-		this.clientUpstreamWriter.write(new Uint8Array(data));
+		const bytes =
+			typeof data === 'string'
+				? new TextEncoder().encode(data)
+				: data instanceof ArrayBuffer
+					? new Uint8Array(data)
+					: data;
+
+		this.clientUpstreamWriter.write(bytes);
 
 		if (this.fetchInitiated) {
 			return;
@@ -256,7 +263,7 @@ export class TCPOverFetchWebsocket {
 		// what to do with the incoming bytes.
 		this.bufferedBytesFromClient = concatUint8Arrays([
 			this.bufferedBytesFromClient,
-			new Uint8Array(data),
+			bytes,
 		]);
 		switch (guessProtocol(this.port, this.bufferedBytesFromClient)) {
 			case false:


### PR DESCRIPTION
## Summary

Adds adapter/runtime plumbing that turns captured sendmail and SMTP traffic into structured `CaughtMessage` objects.

## Motivation for the change, related issues

The earlier PRs establish raw sendmail capture, shared Base64 helpers, and the `SmtpSink` protocol/parser core. This PR joins them into runtime loader options so callers can capture outbound mail from both `mail()` / sendmail and direct SMTP socket traffic.

This is the last SMTP-stack PR. It is based on #3953 and uses the raw capture plumbing from #3956.

## Implementation details

- Adds `SmtpSinkWebSocket`, a WebSocket-compatible shim that pipes socket bytes into `SmtpSink` and emits the expected WebSocket lifecycle events.
- Adds `createSendmailSpawnHandler()`, which builds on the raw sendmail capture helper, awaits `postal-mime` parsing through `parseMessage()`, and falls back to an unparsed message if parsing fails.
- Adds `withSMTPSink()` in `@php-wasm/universal`, which wraps the existing spawn handler for sendmail interception and decorates WebSocket construction for SMTP-port interception.
- Adds `withSMTPSink` loader options to the node and web runtime loaders.
- Updates `TCPOverFetchWebsocket.send()` to accept `string`, `Uint8Array`, and `ArrayBuffer` payloads.
- Adds PHP 8.4 node tests covering sendmail, raw SMTP, `mail()`, and MIME attachment capture.
- Exports the adapter APIs from `@php-wasm/util`.

## Testing Instructions

Run the utility package tests, package build, and targeted node SMTP e2e test:

```bash
npm exec nx test php-wasm-util -- --runInBand
npm exec nx build php-wasm-util
npm exec nx run php-wasm-node:test-group-2-asyncify -- --testFiles=php-smtp.spec.ts
```
