### PR TITLE
[wasm-posix-kernel] WordPress Playground Web Kandelo Beta - Proof of concept

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -76,8 +76,29 @@ jobs:
                   # Allow deploying a specific ref for folks who want to pin a specific version.
                   ref: ${{ vars.GIT_REF_TO_DEPLOY }}
             - uses: ./.github/actions/prepare-playground
+              with:
+                  # The kandelo binary fetch script needs Node >= 22.18;
+                  # 24 matches the posix-kernel CI jobs.
+                  node-version: 24
             - name: Sync PHP next build assets
               run: npm run sync:php-next
+            # host/dist/ and binaries/ are gitignored upstream; build and
+            # fetch them so the kernel-mode remote build finds its
+            # artifacts. Mirrors the posix-kernel jobs in ci.yml.
+            - name: Build kandelo host
+              shell: bash
+              working-directory: kandelo/host
+              run: |
+                  PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm ci --no-audit --no-fund
+                  npm run build
+            - name: Fetch kandelo wasm binaries
+              run: node packages/playground/cli/src/posix-kernel/scripts/fetch-kandelo-binaries.mts
+            # Built before the website so `build:wasm-wordpress-net`
+            # packages the kernel-mode remote into the artifact.
+            - name: Build the kernel-mode remote
+              run: npx nx run playground-remote:build-experimental-posix-kernel
+              env:
+                  CORS_PROXY_URL: ${{ vars.CORS_PROXY_URL }}
             - run: npx nx build playground-website
               env:
                   CORS_PROXY_URL: ${{ vars.CORS_PROXY_URL }}

--- a/packages/playground/client/src/index.spec.ts
+++ b/packages/playground/client/src/index.spec.ts
@@ -119,6 +119,29 @@ describe('startPlaygroundWeb', () => {
 		expect(mocks.BlueprintsV1Handler).not.toHaveBeenCalled();
 		expect(iframe.src).not.toContain('blueprints-runner');
 	});
+
+	it('accepts the kernel-mode remote entry used by ?experimental=kandelo', async () => {
+		// Narrowing the accepted pathnames back to only `/remote.html`
+		// would make kernel-mode sessions throw "Invalid remote URL"
+		// before booting.
+		const playground = { connected: true };
+		mocks.BlueprintsV2Handler.mockImplementation(() => ({
+			bootPlayground: mocks.bootPlaygroundV2,
+		}));
+		mocks.bootPlaygroundV2.mockResolvedValue(playground);
+		const iframe = createIframe();
+
+		await expect(
+			startPlaygroundWeb({
+				iframe,
+				remoteUrl: 'http://localhost/remote-posix-kernel.html',
+				progressTracker: createProgressTracker(),
+				blueprint: { version: 2 },
+			})
+		).resolves.toBe(playground);
+
+		expect(iframe.src).toContain('remote-posix-kernel.html');
+	});
 });
 
 describe('startPlaygroundAPI', () => {

--- a/packages/playground/client/src/index.ts
+++ b/packages/playground/client/src/index.ts
@@ -319,6 +319,11 @@ const remoteOrigin =
 	import.meta.env.MODE == 'development'
 		? devRemoteOrigin
 		: officialRemoteOrigin;
+const validRemotePathnames = [
+	'/remote.html',
+	// Kernel-mode entry used by `?experimental=kandelo` sessions.
+	'/remote-posix-kernel.html',
+];
 /**
  * Assert that the remote origin is likely compatible with this client library.
  *
@@ -344,15 +349,20 @@ function assertLikelyCompatibleRemotePath(
 ) {
 	const url = new URL(urlString, remoteOrigin);
 	const endpointName = expectedPath === '/api.html' ? 'API' : 'remote';
+	const validPathnames =
+		expectedPath === '/remote.html' ? validRemotePathnames : [expectedPath];
 
 	const validRemote =
 		validRemoteOrigins.includes(url.origin) &&
-		url.pathname === expectedPath;
+		validPathnames.includes(url.pathname);
 
 	if (!validRemote) {
 		throw new Error(
 			`Invalid ${endpointName} URL: ${url}. ` +
-				`Expected ${endpointName} URL to have a path of "${expectedPath}" based ` +
+				`Expected ${endpointName} URL to have a path of ` +
+				`${validPathnames
+					.map((pathname) => `"${pathname}"`)
+					.join(' or ')} based ` +
 				`on one of the following origins:\n ${validRemoteOrigins.join(
 					'\n'
 				)}`

--- a/packages/playground/remote/project.json
+++ b/packages/playground/remote/project.json
@@ -57,6 +57,13 @@
 				"cwd": "packages/playground/remote"
 			}
 		},
+		"build-experimental-posix-kernel": {
+			"executor": "nx:run-commands",
+			"options": {
+				"command": "vite build --config packages/playground/remote/vite.posix-kernel.config.ts"
+			},
+			"dependsOn": ["playground-blueprints:build:blueprint-schema"]
+		},
 		"preview": {
 			"executor": "@nx/vite:preview-server",
 			"defaultConfiguration": "production",

--- a/packages/playground/remote/vite.posix-kernel.config.ts
+++ b/packages/playground/remote/vite.posix-kernel.config.ts
@@ -4,11 +4,23 @@
  *
  * Sibling of `vite.config.ts` — the original config is kept untouched
  * so `npm run dev` continues to boot the classic Playground unchanged.
- * Serves two targets (see `packages/playground/remote/project.json`):
- * the `dev-experimental-posix-kernel` dev server and the
- * `test-remote-posix-kernel` vitest run for the posix-kernel unit
- * specs, which `vite.config.ts` excludes from its generic test target.
- * Build / preview targets remain owned by `vite.config.ts`.
+ * Serves three targets (see `packages/playground/remote/project.json`):
+ *   - the `dev-experimental-posix-kernel` dev server,
+ *   - the `build-experimental-posix-kernel` production build, which
+ *     emits the kernel-mode entry into `dist/packages/playground/
+ *     remote-posix-kernel` — a separate directory from the classic
+ *     build so the two asset graphs never overwrite each other, and
+ *   - the `test-remote-posix-kernel` vitest run for the posix-kernel
+ *     unit specs, which `vite.config.ts` excludes from its generic
+ *     test target.
+ * The preview target remains owned by `vite.config.ts`.
+ *
+ * The production build needs the `kandelo/` submodule with its host
+ * dependencies installed and its wasm binaries fetched, which regular
+ * `nx build playground-website` runs — locally and in CI — do not
+ * have. It is therefore not part of the website build graph:
+ * `deploy-website.yml` invokes the target explicitly, and
+ * `build:wasm-wordpress-net` packages the output only when present.
  *
  * Key differences from `vite.config.ts`:
  *   1. A `resolveKernelBinariesPlugin` resolves `@kernel-wasm` and
@@ -188,6 +200,20 @@ function aliasClientIndexPlugin(): Plugin {
 	};
 }
 
+/**
+ * Same output rule as `vite.config.ts`: extension modules (`.so`) and
+ * their data files (`.dat`) land in `assets/extensions/`.
+ */
+function extensionAwareAssetFileNames(chunkInfo: { names?: string[] }) {
+	if (
+		chunkInfo.names?.[0]?.endsWith('.so') ||
+		chunkInfo.names?.[0]?.endsWith('.dat')
+	) {
+		return 'assets/extensions/[name]-[hash][extname]';
+	}
+	return 'assets/[name]-[hash][extname]';
+}
+
 const plugins = [
 	viteTsConfigPaths({
 		root: '../../../',
@@ -342,6 +368,65 @@ export default defineConfig(() => {
 		worker: {
 			format: 'es',
 			plugins: () => plugins,
+			/**
+			 * Mirrors `vite.config.ts`. The stable `sw.js` name matters
+			 * doubly here: the posix-kernel boot registers the same
+			 * `service-worker.ts` as the classic remote, and the website
+			 * artifact ships the classic-built copy — both builds must
+			 * resolve the registration URL to the same `/sw.js`.
+			 */
+			rollupOptions: {
+				output: {
+					assetFileNames: extensionAwareAssetFileNames,
+					chunkFileNames: (chunkInfo: any) => {
+						if (
+							chunkInfo.facadeModuleId?.endsWith('.so') ||
+							chunkInfo.facadeModuleId?.endsWith('.dat')
+						) {
+							return 'assets/extensions/[name]-[hash].js';
+						}
+						return 'assets/[name]-[hash].js';
+					},
+					// See the `manualChunks` comment in `vite.config.ts` —
+					// keeps `wasm-feature-detect` out of worker entry chunks.
+					manualChunks(id) {
+						if (/[\\/]wasm-feature-detect[\\/]/.test(id)) {
+							return 'wasm-feature-detect';
+						}
+						return undefined;
+					},
+					entryFileNames: (chunkInfo: any) => {
+						if (chunkInfo.name === 'service-worker') {
+							return 'sw.js';
+						}
+						return '[name]-[hash].js';
+					},
+				},
+			},
+		},
+
+		build: {
+			target: 'esnext',
+			// See vite.config.ts — assets must be real files, not inlined.
+			assetsInlineLimit: 0,
+			sourcemap: true,
+			outDir: '../../../dist/packages/playground/remote-posix-kernel',
+			emptyOutDir: true,
+			// The classic build already ships the `wordpress-builds`
+			// public assets into the website artifact; do not copy the
+			// same files a second time.
+			copyPublicDir: false,
+			rollupOptions: {
+				input: {
+					'remote-posix-kernel': resolve(
+						__dirname,
+						'remote-posix-kernel.html'
+					),
+				},
+				output: {
+					assetFileNames: extensionAwareAssetFileNames,
+				},
+			},
 		},
 
 		test: {

--- a/packages/playground/website-deployment/custom-redirects-lib.php
+++ b/packages/playground/website-deployment/custom-redirects-lib.php
@@ -403,6 +403,27 @@ function playground_get_custom_response_headers( $requested_path ) {
 
 	if ( 'iframe-worker.html' === $filename ) {
 		return array( 'Origin-Agent-Cluster: ?1' );
+	} elseif ( 'remote-posix-kernel.html' === $filename ) {
+		// The kandelo kernel remote allocates SharedArrayBuffer, which
+		// browsers only enable on cross-origin isolated documents.
+		return array(
+			'Cross-Origin-Opener-Policy: same-origin',
+			'Cross-Origin-Embedder-Policy: require-corp',
+			'Document-Isolation-Policy: isolate-and-require-corp',
+			'Cache-Control: max-age=0, no-cache, no-store, must-revalidate',
+		);
+	} elseif ( playground_is_worker_script( $filename ) ) {
+		// Dedicated worker scripts must carry a COEP header compatible
+		// with the document that spawns them. The kernel-mode remote
+		// (`?experimental=kandelo`) is COEP `require-corp` and the
+		// opted-in parent page is COEP `credentialless`; `require-corp`
+		// on the worker script satisfies both, and browsers ignore the
+		// header on non-worker loads. These files are hash-named and
+		// immutable, so keep them edge-cacheable.
+		return array(
+			'Cross-Origin-Embedder-Policy: require-corp',
+			'A8C-Edge-Cache: cache',
+		);
 	} elseif ( in_array( $filename, array( 'mywp-event.php', 'mywp-event-dashboard.php', 'relay.php' ), true ) ) {
 		return array( 'Cache-Control: no-store' );
 	} elseif ( str_ends_with( $filename, 'store.zip' ) ) {
@@ -417,7 +438,18 @@ function playground_get_custom_response_headers( $requested_path ) {
 		'/index.html' === $requested_path ||
 		'/api.html' === $requested_path
 	) {
-		return array( 'Cache-Control: max-age=0, no-cache, no-store, must-revalidate' );
+		$headers = array( 'Cache-Control: max-age=0, no-cache, no-store, must-revalidate' );
+		if ( playground_request_opts_into_kandelo() ) {
+			// The website only switches the iframe to the kernel-mode
+			// remote when the parent document is cross-origin isolated.
+			// Sent only on opt-in because COOP `same-origin` breaks the
+			// GitHub OAuth popup flow; COEP `credentialless` (rather
+			// than `require-corp`) keeps cross-origin subresources
+			// loading without CORP headers.
+			$headers[] = 'Cross-Origin-Opener-Policy: same-origin';
+			$headers[] = 'Cross-Origin-Embedder-Policy: credentialless';
+		}
+		return $headers;
 	} elseif (
 		in_array(
 			$filename,
@@ -439,6 +471,31 @@ function playground_get_custom_response_headers( $requested_path ) {
 		);
 	}
 
+	return false;
+}
+
+function playground_request_opts_into_kandelo() {
+	return isset( $_GET['experimental'] ) && 'kandelo' === $_GET['experimental'];
+}
+
+function playground_is_worker_script( $filename ) {
+	$worker_script_prefixes = array(
+		// Spawned by the remote iframe (classic and kernel-mode).
+		'playground-worker-endpoint-',
+		// Spawned by the kernel-mode remote (`remote-posix-kernel.html`).
+		'browser-kernel-worker-entry-',
+		'worker-entry-browser-',
+		// Spawned by the website when saving a site to OPFS.
+		'opfs-site-storage-worker-',
+	);
+	if ( ! str_ends_with( $filename, '.js' ) ) {
+		return false;
+	}
+	foreach ( $worker_script_prefixes as $prefix ) {
+		if ( str_starts_with( $filename, $prefix ) ) {
+			return true;
+		}
+	}
 	return false;
 }
 

--- a/packages/playground/website-deployment/tests.php
+++ b/packages/playground/website-deployment/tests.php
@@ -69,6 +69,82 @@ assert_throws(
     }
 );
 
+assert_equal(
+    json_encode( array(
+        'Cross-Origin-Opener-Policy: same-origin',
+        'Cross-Origin-Embedder-Policy: require-corp',
+        'Document-Isolation-Policy: isolate-and-require-corp',
+        'Cache-Control: max-age=0, no-cache, no-store, must-revalidate',
+    ) ),
+    json_encode( playground_get_custom_response_headers( '/remote-posix-kernel.html' ) ),
+    'The kernel-mode remote entry must be served cross-origin isolated'
+);
+
+assert_equal(
+    true,
+    playground_is_static_file_needing_special_treatment( '/remote-posix-kernel.html' ),
+    'The kernel-mode remote entry must be served via PHP so its headers apply'
+);
+
+foreach ( array(
+    '/playground-worker-endpoint-CgltsLwW.js',
+    '/browser-kernel-worker-entry-CG9-Ll6m.js',
+    '/worker-entry-browser-l3O2__qb.js',
+    '/assets/opfs-site-storage-worker-for-safari-pJM5slyx.js',
+) as $worker_script_path ) {
+    assert_equal(
+        json_encode( array(
+            'Cross-Origin-Embedder-Policy: require-corp',
+            'A8C-Edge-Cache: cache',
+        ) ),
+        json_encode( playground_get_custom_response_headers( $worker_script_path ) ),
+        "Worker script '$worker_script_path' must carry a COEP header so cross-origin isolated documents can spawn it"
+    );
+    assert_equal(
+        true,
+        playground_is_static_file_needing_special_treatment( $worker_script_path ),
+        "Worker script '$worker_script_path' must be served via PHP so its headers apply"
+    );
+}
+
+assert_equal(
+    false,
+    playground_get_custom_response_headers( '/assets/index-DPZBRXIa.js' ),
+    'Non-worker scripts must keep the default header treatment'
+);
+
+unset( $_GET['experimental'] );
+assert_equal(
+    json_encode( array(
+        'Cache-Control: max-age=0, no-cache, no-store, must-revalidate',
+    ) ),
+    json_encode( playground_get_custom_response_headers( '/index.html' ) ),
+    'Without the kandelo opt-in, index.html must not be cross-origin isolated'
+);
+
+$_GET['experimental'] = 'other';
+assert_equal(
+    json_encode( array(
+        'Cache-Control: max-age=0, no-cache, no-store, must-revalidate',
+    ) ),
+    json_encode( playground_get_custom_response_headers( '/index.html' ) ),
+    'Other experimental values must not opt into cross-origin isolation'
+);
+
+$_GET['experimental'] = 'kandelo';
+foreach ( array( '/', '/index.html' ) as $kandelo_opt_in_path ) {
+    assert_equal(
+        json_encode( array(
+            'Cache-Control: max-age=0, no-cache, no-store, must-revalidate',
+            'Cross-Origin-Opener-Policy: same-origin',
+            'Cross-Origin-Embedder-Policy: credentialless',
+        ) ),
+        json_encode( playground_get_custom_response_headers( $kandelo_opt_in_path ) ),
+        "With ?experimental=kandelo, '$kandelo_opt_in_path' must opt into cross-origin isolation"
+    );
+}
+unset( $_GET['experimental'] );
+
 $mywp_event_headers = playground_get_custom_response_headers( '/mywp-event.php' );
 assert_equal(
     true,

--- a/packages/playground/website/.htaccess
+++ b/packages/playground/website/.htaccess
@@ -10,3 +10,13 @@ Header set Access-Control-Allow-Origin "*"
 Header unset ETag
 Header set Cache-Control "max-age=0, no-cache, no-store, must-revalidate"
 </FilesMatch>
+<FilesMatch "remote-posix-kernel\.html">
+Header set Cross-Origin-Opener-Policy "same-origin"
+Header set Cross-Origin-Embedder-Policy "require-corp"
+Header set Document-Isolation-Policy "isolate-and-require-corp"
+Header unset ETag
+Header set Cache-Control "max-age=0, no-cache, no-store, must-revalidate"
+</FilesMatch>
+<FilesMatch "^(playground-worker-endpoint-|browser-kernel-worker-entry-|worker-entry-browser-|opfs-site-storage-worker-).*\.js$">
+Header set Cross-Origin-Embedder-Policy "require-corp"
+</FilesMatch>

--- a/packages/playground/website/playwright/e2e/posix-kernel/experimental-kandelo-param.spec.ts
+++ b/packages/playground/website/playwright/e2e/posix-kernel/experimental-kandelo-param.spec.ts
@@ -1,0 +1,39 @@
+import { test, expect } from '../../playground-fixtures';
+
+/**
+ * `?experimental=kandelo` must swap the remote iframe entry from the
+ * classic `/remote.html` to the kernel-mode
+ * `/remote-posix-kernel.html` (see `website/src/lib/config.ts`).
+ *
+ * Note both assertions run against the kernel dev config, where the
+ * remote dev server also aliases `/remote.html` to the kernel entry —
+ * so the param-less test asserts URL selection, not runtime choice.
+ */
+
+const viewportSelector =
+	'#playground-viewport:visible,.playground-viewport:visible';
+
+test('?experimental=kandelo selects the kernel-mode remote entry', async ({
+	website,
+	page,
+	wordpress,
+}) => {
+	await website.goto('./?experimental=kandelo');
+	const iframeSrc = await page.locator(viewportSelector).getAttribute('src');
+	expect(new URL(iframeSrc!, page.url()).pathname).toBe(
+		'/remote-posix-kernel.html'
+	);
+	// A rendered WordPress proves the boot got past the client's
+	// `assertLikelyCompatibleRemoteOrigin`, which must accept the
+	// kernel-mode pathname.
+	await expect(wordpress.locator('body')).toBeVisible();
+});
+
+test('without the param the classic remote entry URL is used', async ({
+	website,
+	page,
+}) => {
+	await website.goto('./');
+	const iframeSrc = await page.locator(viewportSelector).getAttribute('src');
+	expect(new URL(iframeSrc!, page.url()).pathname).toBe('/remote.html');
+});

--- a/packages/playground/website/project.json
+++ b/packages/playground/website/project.json
@@ -18,6 +18,7 @@
 					"mkdir ./wasm-wordpress-net",
 					"cp -r ./blueprints/blueprint-schema.json ./wasm-wordpress-net/",
 					"cp -r ./client ./wasm-wordpress-net/",
+					"if [ -d ./remote-posix-kernel ]; then cp -r ./remote-posix-kernel/* ./wasm-wordpress-net/; fi",
 					"cp -r ./remote/* ./wasm-wordpress-net/",
 					"cp -r ./website/* ./wasm-wordpress-net/",
 					"cp -r ./website-extras/* ./wasm-wordpress-net/",

--- a/packages/playground/website/src/lib/config.spec.ts
+++ b/packages/playground/website/src/lib/config.spec.ts
@@ -1,0 +1,51 @@
+import { vi } from 'vitest';
+import { logger } from '@php-wasm/logger';
+import { getRemoteUrl, isExperimentalKandeloEnabled } from './config';
+
+// The default vitest environment for this package is `node`, so we
+// stub the few `window` fields the config helpers read.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const g = globalThis as any;
+
+function stubWindow({ search = '', crossOriginIsolated = false } = {}) {
+	g.window = {
+		location: {
+			search,
+			origin: 'http://localhost:5400',
+		},
+		crossOriginIsolated,
+	};
+}
+
+describe('isExperimentalKandeloEnabled', () => {
+	afterEach(() => {
+		delete g.window;
+		vi.restoreAllMocks();
+	});
+
+	it('is false without the query param', () => {
+		stubWindow({ crossOriginIsolated: true });
+		expect(isExperimentalKandeloEnabled()).toBe(false);
+		expect(getRemoteUrl().pathname).toBe('/remote.html');
+	});
+
+	it('is true when requested on a cross-origin isolated page', () => {
+		stubWindow({
+			search: '?experimental=kandelo',
+			crossOriginIsolated: true,
+		});
+		expect(isExperimentalKandeloEnabled()).toBe(true);
+		expect(getRemoteUrl().pathname).toBe('/remote-posix-kernel.html');
+	});
+
+	it('falls back to the classic runtime with a warning when the page is not cross-origin isolated', () => {
+		stubWindow({
+			search: '?experimental=kandelo',
+			crossOriginIsolated: false,
+		});
+		const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+		expect(isExperimentalKandeloEnabled()).toBe(false);
+		expect(getRemoteUrl().pathname).toBe('/remote.html');
+		expect(warn).toHaveBeenCalled();
+	});
+});

--- a/packages/playground/website/src/lib/config.ts
+++ b/packages/playground/website/src/lib/config.ts
@@ -1,10 +1,39 @@
 // Provided by vite
 import { buildVersion } from 'virtual:website-config';
+import { logger } from '@php-wasm/logger';
 export { buildVersion } from 'virtual:website-config';
+
+/**
+ * Whether this session runs the experimental kandelo POSIX-kernel
+ * runtime instead of the classic PHP worker. Opted into via
+ * `?experimental=kandelo`.
+ *
+ * The kernel remote needs `SharedArrayBuffer`, which browsers only
+ * enable on cross-origin isolated pages. The COOP/COEP headers are
+ * server-side, so when they're missing we fall back to the classic
+ * runtime with a warning instead of failing inside the kernel worker.
+ */
+export function isExperimentalKandeloEnabled() {
+	const requested =
+		new URLSearchParams(window.location.search).get('experimental') ===
+		'kandelo';
+	if (requested && !window.crossOriginIsolated) {
+		logger.warn(
+			'?experimental=kandelo needs a cross-origin isolated page, but ' +
+				'this server did not send the Cross-Origin-Opener-Policy / ' +
+				'Cross-Origin-Embedder-Policy headers. Falling back to the ' +
+				'classic Playground runtime.'
+		);
+		return false;
+	}
+	return requested;
+}
 
 export function getRemoteUrl() {
 	const remoteUrl = new URL(window.location.origin);
-	remoteUrl.pathname = '/remote.html';
+	remoteUrl.pathname = isExperimentalKandeloEnabled()
+		? '/remote-posix-kernel.html'
+		: '/remote.html';
 	remoteUrl.searchParams.set('v', buildVersion);
 	// The e2e "boot-once" suite stashes snapshot URLs on these window globals
 	// (set by the Playwright fixtures); forward them to the remote iframe so

--- a/packages/playground/website/src/lib/state/url/router.spec.ts
+++ b/packages/playground/website/src/lib/state/url/router.spec.ts
@@ -225,3 +225,23 @@ describe('isSiteSavingDisabled', () => {
 		).toBe(true);
 	});
 });
+
+describe('PlaygroundRoute.site experimental runtime param', () => {
+	const storedSite = {
+		slug: 'my-site',
+		metadata: { storage: 'opfs' },
+	} as unknown as SiteInfo;
+
+	it('preserves the `experimental` param when rewriting a stored-site URL', () => {
+		// Dropping it would silently switch `?experimental=kandelo`
+		// sessions back to the classic runtime when selecting a saved site.
+		const url = new URL(
+			PlaygroundRoute.site(
+				storedSite,
+				'http://localhost:5400/?experimental=kandelo&wp=6.8'
+			)
+		);
+		expect(url.searchParams.get('site-slug')).toBe('my-site');
+		expect(url.searchParams.get('experimental')).toBe('kandelo');
+	});
+});

--- a/packages/playground/website/src/lib/state/url/router.ts
+++ b/packages/playground/website/src/lib/state/url/router.ts
@@ -115,6 +115,9 @@ export class PlaygroundRoute {
 				'mcp',
 				'mcp-port',
 				'can-save',
+				// Dropping it would silently switch `?experimental=kandelo`
+				// sessions back to the classic runtime.
+				'experimental',
 			];
 			const preserveParams: Record<string, string | null> = {};
 			for (const param of preserveParamsKeys) {


### PR DESCRIPTION
Adds an experimental `?experimental=kandelo` opt-in that runs WordPress Playground **Web** on the wasm-posix-kernel (kandelo) runtime instead of the classic PHP worker.

Built on top of #3635 (the kernel-mode web proof of concept); this PR is the opt-in wiring plus the deployment glue needed to actually serve it.

## What it does

- **Client** (`@wp-playground/client`) — `assertLikelyCompatibleRemoteOrigin` accepts `/remote-posix-kernel.html` alongside `/remote.html`, so kernel-mode sessions boot instead of throwing "Invalid remote URL".
- **Website** — `getRemoteUrl` points the remote iframe at `/remote-posix-kernel.html` when `?experimental=kandelo` is present. The kernel remote needs `SharedArrayBuffer`, which the browser only grants on cross-origin isolated pages, so when the page is not isolated we fall back to the classic runtime with a console warning instead of failing inside the worker. `PlaygroundRoute.site` preserves the `experimental` param when rewriting a stored-site URL (dropping it would silently switch a saved-site selection back to classic).
- **Deployment (serving)** — `/remote-posix-kernel.html` is served cross-origin isolated (COOP `same-origin`, COEP `require-corp`, `Document-Isolation-Policy`). `/` and `/index.html` opt into isolation **only** under `?experimental=kandelo`, because COOP `same-origin` otherwise breaks the GitHub OAuth popup for everyone else; those use COEP `credentialless` to keep cross-origin subresources loading without CORP headers. Dedicated worker scripts (the kernel remote's worker entries and the website's OPFS workers) are served with COEP `require-corp`: a dedicated worker script must carry a COEP header compatible with the document that spawns it, the dev server sets headers on every response, production did not — without this the workers fail to load. `custom-redirects-lib.php` covers the PHP deployment, `.htaccess` mirrors the headers for the static one.
- **Deployment (build & ship)** — a `build-experimental-posix-kernel` nx target builds `/remote-posix-kernel.html` for production via a new build section in `vite.posix-kernel.config.ts`: its own `dist/packages/playground/remote-posix-kernel` output so the classic and kernel asset graphs never overwrite each other, plus the classic worker output rules so the shared service worker resolves to the same `/sw.js` (the artifact ships the classic-built copy). The build needs the `kandelo/` submodule with its host dependencies installed and its wasm binaries fetched, which regular website builds do not have, so it is not part of the website build graph: `deploy-website.yml` builds the kandelo host, fetches the pinned wasm binaries, and invokes the target before the website build; `build:wasm-wordpress-net` packages the output only when present. The deploy workflow now runs under Node 24 (the binary fetch script needs Node >= 22.18; 24 matches the posix-kernel CI jobs).

## Tests

- `client/src/index.spec.ts` — client accepts the kernel-mode remote entry pathname.
- `website/src/lib/config.spec.ts` — runtime selection and the not-isolated fallback (+ warning).
- `website/src/lib/state/url/router.spec.ts` — the `experimental` param is preserved across stored-site URL rewrites.
- `website-deployment/tests.php` — the new cross-origin-isolation and worker-script header branches, plus the special-treatment routing that serves them via PHP.
- `website/playwright/e2e/posix-kernel/experimental-kandelo-param.spec.ts` — e2e asserting the iframe entry URL swaps with the param.

Verified end to end against a static server replaying the production header logic: the kandelo-opted artifact boots WordPress on first load and on the service-worker-controlled reload, and the classic mode stays non-isolated with cross-origin embeds loading.

## Breaking changes

None.
