### PR TITLE
[Website] Store setup params in OPFS site metadata

### DIFF
--- a/packages/playground/website/src/lib/state/opfs/opfs-site-storage.spec.ts
+++ b/packages/playground/website/src/lib/state/opfs/opfs-site-storage.spec.ts
@@ -17,6 +17,34 @@ describe('opfsSiteStorage', () => {
 				getDirectory: vi.fn(async () => opfsRoot),
 			},
 		});
+		vi.stubGlobal(
+			'Worker',
+			class {
+				postMessage(
+					message: { path: string; content: string },
+					options?: { transfer?: MessagePort[] }
+				) {
+					const port = options?.transfer?.[0];
+					setTimeout(async () => {
+						try {
+							await writeOpfsPath(
+								opfsRoot,
+								message.path,
+								message.content
+							);
+							port?.postMessage('done');
+						} catch (error) {
+							port?.postMessage(
+								error instanceof Error
+									? error.message
+									: String(error)
+							);
+						}
+					}, 0);
+				}
+				terminate() {}
+			}
+		);
 		vi.doMock('./opfs-blueprint-bundle-storage', () => ({
 			BUNDLE_DIR_NAME: 'blueprint-bundle',
 			loadPersistedBlueprintBundle,
@@ -57,6 +85,52 @@ describe('opfsSiteStorage', () => {
 		await expect(
 			storage.create('a/b', createSiteMetadata())
 		).rejects.toThrow("Site with slug 'a/b' already exists.");
+	});
+
+	it('stores setup URL params alongside site metadata', async () => {
+		const originalUrlParams = {
+			searchParams: {
+				language: 'pl_PL',
+				plugin: ['akismet', 'gutenberg'],
+			},
+			hash: '#blueprint',
+		};
+
+		await storage.create(
+			'stored-site',
+			createSiteMetadata(),
+			originalUrlParams
+		);
+
+		await expect(storage.read('stored-site')).resolves.toMatchObject({
+			slug: 'stored-site',
+			originalUrlParams,
+		});
+	});
+
+	it('updates setup URL params alongside site metadata', async () => {
+		await storage.create('stored-site', createSiteMetadata(), {
+			searchParams: { language: 'en_US' },
+		});
+		const originalUrlParams = {
+			searchParams: {
+				language: 'pl_PL',
+				multisite: 'yes',
+			},
+		};
+
+		await storage.update(
+			'stored-site',
+			createSiteMetadata({ name: 'Renamed Playground' }),
+			originalUrlParams
+		);
+
+		await expect(storage.read('stored-site')).resolves.toMatchObject({
+			metadata: {
+				name: 'Renamed Playground',
+			},
+			originalUrlParams,
+		});
 	});
 
 	it('deletes the legacy site directory when the encoded directory is incomplete', async () => {
@@ -111,6 +185,25 @@ async function writeSiteMetadata(
 			...createSiteMetadata(metadata),
 		})
 	);
+}
+
+async function writeOpfsPath(
+	opfsRoot: MemoryDirectoryHandle,
+	path: string,
+	content: string
+) {
+	const pathParts = path.split('/').filter(Boolean);
+	const fileName = pathParts.pop();
+	if (!fileName) {
+		throw new Error(`Cannot write OPFS file without a file name: ${path}`);
+	}
+	let directory = opfsRoot;
+	for (const pathPart of pathParts) {
+		directory = await directory.getDirectoryHandle(pathPart, {
+			create: true,
+		});
+	}
+	directory.setFile(fileName, content);
 }
 
 function createSiteMetadata(

--- a/packages/playground/website/src/lib/state/opfs/opfs-site-storage.ts
+++ b/packages/playground/website/src/lib/state/opfs/opfs-site-storage.ts
@@ -6,8 +6,8 @@
  */
 
 import metadataWorkerUrl from './opfs-site-storage-worker-for-safari?worker&url';
-import type { SiteMetadata } from '../redux/slice-sites';
-import type { SiteInfo } from '../redux/slice-sites';
+import type { SiteInfo, SiteMetadata } from '../redux/slice-sites';
+import type { OriginalUrlParams } from '../original-url-params';
 import { logger } from '@php-wasm/logger';
 import { joinPaths } from '@php-wasm/util';
 import {
@@ -45,13 +45,16 @@ export const legacyOpfsPathSymbol = Symbol('legacyOpfsPath');
  * It's different from SiteInfo:
  * * It extends SiteMetadata instead of embedding it.
  * * It adds slug to SiteMetadata so we can recover it after a page reload.
- * * It's not concerned with any extra information stored in SiteInfo by the redux store.
+ * * It keeps the setup URL params that settings and sharing panes need after reload.
+ * * It's not concerned with any other extra information stored in SiteInfo by
+ *   the redux store.
  *
  * I'm not yet sure whether that's the right approach. Let's keep going and find out as the
  * design matures.
  */
 export interface StoredSiteMetadata extends SiteMetadata {
 	slug: string;
+	originalUrlParams?: OriginalUrlParams;
 }
 
 let opfsSitesRoot: FileSystemDirectoryHandle | undefined = undefined;
@@ -72,23 +75,36 @@ class OpfsSiteStorage {
 		this.root = root;
 	}
 
-	async create(slug: string, metadata: SiteMetadata): Promise<void> {
+	/**
+	 * Creates an OPFS site directory and stores its reloadable metadata.
+	 */
+	async create(
+		slug: string,
+		metadata: SiteMetadata,
+		originalUrlParams?: OriginalUrlParams
+	): Promise<void> {
 		const newSiteDirName = getDirectoryNameForSlug(slug);
 		const existingSiteDirName = await this.findExistingSiteDirName(slug);
 		if (existingSiteDirName) {
 			throw new Error(`Site with slug '${slug}' already exists.`);
 		}
-
 		await this.root.getDirectoryHandle(newSiteDirName, {
 			create: true,
 		});
 		await opfsWriteFile(
 			getSiteMetadataPath(newSiteDirName),
-			await metadataToStoredFormat(slug, metadata)
+			await metadataToStoredFormat(slug, metadata, originalUrlParams)
 		);
 	}
 
-	async update(slug: string, metadata: SiteMetadata): Promise<void> {
+	/**
+	 * Updates OPFS site metadata without changing the site directory name.
+	 */
+	async update(
+		slug: string,
+		metadata: SiteMetadata,
+		originalUrlParams?: OriginalUrlParams
+	): Promise<void> {
 		const siteDirName = await this.findExistingSiteDirName(slug);
 		if (!siteDirName) {
 			throw new Error(`Site with slug '${slug}' does not exist.`);
@@ -96,7 +112,7 @@ class OpfsSiteStorage {
 
 		await opfsWriteFile(
 			getSiteMetadataPath(siteDirName),
-			await metadataToStoredFormat(slug, metadata)
+			await metadataToStoredFormat(slug, metadata, originalUrlParams)
 		);
 	}
 
@@ -252,11 +268,13 @@ function getSiteMetadataPath(siteDirName: string) {
 
 async function metadataToStoredFormat(
 	slug: string,
-	{ originalBlueprint, originalBlueprintSource, ...metadata }: SiteMetadata
+	{ originalBlueprint, originalBlueprintSource, ...metadata }: SiteMetadata,
+	originalUrlParams?: OriginalUrlParams
 ): Promise<string> {
 	return JSON.stringify(
 		{
 			slug,
+			originalUrlParams,
 			originalBlueprintSource,
 			/**
 			 * Site metadata stores Blueprint declaration JSON, not arbitrary
@@ -278,7 +296,9 @@ async function metadataToStoredFormat(
 }
 
 function storedFormatToMetadata(data: string) {
-	const { slug, ...metadata } = JSON.parse(data) as StoredSiteMetadata;
+	const { slug, originalUrlParams, ...metadata } = JSON.parse(
+		data
+	) as StoredSiteMetadata;
 
 	/**
 	 * Migrate the legacy runtimeConfiguration data format to the new, flat one.
@@ -329,6 +349,7 @@ function storedFormatToMetadata(data: string) {
 
 	return {
 		slug,
+		originalUrlParams,
 		metadata,
 	};
 }

--- a/packages/playground/website/src/lib/state/original-url-params.ts
+++ b/packages/playground/website/src/lib/state/original-url-params.ts
@@ -1,0 +1,11 @@
+/**
+ * Original Query API setup params captured when a Playground is created.
+ *
+ * These fields are stored separately from runtime configuration because some
+ * setup choices, such as `language` and repeated `plugin` params, are needed
+ * later when recreating the same Playground but are not runtime boot settings.
+ */
+export type OriginalUrlParams = {
+	searchParams?: Record<string, string | string[]>;
+	hash?: string;
+};

--- a/packages/playground/website/src/lib/state/redux/slice-sites.spec.ts
+++ b/packages/playground/website/src/lib/state/redux/slice-sites.spec.ts
@@ -1,10 +1,17 @@
+import type { OriginalUrlParams } from '../original-url-params';
+import type { SiteInfo } from './slice-sites';
+
 describe('stored site specs', () => {
+	let createSite: ReturnType<typeof vi.fn>;
+	let updateSiteStorage: ReturnType<typeof vi.fn>;
 	let persistBlueprintBundle: ReturnType<typeof vi.fn>;
 	let resetSiteFiles: ReturnType<typeof vi.fn>;
 	let resolveRuntimeConfiguration: ReturnType<typeof vi.fn>;
 
 	beforeEach(() => {
 		vi.resetModules();
+		createSite = vi.fn();
+		updateSiteStorage = vi.fn();
 		persistBlueprintBundle = vi.fn();
 		resetSiteFiles = vi.fn();
 		resolveRuntimeConfiguration = vi.fn();
@@ -39,6 +46,8 @@ describe('stored site specs', () => {
 		}));
 		vi.doMock('../opfs/opfs-site-storage', () => ({
 			opfsSiteStorage: {
+				create: createSite,
+				update: updateSiteStorage,
 				resetSiteFiles,
 			},
 		}));
@@ -79,12 +88,83 @@ describe('stored site specs', () => {
 		vi.doUnmock('./store');
 	});
 
+	it('persists setup URL params when adding a saved site', async () => {
+		const { addSite } = await import('./slice-sites');
+		const originalUrlParams = {
+			searchParams: {
+				language: 'pl_PL',
+				plugin: ['akismet', 'gutenberg'],
+			},
+			hash: '#blueprint',
+		};
+		const site = createSiteInfo({
+			originalUrlParams,
+		});
+
+		await addSite(site)(
+			createDispatch() as any,
+			createEmptyGetState() as any
+		);
+
+		expect(createSite).toHaveBeenCalledWith(
+			site.slug,
+			site.metadata,
+			originalUrlParams
+		);
+	});
+
+	it('keeps setup URL params when updating persisted metadata', async () => {
+		const { sitesSlice, updateSite } = await import('./slice-sites');
+		const originalUrlParams = {
+			searchParams: {
+				language: 'pl_PL',
+				multisite: 'yes',
+			},
+		};
+		const site = createSiteInfo({
+			originalUrlParams,
+		});
+		let state = {
+			sites: sitesSlice.reducer(
+				undefined,
+				sitesSlice.actions.addSite(site)
+			),
+		};
+		const dispatch = vi.fn((action) => {
+			state = {
+				sites: sitesSlice.reducer(state.sites, action),
+			};
+			return action;
+		});
+		const updatedMetadata = {
+			...site.metadata,
+			name: 'Renamed Playground',
+		};
+
+		await updateSite({
+			slug: site.slug,
+			changes: {
+				metadata: updatedMetadata,
+			},
+		})(dispatch as any, () => state as any);
+
+		expect(updateSiteStorage).toHaveBeenCalledWith(
+			site.slug,
+			updatedMetadata,
+			originalUrlParams
+		);
+	});
+
 	it('does not replace a persisted bundle before validating the new setup', async () => {
-		resolveRuntimeConfiguration.mockRejectedValue(new Error('Invalid setup'));
+		resolveRuntimeConfiguration.mockRejectedValue(
+			new Error('Invalid setup')
+		);
 		const { resetAutosavedSiteSpec } = await import('./slice-sites');
 		const resetSite = resetAutosavedSiteSpec(
 			'autosaved-site',
-			new URL('https://playground.test/?blueprint-url=https://example.com')
+			new URL(
+				'https://playground.test/?blueprint-url=https://example.com'
+			)
 		);
 
 		await expect(
@@ -96,11 +176,15 @@ describe('stored site specs', () => {
 	});
 
 	it('does not persist a bundle for a new stored site before validating setup', async () => {
-		resolveRuntimeConfiguration.mockRejectedValue(new Error('Invalid setup'));
+		resolveRuntimeConfiguration.mockRejectedValue(
+			new Error('Invalid setup')
+		);
 		const { setStoredSiteSpec } = await import('./slice-sites');
 		const addSite = setStoredSiteSpec(
 			'Autosaved site',
-			new URL('https://playground.test/?blueprint-url=https://example.com'),
+			new URL(
+				'https://playground.test/?blueprint-url=https://example.com'
+			),
 			'autosaved-site',
 			{ persistence: 'autosave' }
 		);
@@ -153,6 +237,32 @@ function createGetState() {
 			firstTemporarySiteCreated: false,
 		},
 	});
+}
+
+function createSiteInfo({
+	originalUrlParams,
+}: {
+	originalUrlParams?: OriginalUrlParams;
+} = {}): SiteInfo {
+	return {
+		slug: 'stored-site',
+		originalUrlParams,
+		metadata: {
+			id: 'stored-site',
+			name: 'Stored site',
+			storage: 'opfs' as const,
+			originalBlueprint: {},
+			originalBlueprintSource: { type: 'none' as const },
+			runtimeConfiguration: {
+				phpVersion: '8.3' as const,
+				wpVersion: 'latest',
+				intl: false,
+				networking: true,
+				extraLibraries: [],
+				constants: {},
+			},
+		},
+	};
 }
 
 function createDispatch() {

--- a/packages/playground/website/src/lib/state/redux/slice-sites.ts
+++ b/packages/playground/website/src/lib/state/redux/slice-sites.ts
@@ -7,6 +7,7 @@ import {
 import type { PlaygroundDispatch, PlaygroundReduxState } from './store';
 import { selectActiveSite, setActiveSite } from './store';
 import { opfsSiteStorage } from '../opfs/opfs-site-storage';
+import type { OriginalUrlParams } from '../original-url-params';
 import {
 	BlueprintReflection,
 	type RuntimeConfiguration,
@@ -67,10 +68,7 @@ const DEFAULT_BLUEPRINT =
 export interface SiteInfo {
 	slug: string;
 	loadedFromStorage?: boolean;
-	originalUrlParams?: {
-		searchParams?: Record<string, string | string[]>;
-		hash?: string;
-	};
+	originalUrlParams?: OriginalUrlParams;
 	metadata: SiteMetadata;
 }
 
@@ -248,7 +246,8 @@ export function updateSite({
 		if (updatedSite.metadata.storage !== 'none') {
 			await opfsSiteStorage?.update(
 				updatedSite.slug,
-				updatedSite.metadata
+				updatedSite.metadata,
+				updatedSite.originalUrlParams
 			);
 		}
 	};
@@ -277,7 +276,11 @@ export function addSite(siteInfo: SiteInfo) {
 				'Cannot add a saved Playground because browser storage is not available.'
 			);
 		}
-		await opfsSiteStorage.create(siteInfo.slug, siteInfo.metadata);
+		await opfsSiteStorage.create(
+			siteInfo.slug,
+			siteInfo.metadata,
+			siteInfo.originalUrlParams
+		);
 		dispatch(sitesSlice.actions.addSite(siteInfo));
 	};
 }


### PR DESCRIPTION
## What it does

Stores each saved Playground's original setup URL params in OPFS site metadata so OPFS-loaded sites still know the setup params that created them after a reload.

This keeps `originalUrlParams` alongside the existing serialized site metadata, passes those params through OPFS create/update writes, and reloads them with the saved site. It does not change OPFS boot, recovery, or autosave reset behavior.

## Rationale

Recent changes already use `site.originalUrlParams` when recreating autosaved Playgrounds, but that only works while the site object in Redux still has those params. OPFS metadata persisted runtime configuration, Blueprint metadata, and the site slug, but not `originalUrlParams`.

When a browser-stored Playground was loaded from OPFS after a page reload, the Redux site was rebuilt from `wp-runtime.json` without the original setup params. Later settings or recreation flows could no longer read setup-only fields such as `language`, `multisite`, or repeated `plugin` params from the saved site.

## Testing instructions

```bash
npm exec nx test playground-website -- --testFiles=src/lib/state/opfs/opfs-site-storage.spec.ts --testFiles=src/lib/state/redux/slice-sites.spec.ts
npm exec nx run playground-website:typecheck
npm exec nx lint playground-website
git diff --check origin/trunk...HEAD
```
