### PR TITLE
[Website] API for exporting saved OPFS Playground files as ZIP

### DIFF
--- a/packages/playground/website/src/lib/state/opfs/opfs-site-storage.spec.ts
+++ b/packages/playground/website/src/lib/state/opfs/opfs-site-storage.spec.ts
@@ -1,3 +1,4 @@
+import { BlobReader, TextWriter, ZipReader } from '@zip.js/zip.js';
 import type { SiteMetadata } from '../redux/slice-sites';
 import type { opfsSiteStorage as exportedOpfsSiteStorage } from './opfs-site-storage';
 
@@ -148,6 +149,126 @@ describe('opfsSiteStorage', () => {
 		).resolves.toBeDefined();
 	});
 
+	it('exports complete saved OPFS site files as a ZIP', async () => {
+		const sitesRoot = await getSitesRoot(opfsRoot);
+		const siteDirectory = await writeSiteMetadata(
+			sitesRoot,
+			'site-files',
+			'files'
+		);
+		const wpContent = await siteDirectory.getDirectoryHandle('wp-content', {
+			create: true,
+		});
+		wpContent.setFile('hello.txt', 'Hello from OPFS');
+		await wpContent.getDirectoryHandle('empty-cache', { create: true });
+
+		const zipFile = await storage.exportSavedSiteAsZip('files');
+
+		expect(zipFile?.type).toBe('application/zip');
+		const archive = await readZipEntries(zipFile!);
+
+		expect(archive.files.get('wp-content/hello.txt')).toBe(
+			'Hello from OPFS'
+		);
+		expect(archive.files.has('wp-runtime.json')).toBe(true);
+		expect(archive.directories.has('wp-content/empty-cache/')).toBe(true);
+	});
+
+	it('does not export directories without saved Playground metadata', async () => {
+		const sitesRoot = await getSitesRoot(opfsRoot);
+		const siteDirectory = await sitesRoot.getDirectoryHandle(
+			'site-incomplete',
+			{ create: true }
+		);
+		siteDirectory.setFile('wp-config.php', 'not enough to count as saved');
+
+		await expect(
+			storage.exportSavedSiteAsZip('incomplete')
+		).resolves.toBeUndefined();
+	});
+
+	it('does not export saved sites whose initial OPFS sync never finished', async () => {
+		const sitesRoot = await getSitesRoot(opfsRoot);
+		await writeSiteMetadata(
+			sitesRoot,
+			'site-pending-sync',
+			'pending-sync',
+			{
+				initialOpfsSyncPending: true,
+			}
+		);
+
+		await expect(
+			storage.exportSavedSiteAsZip('pending-sync')
+		).resolves.toBeUndefined();
+	});
+
+	it('does not export saved sites while old OPFS files are being reset', async () => {
+		const sitesRoot = await getSitesRoot(opfsRoot);
+		await writeSiteMetadata(
+			sitesRoot,
+			'site-pending-reset',
+			'pending-reset',
+			{
+				opfsSiteRemovalPending: true,
+			}
+		);
+
+		await expect(
+			storage.exportSavedSiteAsZip('pending-reset')
+		).resolves.toBeUndefined();
+	});
+
+	it('returns undefined when a saved site is deleted after metadata lookup', async () => {
+		const sitesRoot = await getSitesRoot(opfsRoot);
+		await writeSiteMetadata(sitesRoot, 'site-deleted', 'deleted');
+		const getDirectoryHandle = sitesRoot.getDirectoryHandle.bind(sitesRoot);
+		let siteDirectoryWasFoundByMetadataLookup = false;
+		vi.spyOn(sitesRoot, 'getDirectoryHandle').mockImplementation(
+			async (name, options) => {
+				if (name !== 'site-deleted' || options?.create) {
+					return await getDirectoryHandle(name, options);
+				}
+				if (siteDirectoryWasFoundByMetadataLookup) {
+					throw createDomException('NotFoundError');
+				}
+				siteDirectoryWasFoundByMetadataLookup = true;
+				return await getDirectoryHandle(name, options);
+			}
+		);
+
+		await expect(
+			storage.exportSavedSiteAsZip('deleted')
+		).resolves.toBeUndefined();
+	});
+
+	it('returns undefined when saved Playground metadata disappears before export starts', async () => {
+		const sitesRoot = await getSitesRoot(opfsRoot);
+		const siteDirectory = await writeSiteMetadata(
+			sitesRoot,
+			'site-missing-metadata',
+			'missing-metadata'
+		);
+		const getFileHandle = siteDirectory.getFileHandle.bind(siteDirectory);
+		let metadataWasFoundByDirectoryLookup = false;
+		vi.spyOn(siteDirectory, 'getFileHandle').mockImplementation(
+			async (name) => {
+				if (name !== 'wp-runtime.json') {
+					return await getFileHandle(name);
+				}
+				if (metadataWasFoundByDirectoryLookup) {
+					throw createDomException('NotFoundError');
+				}
+				metadataWasFoundByDirectoryLookup = true;
+				return await getFileHandle(name);
+			}
+		);
+
+		await expect(
+			storage.exportSavedSiteAsZip('missing-metadata')
+		).resolves.toBeUndefined();
+	});
+
 	it('loads persisted Blueprint bundles for stored bundle metadata', async () => {
 		const bundle = { read: vi.fn(), listFiles: vi.fn(), isDir: vi.fn() };
 		loadPersistedBlueprintBundle.mockResolvedValue(bundle);
@@ -164,6 +285,28 @@ describe('opfsSiteStorage', () => {
 		expect(site?.metadata.originalBlueprint).toBe(bundle);
 	});
 });
+
+async function readZipEntries(zipFile: Blob) {
+	const reader = new ZipReader(new BlobReader(zipFile));
+	try {
+		const entries = await reader.getEntries();
+		const files = new Map<string, string>();
+		const directories = new Set<string>();
+		for (const entry of entries) {
+			if (entry.directory) {
+				directories.add(entry.filename);
+			} else {
+				files.set(
+					entry.filename,
+					await entry.getData!(new TextWriter())
+				);
+			}
+		}
+		return { files, directories };
+	} finally {
+		await reader.close();
+	}
+}
 
 async function getSitesRoot(opfsRoot: MemoryDirectoryHandle) {
 	return opfsRoot.getDirectoryHandle('sites');
@@ -185,6 +328,7 @@ async function writeSiteMetadata(
 			...createSiteMetadata(metadata),
 		})
 	);
+	return siteDirectory;
 }
 
 async function writeOpfsPath(
@@ -275,6 +419,10 @@ class MemoryDirectoryHandle {
 		yield* this.children.values();
 	}
 
+	async *entries() {
+		yield* this.children.entries();
+	}
+
 	async removeEntry(name: string) {
 		if (!this.children.delete(name)) {
 			throw createDomException('NotFoundError');
@@ -297,9 +445,7 @@ class MemoryFileHandle {
 	}
 
 	async getFile() {
-		return {
-			text: async () => this.content,
-		};
+		return new Blob([this.content]);
 	}
 }
 

--- a/packages/playground/website/src/lib/state/opfs/opfs-site-storage.ts
+++ b/packages/playground/website/src/lib/state/opfs/opfs-site-storage.ts
@@ -10,6 +10,7 @@ import type { SiteInfo, SiteMetadata } from '../redux/slice-sites';
 import type { OriginalUrlParams } from '../original-url-params';
 import { logger } from '@php-wasm/logger';
 import { joinPaths } from '@php-wasm/util';
+import { BlobReader, BlobWriter, ZipWriter } from '@zip.js/zip.js';
 import {
 	type ExtraLibrary,
 	type PHPConstants,
@@ -145,6 +146,66 @@ class OpfsSiteStorage {
 		return await this.readSite(siteDirName);
 	}
 
+	/**
+	 * Returns a ZIP for a saved OPFS Playground that is actually exportable.
+	 *
+	 * WordPress-looking files prove nothing. `wp-config.php`, plugins, uploads,
+	 * or a SQLite database can be leftovers from an interrupted save. The only
+	 * authority here is `wp-runtime.json`, and even that is not enough if it says
+	 * the first OPFS sync is still pending or an in-place reset is unfinished.
+	 * Do not add file-based heuristics here.
+	 *
+	 * Return `undefined` for those cases. A missing ZIP is correct; a ZIP of
+	 * half-written or mismatched files is just corrupt output with a nicer file
+	 * extension.
+	 */
+	async exportSavedSiteAsZip(slug: string): Promise<Blob | undefined> {
+		const siteDirectory = await this.getSavedSiteDirectory(slug);
+		if (!siteDirectory) {
+			return undefined;
+		}
+		return await zipDirectory(siteDirectory);
+	}
+
+	/**
+	 * Opens the saved-site directory only if its metadata says the files are complete.
+	 *
+	 * This intentionally re-reads `wp-runtime.json` after `findExistingSiteDirName()`.
+	 * The earlier lookup finds a candidate. This method verifies the candidate still
+	 * exists, still has metadata, and is not marked as half-saved or mid-reset.
+	 */
+	private async getSavedSiteDirectory(
+		slug: string
+	): Promise<FileSystemDirectoryHandle | undefined> {
+		const siteDirName = await this.findExistingSiteDirName(slug);
+		if (!siteDirName) {
+			return undefined;
+		}
+		try {
+			const siteDirectory =
+				await this.root.getDirectoryHandle(siteDirName);
+			const site = await this.readStoredSiteMetadata(siteDirectory);
+			// If bootSiteClient() refuses to mount these files, export must
+			// refuse them too. Otherwise we hand callers a ZIP of files we
+			// already know are incomplete or being replaced.
+			if (
+				site.metadata.initialOpfsSyncPending === true ||
+				site.metadata.opfsSiteRemovalPending === true
+			) {
+				return undefined;
+			}
+			return siteDirectory;
+		} catch (error) {
+			// The first lookup only proved the metadata existed at that
+			// instant. Another tab can delete the directory or wp-runtime.json
+			// before export starts. That is not an exportable Playground.
+			if (isMissingOpfsEntry(error)) {
+				return undefined;
+			}
+			throw error;
+		}
+	}
+
 	private async readSite(siteDirName: string) {
 		const siteDirectory = await this.root.getDirectoryHandle(siteDirName);
 		if (!siteDirectory) {
@@ -156,15 +217,7 @@ class OpfsSiteStorage {
 	private async readSiteFromDirHandle(
 		siteDirectory: FileSystemDirectoryHandle
 	) {
-		const siteInfoFileHandle = await siteDirectory.getFileHandle(
-			SITE_METADATA_FILENAME
-		);
-		const file = await siteInfoFileHandle.getFile();
-		// TODO: Read metadata file and parse and validate via JSON schema
-		// TODO: Backfill site info file if missing, detecting actual WP version if possible
-		//       ^ do not do it implicitly. Require user interaction. Maybe constrain this just
-		//         to the site files import flow.
-		const siteInfo = storedFormatToMetadata(await file.text());
+		const siteInfo = await this.readStoredSiteMetadata(siteDirectory);
 		const sitePath = joinPaths(OPFS_SITES_ROOT_PATH, siteDirectory.name);
 		const isLegacyDirectoryName =
 			siteDirectory.name !== getDirectoryNameForSlug(siteInfo.slug);
@@ -189,6 +242,26 @@ class OpfsSiteStorage {
 		}
 
 		return siteInfo;
+	}
+
+	/**
+	 * Reads the saved Playground metadata file from an OPFS site directory.
+	 *
+	 * Keep site loading and ZIP export on this same parser. If the metadata format
+	 * changes, both paths need to agree on what the saved site state means.
+	 */
+	private async readStoredSiteMetadata(
+		siteDirectory: FileSystemDirectoryHandle
+	) {
+		const siteInfoFileHandle = await siteDirectory.getFileHandle(
+			SITE_METADATA_FILENAME
+		);
+		const file = await siteInfoFileHandle.getFile();
+		// TODO: Read metadata file and parse and validate via JSON schema
+		// TODO: Backfill site info file if missing, detecting actual WP version if possible
+		//       ^ do not do it implicitly. Require user interaction. Maybe constrain this just
+		//         to the site files import flow.
+		return storedFormatToMetadata(await file.text());
 	}
 
 	async delete(slug: string): Promise<void> {
@@ -384,6 +457,55 @@ async function opfsFileExists(handle: FileSystemDirectoryHandle, name: string) {
 function isMissingOpfsEntry(error: unknown) {
 	const name = (error as DOMException | undefined)?.name;
 	return name === 'NotFoundError' || name === 'TypeMismatchError';
+}
+
+/**
+ * Writes an OPFS directory into a ZIP Blob.
+ *
+ * Return the Blob. Do not turn it into a `Uint8Array`: download and upload
+ * callers can use the Blob directly, and converting it copies the whole archive
+ * for no useful reason.
+ */
+async function zipDirectory(directory: FileSystemDirectoryHandle) {
+	const zipWriter = new ZipWriter(new BlobWriter('application/zip'));
+	try {
+		await addDirectoryEntries(zipWriter, directory, '');
+		return await zipWriter.close();
+	} catch (error) {
+		await zipWriter.close().catch(() => undefined);
+		throw error;
+	}
+}
+
+/**
+ * Adds every file and empty directory below `directory` to `zipWriter`.
+ *
+ * Directory entries are explicit because empty directories otherwise disappear
+ * from ZIP archives. Files go through `BlobReader` so zip.js reads from the
+ * browser `File` object instead of us first copying each file into memory.
+ */
+async function addDirectoryEntries(
+	zipWriter: ZipWriter<Blob>,
+	directory: FileSystemDirectoryHandle,
+	relativeDirPath: string
+) {
+	for await (const [name, entry] of directory.entries()) {
+		const relativePath = relativeDirPath
+			? joinPaths(relativeDirPath, name)
+			: name;
+
+		if (entry.kind === 'directory') {
+			await zipWriter.add(`${relativePath}/`, undefined, {
+				directory: true,
+			});
+			await addDirectoryEntries(zipWriter, entry, relativePath);
+		} else {
+			await zipWriter.add(
+				relativePath,
+				new BlobReader(await entry.getFile())
+			);
+		}
+	}
 }
 
 export async function deleteDirectory(path: string) {


### PR DESCRIPTION
## What it does

Adds one website API: `opfsSiteStorage.exportSavedSiteAsZip(slug)`.

It takes a saved OPFS Playground and returns a ZIP `Blob` of its files. It does not boot WordPress. It does not add a client bridge. It does not push anything to GitHub.

## Rationale

The push flow needs an archive of the saved browser files.

## Testing instructions

```bash
npm exec nx test playground-website -- --testFiles=src/lib/state/opfs/opfs-site-storage.spec.ts
npm exec nx typecheck playground-website
npm exec nx lint playground-website
```
