### PR TITLE
[Website] Mark Playground as persisted in the Redux store only after it is actually persisted

### DIFF
--- a/packages/playground/website/src/lib/state/redux/persist-temporary-site.spec.ts
+++ b/packages/playground/website/src/lib/state/redux/persist-temporary-site.spec.ts
@@ -1,0 +1,456 @@
+// @vitest-environment jsdom
+
+import type { PlaygroundClient } from '@wp-playground/remote';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { persistTemporarySite } from './persist-temporary-site';
+
+const mocks = vi.hoisted(() => ({
+	getDirectoryPathForSlug: vi.fn((slug: string) => `/sites/${slug}`),
+	getSetupUrlFromSite: vi.fn(
+		() => new URL('https://playground.test/?php=8.3')
+	),
+	opfsSiteStorage: {
+		create: vi.fn(),
+		delete: vi.fn(),
+		read: vi.fn(),
+	},
+	opfsSiteStorageMock: undefined as
+		| {
+				create: ReturnType<typeof vi.fn>;
+				delete: ReturnType<typeof vi.fn>;
+				read: ReturnType<typeof vi.fn>;
+		  }
+		| undefined,
+	persistBlueprintBundle: vi.fn(),
+	redirectTo: vi.fn(),
+	selectClientBySiteSlug: vi.fn(),
+	selectClientInfoBySiteSlug: vi.fn(),
+	selectSiteBySlug: vi.fn(),
+	setActiveModal: vi.fn((modal) => ({
+		type: 'ui/setActiveModal',
+		payload: modal,
+	})),
+	updateClientInfo: vi.fn((payload) => ({
+		type: 'clients/updateClientInfo',
+		payload,
+	})),
+	updateSite: vi.fn(() => async () => undefined),
+}));
+
+vi.mock('@php-wasm/logger', () => ({
+	logger: {
+		error: vi.fn(),
+	},
+}));
+
+vi.mock('../opfs/opfs-blueprint-bundle-storage', () => ({
+	isTraversableFilesystemBackend: (value: unknown) =>
+		typeof value === 'object' &&
+		value !== null &&
+		typeof (value as { read?: unknown }).read === 'function' &&
+		typeof (value as { listFiles?: unknown }).listFiles === 'function' &&
+		typeof (value as { isDir?: unknown }).isDir === 'function',
+	persistBlueprintBundle: mocks.persistBlueprintBundle,
+}));
+
+vi.mock('../opfs/opfs-directory-handle-storage', () => ({
+	saveDirectoryHandle: vi.fn(),
+}));
+
+vi.mock('../opfs/opfs-site-storage', () => ({
+	getDirectoryPathForSlug: mocks.getDirectoryPathForSlug,
+	get opfsSiteStorage() {
+		return mocks.opfsSiteStorage;
+	},
+}));
+
+vi.mock('../playground-identity', () => ({
+	getSetupUrlFromSite: mocks.getSetupUrlFromSite,
+}));
+
+vi.mock('../url/router', () => ({
+	PlaygroundRoute: {
+		site: vi.fn(() => '/website-server/#/site/test-site'),
+	},
+	redirectTo: mocks.redirectTo,
+}));
+
+vi.mock('./slice-clients', () => ({
+	selectClientBySiteSlug: mocks.selectClientBySiteSlug,
+	selectClientInfoBySiteSlug: mocks.selectClientInfoBySiteSlug,
+	updateClientInfo: mocks.updateClientInfo,
+}));
+
+vi.mock('./slice-sites', () => ({
+	selectSiteBySlug: mocks.selectSiteBySlug,
+	updateSite: mocks.updateSite,
+}));
+
+vi.mock('./slice-ui', () => ({
+	setActiveModal: mocks.setActiveModal,
+}));
+
+describe('persistTemporarySite', () => {
+	beforeEach(() => {
+		if (!mocks.opfsSiteStorageMock) {
+			mocks.opfsSiteStorageMock = mocks.opfsSiteStorage;
+		}
+		mocks.opfsSiteStorage = mocks.opfsSiteStorageMock;
+		mocks.getDirectoryPathForSlug.mockReset();
+		mocks.getDirectoryPathForSlug.mockImplementation(
+			(slug: string) => `/sites/${slug}`
+		);
+		mocks.getSetupUrlFromSite.mockReset();
+		mocks.getSetupUrlFromSite.mockReturnValue(
+			new URL('https://playground.test/?php=8.3')
+		);
+		mocks.opfsSiteStorage.create.mockReset();
+		mocks.opfsSiteStorage.delete.mockReset();
+		mocks.opfsSiteStorage.read.mockReset();
+		mocks.persistBlueprintBundle.mockReset();
+		mocks.redirectTo.mockReset();
+		mocks.selectClientBySiteSlug.mockReset();
+		mocks.selectClientInfoBySiteSlug.mockReset();
+		mocks.selectSiteBySlug.mockReset();
+		mocks.setActiveModal.mockClear();
+		mocks.updateClientInfo.mockClear();
+		mocks.updateSite.mockReset();
+		mocks.updateSite.mockReturnValue(async () => undefined);
+	});
+
+	it('keeps a pending OPFS save record when this runtime uses its directory', async () => {
+		const playground = createPlaygroundWithConstants('{}') as any;
+		playground.hasOpfsMount = vi.fn(async () => true);
+		playground.unmountOpfs = vi.fn(async () => undefined);
+		playground.mountOpfs = vi.fn(async () => undefined);
+		mocks.selectClientInfoBySiteSlug.mockReturnValue({
+			client: playground,
+			opfsMountDescriptor: {
+				device: {
+					type: 'opfs',
+					path: '/sites/test-site',
+				},
+				mountpoint: '/wordpress',
+			},
+		});
+		mocks.opfsSiteStorage.read.mockResolvedValue({
+			metadata: { storage: 'none' },
+		});
+		mocks.selectSiteBySlug.mockReturnValue(createTemporarySiteInfo());
+
+		await persistTemporarySite('test-site', 'opfs')(
+			createDispatch() as any,
+			createEmptyGetState() as any
+		);
+
+		expect(mocks.opfsSiteStorage.delete).not.toHaveBeenCalled();
+		expect(mocks.opfsSiteStorage.create).not.toHaveBeenCalled();
+		expect(playground.unmountOpfs).toHaveBeenCalledWith('/wordpress');
+	});
+
+	it('deletes a stale pending OPFS save record before retrying', async () => {
+		const playground = createPlaygroundWithConstants('{}') as any;
+		playground.hasOpfsMount = vi.fn(async () => false);
+		playground.unmountOpfs = vi.fn();
+		playground.mountOpfs = vi.fn(async () => undefined);
+		mocks.selectClientBySiteSlug.mockReturnValue(playground);
+		mocks.opfsSiteStorage.read.mockResolvedValue({
+			metadata: { storage: 'none' },
+		});
+		mocks.selectSiteBySlug.mockReturnValue(createTemporarySiteInfo());
+
+		await persistTemporarySite('test-site', 'opfs')(
+			createDispatch() as any,
+			createEmptyGetState() as any
+		);
+
+		expect(mocks.opfsSiteStorage.delete).toHaveBeenCalledWith('test-site');
+		expect(mocks.opfsSiteStorage.create).toHaveBeenCalled();
+	});
+
+	it('updates the site only after files are mounted into durable storage', async () => {
+		const order: string[] = [];
+		const playground = createPlaygroundWithConstants(
+			JSON.stringify({ WP_DEBUG: true })
+		) as any;
+		playground.hasOpfsMount = vi.fn(async () => false);
+		playground.unmountOpfs = vi.fn();
+		playground.mountOpfs = vi.fn(async () => {
+			order.push('mount');
+		});
+		mocks.selectClientBySiteSlug.mockReturnValue(playground);
+		mocks.selectSiteBySlug.mockReturnValue(
+			createTemporarySiteInfo({
+				originalUrlParams: {
+					searchParams: {
+						language: 'pl_PL',
+						plugin: ['akismet', 'gutenberg'],
+					},
+					hash: '#blueprint',
+				},
+			})
+		);
+		mocks.getSetupUrlFromSite.mockReturnValue(
+			new URL(
+				'https://playground.test/?language=pl_PL&plugin=akismet&plugin=gutenberg#blueprint'
+			)
+		);
+		mocks.updateSite.mockReturnValue(async () => {
+			order.push('updateSite');
+		});
+
+		await persistTemporarySite('test-site', 'opfs')(
+			createDispatch() as any,
+			createEmptyGetState() as any
+		);
+
+		expect(order).toEqual(['mount', 'updateSite']);
+		expect(mocks.opfsSiteStorage.create).toHaveBeenCalledWith(
+			'test-site',
+			expect.objectContaining({ storage: 'none' }),
+			{
+				searchParams: {
+					language: 'pl_PL',
+					plugin: ['akismet', 'gutenberg'],
+				},
+				hash: '#blueprint',
+			}
+		);
+		expect(mocks.updateSite).toHaveBeenCalledWith({
+			slug: 'test-site',
+			changes: {
+				originalUrlParams: {
+					searchParams: {
+						language: 'pl_PL',
+						plugin: ['akismet', 'gutenberg'],
+					},
+					hash: '#blueprint',
+				},
+				metadata: expect.objectContaining({
+					storage: 'opfs',
+					persistence: 'explicit',
+					playgroundDefinedConstants: { WP_DEBUG: true },
+				}),
+			},
+		});
+	});
+
+	it('does not update the site when the durable file mount fails', async () => {
+		const mountError = new Error('mount failed');
+		const playground = createPlaygroundWithConstants('{}') as any;
+		playground.hasOpfsMount = vi.fn(async () => false);
+		playground.unmountOpfs = vi.fn();
+		playground.mountOpfs = vi.fn(async () => {
+			throw mountError;
+		});
+		mocks.selectClientBySiteSlug.mockReturnValue(playground);
+		mocks.selectSiteBySlug.mockReturnValue(createTemporarySiteInfo());
+
+		await expect(
+			persistTemporarySite('test-site', 'opfs')(
+				createDispatch() as any,
+				createEmptyGetState() as any
+			)
+		).rejects.toThrow(mountError);
+
+		expect(mocks.updateSite).not.toHaveBeenCalled();
+	});
+
+	it('restores the previous mount when saving to a local directory fails', async () => {
+		const previousMountDescriptor = {
+			device: {
+				type: 'opfs',
+				path: '/sites/test-site',
+			},
+			mountpoint: '/wordpress',
+		} as const;
+		const localFsHandle = {} as FileSystemDirectoryHandle;
+		const localFsError = new Error('local directory unavailable');
+		const playground = createPlaygroundWithConstants('{}') as any;
+		playground.hasOpfsMount = vi.fn(async () => true);
+		playground.unmountOpfs = vi.fn(async () => undefined);
+		playground.mountOpfs = vi.fn(async (descriptor) => {
+			if (descriptor.device.type === 'local-fs') {
+				throw localFsError;
+			}
+		});
+		mocks.selectClientInfoBySiteSlug.mockReturnValue({
+			client: playground,
+			opfsMountDescriptor: previousMountDescriptor,
+		});
+		mocks.selectSiteBySlug.mockReturnValue(createAutosavedSiteInfo());
+		const dispatchedActions: any[] = [];
+
+		await expect(
+			persistTemporarySite('test-site', 'local-fs', {
+				localFsHandle,
+			})(
+				createDispatch(dispatchedActions) as any,
+				createEmptyGetState() as any
+			)
+		).rejects.toThrow(localFsError);
+
+		expect(playground.unmountOpfs).toHaveBeenCalledWith('/wordpress');
+		expect(playground.mountOpfs).toHaveBeenNthCalledWith(
+			1,
+			{
+				device: {
+					type: 'local-fs',
+					handle: localFsHandle,
+				},
+				mountpoint: '/wordpress',
+				initialSyncDirection: 'memfs-to-opfs',
+			},
+			expect.any(Function)
+		);
+		expect(playground.mountOpfs).toHaveBeenNthCalledWith(2, {
+			...previousMountDescriptor,
+			initialSyncDirection: 'memfs-to-opfs',
+		});
+		expect(dispatchedActions.at(-1)).toEqual(
+			mocks.updateClientInfo({
+				siteSlug: 'test-site',
+				changes: {
+					opfsMountDescriptor: previousMountDescriptor,
+					opfsSync: {
+						status: 'error',
+						operation: 'save',
+					},
+				},
+			})
+		);
+	});
+
+	it('restores the previous mount when local-directory metadata persistence fails', async () => {
+		const previousMountDescriptor = {
+			device: {
+				type: 'opfs',
+				path: '/sites/test-site',
+			},
+			mountpoint: '/wordpress',
+		} as const;
+		const localFsHandle = {} as FileSystemDirectoryHandle;
+		const metadataError = new Error('metadata write failed');
+		const playground = createPlaygroundWithConstants('{}') as any;
+		playground.hasOpfsMount = vi.fn(async () => true);
+		playground.unmountOpfs = vi.fn(async () => undefined);
+		playground.mountOpfs = vi.fn(async () => undefined);
+		mocks.selectClientInfoBySiteSlug.mockReturnValue({
+			client: playground,
+			opfsMountDescriptor: previousMountDescriptor,
+		});
+		mocks.selectSiteBySlug.mockReturnValue(createAutosavedSiteInfo());
+		mocks.updateSite.mockReturnValueOnce(async () => {
+			throw metadataError;
+		});
+		const dispatchedActions: any[] = [];
+
+		await expect(
+			persistTemporarySite('test-site', 'local-fs', {
+				localFsHandle,
+			})(
+				createDispatch(dispatchedActions) as any,
+				createEmptyGetState() as any
+			)
+		).rejects.toThrow(metadataError);
+
+		expect(playground.unmountOpfs).toHaveBeenNthCalledWith(1, '/wordpress');
+		expect(playground.unmountOpfs).toHaveBeenNthCalledWith(2, '/wordpress');
+		expect(playground.mountOpfs).toHaveBeenNthCalledWith(
+			1,
+			{
+				device: {
+					type: 'local-fs',
+					handle: localFsHandle,
+				},
+				mountpoint: '/wordpress',
+				initialSyncDirection: 'memfs-to-opfs',
+			},
+			expect.any(Function)
+		);
+		expect(playground.mountOpfs).toHaveBeenNthCalledWith(2, {
+			...previousMountDescriptor,
+			initialSyncDirection: 'memfs-to-opfs',
+		});
+		expect(dispatchedActions.at(-1)).toEqual(
+			mocks.updateClientInfo({
+				siteSlug: 'test-site',
+				changes: {
+					opfsMountDescriptor: previousMountDescriptor,
+					opfsSync: {
+						status: 'error',
+						operation: 'save',
+					},
+				},
+			})
+		);
+	});
+});
+
+function createTemporarySiteInfo({
+	originalUrlParams,
+}: {
+	originalUrlParams?: {
+		searchParams?: Record<string, string | string[]>;
+		hash?: string;
+	};
+} = {}) {
+	return {
+		slug: 'test-site',
+		originalUrlParams,
+		metadata: {
+			id: 'test-site-id',
+			name: 'Test site',
+			storage: 'none',
+			runtimeConfiguration: {},
+			originalBlueprint: {},
+			originalBlueprintSource: { type: 'none' },
+		},
+	};
+}
+
+function createAutosavedSiteInfo() {
+	return {
+		slug: 'test-site',
+		metadata: {
+			id: 'test-site-id',
+			name: 'Test site',
+			persistence: 'autosave',
+			storage: 'opfs',
+			whenCreated: 1,
+			whenLastUsed: 1,
+			runtimeConfiguration: {},
+			originalBlueprint: {},
+			originalBlueprintSource: { type: 'none' },
+		},
+	};
+}
+
+function createEmptyGetState() {
+	return () => ({});
+}
+
+function createDispatch(
+	dispatchedActions: any[] = []
+): ReturnType<typeof vi.fn> {
+	const dispatch: ReturnType<typeof vi.fn> = vi.fn((action: any) => {
+		if (typeof action === 'function') {
+			return action(dispatch, createEmptyGetState());
+		}
+		dispatchedActions.push(action);
+		return action;
+	});
+	return dispatch;
+}
+
+function createPlaygroundWithConstants(contents: string | undefined) {
+	return {
+		readFileAsText: vi.fn(async (path: string) => {
+			expect(path).toBe('/internal/shared/consts.json');
+			if (contents === undefined) {
+				throw new Error('File not found');
+			}
+			return contents;
+		}),
+	} as unknown as PlaygroundClient;
+}

--- a/packages/playground/website/src/lib/state/redux/persist-temporary-site.ts
+++ b/packages/playground/website/src/lib/state/redux/persist-temporary-site.ts
@@ -62,7 +62,7 @@ export function persistTemporarySite(
 		}
 		const previousMountDescriptor = clientInfo?.opfsMountDescriptor;
 
-		const siteInfo = selectSiteBySlug(state, siteSlug)!;
+		const siteInfo = selectSiteBySlug(state, siteSlug);
 		if (!siteInfo) {
 			throw new Error(`Cannot find site ${siteSlug} to save.`);
 		}

--- a/packages/playground/website/src/lib/state/redux/persist-temporary-site.ts
+++ b/packages/playground/website/src/lib/state/redux/persist-temporary-site.ts
@@ -13,16 +13,21 @@ import {
 import type { TraversableFilesystemBackend } from '@wp-playground/storage';
 import type { PlaygroundReduxState } from './store';
 import type store from './store';
-import { selectClientBySiteSlug, updateClientInfo } from './slice-clients';
+import {
+	selectClientBySiteSlug,
+	selectClientInfoBySiteSlug,
+	updateClientInfo,
+} from './slice-clients';
 import {
 	selectSiteBySlug,
+	type SiteInfo,
 	type SitePersistence,
 	updateSite,
-	updateSiteMetadata,
 } from './slice-sites';
 import { PlaygroundRoute, redirectTo } from '../url/router';
 import type { SiteStorageType } from './slice-sites';
 import { setActiveModal } from './slice-ui';
+import { getSetupUrlFromSite } from '../playground-identity';
 
 /**
  * Copies the running Playground into a durable storage backend.
@@ -47,54 +52,80 @@ export function persistTemporarySite(
 		getState: () => PlaygroundReduxState
 	) => {
 		const state = getState();
-		const playground = selectClientBySiteSlug(state, siteSlug);
+		const clientInfo = selectClientInfoBySiteSlug(state, siteSlug);
+		const playground =
+			clientInfo?.client ?? selectClientBySiteSlug(state, siteSlug);
 		if (!playground) {
 			throw new Error(
 				`Site ${siteSlug} must have an active client to be saved, but none was found.`
 			);
 		}
+		const previousMountDescriptor = clientInfo?.opfsMountDescriptor;
 
-		let siteInfo = selectSiteBySlug(state, siteSlug)!;
+		const siteInfo = selectSiteBySlug(state, siteSlug)!;
 		if (!siteInfo) {
 			throw new Error(`Cannot find site ${siteSlug} to save.`);
 		}
-		const trimmedName = options.siteName?.trim();
-		if (trimmedName && trimmedName !== siteInfo.metadata.name) {
-			await dispatch(
-				updateSiteMetadata({
-					slug: siteSlug,
-					changes: { name: trimmedName },
-				})
+		if (storageType === 'opfs' && !opfsSiteStorage) {
+			throw new Error(
+				'Cannot save this Playground because browser storage is not available.'
 			);
-			siteInfo = selectSiteBySlug(getState(), siteSlug)!;
 		}
+		const trimmedName = options.siteName?.trim();
 
 		const isTemporarySite = siteInfo.metadata.storage === 'none';
-		if (isTemporarySite) {
+		let shouldCreatePendingOpfsSaveRecord = true;
+		if (isTemporarySite && opfsSiteStorage) {
 			try {
 				const existingSiteInfo = await opfsSiteStorage?.read(
 					siteInfo.slug
 				);
 				if (existingSiteInfo?.metadata.storage === 'none') {
-					// It is likely we are dealing with the remnants of a failed save
-					// of a temporary site to OPFS. Let's clean up and try again.
-					await opfsSiteStorage?.delete(siteInfo.slug);
+					const pendingSaveDirectory = getDirectoryPathForSlug(
+						siteInfo.slug
+					);
+					const currentRuntimeUsesPendingOpfsDirectory =
+						previousMountDescriptor?.device.type === 'opfs' &&
+						previousMountDescriptor.device.path ===
+							pendingSaveDirectory &&
+						(await playground
+							.hasOpfsMount(previousMountDescriptor.mountpoint)
+							.catch(() => false));
+
+					shouldCreatePendingOpfsSaveRecord =
+						!currentRuntimeUsesPendingOpfsDirectory;
+					if (shouldCreatePendingOpfsSaveRecord) {
+						// A failed first save can leave `wp-runtime.json` with
+						// `storage: "none"`. That record only reserves the OPFS
+						// directory until the file copy finishes; it is not a
+						// saved Playground yet. If the current runtime is not
+						// mounted to that directory, remove the stale directory
+						// before retrying so old files cannot mix into the new
+						// save.
+						await opfsSiteStorage?.delete(siteInfo.slug);
+					}
 				}
 			} catch (error: any) {
 				if (error?.name === 'NotFoundError') {
-					// No failed temporary-site placeholder exists, so this save can
+					// No pending OPFS save record exists, so this save can
 					// continue with a fresh OPFS record.
 				} else {
 					throw error;
 				}
 			}
-			await opfsSiteStorage?.create(siteInfo.slug, {
-				...siteInfo.metadata,
-				// The placeholder stays marked as temporary until the copy
-				// succeeds, so a later save can recognize and clean up a failed
-				// attempt.
-				storage: 'none',
-			});
+			if (shouldCreatePendingOpfsSaveRecord) {
+				await opfsSiteStorage.create(
+					siteInfo.slug,
+					{
+						...siteInfo.metadata,
+						// The record stays marked as temporary until the copy
+						// succeeds, so a later retry can tell whether the first
+						// save became a real stored Playground.
+						storage: 'none',
+					},
+					siteInfo.originalUrlParams
+				);
+			}
 		}
 
 		// Persist a Blueprint bundle only after the user has run the edited
@@ -161,7 +192,6 @@ export function persistTemporarySite(
 			updateClientInfo({
 				siteSlug,
 				changes: {
-					opfsMountDescriptor: mountDescriptor,
 					opfsSync: {
 						status: 'syncing',
 						operation: syncOperation,
@@ -169,6 +199,11 @@ export function persistTemporarySite(
 				},
 			})
 		);
+		let restorePreviousMount = false;
+		let currentRuntimeMountDescriptor:
+			| typeof mountDescriptor
+			| typeof previousMountDescriptor
+			| undefined = previousMountDescriptor;
 		try {
 			/**
 			 * Autosaved browser sites already mount OPFS at `/wordpress`.
@@ -182,6 +217,8 @@ export function persistTemporarySite(
 			 */
 			if (await playground.hasOpfsMount(mountDescriptor.mountpoint)) {
 				await playground.unmountOpfs(mountDescriptor.mountpoint);
+				currentRuntimeMountDescriptor = undefined;
+				restorePreviousMount = Boolean(previousMountDescriptor);
 			}
 			await playground.mountOpfs(
 				{
@@ -203,61 +240,33 @@ export function persistTemporarySite(
 					);
 				}
 			);
+			restorePreviousMount = false;
+			currentRuntimeMountDescriptor = mountDescriptor;
 
-			// @TODO: Create a notification to tell the user the operation is complete
-			dispatch(
-				updateClientInfo({
-					siteSlug,
-					changes: {
-						opfsSync: undefined,
-					},
-				})
-			);
-		} catch (error) {
-			dispatch(
-				updateClientInfo({
-					siteSlug,
-					changes: {
-						opfsSync: {
-							status: 'error',
-							operation: syncOperation,
-						},
-					},
-				})
-			);
-			throw error;
-		}
-
-		// Autosaves stay tied to their source setup URL so restore matching and
-		// boot-time query options can still inspect it. Explicit saves open by
-		// slug, so drop the temporary route params after persistence.
-		if (!isAutosave) {
-			await dispatch(
-				updateSite({
-					slug: siteSlug,
-					changes: {
-						originalUrlParams: undefined,
-					},
-				})
-			);
-		}
-
-		const persistedAt = Date.now();
-		const playgroundDefinedConstants =
-			await getPlaygroundDefinedPHPConstants(playground);
-		await dispatch(
-			updateSiteMetadata({
-				slug: siteSlug,
-				changes: {
+			const persistedAt = Date.now();
+			const playgroundDefinedConstants =
+				await getPlaygroundDefinedPHPConstants(playground);
+			const siteChanges: Partial<SiteInfo> = {
+				// Autosaves stay tied to their source setup URL so restore
+				// matching and boot-time query options can still inspect it.
+				// Explicit saves open by slug, but they still keep their setup
+				// URL for settings and sharing.
+				...(isAutosave
+					? {}
+					: {
+							originalUrlParams: getSavedSetupUrlParams(siteInfo),
+						}),
+				metadata: {
+					...siteInfo.metadata,
 					storage: storageType,
 					persistence: options.persistence ?? 'explicit',
-					// The viewport key includes whenCreated. Changing it would
-					// remount the iframe, so autosave keeps the current value
-					// while explicit saves reset the creation time.
+					// The viewport key includes whenCreated. Changing it
+					// would remount the iframe, so autosave keeps the current
+					// value while explicit saves reset the creation time.
 					...(isAutosave ? {} : { whenCreated: persistedAt }),
 					whenLastUsed: persistedAt,
-					// Keep these outside runtimeConfiguration so autosave does not
-					// change the running iframe's boot fingerprint.
+					// Keep these outside runtimeConfiguration so autosave does
+					// not change the running iframe's boot fingerprint.
 					playgroundDefinedConstants,
 					// If we persisted a blueprint bundle, point to it so we can
 					// load the full bundle (not just the declaration) on next load.
@@ -270,8 +279,68 @@ export function persistTemporarySite(
 						: {}),
 					...(trimmedName ? { name: trimmedName } : {}),
 				},
-			})
-		);
+			};
+			await dispatch(
+				updateSite({
+					slug: siteSlug,
+					changes: siteChanges,
+				})
+			);
+
+			// @TODO: Create a notification to tell the user the operation is complete
+			dispatch(
+				updateClientInfo({
+					siteSlug,
+					changes: {
+						opfsMountDescriptor: mountDescriptor,
+						opfsSync: undefined,
+					},
+				})
+			);
+		} catch (error) {
+			if (
+				storageType === 'local-fs' &&
+				currentRuntimeMountDescriptor === mountDescriptor
+			) {
+				try {
+					await playground.unmountOpfs(mountDescriptor.mountpoint);
+					currentRuntimeMountDescriptor = undefined;
+					restorePreviousMount = Boolean(previousMountDescriptor);
+				} catch (unmountNewMountError) {
+					logger.error(
+						'Error unmounting the local directory after save failure.',
+						unmountNewMountError
+					);
+				}
+			}
+			if (restorePreviousMount && previousMountDescriptor) {
+				try {
+					await playground.mountOpfs({
+						...previousMountDescriptor,
+						initialSyncDirection: 'memfs-to-opfs',
+					});
+					currentRuntimeMountDescriptor = previousMountDescriptor;
+				} catch (restoreError) {
+					logger.error(
+						'Error restoring the previous storage mount after save failure.',
+						restoreError
+					);
+				}
+			}
+			dispatch(
+				updateClientInfo({
+					siteSlug,
+					changes: {
+						opfsMountDescriptor: currentRuntimeMountDescriptor,
+						opfsSync: {
+							status: 'error',
+							operation: syncOperation,
+						},
+					},
+				})
+			);
+			throw error;
+		}
 		/**
 		 * @TODO: Fix OPFS site storage write timeout that happens alongside 2000
 		 *        "Cannot read properties of undefined (reading 'apply')" errors here:
@@ -288,6 +357,38 @@ export function persistTemporarySite(
 		if (!options.skipRenameModal) {
 			dispatch(setActiveModal('rename-site'));
 		}
+	};
+}
+
+/**
+ * Returns the setup params that should stay attached after an explicit save.
+ *
+ * Explicit saves open by site slug, but settings and sharing still need the
+ * original setup URL. Start from the site record rather than `window.location`
+ * so routing-only params from the current page are not persisted.
+ */
+function getSavedSetupUrlParams(
+	siteInfo: SiteInfo
+): NonNullable<SiteInfo['originalUrlParams']> {
+	return getOriginalUrlParamsFromUrl(
+		getSetupUrlFromSite(siteInfo, window.location.href)
+	);
+}
+
+/**
+ * Serializes repeated URL search params using the shape stored in site metadata.
+ */
+function getOriginalUrlParamsFromUrl(
+	url: URL
+): NonNullable<SiteInfo['originalUrlParams']> {
+	const searchParams: Record<string, string | string[]> = {};
+	for (const key of new Set(url.searchParams.keys())) {
+		const value = url.searchParams.getAll(key);
+		searchParams[key] = value.length > 1 ? value : value[0];
+	}
+	return {
+		searchParams,
+		hash: url.hash,
 	};
 }
 

--- a/packages/playground/website/src/lib/state/redux/slice-sites.spec.ts
+++ b/packages/playground/website/src/lib/state/redux/slice-sites.spec.ts
@@ -193,8 +193,7 @@ describe('stored site specs', () => {
 	it('does not update redux when persisted metadata write fails', async () => {
 		const storageError = new Error('metadata write failed');
 		updateSiteStorage.mockRejectedValue(storageError);
-		const { sitesSlice, updateSite, selectSiteBySlug } =
-			await import('./slice-sites');
+		const { sitesSlice, updateSite } = await import('./slice-sites');
 		const site = createSiteInfo();
 		const state = {
 			sites: sitesSlice.reducer(
@@ -221,9 +220,79 @@ describe('stored site specs', () => {
 		).rejects.toThrow(storageError);
 
 		expect(dispatch).not.toHaveBeenCalled();
-		expect(selectSiteBySlug(state as any, site.slug)?.metadata.name).toBe(
+		expect(state.sites.entities[site.slug]?.metadata.name).toBe(
 			'Stored site'
 		);
+	});
+
+	it('merges partial metadata before writing and dispatching', async () => {
+		const { sitesSlice, updateSite } = await import('./slice-sites');
+		const site = createSiteInfo();
+		const state = {
+			sites: sitesSlice.reducer(
+				undefined,
+				sitesSlice.actions.addSite(site)
+			),
+		};
+		const dispatch = vi.fn((action) => {
+			state.sites = sitesSlice.reducer(state.sites, action);
+			return action;
+		});
+
+		await updateSite({
+			slug: site.slug,
+			changes: {
+				metadata: {
+					name: 'Renamed Playground',
+				} as any,
+			},
+		})(dispatch as any, () => state as any);
+
+		expect(updateSiteStorage).toHaveBeenCalledWith(
+			site.slug,
+			expect.objectContaining({
+				name: 'Renamed Playground',
+				storage: 'opfs',
+				runtimeConfiguration: site.metadata.runtimeConfiguration,
+			}),
+			undefined
+		);
+		expect(state.sites.entities[site.slug]?.metadata).toEqual({
+			...site.metadata,
+			name: 'Renamed Playground',
+		});
+	});
+
+	it('does not update redux when saved-site storage is unavailable', async () => {
+		vi.doMock('../opfs/opfs-site-storage', () => ({
+			opfsSiteStorage: undefined,
+		}));
+		const { sitesSlice, updateSite } = await import('./slice-sites');
+		const site = createSiteInfo();
+		const state = {
+			sites: sitesSlice.reducer(
+				undefined,
+				sitesSlice.actions.addSite(site)
+			),
+		};
+		const dispatch = vi.fn((action) => {
+			state.sites = sitesSlice.reducer(state.sites, action);
+			return action;
+		});
+
+		await expect(
+			updateSite({
+				slug: site.slug,
+				changes: {
+					metadata: {
+						...site.metadata,
+						name: 'Renamed Playground',
+					},
+				},
+			})(dispatch as any, () => state as any)
+		).rejects.toThrow('browser storage is not available');
+
+		expect(dispatch).not.toHaveBeenCalled();
 	});
 
 	it('does not replace a persisted bundle before validating the new setup', async () => {

--- a/packages/playground/website/src/lib/state/redux/slice-sites.spec.ts
+++ b/packages/playground/website/src/lib/state/redux/slice-sites.spec.ts
@@ -155,6 +155,77 @@ describe('stored site specs', () => {
 		);
 	});
 
+	it('updates redux only after persisted metadata is written', async () => {
+		const { sitesSlice, updateSite } = await import('./slice-sites');
+		const site = createSiteInfo();
+		let state = {
+			sites: sitesSlice.reducer(
+				undefined,
+				sitesSlice.actions.addSite(site)
+			),
+		};
+		const order: string[] = [];
+		updateSiteStorage.mockImplementation(async () => {
+			order.push('opfs');
+		});
+		const dispatch = vi.fn((action) => {
+			order.push('redux');
+			state = {
+				sites: sitesSlice.reducer(state.sites, action),
+			};
+			return action;
+		});
+		const updatedMetadata = {
+			...site.metadata,
+			name: 'Renamed Playground',
+		};
+
+		await updateSite({
+			slug: site.slug,
+			changes: {
+				metadata: updatedMetadata,
+			},
+		})(dispatch as any, () => state as any);
+
+		expect(order).toEqual(['opfs', 'redux']);
+	});
+
+	it('does not update redux when persisted metadata write fails', async () => {
+		const storageError = new Error('metadata write failed');
+		updateSiteStorage.mockRejectedValue(storageError);
+		const { sitesSlice, updateSite, selectSiteBySlug } =
+			await import('./slice-sites');
+		const site = createSiteInfo();
+		const state = {
+			sites: sitesSlice.reducer(
+				undefined,
+				sitesSlice.actions.addSite(site)
+			),
+		};
+		const dispatch = vi.fn((action) => {
+			state.sites = sitesSlice.reducer(state.sites, action);
+			return action;
+		});
+		const updatedMetadata = {
+			...site.metadata,
+			name: 'Renamed Playground',
+		};
+
+		await expect(
+			updateSite({
+				slug: site.slug,
+				changes: {
+					metadata: updatedMetadata,
+				},
+			})(dispatch as any, () => state as any)
+		).rejects.toThrow(storageError);
+
+		expect(dispatch).not.toHaveBeenCalled();
+		expect(selectSiteBySlug(state as any, site.slug)?.metadata.name).toBe(
+			'Stored site'
+		);
+	});
+
 	it('does not replace a persisted bundle before validating the new setup', async () => {
 		resolveRuntimeConfiguration.mockRejectedValue(
 			new Error('Invalid setup')

--- a/packages/playground/website/src/lib/state/redux/slice-sites.ts
+++ b/packages/playground/website/src/lib/state/redux/slice-sites.ts
@@ -236,13 +236,14 @@ export function updateSite({
 		if ('storage' in changes) {
 			throw new Error('Cannot update storage for a site.');
 		}
-		dispatch(
-			sitesSlice.actions.updateSite({
-				id: slug,
-				changes,
-			})
-		);
-		const updatedSite = selectSiteBySlug(getState(), slug);
+		const existingSite = selectSiteBySlug(getState(), slug);
+		if (!existingSite) {
+			throw new Error(`Site not found: ${slug}`);
+		}
+		const updatedSite = {
+			...existingSite,
+			...changes,
+		};
 		if (updatedSite.metadata.storage !== 'none') {
 			await opfsSiteStorage?.update(
 				updatedSite.slug,
@@ -250,6 +251,12 @@ export function updateSite({
 				updatedSite.originalUrlParams
 			);
 		}
+		dispatch(
+			sitesSlice.actions.updateSite({
+				id: slug,
+				changes,
+			})
+		);
 	};
 }
 

--- a/packages/playground/website/src/lib/state/redux/slice-sites.ts
+++ b/packages/playground/website/src/lib/state/redux/slice-sites.ts
@@ -240,12 +240,24 @@ export function updateSite({
 		if (!existingSite) {
 			throw new Error(`Site not found: ${slug}`);
 		}
+		const { metadata, ...topLevelChanges } = changes;
 		const updatedSite = {
 			...existingSite,
-			...changes,
+			...topLevelChanges,
+			metadata: metadata
+				? {
+						...existingSite.metadata,
+						...metadata,
+					}
+				: existingSite.metadata,
 		};
 		if (updatedSite.metadata.storage !== 'none') {
-			await opfsSiteStorage?.update(
+			if (!opfsSiteStorage) {
+				throw new Error(
+					'Cannot update a saved Playground because browser storage is not available.'
+				);
+			}
+			await opfsSiteStorage.update(
 				updatedSite.slug,
 				updatedSite.metadata,
 				updatedSite.originalUrlParams
@@ -254,7 +266,10 @@ export function updateSite({
 		dispatch(
 			sitesSlice.actions.updateSite({
 				id: slug,
-				changes,
+				changes: {
+					...topLevelChanges,
+					...(metadata ? { metadata: updatedSite.metadata } : {}),
+				},
 			})
 		);
 	};


### PR DESCRIPTION
## What it does

Delays the Redux state changes that mark a Playground as saved to the new storage target until it's actually finished saving.

When saving an OPFS-backed Playground to a local directory fails, the previous OPFS mount is restored and Redux keeps the previous mount descriptor.

## Rationale

Before this PR, the save flow could update Redux before the durable storage work finished. That meant the UI could say a site was saved to a new storage target even when the OPFS metadata write, file copy, or local-directory mount had failed.

For example, if saving an existing OPFS site into a local directory failed after unmounting `/wordpress`, Redux could say the site used `local-fs` while the runtime was no longer mounted to the original browser-storage directory.

## Testing instructions

* CI
* Close the page to interrupt an OPFS site save, reload Playground, and save the same site again. Confirm stale pending OPFS save state is cleaned up instead of reusing partial files
* Save an existing browser-storage Playground to a local directory, fail/cancel before metadata finishes, and confirm it still points at the previous browser-storage mount instead of `local-fs`
