### PR TITLE
[Website] Add reusable dock pane primitives

### DIFF
--- a/packages/playground/website/src/components/dock/dock-corner-launcher.spec.tsx
+++ b/packages/playground/website/src/components/dock/dock-corner-launcher.spec.tsx
@@ -1,0 +1,28 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { DockCornerLauncher } from './dock-corner-launcher';
+
+describe('DockCornerLauncher', () => {
+	it('renders the minimized dock launcher with its logo content', () => {
+		const markup = renderToStaticMarkup(
+			<DockCornerLauncher side="left">
+				<span>WP</span>
+			</DockCornerLauncher>
+		);
+
+		expect(markup).toContain('aria-label="Show Playground tools"');
+		expect(markup).toContain(
+			'title="Drag out or click to show Playground tools"'
+		);
+		expect(markup).toContain('WP');
+	});
+
+	it('disables clicks while the dock is folding into the corner', () => {
+		const markup = renderToStaticMarkup(
+			<DockCornerLauncher side="right" isFolding>
+				<span>WP</span>
+			</DockCornerLauncher>
+		);
+
+		expect(markup).toContain('disabled=""');
+	});
+});

--- a/packages/playground/website/src/components/dock/dock-corner-launcher.tsx
+++ b/packages/playground/website/src/components/dock/dock-corner-launcher.tsx
@@ -1,0 +1,60 @@
+import classNames from 'classnames';
+import type { MouseEventHandler, PointerEventHandler, ReactNode } from 'react';
+import css from './style.module.css';
+
+export type DockCornerSide = 'left' | 'right';
+
+export type DockCornerLauncherProps = {
+	side: DockCornerSide;
+	children: ReactNode;
+	isDragging?: boolean;
+	isFolding?: boolean;
+	ariaLabel?: string;
+	title?: string;
+	onClick?: MouseEventHandler<HTMLButtonElement>;
+	onPointerDown?: PointerEventHandler<HTMLButtonElement>;
+	onPointerMove?: PointerEventHandler<HTMLButtonElement>;
+	onPointerUp?: PointerEventHandler<HTMLButtonElement>;
+	onPointerCancel?: PointerEventHandler<HTMLButtonElement>;
+};
+
+/**
+ * The minimized dock launcher. It can stay mounted through fold/unfold gestures
+ * while the full dock animates into or out of a bottom corner.
+ */
+export function DockCornerLauncher({
+	side,
+	children,
+	isDragging = false,
+	isFolding = false,
+	ariaLabel = 'Show Playground tools',
+	title = 'Drag out or click to show Playground tools',
+	onClick,
+	onPointerDown,
+	onPointerMove,
+	onPointerUp,
+	onPointerCancel,
+}: DockCornerLauncherProps) {
+	return (
+		<button
+			type="button"
+			className={classNames(css.dockCorner, {
+				[css.dockCornerLeft]: side === 'left',
+				[css.dockCornerRight]: side === 'right',
+				[css.dockCornerDragging]: isDragging,
+			})}
+			aria-label={ariaLabel}
+			title={title}
+			disabled={isFolding}
+			onPointerDown={onPointerDown}
+			onPointerMove={onPointerMove}
+			onPointerUp={onPointerUp}
+			onPointerCancel={onPointerCancel}
+			onClick={onClick}
+		>
+			<span className={css.dockCornerLogo} aria-hidden="true">
+				{children}
+			</span>
+		</button>
+	);
+}

--- a/packages/playground/website/src/components/dock/dock-item-button.spec.tsx
+++ b/packages/playground/website/src/components/dock/dock-item-button.spec.tsx
@@ -1,0 +1,39 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { DockItemButton } from './dock-item-button';
+import { DockBlueprintIcon, DockDatabaseIcon } from './icons';
+
+describe('DockItemButton', () => {
+	it('renders a stable accessible name and pressed state', () => {
+		const markup = renderToStaticMarkup(
+			<DockItemButton
+				label="Database"
+				ariaLabel="Database"
+				icon={<DockDatabaseIcon />}
+				isActive
+				dataCy="database-tool"
+			/>
+		);
+
+		expect(markup).toContain('aria-label="Database"');
+		expect(markup).toContain('aria-pressed="true"');
+		expect(markup).toContain('data-cy="database-tool"');
+		expect(markup).toContain('Database');
+	});
+
+	it('announces notification dots without exposing decorative dots', () => {
+		const markup = renderToStaticMarkup(
+			<DockItemButton
+				label="Blueprint"
+				ariaLabel="Current Blueprint"
+				icon={<DockBlueprintIcon />}
+				hasNotification
+				notificationAriaSuffix="recent autosave available"
+			/>
+		);
+
+		expect(markup).toContain(
+			'aria-label="Current Blueprint — recent autosave available"'
+		);
+		expect(markup).toContain('aria-hidden="true"');
+	});
+});

--- a/packages/playground/website/src/components/dock/dock-item-button.spec.tsx
+++ b/packages/playground/website/src/components/dock/dock-item-button.spec.tsx
@@ -1,6 +1,6 @@
 import { renderToStaticMarkup } from 'react-dom/server';
 import { DockItemButton } from './dock-item-button';
-import { DockBlueprintIcon, DockDatabaseIcon } from './icons';
+import { DockDatabaseIcon } from './icons';
 
 describe('DockItemButton', () => {
 	it('renders a stable accessible name and pressed state', () => {
@@ -25,15 +25,20 @@ describe('DockItemButton', () => {
 			<DockItemButton
 				label="Blueprint"
 				ariaLabel="Current Blueprint"
-				icon={<DockBlueprintIcon />}
+				icon={<span>Blueprint icon</span>}
 				hasNotification
 				notificationAriaSuffix="recent autosave available"
 			/>
 		);
+		const hiddenMarkerCount = countMatches(markup, 'aria-hidden="true"');
 
 		expect(markup).toContain(
 			'aria-label="Current Blueprint — recent autosave available"'
 		);
-		expect(markup).toContain('aria-hidden="true"');
+		expect(hiddenMarkerCount).toBe(2);
 	});
 });
+
+function countMatches(value: string, substring: string) {
+	return value.split(substring).length - 1;
+}

--- a/packages/playground/website/src/components/dock/dock-item-button.tsx
+++ b/packages/playground/website/src/components/dock/dock-item-button.tsx
@@ -1,0 +1,73 @@
+import classNames from 'classnames';
+import { forwardRef } from 'react';
+import type { MouseEventHandler, ReactNode } from 'react';
+import css from './style.module.css';
+
+export type DockItemButtonProps = {
+	label: string;
+	ariaLabel: string;
+	icon: ReactNode;
+	isActive?: boolean;
+	isPrimary?: boolean;
+	hasSeparator?: boolean;
+	hasNotification?: boolean;
+	notificationAriaSuffix?: string;
+	dataCy?: string;
+	onClick?: MouseEventHandler<HTMLButtonElement>;
+};
+
+/**
+ * A reusable two-line dock tool button: icon above label, optional primary
+ * treatment, optional group divider, and optional notification dot.
+ */
+export const DockItemButton = forwardRef<
+	HTMLButtonElement,
+	DockItemButtonProps
+>(function DockItemButton(
+	{
+		label,
+		ariaLabel,
+		icon,
+		isActive = false,
+		isPrimary = false,
+		hasSeparator = false,
+		hasNotification = false,
+		notificationAriaSuffix = 'notification available',
+		dataCy,
+		onClick,
+	},
+	ref
+) {
+	const buttonAriaLabel = hasNotification
+		? `${ariaLabel} — ${notificationAriaSuffix}`
+		: ariaLabel;
+
+	return (
+		<span
+			className={classNames({
+				[css.withSeparator]: hasSeparator,
+			})}
+		>
+			<button
+				type="button"
+				ref={ref}
+				className={classNames(css.dockItem, {
+					[css.dockItemPrimary]: isPrimary,
+					[css.dockItemActive]: isActive,
+				})}
+				aria-label={buttonAriaLabel}
+				aria-pressed={isActive}
+				onClick={onClick}
+				data-cy={dataCy}
+			>
+				<span className={css.dockIcon} aria-hidden="true">
+					{icon}
+				</span>
+				<span className={css.dockLabel}>{label}</span>
+				{hasNotification && (
+					<span className={css.dockItemDot} aria-hidden="true" />
+				)}
+			</button>
+		</span>
+	);
+});

--- a/packages/playground/website/src/components/dock/dock-pane.spec.tsx
+++ b/packages/playground/website/src/components/dock/dock-pane.spec.tsx
@@ -45,9 +45,11 @@ describe('DockPane', () => {
 		);
 
 		expect(markup).toContain('aria-label="Close"');
+		expect(markup).toContain('aria-describedby=');
 		expect(markup).toContain(
 			'title="Wait for the current action to finish"'
 		);
+		expect(markup).toContain('Wait for the current action to finish');
 		expect(markup).toContain('disabled=""');
 	});
 });

--- a/packages/playground/website/src/components/dock/dock-pane.spec.tsx
+++ b/packages/playground/website/src/components/dock/dock-pane.spec.tsx
@@ -1,0 +1,53 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { DockPane } from './dock-pane';
+
+describe('DockPane', () => {
+	it('renders a dialog shell with heading, description, and body', () => {
+		const markup = renderToStaticMarkup(
+			<DockPane
+				title="Files"
+				description="Browse and edit the active Playground filesystem."
+			>
+				<p>Pane content</p>
+			</DockPane>
+		);
+
+		expect(markup).toContain('role="dialog"');
+		expect(markup).toContain('aria-label="Files pane"');
+		expect(markup).toContain('<h2>Files</h2>');
+		expect(markup).toContain(
+			'Browse and edit the active Playground filesystem.'
+		);
+		expect(markup).toContain('Pane content');
+	});
+
+	it('can render pane content without the shared header', () => {
+		const markup = renderToStaticMarkup(
+			<DockPane title="Blueprint" showHeader={false}>
+				<p>Editor content</p>
+			</DockPane>
+		);
+
+		expect(markup).not.toContain('<h2>Blueprint</h2>');
+		expect(markup).toContain('Editor content');
+	});
+
+	it('renders a disabled close button when pane closing is blocked', () => {
+		const markup = renderToStaticMarkup(
+			<DockPane
+				title="Export"
+				onClose={() => {}}
+				closeDisabled
+				closeTitle="Wait for the current action to finish"
+			>
+				<p>Export content</p>
+			</DockPane>
+		);
+
+		expect(markup).toContain('aria-label="Close"');
+		expect(markup).toContain(
+			'title="Wait for the current action to finish"'
+		);
+		expect(markup).toContain('disabled=""');
+	});
+});

--- a/packages/playground/website/src/components/dock/dock-pane.tsx
+++ b/packages/playground/website/src/components/dock/dock-pane.tsx
@@ -1,0 +1,94 @@
+import classNames from 'classnames';
+import { forwardRef } from 'react';
+import type { CSSProperties, MouseEventHandler, ReactNode } from 'react';
+import { Icon, close } from '@wordpress/icons';
+import css from './style.module.css';
+
+export type DockPaneProps = {
+	title: string;
+	children: ReactNode;
+	description?: string;
+	className?: string;
+	style?: CSSProperties;
+	isEditor?: boolean;
+	isFixedHeight?: boolean;
+	isCompact?: boolean;
+	showHeader?: boolean;
+	headerAction?: ReactNode;
+	ariaLabel?: string;
+	closeDisabled?: boolean;
+	closeTitle?: string;
+	onClose?: MouseEventHandler<HTMLButtonElement>;
+};
+
+/**
+ * Shared shell for floating dock panes. It owns the dialog semantics, optional
+ * mobile close control, common header, and body slot without choosing content.
+ */
+export const DockPane = forwardRef<HTMLElement, DockPaneProps>(
+	function DockPane(
+		{
+			title,
+			description,
+			children,
+			className,
+			style,
+			isEditor = false,
+			isFixedHeight = false,
+			isCompact = false,
+			showHeader = true,
+			headerAction,
+			ariaLabel,
+			closeDisabled = false,
+			closeTitle,
+			onClose,
+		},
+		ref
+	) {
+		return (
+			<section
+				ref={ref}
+				className={classNames(
+					css.pane,
+					{
+						[css.paneEditor]: isEditor,
+						[css.paneFixedHeight]: isFixedHeight,
+						[css.paneCompact]: isCompact,
+					},
+					className
+				)}
+				style={style}
+				role="dialog"
+				tabIndex={-1}
+				aria-label={ariaLabel ?? `${title} pane`}
+			>
+				{onClose && (
+					<button
+						type="button"
+						className={css.paneClose}
+						aria-label="Close"
+						title={closeTitle ?? 'Close'}
+						disabled={closeDisabled}
+						onClick={onClose}
+					>
+						<Icon icon={close} size={24} />
+					</button>
+				)}
+				{showHeader && (
+					<div className={css.paneHeader}>
+						<div className={css.paneHeaderMain}>
+							<h2>{title}</h2>
+							{description && (
+								<p className={css.paneDescription}>
+									{description}
+								</p>
+							)}
+						</div>
+						{headerAction}
+					</div>
+				)}
+				<div className={css.paneBody}>{children}</div>
+			</section>
+		);
+	}
+);

--- a/packages/playground/website/src/components/dock/dock-pane.tsx
+++ b/packages/playground/website/src/components/dock/dock-pane.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames';
-import { forwardRef } from 'react';
+import { forwardRef, useId } from 'react';
 import type { CSSProperties, MouseEventHandler, ReactNode } from 'react';
 import { Icon, close } from '@wordpress/icons';
 import css from './style.module.css';
@@ -45,6 +45,10 @@ export const DockPane = forwardRef<HTMLElement, DockPaneProps>(
 		},
 		ref
 	) {
+		const closeDescriptionId = useId();
+		const closeDescription =
+			closeTitle && closeTitle !== 'Close' ? closeTitle : undefined;
+
 		return (
 			<section
 				ref={ref}
@@ -63,16 +67,31 @@ export const DockPane = forwardRef<HTMLElement, DockPaneProps>(
 				aria-label={ariaLabel ?? `${title} pane`}
 			>
 				{onClose && (
-					<button
-						type="button"
-						className={css.paneClose}
-						aria-label="Close"
-						title={closeTitle ?? 'Close'}
-						disabled={closeDisabled}
-						onClick={onClose}
-					>
-						<Icon icon={close} size={24} />
-					</button>
+					<>
+						<button
+							type="button"
+							className={css.paneClose}
+							aria-label="Close"
+							aria-describedby={
+								closeDescription
+									? closeDescriptionId
+									: undefined
+							}
+							title={closeTitle ?? 'Close'}
+							disabled={closeDisabled}
+							onClick={onClose}
+						>
+							<Icon icon={close} size={24} />
+						</button>
+						{closeDescription && (
+							<span
+								id={closeDescriptionId}
+								className={css.visuallyHidden}
+							>
+								{closeDescription}
+							</span>
+						)}
+					</>
 				)}
 				{showHeader && (
 					<div className={css.paneHeader}>

--- a/packages/playground/website/src/components/dock/dock-toggle-pill.spec.tsx
+++ b/packages/playground/website/src/components/dock/dock-toggle-pill.spec.tsx
@@ -13,8 +13,10 @@ describe('DockTogglePill', () => {
 		);
 
 		expect(markup).toContain('aria-label="Show tools"');
+		expect(markup).toContain('aria-expanded="false"');
 		expect(markup).toContain('title="Show tools"');
 		expect(markup).toContain('aria-label="Exit full width"');
+		expect(markup).toContain('aria-pressed="true"');
 		expect(markup).toContain('title="Exit full width"');
 	});
 
@@ -29,6 +31,8 @@ describe('DockTogglePill', () => {
 		);
 
 		expect(markup).toContain('aria-label="Hide tools"');
+		expect(markup).toContain('aria-expanded="true"');
 		expect(markup).toContain('aria-label="Full width"');
+		expect(markup).toContain('aria-pressed="false"');
 	});
 });

--- a/packages/playground/website/src/components/dock/dock-toggle-pill.spec.tsx
+++ b/packages/playground/website/src/components/dock/dock-toggle-pill.spec.tsx
@@ -1,0 +1,34 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { DockTogglePill } from './dock-toggle-pill';
+
+describe('DockTogglePill', () => {
+	it('labels the collapsed and full-width actions', () => {
+		const markup = renderToStaticMarkup(
+			<DockTogglePill
+				isCollapsed
+				isFullWidth
+				onToggleCollapsed={() => {}}
+				onToggleFullWidth={() => {}}
+			/>
+		);
+
+		expect(markup).toContain('aria-label="Show tools"');
+		expect(markup).toContain('title="Show tools"');
+		expect(markup).toContain('aria-label="Exit full width"');
+		expect(markup).toContain('title="Exit full width"');
+	});
+
+	it('labels the expanded and floating actions', () => {
+		const markup = renderToStaticMarkup(
+			<DockTogglePill
+				isCollapsed={false}
+				isFullWidth={false}
+				onToggleCollapsed={() => {}}
+				onToggleFullWidth={() => {}}
+			/>
+		);
+
+		expect(markup).toContain('aria-label="Hide tools"');
+		expect(markup).toContain('aria-label="Full width"');
+	});
+});

--- a/packages/playground/website/src/components/dock/dock-toggle-pill.tsx
+++ b/packages/playground/website/src/components/dock/dock-toggle-pill.tsx
@@ -1,0 +1,55 @@
+import type { MouseEventHandler, Ref } from 'react';
+import classNames from 'classnames';
+import {
+	DockCollapseChevronIcon,
+	DockFloatingIcon,
+	DockFullWidthIcon,
+} from './icons';
+import css from './style.module.css';
+
+export type DockTogglePillProps = {
+	isCollapsed: boolean;
+	isFullWidth: boolean;
+	collapseButtonRef?: Ref<HTMLButtonElement>;
+	onToggleCollapsed: MouseEventHandler<HTMLButtonElement>;
+	onToggleFullWidth: MouseEventHandler<HTMLButtonElement>;
+};
+
+/**
+ * Two switches fused into one split capsule: hide/show tools on the left,
+ * floating/full-width mode on the right.
+ */
+export function DockTogglePill({
+	isCollapsed,
+	isFullWidth,
+	collapseButtonRef,
+	onToggleCollapsed,
+	onToggleFullWidth,
+}: DockTogglePillProps) {
+	return (
+		<div className={css.dockTogglePill}>
+			<button
+				type="button"
+				ref={collapseButtonRef}
+				className={classNames(css.dockPillBtn, {
+					[css.dockPillCollapse]: true,
+					[css.dockPillCollapseClosed]: isCollapsed,
+				})}
+				aria-label={isCollapsed ? 'Show tools' : 'Hide tools'}
+				title={isCollapsed ? 'Show tools' : 'Hide tools'}
+				onClick={onToggleCollapsed}
+			>
+				<DockCollapseChevronIcon />
+			</button>
+			<button
+				type="button"
+				className={css.dockPillBtn}
+				aria-label={isFullWidth ? 'Exit full width' : 'Full width'}
+				title={isFullWidth ? 'Exit full width' : 'Full width'}
+				onClick={onToggleFullWidth}
+			>
+				{isFullWidth ? <DockFloatingIcon /> : <DockFullWidthIcon />}
+			</button>
+		</div>
+	);
+}

--- a/packages/playground/website/src/components/dock/dock-toggle-pill.tsx
+++ b/packages/playground/website/src/components/dock/dock-toggle-pill.tsx
@@ -31,11 +31,11 @@ export function DockTogglePill({
 			<button
 				type="button"
 				ref={collapseButtonRef}
-				className={classNames(css.dockPillBtn, {
-					[css.dockPillCollapse]: true,
+				className={classNames(css.dockPillBtn, css.dockPillCollapse, {
 					[css.dockPillCollapseClosed]: isCollapsed,
 				})}
 				aria-label={isCollapsed ? 'Show tools' : 'Hide tools'}
+				aria-expanded={!isCollapsed}
 				title={isCollapsed ? 'Show tools' : 'Hide tools'}
 				onClick={onToggleCollapsed}
 			>
@@ -45,6 +45,7 @@ export function DockTogglePill({
 				type="button"
 				className={css.dockPillBtn}
 				aria-label={isFullWidth ? 'Exit full width' : 'Full width'}
+				aria-pressed={isFullWidth}
 				title={isFullWidth ? 'Exit full width' : 'Full width'}
 				onClick={onToggleFullWidth}
 			>

--- a/packages/playground/website/src/components/dock/icons.tsx
+++ b/packages/playground/website/src/components/dock/icons.tsx
@@ -1,0 +1,155 @@
+/**
+ * Cylinder mark for the Database tool. @wordpress/icons has no database glyph,
+ * so we draw one here, matching the local-SVG pattern used elsewhere in the app.
+ */
+export function DockDatabaseIcon() {
+	return (
+		<svg
+			width="24"
+			height="24"
+			viewBox="0 0 24 24"
+			fill="none"
+			aria-hidden="true"
+		>
+			<ellipse
+				cx="12"
+				cy="6"
+				rx="6.25"
+				ry="2.75"
+				fill="none"
+				stroke="currentColor"
+				strokeWidth="1.6"
+			/>
+			<path
+				d="M5.75 6v12c0 1.52 2.8 2.75 6.25 2.75s6.25-1.23 6.25-2.75V6"
+				fill="none"
+				stroke="currentColor"
+				strokeWidth="1.6"
+			/>
+			<path
+				d="M5.75 12c0 1.52 2.8 2.75 6.25 2.75s6.25-1.23 6.25-2.75"
+				fill="none"
+				stroke="currentColor"
+				strokeWidth="1.6"
+			/>
+		</svg>
+	);
+}
+
+/**
+ * Curly-braces mark for the Blueprint tool. Blueprints are JSON, so `{}` reads
+ * truer than the angle-bracket `<>` glyph, which connotes HTML/markup. The arms
+ * curve continuously into the tongue so it reads as calligraphic braces.
+ */
+export function DockBlueprintIcon() {
+	return (
+		<svg
+			width="24"
+			height="24"
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="1.6"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			aria-hidden="true"
+		>
+			{/* Keep fill none so future dock CSS cannot fill the open paths. */}
+			<path
+				fill="none"
+				d="M9 4C7 4 7 6 6.8 8.5C6.65 10.4 6 11.4 4.5 12C6 12.6 6.65 13.6 6.8 15.5C7 18 7 20 9 20"
+			/>
+			<path
+				fill="none"
+				d="M15 4C17 4 17 6 17.2 8.5C17.35 10.4 18 11.4 19.5 12C18 12.6 17.35 13.6 17.2 15.5C17 18 17 20 15 20"
+			/>
+		</svg>
+	);
+}
+
+/**
+ * Chevron for the toggle pill's left half. CSS can rotate it when collapsed.
+ */
+export function DockCollapseChevronIcon() {
+	return (
+		<svg
+			width="20"
+			height="20"
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="2"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			aria-hidden="true"
+		>
+			<path d="M6 9l6 6 6-6" />
+		</svg>
+	);
+}
+
+/**
+ * Screen mark for the full-width action: a monitor whose content fills it.
+ */
+export function DockFullWidthIcon() {
+	return (
+		<svg
+			width="20"
+			height="20"
+			viewBox="0 0 24 24"
+			fill="none"
+			aria-hidden="true"
+		>
+			<rect
+				x="3"
+				y="6"
+				width="18"
+				height="12"
+				rx="2.5"
+				stroke="currentColor"
+				strokeWidth="1.7"
+			/>
+			<rect
+				x="5.4"
+				y="8.4"
+				width="13.2"
+				height="7.2"
+				rx="1.3"
+				fill="currentColor"
+			/>
+		</svg>
+	);
+}
+
+/**
+ * Screen mark for the floating action: a small window inside the monitor.
+ */
+export function DockFloatingIcon() {
+	return (
+		<svg
+			width="20"
+			height="20"
+			viewBox="0 0 24 24"
+			fill="none"
+			aria-hidden="true"
+		>
+			<rect
+				x="3"
+				y="6"
+				width="18"
+				height="12"
+				rx="2.5"
+				stroke="currentColor"
+				strokeWidth="1.7"
+			/>
+			<rect
+				x="7"
+				y="9.5"
+				width="10"
+				height="5"
+				rx="1.3"
+				fill="currentColor"
+			/>
+		</svg>
+	);
+}

--- a/packages/playground/website/src/components/dock/index.ts
+++ b/packages/playground/website/src/components/dock/index.ts
@@ -1,0 +1,5 @@
+export * from './dock-corner-launcher';
+export * from './dock-item-button';
+export * from './dock-pane';
+export * from './dock-toggle-pill';
+export * from './icons';

--- a/packages/playground/website/src/components/dock/style.module.css
+++ b/packages/playground/website/src/components/dock/style.module.css
@@ -245,6 +245,18 @@
 	outline-offset: 2px;
 }
 
+.visually-hidden {
+	border: 0;
+	clip: rect(0, 0, 0, 0);
+	height: 1px;
+	margin: -1px;
+	overflow: hidden;
+	padding: 0;
+	position: absolute;
+	white-space: nowrap;
+	width: 1px;
+}
+
 .pane-header {
 	align-items: flex-start;
 	border-bottom: 1px solid var(--line-subtle);

--- a/packages/playground/website/src/components/dock/style.module.css
+++ b/packages/playground/website/src/components/dock/style.module.css
@@ -1,0 +1,302 @@
+.with-separator {
+	margin-left: 9px;
+	position: relative;
+}
+
+.with-separator::before {
+	background: rgba(247, 245, 242, 0.16);
+	content: '';
+	height: 24px;
+	left: -5px;
+	position: absolute;
+	top: 50%;
+	transform: translateY(-50%);
+	width: 1px;
+}
+
+.dock-item {
+	align-items: center;
+	background: transparent;
+	border: 0;
+	border-radius: 12px;
+	color: rgba(247, 245, 242, 0.68);
+	cursor: pointer;
+	display: flex;
+	flex-direction: column;
+	font: inherit;
+	gap: 3px;
+	justify-content: center;
+	min-height: 52px;
+	min-width: 72px;
+	padding: 8px 7px 7px;
+	position: relative;
+	transition:
+		background 120ms ease,
+		color 120ms ease;
+}
+
+.dock-item:hover {
+	background: rgba(247, 245, 242, 0.14);
+	color: #f7f5f2;
+}
+
+.dock-item-active {
+	background: rgba(247, 245, 242, 0.22);
+	color: #ffffff;
+}
+
+.dock-item:focus-visible {
+	outline: 2px solid #3858e9;
+	outline-offset: 3px;
+}
+
+.dock-item-primary {
+	background: #3858e9;
+	color: #ffffff;
+}
+
+.dock-item-primary:hover,
+.dock-item-primary.dock-item-active {
+	background: #2f4ad1;
+	color: #ffffff;
+}
+
+.dock-icon {
+	align-items: center;
+	display: flex;
+	justify-content: center;
+	line-height: 1;
+	min-height: 24px;
+}
+
+.dock-icon svg {
+	display: block;
+	fill: currentColor;
+}
+
+.dock-label {
+	font-size: 11px;
+	font-weight: 500;
+	letter-spacing: 0.015em;
+	line-height: 1;
+	white-space: nowrap;
+}
+
+.dock-item-dot {
+	background: #d63638;
+	border: 2px solid #21201d;
+	border-radius: 999px;
+	height: 10px;
+	position: absolute;
+	right: 12px;
+	top: 8px;
+	width: 10px;
+}
+
+.dock-toggle-pill {
+	align-items: stretch;
+	background: rgba(247, 245, 242, 0.1);
+	border: 1px solid rgba(247, 245, 242, 0.16);
+	border-radius: 999px;
+	display: flex;
+	overflow: hidden;
+}
+
+.dock-pill-btn {
+	align-items: center;
+	background: transparent;
+	border: 0;
+	color: rgba(247, 245, 242, 0.72);
+	cursor: pointer;
+	display: inline-flex;
+	justify-content: center;
+	min-height: 34px;
+	padding: 0 10px;
+}
+
+.dock-pill-btn:hover {
+	background: rgba(247, 245, 242, 0.14);
+	color: #ffffff;
+}
+
+.dock-pill-btn:focus-visible {
+	outline: 2px solid #3858e9;
+	outline-offset: -2px;
+}
+
+.dock-pill-collapse {
+	border-right: 1px solid rgba(247, 245, 242, 0.16);
+}
+
+.dock-pill-collapse svg {
+	transition: transform 160ms ease;
+}
+
+.dock-pill-collapse-closed svg {
+	transform: rotate(180deg);
+}
+
+.dock-corner {
+	align-items: center;
+	background: #21201d;
+	border: 0;
+	border-radius: 999px;
+	bottom: 12px;
+	box-shadow:
+		inset 0 0 0 1px rgba(255, 251, 243, 0.16),
+		0 8px 24px rgba(12, 10, 8, 0.34);
+	color: #f7f5f2;
+	cursor: pointer;
+	display: inline-flex;
+	height: 48px;
+	justify-content: center;
+	position: fixed;
+	width: 48px;
+	z-index: 50;
+}
+
+.dock-corner:disabled {
+	cursor: default;
+}
+
+.dock-corner-left {
+	left: 12px;
+}
+
+.dock-corner-right {
+	right: 12px;
+}
+
+.dock-corner-dragging {
+	opacity: 0;
+}
+
+.dock-corner-logo {
+	display: inline-flex;
+	line-height: 0;
+}
+
+.pane {
+	--space-3: 12px;
+	--space-4: 16px;
+	--space-6: 24px;
+	--space-8: 32px;
+	--paper-1: #f7f5f2;
+	--ink: #21201d;
+	--ink-muted: #5f5b54;
+	--line-subtle: rgba(33, 32, 29, 0.08);
+
+	background: var(--paper-1);
+	border-radius: 14px;
+	box-shadow:
+		inset 0 1px 0 rgba(255, 255, 255, 0.55),
+		0 1px 2px rgba(40, 33, 23, 0.05),
+		0 8px 18px rgba(40, 33, 23, 0.09),
+		0 26px 56px rgba(40, 33, 23, 0.18);
+	color: var(--ink);
+	display: block;
+	max-height: min(620px, calc(100dvh - 174px));
+	overflow-x: hidden;
+	overflow-y: auto;
+	position: fixed;
+	width: min(600px, calc(100vw - 40px));
+	z-index: 40;
+}
+
+.pane-editor {
+	display: flex;
+	flex-direction: column;
+	min-height: min(620px, calc(100dvh - 174px));
+	width: min(1120px, calc(100vw - 40px));
+}
+
+.pane-fixed-height {
+	display: flex;
+	flex-direction: column;
+}
+
+.pane-compact {
+	width: min(480px, calc(100vw - 40px));
+}
+
+.pane-close {
+	align-items: center;
+	background: transparent;
+	border: 0;
+	border-radius: 999px;
+	color: var(--ink-muted);
+	cursor: pointer;
+	display: none;
+	height: 40px;
+	justify-content: center;
+	position: absolute;
+	right: var(--space-4);
+	top: var(--space-4);
+	width: 40px;
+}
+
+.pane-close:disabled {
+	cursor: default;
+	opacity: 0.45;
+}
+
+.pane-close:focus-visible {
+	outline: 2px solid #3858e9;
+	outline-offset: 2px;
+}
+
+.pane-header {
+	align-items: flex-start;
+	border-bottom: 1px solid var(--line-subtle);
+	display: flex;
+	gap: var(--space-4);
+	justify-content: space-between;
+	padding: var(--space-6) var(--space-6) var(--space-4);
+}
+
+.pane-header-main {
+	min-width: 0;
+}
+
+.pane-header h2 {
+	font-size: 20px;
+	line-height: 1.2;
+	margin: 0;
+}
+
+.pane-description {
+	color: var(--ink-muted);
+	font-size: 13px;
+	line-height: 1.4;
+	margin: var(--space-3) 0 0;
+}
+
+.pane-body {
+	display: flex;
+	flex: 1;
+	flex-direction: column;
+	min-height: 0;
+}
+
+@media (max-width: 1024px) {
+	.pane {
+		border-radius: 0;
+		bottom: var(--dock-height, 0);
+		left: 0;
+		max-height: none;
+		position: fixed;
+		right: 0;
+		top: 0;
+		width: auto;
+	}
+
+	.pane-close {
+		display: inline-flex;
+	}
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.dock-pill-collapse svg {
+		transition: none;
+	}
+}

--- a/packages/playground/website/src/components/pane-loading/index.tsx
+++ b/packages/playground/website/src/components/pane-loading/index.tsx
@@ -1,0 +1,55 @@
+import type { CSSProperties } from 'react';
+import classNames from 'classnames';
+import { Spinner } from '../spinner';
+import css from './style.module.css';
+
+/**
+ * A calm, centered loading state for dock panes whose content isn't ready yet.
+ * It replaces a blank pane, which can read as broken on full-screen mobile UI.
+ */
+export function PaneLoading({ message }: { message: string }) {
+	return (
+		<div className={css.paneLoading} role="status" aria-live="polite">
+			<Spinner size={28} />
+			<p className={css.paneLoadingText}>{message}</p>
+		</div>
+	);
+}
+
+/**
+ * A compact inline notice for panes whose actions are disabled while the
+ * Playground boots. It stays mounted so the surrounding pane can collapse the
+ * notice smoothly when `show` flips to false.
+ */
+export function PlaygroundBootNotice({
+	show,
+	className,
+	message = 'The Playground is still loading — these tools will be ready in a moment.',
+	gap = 'var(--space-3)',
+}: {
+	show: boolean;
+	className?: string;
+	message?: string;
+	gap?: string;
+}) {
+	return (
+		<div
+			className={classNames(css.bootNoticeCollapsible, className, {
+				[css.isHidden]: !show,
+			})}
+			style={{ '--boot-gap': gap } as CSSProperties}
+			aria-hidden={!show || undefined}
+		>
+			<div className={css.bootNoticeInner}>
+				<div
+					className={css.bootNotice}
+					role="status"
+					aria-live="polite"
+				>
+					<Spinner size={16} />
+					<span className={css.bootNoticeText}>{message}</span>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/packages/playground/website/src/components/pane-loading/pane-loading.spec.tsx
+++ b/packages/playground/website/src/components/pane-loading/pane-loading.spec.tsx
@@ -1,0 +1,43 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { PaneLoading, PlaygroundBootNotice } from './index';
+
+describe('PaneLoading', () => {
+	it('announces the loading message politely', () => {
+		const markup = renderToStaticMarkup(
+			<PaneLoading message="Loading the file browser…" />
+		);
+
+		expect(markup).toContain('role="status"');
+		expect(markup).toContain('aria-live="polite"');
+		expect(markup).toContain('Loading the file browser…');
+	});
+});
+
+describe('PlaygroundBootNotice', () => {
+	it('keeps the boot message visible while shown', () => {
+		const markup = renderToStaticMarkup(
+			<PlaygroundBootNotice
+				show
+				message="Database tools will be ready in a moment."
+			/>
+		);
+
+		expect(markup).toContain('role="status"');
+		expect(markup).not.toContain('aria-hidden="true"');
+		expect(markup).toContain('Database tools will be ready in a moment.');
+	});
+
+	it('marks the collapsible notice hidden without unmounting it', () => {
+		const markup = renderToStaticMarkup(
+			<PlaygroundBootNotice
+				show={false}
+				message="Database tools will be ready in a moment."
+				gap="20px"
+			/>
+		);
+
+		expect(markup).toContain('aria-hidden="true"');
+		expect(markup).toContain('--boot-gap:20px');
+		expect(markup).toContain('Database tools will be ready in a moment.');
+	});
+});

--- a/packages/playground/website/src/components/pane-loading/style.module.css
+++ b/packages/playground/website/src/components/pane-loading/style.module.css
@@ -1,0 +1,61 @@
+.pane-loading {
+	align-items: center;
+	color: var(--ink-muted, #5f5b54);
+	display: flex;
+	flex: 1;
+	flex-direction: column;
+	gap: var(--space-3, 12px);
+	justify-content: center;
+	min-height: 160px;
+	padding: var(--space-8, 32px) var(--space-6, 24px);
+	text-align: center;
+}
+
+.pane-loading-text {
+	font-size: 13px;
+	line-height: 1.4;
+	margin: 0;
+}
+
+.boot-notice-collapsible {
+	display: grid;
+	grid-template-rows: 1fr;
+	opacity: 1;
+	transition:
+		grid-template-rows 0.3s cubic-bezier(0.22, 1, 0.36, 1),
+		opacity 0.22s ease,
+		margin-bottom 0.3s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.boot-notice-collapsible.is-hidden {
+	grid-template-rows: 0fr;
+	margin-bottom: calc(-1 * var(--boot-gap, 0px));
+	opacity: 0;
+	pointer-events: none;
+}
+
+.boot-notice-inner {
+	min-height: 0;
+	overflow: hidden;
+}
+
+.boot-notice {
+	align-items: center;
+	background: var(--paper-3, #ece8e1);
+	border-radius: var(--radius-card, 8px);
+	color: var(--ink-muted, #5f5b54);
+	display: flex;
+	gap: var(--space-2, 8px);
+	padding: var(--space-3, 12px) var(--space-4, 16px);
+}
+
+.boot-notice-text {
+	font-size: 13px;
+	line-height: 1.4;
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.boot-notice-collapsible {
+		transition: none;
+	}
+}


### PR DESCRIPTION
Part of #3965.

## What it does

Adds reusable website UI building blocks that can be used by the final Dock work without wiring them into the current active UI:

- Dock tool button, toggle pill, corner launcher, and pane shell primitives.
- Dock-specific SVG icons for Blueprint, Database, collapse, full-width, and floating states.
- Shared pane loading and Playground boot notice components.
- Server-rendered component tests covering accessibility labels, hidden/disabled states, and pane structure.

## Rationale

The final Dock PR has several self-contained components that can land before the Dock itself. Pulling them forward keeps this PR additive and low risk: it creates the component structure we want for the fully merged Dock while avoiding changes to actively used layout, chrome, site manager, or overlay UI.

## Implementation

The new components live under `packages/playground/website/src/components/dock/` with a barrel export so the eventual Dock can import primitives from one place. `PaneLoading` and `PlaygroundBootNotice` live separately under `components/pane-loading/` because they are pane-level states shared by Dock panes and site-manager panels.

No existing components import these files yet, so this PR should not change runtime behavior.

## Testing instructions

- `npm exec nx test playground-website`
- `npm exec nx lint playground-website`
- `npm exec nx typecheck playground-website`

