### PR TITLE
[Website] Detect incomplete OPFS saves before boot

### DIFF
--- a/packages/playground/website/playwright/e2e/opfs.spec.ts
+++ b/packages/playground/website/playwright/e2e/opfs.spec.ts
@@ -1,7 +1,8 @@
 import { test, expect } from '../playground-fixtures.ts';
 import type { Blueprint } from '@wp-playground/blueprints';
-import type { Page } from '@playwright/test';
+import type { BrowserContext, Page } from '@playwright/test';
 import { encodeZip, collectBytes } from '@php-wasm/stream-compression';
+import { getDirectoryNameForSlug } from '../../src/lib/state/opfs/opfs-site-path';
 
 /**
  * Creates a minimal WordPress export ZIP file for testing imports.
@@ -30,6 +31,201 @@ test.describe.configure({ mode: 'serial' });
  */
 function getTemporaryPlaygroundUrl(hash = '') {
 	return `./?storage=temp&random=${Math.random().toString(36).slice(2)}${hash}`;
+}
+
+const OPFS_CLEANUP_LOCK_HOLDER_KEY = 'simulate-opfs-cleanup-lock-holder';
+const OPFS_CLEANUP_FAILURE_COUNT_KEY = 'opfs-cleanup-failure-count';
+
+/**
+ * Makes OPFS file removal fail while another test tab is marked as open.
+ *
+ * Chromium does not give us a reliable way to force a real OPFS lock in CI.
+ * This patch creates the same kind of failure the boot code sees: removing an
+ * old file rejects until the other tab closes. Closing the holder tab removes
+ * the marker through `beforeunload`/`pagehide`, so the next retry can succeed.
+ */
+async function simulateOpfsCleanupBlockedByAnotherTab(context: BrowserContext) {
+	await context.addInitScript(
+		({ lockHolderKey, failureCountKey }) => {
+			const tabId = `${Date.now()}-${Math.random()}`;
+			const releaseLockForThisTab = () => {
+				if (localStorage.getItem(lockHolderKey) === tabId) {
+					localStorage.removeItem(lockHolderKey);
+				}
+			};
+			(window as any).simulateOpfsCleanupLockForThisTab = () => {
+				localStorage.setItem(lockHolderKey, tabId);
+				localStorage.removeItem(failureCountKey);
+			};
+			window.addEventListener('beforeunload', releaseLockForThisTab);
+			window.addEventListener('pagehide', releaseLockForThisTab);
+
+			const originalRemoveEntry =
+				FileSystemDirectoryHandle.prototype.removeEntry;
+			FileSystemDirectoryHandle.prototype.removeEntry =
+				function removeEntry(name, options) {
+					const lockHolder = localStorage.getItem(lockHolderKey);
+					if (
+						lockHolder &&
+						lockHolder !== tabId &&
+						name !== 'wp-runtime.json' &&
+						name !== 'blueprint'
+					) {
+						const failureCount = Number(
+							localStorage.getItem(failureCountKey) || '0'
+						);
+						localStorage.setItem(
+							failureCountKey,
+							String(failureCount + 1)
+						);
+						return Promise.reject(
+							new DOMException(
+								`Simulated OPFS cleanup lock for ${name}`,
+								'InvalidStateError'
+							)
+						);
+					}
+					return originalRemoveEntry.call(this, name, options);
+				};
+		},
+		{
+			lockHolderKey: OPFS_CLEANUP_LOCK_HOLDER_KEY,
+			failureCountKey: OPFS_CLEANUP_FAILURE_COUNT_KEY,
+		}
+	);
+}
+
+/**
+ * Writes the OPFS state left by an interrupted saved Playground reset.
+ *
+ * `wp-runtime.json` already asks for the new setup, but old WordPress files
+ * still sit next to it because the tab closed before cleanup finished.
+ */
+async function writePendingOpfsResetSite(page: Page, slug: string) {
+	await page.evaluate(
+		async ({ dirName, siteSlug }) => {
+			const root = await navigator.storage.getDirectory();
+			try {
+				await root.removeEntry('sites', { recursive: true });
+			} catch (error) {
+				if (error?.name !== 'NotFoundError') {
+					throw error;
+				}
+			}
+			const sites = await root.getDirectoryHandle('sites', {
+				create: true,
+			});
+			const siteDirectory = await sites.getDirectoryHandle(dirName, {
+				create: true,
+			});
+			const metadata = {
+				slug: siteSlug,
+				originalUrlParams: undefined,
+				originalBlueprintSource: { type: 'none' },
+				originalBlueprint: {
+					preferredVersions: { php: '8.4', wp: false },
+					landingPage: '/index.php',
+					steps: [
+						{
+							step: 'writeFile',
+							path: '/wordpress/index.php',
+							data: '<?php echo "cleanup retry ready";',
+						},
+					],
+				},
+				name: siteSlug,
+				id: siteSlug,
+				whenCreated: Date.now(),
+				whenLastUsed: Date.now(),
+				persistence: 'autosave',
+				storage: 'opfs',
+				initialOpfsSyncPending: true,
+				opfsSiteRemovalPending: true,
+				sourceSetupUrlFingerprint: `test-${siteSlug}`,
+				runtimeConfiguration: {
+					phpVersion: '8.4',
+					wpVersion: 'latest',
+					intl: false,
+					networking: true,
+					extraLibraries: [],
+					constants: {},
+				},
+			};
+			await writeFile(
+				siteDirectory,
+				'wp-runtime.json',
+				JSON.stringify(metadata, null, 2)
+			);
+			await writeFile(
+				siteDirectory,
+				'wp-config.php',
+				'<?php /* old config */'
+			);
+			await writeFile(
+				siteDirectory,
+				'wp-settings.php',
+				'<?php /* old settings */'
+			);
+			await writeFile(
+				siteDirectory,
+				'old-reset-sentinel.php',
+				'old site'
+			);
+			const wpContent = await siteDirectory.getDirectoryHandle(
+				'wp-content',
+				{ create: true }
+			);
+			const database = await wpContent.getDirectoryHandle('database', {
+				create: true,
+			});
+			await writeFile(database, '.ht.sqlite', 'old sqlite placeholder');
+
+			async function writeFile(
+				directory: FileSystemDirectoryHandle,
+				name: string,
+				contents: string
+			) {
+				const file = await directory.getFileHandle(name, {
+					create: true,
+				});
+				const writable = await file.createWritable();
+				await writable.write(contents);
+				await writable.close();
+			}
+		},
+		{ dirName: getDirectoryNameForSlug(slug), siteSlug: slug }
+	);
+}
+
+async function readPendingResetSiteState(page: Page, slug: string) {
+	return await page.evaluate(
+		async ({ dirName }) => {
+			const root = await navigator.storage.getDirectory();
+			const sites = await root.getDirectoryHandle('sites');
+			const siteDirectory = await sites.getDirectoryHandle(dirName);
+			const metadataFile =
+				await siteDirectory.getFileHandle('wp-runtime.json');
+			const metadata = JSON.parse(
+				await (await metadataFile.getFile()).text()
+			);
+			const hasEntry = async (name: string) => {
+				try {
+					await siteDirectory.getFileHandle(name);
+					return true;
+				} catch (error) {
+					if (error?.name === 'NotFoundError') {
+						return false;
+					}
+					throw error;
+				}
+			};
+			return {
+				metadata,
+				hasOldResetSentinel: await hasEntry('old-reset-sentinel.php'),
+			};
+		},
+		{ dirName: getDirectoryNameForSlug(slug) }
+	);
 }
 
 /**
@@ -85,6 +281,66 @@ async function saveSiteViaModal(
 	// The save operation syncs to OPFS which can take time, so we use a longer timeout.
 	await expect(dialog).not.toBeVisible({ timeout: 60000 });
 }
+
+test('should retry pending OPFS cleanup after another tab releases storage', async ({
+	website,
+	context,
+	browserName,
+}) => {
+	test.skip(
+		browserName !== 'chromium',
+		`This test relies on OPFS which isn't available in Playwright's flavor of ${browserName}.`
+	);
+
+	await simulateOpfsCleanupBlockedByAnotherTab(context);
+	const slug = `pending-cleanup-${Date.now()}`;
+	await website.page.goto(getTemporaryPlaygroundUrl());
+	await website.page.waitForFunction(() => !!navigator.storage?.getDirectory);
+	await writePendingOpfsResetSite(website.page, slug);
+
+	const lockPage = await context.newPage();
+	await lockPage.goto(getTemporaryPlaygroundUrl());
+	await lockPage.evaluate(() => {
+		(window as any).simulateOpfsCleanupLockForThisTab();
+	});
+
+	await website.page.goto(
+		`./?site-slug=${encodeURIComponent(slug)}&random=${Date.now()}`
+	);
+	await expect
+		.poll(() =>
+			website.page.evaluate(
+				(failureCountKey) =>
+					Number(localStorage.getItem(failureCountKey) || '0'),
+				OPFS_CLEANUP_FAILURE_COUNT_KEY
+			)
+		)
+		.toBeGreaterThan(0);
+
+	// This mirrors the user closing another Playground tab that still holds on
+	// to the old OPFS files. The next automatic retry should finish cleanup and boot.
+	await lockPage.close({ runBeforeUnload: true });
+	await expect
+		.poll(() =>
+			website.page.evaluate(
+				(lockHolderKey) => localStorage.getItem(lockHolderKey),
+				OPFS_CLEANUP_LOCK_HOLDER_KEY
+			)
+		)
+		.toBeNull();
+
+	await expect(website.wordpress().locator('body')).toContainText(
+		'cleanup retry ready',
+		{ timeout: 120000 }
+	);
+	await expect(
+		website.page.getByText('Close other Playground tabs, then reload')
+	).not.toBeVisible();
+
+	const storedSite = await readPendingResetSiteState(website.page, slug);
+	expect(storedSite.metadata.opfsSiteRemovalPending).toBeUndefined();
+	expect(storedSite.hasOldResetSentinel).toBe(false);
+});
 
 test('should switch between sites', async ({ website, browserName }) => {
 	test.skip(

--- a/packages/playground/website/src/components/blueprint-editor/BlueprintBundleEditor.tsx
+++ b/packages/playground/website/src/components/blueprint-editor/BlueprintBundleEditor.tsx
@@ -440,8 +440,9 @@ export const BlueprintBundleEditor = forwardRef<
 				dispatch(removeClientInfo(site.slug));
 				// "Run Blueprint and reset site" changes the setup for this
 				// autosave. Delete the old WordPress files with
-				// `opfsResetPending` so a tab close after the metadata write
-				// cannot leave the old site booting under the edited Blueprint.
+				// `opfsSiteRemovalPending` so a tab close after the metadata
+				// write cannot leave the old site booting under the edited
+				// Blueprint.
 				const completedChanges =
 					await resetAutosavedSiteFilesWithPendingMarker(
 						site.slug,

--- a/packages/playground/website/src/components/blueprint-editor/BlueprintBundleEditor.tsx
+++ b/packages/playground/website/src/components/blueprint-editor/BlueprintBundleEditor.tsx
@@ -46,14 +46,12 @@ import {
 } from '../../lib/state/redux/slice-clients';
 import {
 	isAutosavedSite,
+	sitesSlice,
 	type SiteInfo,
 	updateSite,
 } from '../../lib/state/redux/slice-sites';
-import {
-	useAppDispatch,
-	useAppSelector,
-} from '../../lib/state/redux/store';
-import { opfsSiteStorage } from '../../lib/state/opfs/opfs-site-storage';
+import { useAppDispatch, useAppSelector } from '../../lib/state/redux/store';
+import { resetAutosavedSiteFilesWithPendingMarker } from '../../lib/state/opfs/opfs-autosave-reset';
 import styles from './blueprint-bundle-editor.module.css';
 import hideRootStyles from './hide-root.module.css';
 import validationStyles from './validation-panel.module.css';
@@ -410,47 +408,63 @@ export const BlueprintBundleEditor = forwardRef<
 			const runtimeConfiguration = await resolveRuntimeConfiguration(
 				bundle as any
 			);
+			const changes = {
+				...(isAutosaved ? { loadedFromStorage: false } : {}),
+				metadata: {
+					...site.metadata,
+					originalBlueprintSource: isAutosaved
+						? { type: 'opfs-site' as const }
+						: { type: 'none' as const },
+					originalBlueprint: isAutosaved
+						? (filesystem as EventedFilesystem).backend
+						: bundle,
+					runtimeConfiguration,
+					initialOpfsSyncPending:
+						isAutosaved || site.metadata.initialOpfsSyncPending,
+					/**
+					 * Recreating an autosaved Playground discards the old
+					 * WordPress files and boots from the edited Blueprint.
+					 * Constants discovered from the previous runtime may no
+					 * longer exist in the recreated site, so they must be
+					 * rediscovered after the first OPFS sync.
+					 */
+					playgroundDefinedConstants: isAutosaved
+						? undefined
+						: site.metadata.playgroundDefinedConstants,
+					whenCreated: Date.now(),
+				},
+				originalUrlParams: undefined,
+			};
 			if (isAutosaved) {
 				await playgroundClient?.unmountOpfs('/wordpress');
 				dispatch(removeClientInfo(site.slug));
-				await opfsSiteStorage!.resetSiteFiles(site.slug);
+				// "Run Blueprint and reset site" changes the setup for this
+				// autosave. Delete the old WordPress files with
+				// `opfsResetPending` so a tab close after the metadata write
+				// cannot leave the old site booting under the edited Blueprint.
+				const completedChanges =
+					await resetAutosavedSiteFilesWithPendingMarker(
+						site.slug,
+						changes
+					);
+				// The helper already wrote these changes to OPFS before and
+				// after deleting files. Update Redux without writing the same
+				// metadata a third time.
+				dispatch(
+					sitesSlice.actions.updateSite({
+						id: site.slug,
+						changes: completedChanges,
+					})
+				);
 			} else {
 				dispatch(removeClientInfo(site.slug));
+				await dispatch(
+					updateSite({
+						slug: site.slug,
+						changes,
+					})
+				);
 			}
-			await dispatch(
-				updateSite({
-					slug: site.slug,
-					changes: {
-						...(isAutosaved
-							? { loadedFromStorage: false }
-							: {}),
-						metadata: {
-							...site.metadata,
-							originalBlueprintSource: isAutosaved
-								? { type: 'opfs-site' }
-								: { type: 'none' },
-							originalBlueprint: isAutosaved
-								? (filesystem as EventedFilesystem).backend
-								: bundle,
-							runtimeConfiguration,
-							initialOpfsSyncPending:
-								isAutosaved ||
-								site.metadata.initialOpfsSyncPending,
-							/**
-							 * Recreating an autosaved Playground discards the old WordPress
-							 * files and boots from the edited Blueprint. Constants discovered
-							 * from the previous runtime may no longer exist in the recreated
-							 * site, so they must be rediscovered after the first OPFS sync.
-							 */
-							playgroundDefinedConstants: isAutosaved
-								? undefined
-								: site.metadata.playgroundDefinedConstants,
-							whenCreated: Date.now(),
-						},
-						originalUrlParams: undefined,
-					},
-				})
-			);
 		} catch (error) {
 			logger.error('Failed to recreate from blueprint', error);
 			setSaveError('Could not recreate Playground. Try again.');

--- a/packages/playground/website/src/components/playground-viewport/index.tsx
+++ b/packages/playground/website/src/components/playground-viewport/index.tsx
@@ -213,6 +213,11 @@ export const JustViewport = function JustViewport({
 			return;
 		}
 
+		// This effect owns one iframe boot. Changing site slug or runtime
+		// settings creates a new iframe while `startPlaygroundWeb()` or OPFS
+		// sync work from the previous iframe may still finish later. The signal
+		// lets `bootSiteClient()` ignore those stale callbacks; cleanup removes
+		// this iframe's client info once.
 		const abortController = new AbortController();
 		dispatch(
 			bootSiteClient(siteSlug, iframe, {

--- a/packages/playground/website/src/components/site-error-modal/get-site-error-view.spec.tsx
+++ b/packages/playground/website/src/components/site-error-modal/get-site-error-view.spec.tsx
@@ -54,16 +54,16 @@ describe('getSiteErrorView', () => {
 
 		expect(view.title).toBe('Close other Playground tabs, then reload');
 		expect(renderToStaticMarkup(view.body)).toContain(
+			'An earlier reset was interrupted, and old site files are'
+		);
+		expect(renderToStaticMarkup(view.body)).toContain(
+			'Playground tried to remove those old files again before'
+		);
+		expect(renderToStaticMarkup(view.body)).toContain(
+			'may show the old site instead of the reset site'
+		);
+		expect(renderToStaticMarkup(view.body)).toContain(
 			'click <strong>Reload</strong>'
-		);
-		expect(renderToStaticMarkup(view.body)).toContain(
-			'old site files are still in this saved Playground'
-		);
-		expect(renderToStaticMarkup(view.body)).toContain(
-			'already tried to clean them up again'
-		);
-		expect(renderToStaticMarkup(view.body)).toContain(
-			'could show the old site with the new settings'
 		);
 		expect(renderToStaticMarkup(view.actions[0])).toContain('Reload');
 	});

--- a/packages/playground/website/src/components/site-error-modal/get-site-error-view.spec.tsx
+++ b/packages/playground/website/src/components/site-error-modal/get-site-error-view.spec.tsx
@@ -38,6 +38,22 @@ describe('getSiteErrorView', () => {
 		);
 	});
 
+	it('uses browser-storage wording when pending cleanup cannot finish', () => {
+		const view = getSiteErrorView({
+			error: 'browser-storage-cleanup-failed',
+			site: createSite(),
+			helpers,
+		});
+
+		expect(view.title).toBe('Browser storage cleanup failed');
+		expect(renderToStaticMarkup(view.body)).toContain(
+			'delete old WordPress files'
+		);
+		expect(renderToStaticMarkup(view.body)).toContain(
+			'files from the previous autosave'
+		);
+	});
+
 	it('says when the entire Blueprint could not be downloaded', () => {
 		const url = 'https://example.com/blueprint.json';
 		const view = getSiteErrorView({

--- a/packages/playground/website/src/components/site-error-modal/get-site-error-view.spec.tsx
+++ b/packages/playground/website/src/components/site-error-modal/get-site-error-view.spec.tsx
@@ -5,6 +5,7 @@ import type { SiteInfo } from '../../lib/state/redux/slice-sites';
 
 const helpers = {
 	deleteSite: () => {},
+	reloadPage: () => {},
 	restartWithoutPr: () => {},
 	reloadWithoutBlueprint: () => {},
 };
@@ -45,13 +46,14 @@ describe('getSiteErrorView', () => {
 			helpers,
 		});
 
-		expect(view.title).toBe('Browser storage cleanup failed');
+		expect(view.title).toBe('Could not reopen this saved Playground');
 		expect(renderToStaticMarkup(view.body)).toContain(
-			'delete old WordPress files'
+			'an earlier reset of this saved site was interrupted'
 		);
 		expect(renderToStaticMarkup(view.body)).toContain(
-			'files from the previous autosave'
+			'Click <strong>Try again</strong>'
 		);
+		expect(renderToStaticMarkup(view.actions[0])).toContain('Try again');
 	});
 
 	it('says when the entire Blueprint could not be downloaded', () => {

--- a/packages/playground/website/src/components/site-error-modal/get-site-error-view.spec.tsx
+++ b/packages/playground/website/src/components/site-error-modal/get-site-error-view.spec.tsx
@@ -33,12 +33,12 @@ describe('getSiteErrorView', () => {
 			helpers,
 		});
 
-		expect(view.title).toBe('This saved Playground is incomplete');
+		expect(view.title).toBe('Start a new Playground to continue');
 		expect(renderToStaticMarkup(view.body)).toContain(
-			'This saved copy can’t be reopened'
+			'This saved Playground is incomplete and can’t be reopened'
 		);
 		expect(renderToStaticMarkup(view.body)).toContain(
-			'Start a new Playground'
+			'the previous save stopped before all WordPress files were copied'
 		);
 		expect(renderToStaticMarkup(view.actions[0])).toContain(
 			'Start a new Playground'
@@ -52,14 +52,15 @@ describe('getSiteErrorView', () => {
 			helpers,
 		});
 
-		expect(view.title).toBe(
-			'Playground couldn’t finish cleaning up this site'
-		);
-		expect(renderToStaticMarkup(view.body)).toContain(
-			'an earlier reset of this saved site was interrupted'
-		);
+		expect(view.title).toBe('Try again to open this Playground');
 		expect(renderToStaticMarkup(view.body)).toContain(
 			'Click <strong>Try again</strong>'
+		);
+		expect(renderToStaticMarkup(view.body)).toContain(
+			'old site files are still in this saved Playground'
+		);
+		expect(renderToStaticMarkup(view.body)).toContain(
+			'could show the old site with the new settings'
 		);
 		expect(renderToStaticMarkup(view.actions[0])).toContain('Try again');
 	});

--- a/packages/playground/website/src/components/site-error-modal/get-site-error-view.spec.tsx
+++ b/packages/playground/website/src/components/site-error-modal/get-site-error-view.spec.tsx
@@ -26,16 +26,22 @@ describe('getSiteErrorView', () => {
 		expect(renderToStaticMarkup(view.body)).toContain(url);
 	});
 
-	it('uses generic browser-storage wording for interrupted initial OPFS syncs', () => {
+	it('explains interrupted initial saves without storage jargon', () => {
 		const view = getSiteErrorView({
 			error: 'initial-opfs-sync-interrupted',
 			site: createSite(),
 			helpers,
 		});
 
-		expect(view.title).toBe('Browser storage save was interrupted');
+		expect(view.title).toBe('This Playground was not saved completely');
 		expect(renderToStaticMarkup(view.body)).toContain(
-			'the browser-storage save finished'
+			'before all files were copied'
+		);
+		expect(renderToStaticMarkup(view.body)).toContain(
+			'Start a new Playground'
+		);
+		expect(renderToStaticMarkup(view.actions[0])).toContain(
+			'Start a new Playground'
 		);
 	});
 

--- a/packages/playground/website/src/components/site-error-modal/get-site-error-view.spec.tsx
+++ b/packages/playground/website/src/components/site-error-modal/get-site-error-view.spec.tsx
@@ -33,9 +33,9 @@ describe('getSiteErrorView', () => {
 			helpers,
 		});
 
-		expect(view.title).toBe('This Playground was not saved completely');
+		expect(view.title).toBe('This saved Playground is incomplete');
 		expect(renderToStaticMarkup(view.body)).toContain(
-			'before all files were copied'
+			'This saved copy can’t be reopened'
 		);
 		expect(renderToStaticMarkup(view.body)).toContain(
 			'Start a new Playground'
@@ -52,7 +52,9 @@ describe('getSiteErrorView', () => {
 			helpers,
 		});
 
-		expect(view.title).toBe('Could not reopen this saved Playground');
+		expect(view.title).toBe(
+			'Playground couldn’t finish cleaning up this site'
+		);
 		expect(renderToStaticMarkup(view.body)).toContain(
 			'an earlier reset of this saved site was interrupted'
 		);

--- a/packages/playground/website/src/components/site-error-modal/get-site-error-view.spec.tsx
+++ b/packages/playground/website/src/components/site-error-modal/get-site-error-view.spec.tsx
@@ -52,17 +52,20 @@ describe('getSiteErrorView', () => {
 			helpers,
 		});
 
-		expect(view.title).toBe('Try again to open this Playground');
+		expect(view.title).toBe('Close other Playground tabs, then reload');
 		expect(renderToStaticMarkup(view.body)).toContain(
-			'Click <strong>Try again</strong>'
+			'click <strong>Reload</strong>'
 		);
 		expect(renderToStaticMarkup(view.body)).toContain(
 			'old site files are still in this saved Playground'
 		);
 		expect(renderToStaticMarkup(view.body)).toContain(
+			'already tried to clean them up again'
+		);
+		expect(renderToStaticMarkup(view.body)).toContain(
 			'could show the old site with the new settings'
 		);
-		expect(renderToStaticMarkup(view.actions[0])).toContain('Try again');
+		expect(renderToStaticMarkup(view.actions[0])).toContain('Reload');
 	});
 
 	it('says when the entire Blueprint could not be downloaded', () => {

--- a/packages/playground/website/src/components/site-error-modal/get-site-error-view.tsx
+++ b/packages/playground/website/src/components/site-error-modal/get-site-error-view.tsx
@@ -76,26 +76,28 @@ function browserStorageCleanupFailedView({
 	helpers,
 }: SiteErrorViewContext): SiteErrorViewConfig {
 	return {
-		title: 'Try again to open this Playground',
+		title: 'Close other Playground tabs, then reload',
 		isDeveloperError: false,
 		body: (
 			<>
 				<p className={css.errorLead}>
-					Click <strong>Try again</strong>. Playground needs another
-					attempt to finish opening this saved site.
+					Close any other Playground tabs that may be using this saved
+					site, then click <strong>Reload</strong>.
 				</p>
 				<ul className={css.errorList}>
 					<li>
-						If this keeps happening, close other Playground tabs and
-						make sure your browser has free storage, then try again.
+						If no other Playground tabs are open, make sure your
+						browser has free storage, then reload.
 					</li>
 					<li>
 						What happened: an earlier reset was interrupted, and old
 						site files are still in this saved Playground.
 					</li>
 					<li>
-						Playground stopped because opening those files could
-						show the old site with the new settings.
+						Playground already tried to clean them up again, but the
+						browser still would not remove them. Playground stopped
+						because opening those files could show the old site with
+						the new settings.
 					</li>
 				</ul>
 			</>
@@ -106,7 +108,7 @@ function browserStorageCleanupFailedView({
 				key="reload-page"
 				onClick={helpers.reloadPage}
 			>
-				Try again
+				Reload
 			</Button>,
 		],
 	};

--- a/packages/playground/website/src/components/site-error-modal/get-site-error-view.tsx
+++ b/packages/playground/website/src/components/site-error-modal/get-site-error-view.tsx
@@ -59,7 +59,7 @@ export function getSiteErrorView(
 		case 'directory-handle-unknown-error':
 			return directoryHandleUnknownErrorView();
 		case 'browser-storage-cleanup-failed':
-			return browserStorageCleanupFailedView();
+			return browserStorageCleanupFailedView(context);
 		case 'initial-opfs-sync-interrupted':
 			return initialOpfsSyncInterruptedView(context);
 		case 'network-firewall-interference':
@@ -72,33 +72,45 @@ export function getSiteErrorView(
 	}
 }
 
-function browserStorageCleanupFailedView(): SiteErrorViewConfig {
+function browserStorageCleanupFailedView({
+	helpers,
+}: SiteErrorViewContext): SiteErrorViewConfig {
 	return {
-		title: 'Browser storage cleanup failed',
+		title: 'Could not reopen this saved Playground',
 		isDeveloperError: false,
 		body: (
 			<>
 				<p className={css.errorLead}>
-					Playground needs to delete old WordPress files before it
-					opens this saved site, but the browser did not finish that
-					cleanup.
+					Playground found that an earlier reset of this saved site
+					was interrupted. It tried to finish cleaning up the old site
+					files before reopening it, but the browser could not remove
+					those files.
 				</p>
 				<ul className={css.errorList}>
 					<li>
-						The saved site metadata says a reset was interrupted.
+						Playground stopped here so it would not accidentally
+						open the old site with the new settings.
 					</li>
 					<li>
-						Playground stopped before booting so it would not open
-						files from the previous autosave under the new setup.
+						Click <strong>Try again</strong> to reload Playground
+						and retry the cleanup.
 					</li>
 					<li>
-						Reloading can try the cleanup again if the browser
-						storage problem was temporary.
+						If this keeps happening, close other Playground tabs and
+						make sure your browser has free storage, then try again.
 					</li>
 				</ul>
 			</>
 		),
-		actions: [],
+		actions: [
+			<Button
+				variant="primary"
+				key="reload-page"
+				onClick={helpers.reloadPage}
+			>
+				Try again
+			</Button>,
+		],
 	};
 }
 

--- a/packages/playground/website/src/components/site-error-modal/get-site-error-view.tsx
+++ b/packages/playground/website/src/components/site-error-modal/get-site-error-view.tsx
@@ -76,27 +76,26 @@ function browserStorageCleanupFailedView({
 	helpers,
 }: SiteErrorViewContext): SiteErrorViewConfig {
 	return {
-		title: 'Playground couldn’t finish cleaning up this site',
+		title: 'Try again to open this Playground',
 		isDeveloperError: false,
 		body: (
 			<>
 				<p className={css.errorLead}>
-					Playground found that an earlier reset of this saved site
-					was interrupted. It tried to finish cleaning up the old site
-					files now, but the browser could not remove them.
+					Click <strong>Try again</strong>. Playground needs another
+					attempt to finish opening this saved site.
 				</p>
 				<ul className={css.errorList}>
 					<li>
-						Playground stopped here so it would not accidentally
-						open the old site with the new settings.
-					</li>
-					<li>
-						Click <strong>Try again</strong> to reload Playground
-						and retry the cleanup.
-					</li>
-					<li>
 						If this keeps happening, close other Playground tabs and
 						make sure your browser has free storage, then try again.
+					</li>
+					<li>
+						What happened: an earlier reset was interrupted, and old
+						site files are still in this saved Playground.
+					</li>
+					<li>
+						Playground stopped because opening those files could
+						show the old site with the new settings.
 					</li>
 				</ul>
 			</>
@@ -117,27 +116,23 @@ function initialOpfsSyncInterruptedView({
 	helpers,
 }: SiteErrorViewContext): SiteErrorViewConfig {
 	return {
-		title: 'This saved Playground is incomplete',
+		title: 'Start a new Playground to continue',
 		isDeveloperError: false,
 		body: (
 			<>
 				<p className={css.errorLead}>
-					Playground started saving this site, but the save stopped
-					before all files were copied. This saved copy can’t be
-					reopened because some WordPress files may be missing.
+					This saved Playground is incomplete and can’t be reopened.
+					Start a new Playground to keep working.
 				</p>
 				<ul className={css.errorList}>
 					<li>
-						This can happen if the tab was closed or reloaded before
-						the save finished.
+						What happened: the previous save stopped before all
+						WordPress files were copied.
 					</li>
 					<li>
-						It can also happen if the browser suspended the page or
-						ran out of space for saved sites.
-					</li>
-					<li>
-						Click <strong>Start a new Playground</strong> to
-						continue with a fresh site.
+						This can happen if the tab was closed or reloaded, the
+						browser suspended the page, or the browser ran out of
+						space for saved sites.
 					</li>
 				</ul>
 			</>

--- a/packages/playground/website/src/components/site-error-modal/get-site-error-view.tsx
+++ b/packages/playground/website/src/components/site-error-modal/get-site-error-view.tsx
@@ -76,15 +76,14 @@ function browserStorageCleanupFailedView({
 	helpers,
 }: SiteErrorViewContext): SiteErrorViewConfig {
 	return {
-		title: 'Could not reopen this saved Playground',
+		title: 'Playground couldn’t finish cleaning up this site',
 		isDeveloperError: false,
 		body: (
 			<>
 				<p className={css.errorLead}>
 					Playground found that an earlier reset of this saved site
 					was interrupted. It tried to finish cleaning up the old site
-					files before reopening it, but the browser could not remove
-					those files.
+					files now, but the browser could not remove them.
 				</p>
 				<ul className={css.errorList}>
 					<li>
@@ -118,15 +117,14 @@ function initialOpfsSyncInterruptedView({
 	helpers,
 }: SiteErrorViewContext): SiteErrorViewConfig {
 	return {
-		title: 'This Playground was not saved completely',
+		title: 'This saved Playground is incomplete',
 		isDeveloperError: false,
 		body: (
 			<>
 				<p className={css.errorLead}>
 					Playground started saving this site, but the save stopped
-					before all files were copied. Playground cannot safely
-					reopen this saved copy because some WordPress files may be
-					missing.
+					before all files were copied. This saved copy can’t be
+					reopened because some WordPress files may be missing.
 				</p>
 				<ul className={css.errorList}>
 					<li>

--- a/packages/playground/website/src/components/site-error-modal/get-site-error-view.tsx
+++ b/packages/playground/website/src/components/site-error-modal/get-site-error-view.tsx
@@ -81,23 +81,24 @@ function browserStorageCleanupFailedView({
 		body: (
 			<>
 				<p className={css.errorLead}>
-					Close any other Playground tabs that may be using this saved
-					site, then click <strong>Reload</strong>.
+					An earlier reset was interrupted, and old site files are
+					still in this saved Playground.
 				</p>
 				<ul className={css.errorList}>
 					<li>
-						If no other Playground tabs are open, make sure your
-						browser has free storage, then reload.
+						Playground tried to remove those old files again before
+						opening the site, but the browser still would not remove
+						them.
 					</li>
 					<li>
-						What happened: an earlier reset was interrupted, and old
-						site files are still in this saved Playground.
+						Playground stopped because those old files may show the
+						old site instead of the reset site.
 					</li>
 					<li>
-						Playground already tried to clean them up again, but the
-						browser still would not remove them. Playground stopped
-						because opening those files could show the old site with
-						the new settings.
+						Close any other Playground tabs that may be using this
+						saved site, then click <strong>Reload</strong>. If no
+						other Playground tabs are open, make sure your browser
+						has free storage, then reload.
 					</li>
 				</ul>
 			</>

--- a/packages/playground/website/src/components/site-error-modal/get-site-error-view.tsx
+++ b/packages/playground/website/src/components/site-error-modal/get-site-error-view.tsx
@@ -118,28 +118,28 @@ function initialOpfsSyncInterruptedView({
 	helpers,
 }: SiteErrorViewContext): SiteErrorViewConfig {
 	return {
-		title: 'Browser storage save was interrupted',
+		title: 'This Playground was not saved completely',
 		isDeveloperError: false,
 		body: (
 			<>
 				<p className={css.errorLead}>
-					Playground started saving this site to browser storage, but
-					the file copy did not finish.
+					Playground started saving this site, but the save stopped
+					before all files were copied. Playground cannot safely
+					reopen this saved copy because some WordPress files may be
+					missing.
 				</p>
 				<ul className={css.errorList}>
 					<li>
 						This can happen if the tab was closed or reloaded before
-						the browser-storage save finished.
+						the save finished.
 					</li>
 					<li>
-						It can also happen if the browser interrupted storage,
-						for example because the tab was suspended or storage
-						quota was reached.
+						It can also happen if the browser suspended the page or
+						ran out of space for saved sites.
 					</li>
 					<li>
-						Playground did not try to repair the stored files
-						because the WordPress copy may be incomplete or
-						corrupted.
+						Click <strong>Start a new Playground</strong> to
+						continue with a fresh site.
 					</li>
 				</ul>
 			</>
@@ -150,7 +150,7 @@ function initialOpfsSyncInterruptedView({
 				key="reload-tab"
 				onClick={helpers.reloadWithoutBlueprint}
 			>
-				Reload Fresh Playground
+				Start a new Playground
 			</Button>,
 		],
 	};

--- a/packages/playground/website/src/components/site-error-modal/get-site-error-view.tsx
+++ b/packages/playground/website/src/components/site-error-modal/get-site-error-view.tsx
@@ -58,6 +58,8 @@ export function getSiteErrorView(
 			return blueprintValidationFailedView(context);
 		case 'directory-handle-unknown-error':
 			return directoryHandleUnknownErrorView();
+		case 'browser-storage-cleanup-failed':
+			return browserStorageCleanupFailedView();
 		case 'initial-opfs-sync-interrupted':
 			return initialOpfsSyncInterruptedView(context);
 		case 'network-firewall-interference':
@@ -68,6 +70,36 @@ export function getSiteErrorView(
 		default:
 			return genericSiteBootFailedView(context);
 	}
+}
+
+function browserStorageCleanupFailedView(): SiteErrorViewConfig {
+	return {
+		title: 'Browser storage cleanup failed',
+		isDeveloperError: false,
+		body: (
+			<>
+				<p className={css.errorLead}>
+					Playground needs to delete old WordPress files before it
+					opens this saved site, but the browser did not finish that
+					cleanup.
+				</p>
+				<ul className={css.errorList}>
+					<li>
+						The saved site metadata says a reset was interrupted.
+					</li>
+					<li>
+						Playground stopped before booting so it would not open
+						files from the previous autosave under the new setup.
+					</li>
+					<li>
+						Reloading can try the cleanup again if the browser
+						storage problem was temporary.
+					</li>
+				</ul>
+			</>
+		),
+		actions: [],
+	};
 }
 
 function initialOpfsSyncInterruptedView({

--- a/packages/playground/website/src/components/site-error-modal/site-error-modal.tsx
+++ b/packages/playground/website/src/components/site-error-modal/site-error-modal.tsx
@@ -52,6 +52,9 @@ export function SiteErrorModal({
 				logger.error('Failed to delete site', error);
 			}
 		},
+		reloadPage: () => {
+			window.location.reload();
+		},
 		restartWithoutPr: () => {
 			const url = new URL(window.location.href);
 			url.searchParams.delete('core-pr');

--- a/packages/playground/website/src/components/site-error-modal/types.ts
+++ b/packages/playground/website/src/components/site-error-modal/types.ts
@@ -15,6 +15,7 @@ export type BlueprintStepError = {
 
 export type PresentationHelpers = {
 	deleteSite: () => void;
+	reloadPage: () => void;
 	restartWithoutPr: () => void;
 	reloadWithoutBlueprint: () => Promise<void> | void;
 };

--- a/packages/playground/website/src/lib/state/opfs/opfs-autosave-reset.spec.ts
+++ b/packages/playground/website/src/lib/state/opfs/opfs-autosave-reset.spec.ts
@@ -5,7 +5,7 @@ import type { SiteInfo } from '../redux/slice-sites';
 const mocks = vi.hoisted(() => ({
 	opfsSiteStorage: {
 		update: vi.fn(),
-		resetSiteFiles: vi.fn(),
+		removeWordPressFilesKeepMetadata: vi.fn(),
 	},
 }));
 
@@ -17,8 +17,10 @@ describe('resetAutosavedSiteFilesWithPendingMarker', () => {
 	beforeEach(() => {
 		mocks.opfsSiteStorage.update.mockReset();
 		mocks.opfsSiteStorage.update.mockResolvedValue(undefined);
-		mocks.opfsSiteStorage.resetSiteFiles.mockReset();
-		mocks.opfsSiteStorage.resetSiteFiles.mockResolvedValue(undefined);
+		mocks.opfsSiteStorage.removeWordPressFilesKeepMetadata.mockReset();
+		mocks.opfsSiteStorage.removeWordPressFilesKeepMetadata.mockResolvedValue(
+			undefined
+		);
 	});
 
 	it('persists a reset marker before deleting old WordPress files', async () => {
@@ -34,38 +36,44 @@ describe('resetAutosavedSiteFilesWithPendingMarker', () => {
 			'autosaved',
 			expect.objectContaining({
 				initialOpfsSyncPending: true,
-				opfsResetPending: true,
+				opfsSiteRemovalPending: true,
 			}),
 			changes.originalUrlParams
 		);
 		expect(
 			mocks.opfsSiteStorage.update.mock.invocationCallOrder[0]
 		).toBeLessThan(
-			mocks.opfsSiteStorage.resetSiteFiles.mock.invocationCallOrder[0]
+			mocks.opfsSiteStorage.removeWordPressFilesKeepMetadata.mock
+				.invocationCallOrder[0]
 		);
-		expect(mocks.opfsSiteStorage.resetSiteFiles).toHaveBeenCalledWith(
-			'autosaved'
-		);
+		expect(
+			mocks.opfsSiteStorage.removeWordPressFilesKeepMetadata
+		).toHaveBeenCalledWith('autosaved');
 		expect(mocks.opfsSiteStorage.update).toHaveBeenNthCalledWith(
 			2,
 			'autosaved',
 			expect.objectContaining({
 				initialOpfsSyncPending: true,
-				opfsResetPending: undefined,
+				opfsSiteRemovalPending: undefined,
 			}),
 			changes.originalUrlParams
 		);
 		expect(
-			mocks.opfsSiteStorage.resetSiteFiles.mock.invocationCallOrder[0]
+			mocks.opfsSiteStorage.removeWordPressFilesKeepMetadata.mock
+				.invocationCallOrder[0]
 		).toBeLessThan(
 			mocks.opfsSiteStorage.update.mock.invocationCallOrder[1]
 		);
-		expect(completedChanges.metadata.opfsResetPending).toBeUndefined();
+		expect(
+			completedChanges.metadata.opfsSiteRemovalPending
+		).toBeUndefined();
 	});
 
 	it('leaves the pending marker for boot recovery when deleting files fails', async () => {
 		const resetError = new Error('reset failed');
-		mocks.opfsSiteStorage.resetSiteFiles.mockRejectedValueOnce(resetError);
+		mocks.opfsSiteStorage.removeWordPressFilesKeepMetadata.mockRejectedValueOnce(
+			resetError
+		);
 
 		await expect(
 			resetAutosavedSiteFilesWithPendingMarker(
@@ -78,13 +86,13 @@ describe('resetAutosavedSiteFilesWithPendingMarker', () => {
 		expect(mocks.opfsSiteStorage.update).toHaveBeenCalledWith(
 			'autosaved',
 			expect.objectContaining({
-				opfsResetPending: true,
+				opfsSiteRemovalPending: true,
 			}),
 			expect.anything()
 		);
-		expect(mocks.opfsSiteStorage.resetSiteFiles).toHaveBeenCalledWith(
-			'autosaved'
-		);
+		expect(
+			mocks.opfsSiteStorage.removeWordPressFilesKeepMetadata
+		).toHaveBeenCalledWith('autosaved');
 	});
 });
 

--- a/packages/playground/website/src/lib/state/opfs/opfs-autosave-reset.spec.ts
+++ b/packages/playground/website/src/lib/state/opfs/opfs-autosave-reset.spec.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { resetAutosavedSiteFilesWithPendingMarker } from './opfs-autosave-reset';
+import type { SiteInfo } from '../redux/slice-sites';
+
+const mocks = vi.hoisted(() => ({
+	opfsSiteStorage: {
+		update: vi.fn(),
+		resetSiteFiles: vi.fn(),
+	},
+}));
+
+vi.mock('./opfs-site-storage', () => ({
+	opfsSiteStorage: mocks.opfsSiteStorage,
+}));
+
+describe('resetAutosavedSiteFilesWithPendingMarker', () => {
+	beforeEach(() => {
+		mocks.opfsSiteStorage.update.mockReset();
+		mocks.opfsSiteStorage.update.mockResolvedValue(undefined);
+		mocks.opfsSiteStorage.resetSiteFiles.mockReset();
+		mocks.opfsSiteStorage.resetSiteFiles.mockResolvedValue(undefined);
+	});
+
+	it('persists a reset marker before deleting old WordPress files', async () => {
+		const changes = createChanges();
+
+		const completedChanges = await resetAutosavedSiteFilesWithPendingMarker(
+			'autosaved',
+			changes
+		);
+
+		expect(mocks.opfsSiteStorage.update).toHaveBeenNthCalledWith(
+			1,
+			'autosaved',
+			expect.objectContaining({
+				initialOpfsSyncPending: true,
+				opfsResetPending: true,
+			}),
+			changes.originalUrlParams
+		);
+		expect(
+			mocks.opfsSiteStorage.update.mock.invocationCallOrder[0]
+		).toBeLessThan(
+			mocks.opfsSiteStorage.resetSiteFiles.mock.invocationCallOrder[0]
+		);
+		expect(mocks.opfsSiteStorage.resetSiteFiles).toHaveBeenCalledWith(
+			'autosaved'
+		);
+		expect(mocks.opfsSiteStorage.update).toHaveBeenNthCalledWith(
+			2,
+			'autosaved',
+			expect.objectContaining({
+				initialOpfsSyncPending: true,
+				opfsResetPending: undefined,
+			}),
+			changes.originalUrlParams
+		);
+		expect(
+			mocks.opfsSiteStorage.resetSiteFiles.mock.invocationCallOrder[0]
+		).toBeLessThan(
+			mocks.opfsSiteStorage.update.mock.invocationCallOrder[1]
+		);
+		expect(completedChanges.metadata.opfsResetPending).toBeUndefined();
+	});
+
+	it('leaves the pending marker for boot recovery when deleting files fails', async () => {
+		const resetError = new Error('reset failed');
+		mocks.opfsSiteStorage.resetSiteFiles.mockRejectedValueOnce(resetError);
+
+		await expect(
+			resetAutosavedSiteFilesWithPendingMarker(
+				'autosaved',
+				createChanges()
+			)
+		).rejects.toBe(resetError);
+
+		expect(mocks.opfsSiteStorage.update).toHaveBeenCalledTimes(1);
+		expect(mocks.opfsSiteStorage.update).toHaveBeenCalledWith(
+			'autosaved',
+			expect.objectContaining({
+				opfsResetPending: true,
+			}),
+			expect.anything()
+		);
+		expect(mocks.opfsSiteStorage.resetSiteFiles).toHaveBeenCalledWith(
+			'autosaved'
+		);
+	});
+});
+
+function createChanges(): {
+	metadata: SiteInfo['metadata'];
+	originalUrlParams: SiteInfo['originalUrlParams'];
+} {
+	return {
+		metadata: {
+			id: 'autosaved-id',
+			name: 'Autosaved',
+			storage: 'opfs',
+			persistence: 'autosave',
+			initialOpfsSyncPending: true,
+			runtimeConfiguration: {
+				phpVersion: '8.3',
+				wpVersion: 'latest',
+				intl: false,
+				networking: true,
+				extraLibraries: [],
+				constants: {},
+			},
+			originalBlueprint: {},
+			originalBlueprintSource: { type: 'none' },
+		},
+		originalUrlParams: {
+			searchParams: { php: '8.3' },
+			hash: '#blueprint',
+		},
+	};
+}

--- a/packages/playground/website/src/lib/state/opfs/opfs-autosave-reset.ts
+++ b/packages/playground/website/src/lib/state/opfs/opfs-autosave-reset.ts
@@ -69,7 +69,7 @@ export async function resetAutosavedSiteFilesWithPendingMarker(
 		pendingChanges.metadata,
 		pendingChanges.originalUrlParams
 	);
-	await opfsSiteStorage.resetSiteFiles(siteSlug);
+	await opfsSiteStorage.removeWordPressFilesKeepMetadata(siteSlug);
 	await opfsSiteStorage.update(
 		siteSlug,
 		completedChanges.metadata,

--- a/packages/playground/website/src/lib/state/opfs/opfs-autosave-reset.ts
+++ b/packages/playground/website/src/lib/state/opfs/opfs-autosave-reset.ts
@@ -1,0 +1,80 @@
+import { opfsSiteStorage } from './opfs-site-storage';
+import type { SiteInfo } from '../redux/slice-sites';
+
+type SiteResetChanges = {
+	loadedFromStorage?: SiteInfo['loadedFromStorage'];
+	metadata: SiteInfo['metadata'];
+	originalUrlParams: SiteInfo['originalUrlParams'];
+};
+
+/**
+ * Deletes old WordPress files before an autosave boots from a different setup.
+ *
+ * Why the files need to be deleted:
+ *
+ * Autosaved Playgrounds keep the same sidebar entry and OPFS directory when the
+ * user clicks "Apply Settings & Recreate Playground" or "Run Blueprint and
+ * reset site". The metadata changes first: `wp-runtime.json` starts describing
+ * the new setup or edited Blueprint. The WordPress files in that OPFS directory
+ * still came from the previous setup, so they must be removed before the next
+ * boot. Otherwise Playground would open the previous WordPress site while the
+ * metadata says it should be using the new setup.
+ *
+ * How this makes that deletion safe across tab closes:
+ *
+ * 1. Write `opfsResetPending: true` into `wp-runtime.json`.
+ * 2. Delete the old WordPress files. `resetSiteFiles()` keeps `wp-runtime.json`
+ *    and the editable Blueprint bundle directory.
+ * 3. Clear `opfsResetPending`.
+ *
+ * If the tab closes after step 1 or during step 2, the next boot sees
+ * `opfsResetPending` and repeats the deletion before it mounts or installs
+ * anything. That leaves the OPFS directory ready for the new setup instead of
+ * opening files from the previous autosave.
+ *
+ * Do not use this when the existing WordPress files can keep running, such as
+ * changing PHP version or networking. Those should update metadata and reboot
+ * the same files. Longer term, the Dock UI should create a new Playground for
+ * setup changes instead of deleting files from the current autosave; this
+ * helper only protects today's behavior of deleting and recreating files under
+ * the same autosaved slug.
+ */
+export async function resetAutosavedSiteFilesWithPendingMarker(
+	siteSlug: string,
+	changes: SiteResetChanges
+): Promise<SiteResetChanges> {
+	if (!opfsSiteStorage) {
+		throw new Error(
+			'Cannot recreate autosaved Playground because browser storage is not available.'
+		);
+	}
+
+	const pendingChanges = {
+		...changes,
+		metadata: {
+			...changes.metadata,
+			opfsResetPending: true,
+		},
+	};
+	const completedChanges = {
+		...changes,
+		metadata: {
+			...changes.metadata,
+			opfsResetPending: undefined,
+		},
+	};
+
+	await opfsSiteStorage.update(
+		siteSlug,
+		pendingChanges.metadata,
+		pendingChanges.originalUrlParams
+	);
+	await opfsSiteStorage.resetSiteFiles(siteSlug);
+	await opfsSiteStorage.update(
+		siteSlug,
+		completedChanges.metadata,
+		completedChanges.originalUrlParams
+	);
+
+	return completedChanges;
+}

--- a/packages/playground/website/src/lib/state/opfs/opfs-autosave-reset.ts
+++ b/packages/playground/website/src/lib/state/opfs/opfs-autosave-reset.ts
@@ -22,15 +22,15 @@ type SiteResetChanges = {
  *
  * How this makes that deletion safe across tab closes:
  *
- * 1. Write `opfsResetPending: true` into `wp-runtime.json`.
- * 2. Delete the old WordPress files. `resetSiteFiles()` keeps `wp-runtime.json`
- *    and the editable Blueprint bundle directory.
- * 3. Clear `opfsResetPending`.
+ * 1. Write `opfsSiteRemovalPending: true` into `wp-runtime.json`.
+ * 2. Delete the old WordPress files. `removeWordPressFilesKeepMetadata()`
+ *    keeps `wp-runtime.json` and the editable Blueprint bundle directory.
+ * 3. Clear `opfsSiteRemovalPending`.
  *
  * If the tab closes after step 1 or during step 2, the next boot sees
- * `opfsResetPending` and repeats the deletion before it mounts or installs
- * anything. That leaves the OPFS directory ready for the new setup instead of
- * opening files from the previous autosave.
+ * `opfsSiteRemovalPending` and repeats the deletion before it mounts or
+ * installs anything. That leaves the OPFS directory ready for the new setup
+ * instead of opening files from the previous autosave.
  *
  * Do not use this when the existing WordPress files can keep running, such as
  * changing PHP version or networking. Those should update metadata and reboot
@@ -53,14 +53,14 @@ export async function resetAutosavedSiteFilesWithPendingMarker(
 		...changes,
 		metadata: {
 			...changes.metadata,
-			opfsResetPending: true,
+			opfsSiteRemovalPending: true,
 		},
 	};
 	const completedChanges = {
 		...changes,
 		metadata: {
 			...changes.metadata,
-			opfsResetPending: undefined,
+			opfsSiteRemovalPending: undefined,
 		},
 	};
 

--- a/packages/playground/website/src/lib/state/opfs/opfs-site-storage.ts
+++ b/packages/playground/website/src/lib/state/opfs/opfs-site-storage.ts
@@ -203,10 +203,11 @@ class OpfsSiteStorage {
 	 * Removes WordPress files from an OPFS-backed site while preserving the
 	 * site metadata file and the editable Blueprint bundle directory.
 	 *
-	 * Autosaved Playgrounds use this before running their edited setup again:
-	 * the Playground keeps the same slug, name, and Blueprint bundle, but
-	 * WordPress must be recreated from that setup instead of reusing files from
-	 * the previous run.
+	 * Autosaved reset paths use this after the user chooses to keep the same
+	 * sidebar entry but boot it from new settings or an edited Blueprint. Keep
+	 * the metadata file and editable Blueprint bundle; delete everything else
+	 * because those entries are the old WordPress runtime tree that the next
+	 * boot must recreate from the new setup.
 	 */
 	async resetSiteFiles(slug: string): Promise<void> {
 		const siteDirName = await this.findExistingSiteDirName(slug);
@@ -216,9 +217,9 @@ class OpfsSiteStorage {
 		const siteDirectory = await this.root.getDirectoryHandle(siteDirName);
 		const namesToDelete: string[] = [];
 		for await (const [name] of siteDirectory.entries()) {
-			// Recreating an autosaved Playground rebuilds WordPress in the same
-			// OPFS site directory. Keep the metadata and editable Blueprint
-			// bundle so the autosave keeps its slug and setup recipe.
+			// The next boot still needs the site metadata and the edited
+			// Blueprint bundle. Everything else belongs to the old WordPress
+			// tree and must be removed before the new setup runs.
 			if (name === SITE_METADATA_FILENAME || name === BUNDLE_DIR_NAME) {
 				continue;
 			}

--- a/packages/playground/website/src/lib/state/opfs/opfs-site-storage.ts
+++ b/packages/playground/website/src/lib/state/opfs/opfs-site-storage.ts
@@ -20,7 +20,6 @@ import { RecommendedPHPVersion } from '@wp-playground/common';
 import {
 	BUNDLE_DIR_NAME,
 	loadPersistedBlueprintBundle,
-	loadPersistedBlueprintBundleFromPath,
 } from './opfs-blueprint-bundle-storage';
 import {
 	OPFS_SITES_ROOT_PATH,
@@ -34,10 +33,6 @@ export {
 
 // TODO: Decide on metadata filename
 const SITE_METADATA_FILENAME = 'wp-runtime.json';
-
-// Use a symbol to mark legacy site metadata to avoid serializing it to JSON.
-// @TODO: Remove this backcompat code after 2024-12-01.
-export const legacyOpfsPathSymbol = Symbol('legacyOpfsPath');
 
 /**
  * StoredSiteMetadata is the data structure that is written to disk.
@@ -165,20 +160,13 @@ class OpfsSiteStorage {
 		//       ^ do not do it implicitly. Require user interaction. Maybe constrain this just
 		//         to the site files import flow.
 		const siteInfo = storedFormatToMetadata(await file.text());
-		const sitePath = joinPaths(OPFS_SITES_ROOT_PATH, siteDirectory.name);
-		const isLegacyDirectoryName =
-			siteDirectory.name !== getDirectoryNameForSlug(siteInfo.slug);
-		if (isLegacyDirectoryName) {
-			(siteInfo.metadata as any)[legacyOpfsPathSymbol] = sitePath;
-		}
 
 		// If the blueprint source points to the bundle directory, load from there.
 		// This allows the site to access bundled resources, not just the JSON declaration.
 		if (siteInfo.metadata.originalBlueprintSource?.type === 'opfs-site') {
 			try {
-				siteInfo.metadata.originalBlueprint = isLegacyDirectoryName
-					? await loadPersistedBlueprintBundleFromPath(sitePath)
-					: await loadPersistedBlueprintBundle(siteInfo.slug);
+				siteInfo.metadata.originalBlueprint =
+					await loadPersistedBlueprintBundle(siteInfo.slug);
 			} catch (error) {
 				logger.error(
 					`Failed to load blueprint bundle for site ${siteInfo.slug}`,

--- a/packages/playground/website/src/lib/state/opfs/opfs-site-storage.ts
+++ b/packages/playground/website/src/lib/state/opfs/opfs-site-storage.ts
@@ -20,6 +20,7 @@ import { RecommendedPHPVersion } from '@wp-playground/common';
 import {
 	BUNDLE_DIR_NAME,
 	loadPersistedBlueprintBundle,
+	loadPersistedBlueprintBundleFromPath,
 } from './opfs-blueprint-bundle-storage';
 import {
 	OPFS_SITES_ROOT_PATH,
@@ -33,6 +34,10 @@ export {
 
 // TODO: Decide on metadata filename
 const SITE_METADATA_FILENAME = 'wp-runtime.json';
+
+// Use a symbol to mark legacy site metadata to avoid serializing it to JSON.
+// @TODO: Remove this backcompat code after 2024-12-01.
+export const legacyOpfsPathSymbol = Symbol('legacyOpfsPath');
 
 /**
  * StoredSiteMetadata is the data structure that is written to disk.
@@ -160,13 +165,20 @@ class OpfsSiteStorage {
 		//       ^ do not do it implicitly. Require user interaction. Maybe constrain this just
 		//         to the site files import flow.
 		const siteInfo = storedFormatToMetadata(await file.text());
+		const sitePath = joinPaths(OPFS_SITES_ROOT_PATH, siteDirectory.name);
+		const isLegacyDirectoryName =
+			siteDirectory.name !== getDirectoryNameForSlug(siteInfo.slug);
+		if (isLegacyDirectoryName) {
+			(siteInfo.metadata as any)[legacyOpfsPathSymbol] = sitePath;
+		}
 
 		// If the blueprint source points to the bundle directory, load from there.
 		// This allows the site to access bundled resources, not just the JSON declaration.
 		if (siteInfo.metadata.originalBlueprintSource?.type === 'opfs-site') {
 			try {
-				siteInfo.metadata.originalBlueprint =
-					await loadPersistedBlueprintBundle(siteInfo.slug);
+				siteInfo.metadata.originalBlueprint = isLegacyDirectoryName
+					? await loadPersistedBlueprintBundleFromPath(sitePath)
+					: await loadPersistedBlueprintBundle(siteInfo.slug);
 			} catch (error) {
 				logger.error(
 					`Failed to load blueprint bundle for site ${siteInfo.slug}`,

--- a/packages/playground/website/src/lib/state/opfs/opfs-site-storage.ts
+++ b/packages/playground/website/src/lib/state/opfs/opfs-site-storage.ts
@@ -209,7 +209,7 @@ class OpfsSiteStorage {
 	 * because those entries are the old WordPress runtime tree that the next
 	 * boot must recreate from the new setup.
 	 */
-	async resetSiteFiles(slug: string): Promise<void> {
+	async removeWordPressFilesKeepMetadata(slug: string): Promise<void> {
 		const siteDirName = await this.findExistingSiteDirName(slug);
 		if (!siteDirName) {
 			throw new Error(`Site with slug '${slug}' does not exist.`);

--- a/packages/playground/website/src/lib/state/redux/boot-site-client.spec.ts
+++ b/packages/playground/website/src/lib/state/redux/boot-site-client.spec.ts
@@ -131,18 +131,67 @@ describe('bootSiteClient', () => {
 		expect(startPlaygroundWeb).toHaveBeenCalled();
 	});
 
-	it('does not boot when a pending reset marker cannot be cleared', async () => {
-		const markerError = new Error('metadata write failed');
-		vi.mocked(opfsSiteStorage!.update).mockRejectedValueOnce(markerError);
+	it('retries pending OPFS reset cleanup before booting', async () => {
+		vi.useFakeTimers();
+		const removalError = new Error('OPFS delete failed once');
+		vi.mocked(
+			opfsSiteStorage!.removeWordPressFilesKeepMetadata
+		).mockRejectedValueOnce(removalError);
 		const site = createSite('autosaved', {
 			metadata: { opfsSiteRemovalPending: true },
 		});
 		const state = createState(site);
 		const dispatch = createDispatch(state);
 
-		await bootSiteClient('autosaved', document.createElement('iframe'), {
-			signal: new AbortController().signal,
-		})(dispatch, () => state);
+		try {
+			const boot = bootSiteClient(
+				'autosaved',
+				document.createElement('iframe'),
+				{
+					signal: new AbortController().signal,
+				}
+			)(dispatch, () => state);
+			await vi.runAllTimersAsync();
+			await boot;
+		} finally {
+			vi.useRealTimers();
+		}
+
+		expect(
+			opfsSiteStorage!.removeWordPressFilesKeepMetadata
+		).toHaveBeenCalledTimes(2);
+		expect(startPlaygroundWeb).toHaveBeenCalled();
+		expect(
+			dispatch.mock.calls.some((call: unknown[]) => {
+				const action = call[0] as { type?: string };
+				return action.type === 'ui/setActiveSiteError';
+			})
+		).toBe(false);
+	});
+
+	it('does not boot when a pending reset marker cannot be cleared', async () => {
+		vi.useFakeTimers();
+		const markerError = new Error('metadata write failed');
+		vi.mocked(opfsSiteStorage!.update).mockRejectedValue(markerError);
+		const site = createSite('autosaved', {
+			metadata: { opfsSiteRemovalPending: true },
+		});
+		const state = createState(site);
+		const dispatch = createDispatch(state);
+
+		try {
+			const boot = bootSiteClient(
+				'autosaved',
+				document.createElement('iframe'),
+				{
+					signal: new AbortController().signal,
+				}
+			)(dispatch, () => state);
+			await vi.runAllTimersAsync();
+			await boot;
+		} finally {
+			vi.useRealTimers();
+		}
 
 		expect(
 			opfsSiteStorage!.removeWordPressFilesKeepMetadata
@@ -159,20 +208,34 @@ describe('bootSiteClient', () => {
 	});
 
 	it('does not boot when old autosaved WordPress files cannot be removed', async () => {
+		vi.useFakeTimers();
 		const removalError = new Error('OPFS delete failed');
 		vi.mocked(
 			opfsSiteStorage!.removeWordPressFilesKeepMetadata
-		).mockRejectedValueOnce(removalError);
+		).mockRejectedValue(removalError);
 		const site = createSite('autosaved', {
 			metadata: { opfsSiteRemovalPending: true },
 		});
 		const state = createState(site);
 		const dispatch = createDispatch(state);
 
-		await bootSiteClient('autosaved', document.createElement('iframe'), {
-			signal: new AbortController().signal,
-		})(dispatch, () => state);
+		try {
+			const boot = bootSiteClient(
+				'autosaved',
+				document.createElement('iframe'),
+				{
+					signal: new AbortController().signal,
+				}
+			)(dispatch, () => state);
+			await vi.runAllTimersAsync();
+			await boot;
+		} finally {
+			vi.useRealTimers();
+		}
 
+		expect(
+			opfsSiteStorage!.removeWordPressFilesKeepMetadata
+		).toHaveBeenCalledTimes(4);
 		expect(startPlaygroundWeb).not.toHaveBeenCalled();
 		expect(dispatch).toHaveBeenCalledWith(
 			expect.objectContaining({

--- a/packages/playground/website/src/lib/state/redux/boot-site-client.spec.ts
+++ b/packages/playground/website/src/lib/state/redux/boot-site-client.spec.ts
@@ -3,7 +3,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { startPlaygroundWeb } from '@wp-playground/client';
 import { loadDirectoryHandle } from '../opfs/opfs-directory-handle-storage';
-import { opfsSiteStorage } from '../opfs/opfs-site-storage';
+import {
+	legacyOpfsPathSymbol,
+	opfsSiteStorage,
+} from '../opfs/opfs-site-storage';
 import { bootSiteClient } from './boot-site-client';
 import reducer, { sitesSlice, type SiteInfo } from './slice-sites';
 import type { PlaygroundReduxState } from './store';
@@ -48,6 +51,7 @@ vi.mock('./store', () => ({
 
 vi.mock('../opfs/opfs-site-storage', () => ({
 	getDirectoryPathForSlug: (slug: string) => `/sites/${slug}`,
+	legacyOpfsPathSymbol: Symbol('legacyOpfsPath'),
 	opfsSiteStorage: {
 		removeWordPressFilesKeepMetadata: vi.fn(),
 		update: vi.fn(),
@@ -196,6 +200,33 @@ describe('bootSiteClient', () => {
 				mounts: [
 					expect.objectContaining({
 						initialSyncDirection: 'opfs-to-memfs',
+					}),
+				],
+			})
+		);
+	});
+
+	it('mounts legacy OPFS directories from stored metadata', async () => {
+		const site = createSite('stored-save', {
+			loadedFromStorage: true,
+			metadata: {
+				[legacyOpfsPathSymbol]: '/sites/site-stored-save',
+			} as Partial<SiteInfo['metadata']>,
+		});
+		const state = createState(site);
+		const dispatch = createDispatch(state);
+
+		await bootSiteClient('stored-save', document.createElement('iframe'), {
+			signal: new AbortController().signal,
+		})(dispatch, () => state);
+
+		expect(startPlaygroundWeb).toHaveBeenCalledWith(
+			expect.objectContaining({
+				mounts: [
+					expect.objectContaining({
+						device: expect.objectContaining({
+							path: '/sites/site-stored-save',
+						}),
 					}),
 				],
 			})

--- a/packages/playground/website/src/lib/state/redux/boot-site-client.spec.ts
+++ b/packages/playground/website/src/lib/state/redux/boot-site-client.spec.ts
@@ -196,7 +196,7 @@ describe('bootSiteClient', () => {
 
 		expect(startPlaygroundWeb).toHaveBeenCalledWith(
 			expect.objectContaining({
-				wordpressInstallMode: 'do-not-attempt-installing',
+				wordpressInstallMode: 'install-from-existing-files-if-needed',
 				mounts: [
 					expect.objectContaining({
 						initialSyncDirection: 'opfs-to-memfs',
@@ -247,7 +247,7 @@ describe('bootSiteClient', () => {
 		expect(loadDirectoryHandle).toHaveBeenCalledWith('local-save');
 		expect(startPlaygroundWeb).toHaveBeenCalledWith(
 			expect.objectContaining({
-				wordpressInstallMode: 'do-not-attempt-installing',
+				wordpressInstallMode: 'install-from-existing-files-if-needed',
 			})
 		);
 	});

--- a/packages/playground/website/src/lib/state/redux/boot-site-client.spec.ts
+++ b/packages/playground/website/src/lib/state/redux/boot-site-client.spec.ts
@@ -1,0 +1,369 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { startPlaygroundWeb } from '@wp-playground/client';
+import { loadDirectoryHandle } from '../opfs/opfs-directory-handle-storage';
+import { opfsSiteStorage } from '../opfs/opfs-site-storage';
+import { bootSiteClient } from './boot-site-client';
+import reducer, { sitesSlice, type SiteInfo } from './slice-sites';
+import type { PlaygroundReduxState } from './store';
+
+vi.mock('@wp-playground/client', () => ({
+	startPlaygroundWeb: vi.fn(),
+}));
+
+vi.mock('../opfs/opfs-directory-handle-storage', () => ({
+	loadDirectoryHandle: vi.fn(),
+}));
+
+vi.mock('@php-wasm/web', () => ({
+	setupPostMessageRelay: vi.fn(),
+}));
+
+vi.mock('virtual:cors-proxy-url', () => ({
+	corsProxyUrl: 'https://playground.test/cors-proxy',
+}));
+
+vi.mock('../../config', () => ({
+	getRemoteUrl: () => new URL('https://playground.test/remote.html'),
+}));
+
+vi.mock('../../tracking', () => ({
+	logBlueprintEvents: vi.fn(),
+	logTrackingEvent: vi.fn(),
+}));
+
+vi.mock('../../../github/git-auth-helpers', () => ({
+	createGitAuthHeaders: vi.fn(() => undefined),
+	shouldShowGitHubAuthModal: vi.fn(() => false),
+}));
+
+vi.mock('./store', () => ({
+	selectActiveSite: vi.fn(),
+	setActiveSite: vi.fn((slug: string | undefined) => ({
+		type: 'ui/setActiveSite',
+		payload: slug,
+	})),
+}));
+
+vi.mock('../opfs/opfs-site-storage', () => ({
+	getDirectoryPathForSlug: (slug: string) => `/sites/${slug}`,
+	legacyOpfsPathSymbol: Symbol('legacyOpfsPath'),
+	opfsSiteStorage: {
+		resetSiteFiles: vi.fn(),
+		update: vi.fn(),
+	},
+}));
+
+vi.mock('@php-wasm/logger', () => ({
+	logger: {
+		error: vi.fn(),
+	},
+}));
+
+describe('bootSiteClient', () => {
+	beforeEach(() => {
+		vi.mocked(loadDirectoryHandle).mockReset();
+		vi.mocked(loadDirectoryHandle).mockResolvedValue({} as any);
+		vi.mocked(startPlaygroundWeb).mockReset();
+		vi.mocked(startPlaygroundWeb).mockImplementation(
+			async (options: any) => {
+				const playground = createPlaygroundClient();
+				options.onClientConnected(playground);
+				return playground;
+			}
+		);
+		vi.mocked(opfsSiteStorage!.resetSiteFiles).mockReset();
+		vi.mocked(opfsSiteStorage!.resetSiteFiles).mockResolvedValue(undefined);
+		vi.mocked(opfsSiteStorage!.update).mockReset();
+		vi.mocked(opfsSiteStorage!.update).mockResolvedValue(undefined);
+	});
+
+	it('does not report a missing site after boot is aborted', async () => {
+		const state = createState();
+		const dispatch = createDispatch(state);
+		const abortController = new AbortController();
+		abortController.abort();
+
+		await bootSiteClient('deleted-site', document.createElement('iframe'), {
+			signal: abortController.signal,
+		})(dispatch, () => state);
+
+		expect(dispatch).not.toHaveBeenCalled();
+	});
+
+	it('finishes pending OPFS resets before booting the site', async () => {
+		const site = createSite('autosaved', {
+			loadedFromStorage: true,
+			metadata: {
+				initialOpfsSyncPending: true,
+				opfsResetPending: true,
+			},
+		});
+		const state = createState(site);
+		const dispatch = createDispatch(state);
+
+		await bootSiteClient('autosaved', document.createElement('iframe'), {
+			signal: new AbortController().signal,
+		})(dispatch, () => state);
+
+		expect(opfsSiteStorage!.resetSiteFiles).toHaveBeenCalledWith(
+			'autosaved'
+		);
+		expect(
+			vi.mocked(opfsSiteStorage!.resetSiteFiles).mock
+				.invocationCallOrder[0]
+		).toBeLessThan(
+			vi.mocked(startPlaygroundWeb).mock.invocationCallOrder[0]
+		);
+		expect(opfsSiteStorage!.update).toHaveBeenCalledWith(
+			'autosaved',
+			expect.objectContaining({ opfsResetPending: undefined }),
+			undefined
+		);
+		expect(startPlaygroundWeb).toHaveBeenCalled();
+	});
+
+	it('does not boot when a pending reset marker cannot be cleared', async () => {
+		const markerError = new Error('metadata write failed');
+		vi.mocked(opfsSiteStorage!.update).mockRejectedValueOnce(markerError);
+		const site = createSite('autosaved', {
+			metadata: { opfsResetPending: true },
+		});
+		const state = createState(site);
+		const dispatch = createDispatch(state);
+
+		await bootSiteClient('autosaved', document.createElement('iframe'), {
+			signal: new AbortController().signal,
+		})(dispatch, () => state);
+
+		expect(opfsSiteStorage!.resetSiteFiles).toHaveBeenCalledWith(
+			'autosaved'
+		);
+		expect(startPlaygroundWeb).not.toHaveBeenCalled();
+		expect(dispatch).toHaveBeenCalledWith(
+			expect.objectContaining({
+				type: 'ui/setActiveSiteError',
+				payload: expect.objectContaining({
+					error: 'directory-handle-unknown-error',
+				}),
+			})
+		);
+	});
+
+	it('does not boot a stored OPFS site whose first file sync was interrupted', async () => {
+		const site = createSite('interrupted-save', {
+			loadedFromStorage: true,
+			metadata: { initialOpfsSyncPending: true },
+		});
+		const state = createState(site);
+		const dispatch = createDispatch(state);
+
+		await bootSiteClient(
+			'interrupted-save',
+			document.createElement('iframe'),
+			{
+				signal: new AbortController().signal,
+			}
+		)(dispatch, () => state);
+
+		expect(startPlaygroundWeb).not.toHaveBeenCalled();
+		expect(dispatch).toHaveBeenCalledWith(
+			expect.objectContaining({
+				type: 'ui/setActiveSiteError',
+				payload: expect.objectContaining({
+					error: 'initial-opfs-sync-interrupted',
+				}),
+			})
+		);
+	});
+
+	it('boots stored OPFS files based on Playground metadata, not WordPress file probes', async () => {
+		const site = createSite('stored-save', { loadedFromStorage: true });
+		const state = createState(site);
+		const dispatch = createDispatch(state);
+
+		await bootSiteClient('stored-save', document.createElement('iframe'), {
+			signal: new AbortController().signal,
+		})(dispatch, () => state);
+
+		expect(startPlaygroundWeb).toHaveBeenCalledWith(
+			expect.objectContaining({
+				wordpressInstallMode: 'do-not-attempt-installing',
+				mounts: [
+					expect.objectContaining({
+						initialSyncDirection: 'opfs-to-memfs',
+					}),
+				],
+			})
+		);
+	});
+
+	it('boots local directories as existing saved sites', async () => {
+		const site = createSite('local-save', {
+			metadata: { storage: 'local-fs' },
+		});
+		const state = createState(site);
+		const dispatch = createDispatch(state);
+
+		await bootSiteClient('local-save', document.createElement('iframe'), {
+			signal: new AbortController().signal,
+		})(dispatch, () => state);
+
+		expect(loadDirectoryHandle).toHaveBeenCalledWith('local-save');
+		expect(startPlaygroundWeb).toHaveBeenCalledWith(
+			expect.objectContaining({
+				wordpressInstallMode: 'do-not-attempt-installing',
+			})
+		);
+	});
+
+	it('does not add client info when iframe boot finishes after abort', async () => {
+		let resolveStart = () => {};
+		const startFinished = new Promise<void>((resolve) => {
+			resolveStart = resolve;
+		});
+		vi.mocked(startPlaygroundWeb).mockImplementationOnce(
+			async (options: any) => {
+				await startFinished;
+				options.onClientConnected(createPlaygroundClient());
+				return createPlaygroundClient();
+			}
+		);
+		const site = createSite('stale-iframe', { loadedFromStorage: true });
+		const state = createState(site);
+		const dispatch = createDispatch(state);
+		const abortController = new AbortController();
+
+		const boot = bootSiteClient(
+			'stale-iframe',
+			document.createElement('iframe'),
+			{
+				signal: abortController.signal,
+			}
+		)(dispatch, () => state);
+		await Promise.resolve();
+		await Promise.resolve();
+		expect(startPlaygroundWeb).toHaveBeenCalled();
+
+		abortController.abort();
+		resolveStart();
+		await boot;
+
+		expect(
+			dispatch.mock.calls.some((call: unknown[]) => {
+				const action = call[0] as { type?: string };
+				return action.type === 'clients/addClientInfo';
+			})
+		).toBe(false);
+	});
+
+	it('does not mutate Redux from an aborted initial OPFS sync', async () => {
+		let reportProgress: ((progress: unknown) => void) | undefined;
+		let resolveMount = () => {};
+		const mountFinished = new Promise<void>((resolve) => {
+			resolveMount = resolve;
+		});
+		const playground = createPlaygroundClient({
+			mountOpfs: vi.fn(async (_descriptor, onProgress) => {
+				reportProgress = onProgress;
+				await mountFinished;
+			}),
+		});
+		vi.mocked(startPlaygroundWeb).mockImplementationOnce(
+			async (options: any) => {
+				options.onClientConnected(playground);
+				return playground;
+			}
+		);
+		const site = createSite('initial-sync', {
+			metadata: { initialOpfsSyncPending: true },
+		});
+		const state = createState(site);
+		const dispatch = createDispatch(state);
+		const abortController = new AbortController();
+
+		await bootSiteClient('initial-sync', document.createElement('iframe'), {
+			signal: abortController.signal,
+		})(dispatch, () => state);
+
+		abortController.abort();
+		const actionCountAfterAbort = dispatch.mock.calls.length;
+		reportProgress?.({} as any);
+		resolveMount();
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(dispatch.mock.calls.length).toBe(actionCountAfterAbort);
+		expect(opfsSiteStorage!.update).not.toHaveBeenCalledWith(
+			'initial-sync',
+			expect.objectContaining({ initialOpfsSyncPending: false }),
+			undefined
+		);
+	});
+});
+
+function createDispatch(state: PlaygroundReduxState) {
+	const dispatch = vi.fn((action: unknown) => {
+		if (typeof action === 'function') {
+			return action(dispatch, () => state);
+		}
+		const reduxAction = action as { type?: string };
+		if (reduxAction.type?.startsWith('sites/')) {
+			state.sites = reducer(state.sites, action as any);
+		}
+		return action;
+	}) as any;
+	return dispatch;
+}
+
+function createState(...sites: SiteInfo[]): PlaygroundReduxState {
+	let sitesState = reducer(undefined, { type: 'init' });
+	for (const site of sites) {
+		sitesState = reducer(sitesState, sitesSlice.actions.addSite(site));
+	}
+	return {
+		sites: sitesState,
+		ui: {
+			activeSite: sites[0] ? { slug: sites[0].slug } : undefined,
+		},
+	} as PlaygroundReduxState;
+}
+
+function createSite(
+	slug: string,
+	options: {
+		loadedFromStorage?: boolean;
+		metadata?: Partial<SiteInfo['metadata']>;
+	} = {}
+): SiteInfo {
+	return {
+		slug,
+		loadedFromStorage: options.loadedFromStorage,
+		metadata: {
+			id: slug,
+			name: slug,
+			storage: 'opfs',
+			persistence: 'autosave',
+			originalBlueprint: {},
+			originalBlueprintSource: { type: 'none' },
+			runtimeConfiguration: {
+				phpVersion: '8.3',
+				wpVersion: 'latest',
+				intl: false,
+				networking: true,
+				extraLibraries: [],
+				constants: {},
+			},
+			...options.metadata,
+		},
+	};
+}
+
+function createPlaygroundClient(overrides: Record<string, unknown> = {}): any {
+	return {
+		mountOpfs: vi.fn(async () => undefined),
+		onNavigation: vi.fn(),
+		...overrides,
+	};
+}

--- a/packages/playground/website/src/lib/state/redux/boot-site-client.spec.ts
+++ b/packages/playground/website/src/lib/state/redux/boot-site-client.spec.ts
@@ -235,7 +235,7 @@ describe('bootSiteClient', () => {
 
 		expect(
 			opfsSiteStorage!.removeWordPressFilesKeepMetadata
-		).toHaveBeenCalledTimes(4);
+		).toHaveBeenCalledTimes(3);
 		expect(startPlaygroundWeb).not.toHaveBeenCalled();
 		expect(dispatch).toHaveBeenCalledWith(
 			expect.objectContaining({

--- a/packages/playground/website/src/lib/state/redux/boot-site-client.spec.ts
+++ b/packages/playground/website/src/lib/state/redux/boot-site-client.spec.ts
@@ -48,9 +48,8 @@ vi.mock('./store', () => ({
 
 vi.mock('../opfs/opfs-site-storage', () => ({
 	getDirectoryPathForSlug: (slug: string) => `/sites/${slug}`,
-	legacyOpfsPathSymbol: Symbol('legacyOpfsPath'),
 	opfsSiteStorage: {
-		resetSiteFiles: vi.fn(),
+		removeWordPressFilesKeepMetadata: vi.fn(),
 		update: vi.fn(),
 	},
 }));
@@ -73,8 +72,12 @@ describe('bootSiteClient', () => {
 				return playground;
 			}
 		);
-		vi.mocked(opfsSiteStorage!.resetSiteFiles).mockReset();
-		vi.mocked(opfsSiteStorage!.resetSiteFiles).mockResolvedValue(undefined);
+		vi.mocked(
+			opfsSiteStorage!.removeWordPressFilesKeepMetadata
+		).mockReset();
+		vi.mocked(
+			opfsSiteStorage!.removeWordPressFilesKeepMetadata
+		).mockResolvedValue(undefined);
 		vi.mocked(opfsSiteStorage!.update).mockReset();
 		vi.mocked(opfsSiteStorage!.update).mockResolvedValue(undefined);
 	});
@@ -97,7 +100,7 @@ describe('bootSiteClient', () => {
 			loadedFromStorage: true,
 			metadata: {
 				initialOpfsSyncPending: true,
-				opfsResetPending: true,
+				opfsSiteRemovalPending: true,
 			},
 		});
 		const state = createState(site);
@@ -107,18 +110,18 @@ describe('bootSiteClient', () => {
 			signal: new AbortController().signal,
 		})(dispatch, () => state);
 
-		expect(opfsSiteStorage!.resetSiteFiles).toHaveBeenCalledWith(
-			'autosaved'
-		);
 		expect(
-			vi.mocked(opfsSiteStorage!.resetSiteFiles).mock
+			opfsSiteStorage!.removeWordPressFilesKeepMetadata
+		).toHaveBeenCalledWith('autosaved');
+		expect(
+			vi.mocked(opfsSiteStorage!.removeWordPressFilesKeepMetadata).mock
 				.invocationCallOrder[0]
 		).toBeLessThan(
 			vi.mocked(startPlaygroundWeb).mock.invocationCallOrder[0]
 		);
 		expect(opfsSiteStorage!.update).toHaveBeenCalledWith(
 			'autosaved',
-			expect.objectContaining({ opfsResetPending: undefined }),
+			expect.objectContaining({ opfsSiteRemovalPending: undefined }),
 			undefined
 		);
 		expect(startPlaygroundWeb).toHaveBeenCalled();
@@ -128,7 +131,7 @@ describe('bootSiteClient', () => {
 		const markerError = new Error('metadata write failed');
 		vi.mocked(opfsSiteStorage!.update).mockRejectedValueOnce(markerError);
 		const site = createSite('autosaved', {
-			metadata: { opfsResetPending: true },
+			metadata: { opfsSiteRemovalPending: true },
 		});
 		const state = createState(site);
 		const dispatch = createDispatch(state);
@@ -137,9 +140,9 @@ describe('bootSiteClient', () => {
 			signal: new AbortController().signal,
 		})(dispatch, () => state);
 
-		expect(opfsSiteStorage!.resetSiteFiles).toHaveBeenCalledWith(
-			'autosaved'
-		);
+		expect(
+			opfsSiteStorage!.removeWordPressFilesKeepMetadata
+		).toHaveBeenCalledWith('autosaved');
 		expect(startPlaygroundWeb).not.toHaveBeenCalled();
 		expect(dispatch).toHaveBeenCalledWith(
 			expect.objectContaining({

--- a/packages/playground/website/src/lib/state/redux/boot-site-client.spec.ts
+++ b/packages/playground/website/src/lib/state/redux/boot-site-client.spec.ts
@@ -152,7 +152,33 @@ describe('bootSiteClient', () => {
 			expect.objectContaining({
 				type: 'ui/setActiveSiteError',
 				payload: expect.objectContaining({
-					error: 'directory-handle-unknown-error',
+					error: 'browser-storage-cleanup-failed',
+				}),
+			})
+		);
+	});
+
+	it('does not boot when old autosaved WordPress files cannot be removed', async () => {
+		const removalError = new Error('OPFS delete failed');
+		vi.mocked(
+			opfsSiteStorage!.removeWordPressFilesKeepMetadata
+		).mockRejectedValueOnce(removalError);
+		const site = createSite('autosaved', {
+			metadata: { opfsSiteRemovalPending: true },
+		});
+		const state = createState(site);
+		const dispatch = createDispatch(state);
+
+		await bootSiteClient('autosaved', document.createElement('iframe'), {
+			signal: new AbortController().signal,
+		})(dispatch, () => state);
+
+		expect(startPlaygroundWeb).not.toHaveBeenCalled();
+		expect(dispatch).toHaveBeenCalledWith(
+			expect.objectContaining({
+				type: 'ui/setActiveSiteError',
+				payload: expect.objectContaining({
+					error: 'browser-storage-cleanup-failed',
 				}),
 			})
 		);

--- a/packages/playground/website/src/lib/state/redux/boot-site-client.ts
+++ b/packages/playground/website/src/lib/state/redux/boot-site-client.ts
@@ -420,7 +420,7 @@ export function bootSiteClient(
 /**
  * Finishes deleting old WordPress files after a tab closed during reset.
  *
- * `opfsResetPending` means `wp-runtime.json` already describes the new setup,
+ * `opfsSiteRemovalPending` means `wp-runtime.json` already describes the new setup,
  * but the OPFS directory may still contain WordPress files from the previous
  * autosave. Boot must delete those files before it mounts OPFS or installs
  * WordPress from the new setup. Otherwise the previous site can open while the

--- a/packages/playground/website/src/lib/state/redux/boot-site-client.ts
+++ b/packages/playground/website/src/lib/state/redux/boot-site-client.ts
@@ -83,9 +83,10 @@ export function bootSiteClient(
 					return;
 				}
 				if (false === removalResult) {
-					// The helper already showed the browser-storage cleanup
-					// error. Stop here so we do not mount a directory that may
-					// still contain the previous autosave's WordPress files.
+					// `finishPendingOpfsSiteRemoval()` returned false after
+					// dispatching `browser-storage-cleanup-failed` for the
+					// cleanup error. Stop here so we do not mount OPFS while
+					// it may still contain the previous autosave's WordPress files.
 					return;
 				}
 				site = selectSiteBySlug(getState(), siteSlug) ?? site;

--- a/packages/playground/website/src/lib/state/redux/boot-site-client.ts
+++ b/packages/playground/website/src/lib/state/redux/boot-site-client.ts
@@ -1,6 +1,7 @@
 import { loadDirectoryHandle } from '../opfs/opfs-directory-handle-storage';
 import {
 	getDirectoryPathForSlug,
+	legacyOpfsPathSymbol,
 	opfsSiteStorage,
 } from '../opfs/opfs-site-storage';
 import { addClientInfo, updateClientInfo } from './slice-clients';
@@ -107,7 +108,10 @@ export function bootSiteClient(
 			mountDescriptor = {
 				device: {
 					type: 'opfs',
-					path: getDirectoryPathForSlug(site.slug),
+					// @TODO: Remove backcompat code after 2024-12-01.
+					path: (site.metadata as any)[legacyOpfsPathSymbol]
+						? (site.metadata as any)[legacyOpfsPathSymbol]
+						: getDirectoryPathForSlug(site.slug),
 				},
 				mountpoint: '/wordpress',
 			} as const;

--- a/packages/playground/website/src/lib/state/redux/boot-site-client.ts
+++ b/packages/playground/website/src/lib/state/redux/boot-site-client.ts
@@ -43,7 +43,7 @@ import {
 import { PHPMYADMIN_INSTALL_PATH } from '@wp-playground/tools';
 import { phpExtensionQueryArgsToExtensionsArray } from '../url/php-extension-query';
 
-const PENDING_OPFS_SITE_REMOVAL_RETRY_DELAYS_MS = [1000, 2000, 4000];
+const PENDING_OPFS_SITE_REMOVAL_RETRY_DELAYS_MS = [700, 1400];
 
 /**
  * Loads Playground in an iframe.
@@ -463,7 +463,7 @@ async function finishPendingOpfsSiteRemoval({
 
 	// Another Playground tab can keep OPFS entries locked long enough for
 	// the first cleanup attempt to fail. Retry before showing the modal; only
-	// ask the user to close tabs and reload after the browser refuses several times.
+	// ask the user to close tabs and reload after two more browser refusals.
 	let cleanupError: unknown;
 	for (
 		let attempt = 0;

--- a/packages/playground/website/src/lib/state/redux/boot-site-client.ts
+++ b/packages/playground/website/src/lib/state/redux/boot-site-client.ts
@@ -1,7 +1,6 @@
 import { loadDirectoryHandle } from '../opfs/opfs-directory-handle-storage';
 import {
 	getDirectoryPathForSlug,
-	legacyOpfsPathSymbol,
 	opfsSiteStorage,
 } from '../opfs/opfs-site-storage';
 import { addClientInfo, updateClientInfo } from './slice-clients';
@@ -27,7 +26,6 @@ import type { PlaygroundDispatch, PlaygroundReduxState } from './store';
 import {
 	isAutosavedSite,
 	selectSiteBySlug,
-	hasInterruptedInitialOpfsSync,
 	updateSiteMetadata,
 } from './slice-sites';
 // @ts-ignore
@@ -45,11 +43,10 @@ import { PHPMYADMIN_INSTALL_PATH } from '@wp-playground/tools';
 import { phpExtensionQueryArgsToExtensionsArray } from '../url/php-extension-query';
 
 /**
- * Boots one iframe and stops stale async work from writing Redux after unmount.
+ * Loads Playground in an iframe.
  *
- * `JustViewport` aborts `signal` when React removes or replaces that iframe.
- * Booting and the first OPFS copy can finish after that cleanup, so every
- * Redux write after an `await` or worker callback checks the signal first.
+ * Aborts any stale async writes once the iframe gets removed, as acknowledged
+ * by the AbortSignal.
  */
 export function bootSiteClient(
 	siteSlug: string,
@@ -74,18 +71,35 @@ export function bootSiteClient(
 			return;
 		}
 
-		const pendingResetResult = await finishPendingAutosaveReset({
-			siteSlug,
-			dispatch,
-			signal,
-			getState,
-		});
-		if (pendingResetResult === 'failed' || signal.aborted) {
-			return;
-		}
-		const pendingResetWasCompleted = pendingResetResult === 'completed';
-		if (pendingResetWasCompleted) {
-			site = selectSiteBySlug(getState(), siteSlug) ?? site;
+		if (site?.metadata.storage === 'opfs') {
+			if (site.metadata.opfsSiteRemovalPending) {
+				const removalResult = await finishPendingOpfsSiteRemoval({
+					siteSlug,
+					dispatch,
+					signal,
+					getState,
+				});
+				if (signal.aborted) {
+					return;
+				}
+				if (false === removalResult) {
+					// TODO: it seems like we should show some error here?
+					return;
+				}
+				site = selectSiteBySlug(getState(), siteSlug) ?? site;
+			} else if (
+				site.loadedFromStorage === true &&
+				site.metadata.initialOpfsSyncPending === true
+			) {
+				// If the initial OPFS sync was interrupted, the site files are incomplete
+				// and we can't boot this site.
+				dispatch(
+					setActiveSiteError({
+						error: 'initial-opfs-sync-interrupted',
+					})
+				);
+				return;
+			}
 		}
 
 		let mountDescriptor = undefined;
@@ -93,10 +107,7 @@ export function bootSiteClient(
 			mountDescriptor = {
 				device: {
 					type: 'opfs',
-					// @TODO: Remove backcompat code after 2024-12-01.
-					path: (site.metadata as any)[legacyOpfsPathSymbol]
-						? (site.metadata as any)[legacyOpfsPathSymbol]
-						: getDirectoryPathForSlug(site.slug),
+					path: getDirectoryPathForSlug(site.slug),
 				},
 				mountpoint: '/wordpress',
 			} as const;
@@ -127,15 +138,6 @@ export function bootSiteClient(
 				},
 				mountpoint: '/wordpress',
 			} as const;
-		}
-
-		const hasInterruptedSync =
-			!pendingResetWasCompleted && hasInterruptedInitialOpfsSync(site);
-		if (hasInterruptedSync) {
-			dispatch(
-				setActiveSiteError({ error: 'initial-opfs-sync-interrupted' })
-			);
-			return;
 		}
 
 		const opfsInitialSyncPending =
@@ -415,8 +417,6 @@ export function bootSiteClient(
 	};
 }
 
-type PendingResetResult = 'completed' | 'skipped' | 'failed';
-
 /**
  * Finishes deleting old WordPress files after a tab closed during reset.
  *
@@ -426,7 +426,7 @@ type PendingResetResult = 'completed' | 'skipped' | 'failed';
  * WordPress from the new setup. Otherwise the previous site can open while the
  * metadata says the site should use the new settings or edited Blueprint.
  */
-async function finishPendingAutosaveReset({
+async function finishPendingOpfsSiteRemoval({
 	siteSlug,
 	dispatch,
 	signal,
@@ -436,11 +436,8 @@ async function finishPendingAutosaveReset({
 	dispatch: PlaygroundDispatch;
 	signal: AbortSignal;
 	getState: () => PlaygroundReduxState;
-}): Promise<PendingResetResult> {
+}): Promise<boolean> {
 	const site = selectSiteBySlug(getState(), siteSlug);
-	if (site?.metadata.storage !== 'opfs' || !site.metadata.opfsResetPending) {
-		return 'skipped';
-	}
 	if (!opfsSiteStorage) {
 		dispatch(
 			setActiveSiteError({
@@ -450,17 +447,17 @@ async function finishPendingAutosaveReset({
 				),
 			})
 		);
-		return 'failed';
+		return false;
 	}
 
 	try {
-		await opfsSiteStorage.resetSiteFiles(site.slug);
+		await opfsSiteStorage.removeWordPressFilesKeepMetadata(site.slug);
 		if (signal.aborted) {
-			return 'failed';
+			return false;
 		}
 	} catch (error) {
 		if (signal.aborted) {
-			return 'failed';
+			return false;
 		}
 		logger.error(error);
 		dispatch(
@@ -473,7 +470,7 @@ async function finishPendingAutosaveReset({
 				details: error,
 			})
 		);
-		return 'failed';
+		return false;
 	}
 
 	try {
@@ -481,13 +478,13 @@ async function finishPendingAutosaveReset({
 			updateSiteMetadata({
 				slug: site.slug,
 				changes: {
-					opfsResetPending: undefined,
+					opfsSiteRemovalPending: undefined,
 				},
 			})
 		);
 	} catch (error) {
 		if (signal.aborted) {
-			return 'failed';
+			return false;
 		}
 		logger.error('Error clearing pending Playground reset marker', error);
 		dispatch(
@@ -500,10 +497,10 @@ async function finishPendingAutosaveReset({
 				details: error,
 			})
 		);
-		return 'failed';
+		return false;
 	}
 
-	return 'completed';
+	return true;
 }
 
 function logSupportedBlueprintEvents(blueprint: BlueprintDeclaration) {

--- a/packages/playground/website/src/lib/state/redux/boot-site-client.ts
+++ b/packages/playground/website/src/lib/state/redux/boot-site-client.ts
@@ -78,7 +78,6 @@ export function bootSiteClient(
 					siteSlug,
 					dispatch,
 					signal,
-					getState,
 				});
 				if (signal.aborted) {
 					return;
@@ -440,14 +439,11 @@ async function finishPendingOpfsSiteRemoval({
 	siteSlug,
 	dispatch,
 	signal,
-	getState,
 }: {
 	siteSlug: string;
 	dispatch: PlaygroundDispatch;
 	signal: AbortSignal;
-	getState: () => PlaygroundReduxState;
 }): Promise<boolean> {
-	const site = selectSiteBySlug(getState(), siteSlug);
 	if (!opfsSiteStorage) {
 		dispatch(
 			setActiveSiteError({
@@ -461,7 +457,7 @@ async function finishPendingOpfsSiteRemoval({
 	}
 
 	try {
-		await opfsSiteStorage.removeWordPressFilesKeepMetadata(site.slug);
+		await opfsSiteStorage.removeWordPressFilesKeepMetadata(siteSlug);
 		if (signal.aborted) {
 			return false;
 		}
@@ -486,7 +482,7 @@ async function finishPendingOpfsSiteRemoval({
 	try {
 		await dispatch(
 			updateSiteMetadata({
-				slug: site.slug,
+				slug: siteSlug,
 				changes: {
 					opfsSiteRemovalPending: undefined,
 				},

--- a/packages/playground/website/src/lib/state/redux/boot-site-client.ts
+++ b/packages/playground/website/src/lib/state/redux/boot-site-client.ts
@@ -43,6 +43,8 @@ import {
 import { PHPMYADMIN_INSTALL_PATH } from '@wp-playground/tools';
 import { phpExtensionQueryArgsToExtensionsArray } from '../url/php-extension-query';
 
+const PENDING_OPFS_SITE_REMOVAL_RETRY_DELAYS_MS = [1000, 2000, 4000];
+
 /**
  * Loads Playground in an iframe.
  *
@@ -83,10 +85,10 @@ export function bootSiteClient(
 					return;
 				}
 				if (false === removalResult) {
-					// `finishPendingOpfsSiteRemoval()` returned false after
-					// dispatching `browser-storage-cleanup-failed` for the
-					// cleanup error. Stop here so we do not mount OPFS while
-					// it may still contain the previous autosave's WordPress files.
+					// `finishPendingOpfsSiteRemoval()` already retried and
+					// dispatched `browser-storage-cleanup-failed`. Stop here
+					// so we do not mount OPFS while it may still contain the
+					// previous autosave's WordPress files.
 					return;
 				}
 				site = selectSiteBySlug(getState(), siteSlug) ?? site;
@@ -459,49 +461,78 @@ async function finishPendingOpfsSiteRemoval({
 		return false;
 	}
 
-	try {
-		await opfsSiteStorage.removeWordPressFilesKeepMetadata(siteSlug);
+	// Another Playground tab can keep OPFS entries locked long enough for
+	// the first cleanup attempt to fail. Retry before showing the modal; only
+	// ask the user to close tabs and reload after the browser refuses several times.
+	let cleanupError: unknown;
+	for (
+		let attempt = 0;
+		attempt <= PENDING_OPFS_SITE_REMOVAL_RETRY_DELAYS_MS.length;
+		attempt++
+	) {
+		try {
+			await opfsSiteStorage.removeWordPressFilesKeepMetadata(siteSlug);
+			if (signal.aborted) {
+				return false;
+			}
+
+			await dispatch(
+				updateSiteMetadata({
+					slug: siteSlug,
+					changes: {
+						opfsSiteRemovalPending: undefined,
+					},
+				})
+			);
+			return true;
+		} catch (error) {
+			if (signal.aborted) {
+				return false;
+			}
+			cleanupError = error;
+		}
+
+		const retryDelay = PENDING_OPFS_SITE_REMOVAL_RETRY_DELAYS_MS[attempt];
+		if (retryDelay === undefined) {
+			break;
+		}
+		await waitForPendingOpfsSiteRemovalRetry(retryDelay, signal);
 		if (signal.aborted) {
 			return false;
 		}
-	} catch (error) {
-		if (signal.aborted) {
-			return false;
-		}
-		logger.error(error);
-		dispatch(
-			setActiveSiteError({
-				error: 'browser-storage-cleanup-failed',
-				details: error,
-			})
-		);
-		return false;
 	}
 
-	try {
-		await dispatch(
-			updateSiteMetadata({
-				slug: siteSlug,
-				changes: {
-					opfsSiteRemovalPending: undefined,
-				},
-			})
-		);
-	} catch (error) {
-		if (signal.aborted) {
-			return false;
-		}
-		logger.error('Error clearing pending Playground reset marker', error);
-		dispatch(
-			setActiveSiteError({
-				error: 'browser-storage-cleanup-failed',
-				details: error,
-			})
-		);
-		return false;
+	logger.error(
+		'Error finishing pending Playground reset cleanup',
+		cleanupError
+	);
+	dispatch(
+		setActiveSiteError({
+			error: 'browser-storage-cleanup-failed',
+			details: cleanupError,
+		})
+	);
+	return false;
+}
+
+function waitForPendingOpfsSiteRemovalRetry(
+	delayMs: number,
+	signal: AbortSignal
+): Promise<void> {
+	if (signal.aborted) {
+		return Promise.resolve();
 	}
 
-	return true;
+	return new Promise((resolve) => {
+		const timeout = setTimeout(done, delayMs);
+		signal.addEventListener('abort', done, { once: true });
+
+		function done() {
+			clearTimeout(timeout);
+			signal.removeEventListener('abort', done);
+			resolve();
+		}
+	});
 }
 
 function logSupportedBlueprintEvents(blueprint: BlueprintDeclaration) {

--- a/packages/playground/website/src/lib/state/redux/boot-site-client.ts
+++ b/packages/playground/website/src/lib/state/redux/boot-site-client.ts
@@ -183,9 +183,15 @@ export function bootSiteClient(
 			!isBlueprintBundle(blueprint) &&
 			'preferredVersions' in blueprint &&
 			blueprint.preferredVersions?.wp === false;
-		const wordpressInstallMode =
-			blueprintRequestedNoWordPress || shouldBootFromStoredFiles
-				? 'do-not-attempt-installing'
+		// Stored WordPress files cannot use `do-not-attempt-installing`:
+		// that mode is for PHP-only boots and returns before the worker loads
+		// the SQLite drop-in. Use the existing-files mode so saved SQLite
+		// sites boot from their database, while incomplete first OPFS saves
+		// are still blocked above by `initialOpfsSyncPending`.
+		const wordpressInstallMode = blueprintRequestedNoWordPress
+			? 'do-not-attempt-installing'
+			: shouldBootFromStoredFiles
+				? 'install-from-existing-files-if-needed'
 				: 'download-and-install';
 
 		/**

--- a/packages/playground/website/src/lib/state/redux/boot-site-client.ts
+++ b/packages/playground/website/src/lib/state/redux/boot-site-client.ts
@@ -83,11 +83,9 @@ export function bootSiteClient(
 					return;
 				}
 				if (false === removalResult) {
-					// The helper already showed the specific site error:
-					// browser storage unavailable, permission denied, or an
-					// OPFS delete/update failure. Stop here so we do not mount
-					// a directory that may still contain the previous autosave's
-					// WordPress files.
+					// The helper already showed the browser-storage cleanup
+					// error. Stop here so we do not mount a directory that may
+					// still contain the previous autosave's WordPress files.
 					return;
 				}
 				site = selectSiteBySlug(getState(), siteSlug) ?? site;
@@ -451,7 +449,7 @@ async function finishPendingOpfsSiteRemoval({
 	if (!opfsSiteStorage) {
 		dispatch(
 			setActiveSiteError({
-				error: 'directory-handle-unknown-error',
+				error: 'browser-storage-cleanup-failed',
 				details: new Error(
 					'Cannot finish resetting the saved Playground because browser storage is not available.'
 				),
@@ -472,11 +470,7 @@ async function finishPendingOpfsSiteRemoval({
 		logger.error(error);
 		dispatch(
 			setActiveSiteError({
-				error:
-					(error instanceof DOMException || error instanceof Error) &&
-					error.name === 'NotAllowedError'
-						? 'directory-handle-permission-denied'
-						: 'directory-handle-unknown-error',
+				error: 'browser-storage-cleanup-failed',
 				details: error,
 			})
 		);
@@ -499,11 +493,7 @@ async function finishPendingOpfsSiteRemoval({
 		logger.error('Error clearing pending Playground reset marker', error);
 		dispatch(
 			setActiveSiteError({
-				error:
-					(error instanceof DOMException || error instanceof Error) &&
-					error.name === 'NotAllowedError'
-						? 'directory-handle-permission-denied'
-						: 'directory-handle-unknown-error',
+				error: 'browser-storage-cleanup-failed',
 				details: error,
 			})
 		);

--- a/packages/playground/website/src/lib/state/redux/boot-site-client.ts
+++ b/packages/playground/website/src/lib/state/redux/boot-site-client.ts
@@ -83,7 +83,11 @@ export function bootSiteClient(
 					return;
 				}
 				if (false === removalResult) {
-					// TODO: it seems like we should show some error here?
+					// The helper already showed the specific site error:
+					// browser storage unavailable, permission denied, or an
+					// OPFS delete/update failure. Stop here so we do not mount
+					// a directory that may still contain the previous autosave's
+					// WordPress files.
 					return;
 				}
 				site = selectSiteBySlug(getState(), siteSlug) ?? site;

--- a/packages/playground/website/src/lib/state/redux/boot-site-client.ts
+++ b/packages/playground/website/src/lib/state/redux/boot-site-client.ts
@@ -1,14 +1,10 @@
-import { directoryHandleFromMountDevice } from '@wp-playground/storage';
 import { loadDirectoryHandle } from '../opfs/opfs-directory-handle-storage';
 import {
 	getDirectoryPathForSlug,
 	legacyOpfsPathSymbol,
+	opfsSiteStorage,
 } from '../opfs/opfs-site-storage';
-import {
-	addClientInfo,
-	removeClientInfo,
-	updateClientInfo,
-} from './slice-clients';
+import { addClientInfo, updateClientInfo } from './slice-clients';
 import { logBlueprintEvents, logTrackingEvent } from '../../tracking';
 import {
 	type Blueprint,
@@ -48,6 +44,13 @@ import {
 import { PHPMYADMIN_INSTALL_PATH } from '@wp-playground/tools';
 import { phpExtensionQueryArgsToExtensionsArray } from '../url/php-extension-query';
 
+/**
+ * Boots one iframe and stops stale async work from writing Redux after unmount.
+ *
+ * `JustViewport` aborts `signal` when React removes or replaces that iframe.
+ * Booting and the first OPFS copy can finish after that cleanup, so every
+ * Redux write after an `await` or worker callback checks the signal first.
+ */
 export function bootSiteClient(
 	siteSlug: string,
 	iframe: HTMLIFrameElement,
@@ -57,10 +60,33 @@ export function bootSiteClient(
 		dispatch: PlaygroundDispatch,
 		getState: () => PlaygroundReduxState
 	) => {
-		signal.onabort = () => {
-			dispatch(removeClientInfo(siteSlug));
-		};
-		const site = selectSiteBySlug(getState(), siteSlug);
+		if (signal.aborted) {
+			return;
+		}
+		let site = selectSiteBySlug(getState(), siteSlug);
+		if (!site) {
+			dispatch(
+				setActiveSiteError({
+					error: 'site-boot-failed',
+					details: new Error(`Site not found: ${siteSlug}`),
+				})
+			);
+			return;
+		}
+
+		const pendingResetResult = await finishPendingAutosaveReset({
+			siteSlug,
+			dispatch,
+			signal,
+			getState,
+		});
+		if (pendingResetResult === 'failed' || signal.aborted) {
+			return;
+		}
+		const pendingResetWasCompleted = pendingResetResult === 'completed';
+		if (pendingResetWasCompleted) {
+			site = selectSiteBySlug(getState(), siteSlug) ?? site;
+		}
 
 		let mountDescriptor = undefined;
 		if (site.metadata.storage === 'opfs') {
@@ -78,7 +104,13 @@ export function bootSiteClient(
 			let localDirectoryHandle;
 			try {
 				localDirectoryHandle = await loadDirectoryHandle(site.slug);
+				if (signal.aborted) {
+					return;
+				}
 			} catch (e) {
+				if (signal.aborted) {
+					return;
+				}
 				logger.error(e);
 				dispatch(
 					setActiveSiteError({
@@ -97,56 +129,26 @@ export function bootSiteClient(
 			} as const;
 		}
 
-		const hasInterruptedSync = hasInterruptedInitialOpfsSync(site);
+		const hasInterruptedSync =
+			!pendingResetWasCompleted && hasInterruptedInitialOpfsSync(site);
 		if (hasInterruptedSync) {
 			dispatch(
-				setActiveSiteError({
-					error: 'initial-opfs-sync-interrupted',
-				})
+				setActiveSiteError({ error: 'initial-opfs-sync-interrupted' })
 			);
 			return;
 		}
 
-		let isWordPressInstalled = false;
-		if (mountDescriptor) {
-			try {
-				isWordPressInstalled = await playgroundAvailableInOpfs(
-					await directoryHandleFromMountDevice(mountDescriptor.device)
-				);
-			} catch (e) {
-				logger.error(e);
-				if (e instanceof DOMException && e.name === 'NotFoundError') {
-					dispatch(
-						setActiveSiteError({
-							error: 'directory-handle-not-found-in-indexeddb',
-							details: e,
-						})
-					);
-					return;
-				}
-				if (e instanceof DOMException && e.name === 'NotAllowedError') {
-					dispatch(
-						setActiveSiteError({
-							error: 'directory-handle-permission-denied',
-							details: e,
-						})
-					);
-					return;
-				}
-				dispatch(
-					setActiveSiteError({
-						error: 'directory-handle-unknown-error',
-						details: e,
-					})
-				);
-				return;
-			}
-		}
+		const opfsInitialSyncPending =
+			site.metadata.storage === 'opfs' &&
+			site.metadata.initialOpfsSyncPending === true;
+		const shouldBootFromStoredFiles =
+			site.metadata.storage === 'local-fs' ||
+			(site.metadata.storage === 'opfs' && !opfsInitialSyncPending);
 
 		logTrackingEvent('load');
 
 		let blueprint: Blueprint;
-		if (isWordPressInstalled) {
+		if (shouldBootFromStoredFiles) {
 			blueprint = {
 				preferredVersions: {
 					php: site.metadata.runtimeConfiguration.phpVersion,
@@ -168,17 +170,16 @@ export function bootSiteClient(
 		}
 
 		// PHP-only mode: a Blueprint with `preferredVersions.wp: false`
-		// declares it doesn't want WordPress, so honor that even if the
-		// storage layer thinks WP isn't installed yet.
+		// declares it does not want WordPress. Respect that on a first OPFS
+		// boot too, where there are no stored files to mount yet.
 		const blueprintRequestedNoWordPress =
 			blueprint &&
 			!isBlueprintBundle(blueprint) &&
 			'preferredVersions' in blueprint &&
 			blueprint.preferredVersions?.wp === false;
-		const wordpressInstallMode = blueprintRequestedNoWordPress
-			? 'do-not-attempt-installing'
-			: isWordPressInstalled
-				? 'install-from-existing-files-if-needed'
+		const wordpressInstallMode =
+			blueprintRequestedNoWordPress || shouldBootFromStoredFiles
+				? 'do-not-attempt-installing'
 				: 'download-and-install';
 
 		/**
@@ -190,7 +191,7 @@ export function bootSiteClient(
 		const isFirstOpfsBoot =
 			site.metadata.initialOpfsSyncPending === true &&
 			site.metadata.storage === 'opfs' &&
-			!isWordPressInstalled;
+			!shouldBootFromStoredFiles;
 		const mounts: MountDescriptor[] = [];
 		let mountDescriptorForInitialOpfsSync: typeof mountDescriptor =
 			undefined;
@@ -219,13 +220,16 @@ export function bootSiteClient(
 				blueprint,
 				extensions: phpExtensions,
 				experimentalBlueprintsV2Runner:
-					!isWordPressInstalled &&
+					!shouldBootFromStoredFiles &&
 					new URLSearchParams(window.location.search).get(
 						'experimental-blueprints-v2-runner'
 					) === 'yes',
 				// Intercept the Playground client even if the
 				// Blueprint fails.
 				onClientConnected: (playgroundClient) => {
+					if (signal.aborted) {
+						return;
+					}
 					playground = (window as any)['playground'] =
 						playgroundClient;
 				},
@@ -243,6 +247,9 @@ export function bootSiteClient(
 				],
 			});
 		} catch (e) {
+			if (signal.aborted) {
+				return;
+			}
 			logger.error(e);
 			logTrackingEvent('error', { source: 'bootSiteClient' });
 
@@ -346,6 +353,9 @@ export function bootSiteClient(
 					: undefined,
 			})
 		);
+		// When metadata says the first OPFS copy is still pending, install
+		// WordPress in MEMFS and copy it into OPFS in the background. Otherwise
+		// the stored files are mounted and boot can only refresh recency metadata.
 		if (mountDescriptorForInitialOpfsSync) {
 			void syncInitialOpfsFilesInBackground({
 				playground: connectedPlayground,
@@ -353,6 +363,7 @@ export function bootSiteClient(
 				siteSlug: site.slug,
 				operation: syncOperation,
 				dispatch,
+				signal,
 			});
 		} else {
 			try {
@@ -370,6 +381,9 @@ export function bootSiteClient(
 					);
 				}
 			} catch (error) {
+				if (signal.aborted) {
+					return;
+				}
 				logger.error('Error updating Playground metadata', error);
 				dispatch(
 					updateClientInfo({
@@ -386,6 +400,9 @@ export function bootSiteClient(
 		}
 
 		connectedPlayground.onNavigation((url) => {
+			if (signal.aborted) {
+				return;
+			}
 			dispatch(
 				updateClientInfo({
 					siteSlug: site.slug,
@@ -395,9 +412,98 @@ export function bootSiteClient(
 				})
 			);
 		});
-
-		signal.onabort = null;
 	};
+}
+
+type PendingResetResult = 'completed' | 'skipped' | 'failed';
+
+/**
+ * Finishes deleting old WordPress files after a tab closed during reset.
+ *
+ * `opfsResetPending` means `wp-runtime.json` already describes the new setup,
+ * but the OPFS directory may still contain WordPress files from the previous
+ * autosave. Boot must delete those files before it mounts OPFS or installs
+ * WordPress from the new setup. Otherwise the previous site can open while the
+ * metadata says the site should use the new settings or edited Blueprint.
+ */
+async function finishPendingAutosaveReset({
+	siteSlug,
+	dispatch,
+	signal,
+	getState,
+}: {
+	siteSlug: string;
+	dispatch: PlaygroundDispatch;
+	signal: AbortSignal;
+	getState: () => PlaygroundReduxState;
+}): Promise<PendingResetResult> {
+	const site = selectSiteBySlug(getState(), siteSlug);
+	if (site?.metadata.storage !== 'opfs' || !site.metadata.opfsResetPending) {
+		return 'skipped';
+	}
+	if (!opfsSiteStorage) {
+		dispatch(
+			setActiveSiteError({
+				error: 'directory-handle-unknown-error',
+				details: new Error(
+					'Cannot finish resetting the saved Playground because browser storage is not available.'
+				),
+			})
+		);
+		return 'failed';
+	}
+
+	try {
+		await opfsSiteStorage.resetSiteFiles(site.slug);
+		if (signal.aborted) {
+			return 'failed';
+		}
+	} catch (error) {
+		if (signal.aborted) {
+			return 'failed';
+		}
+		logger.error(error);
+		dispatch(
+			setActiveSiteError({
+				error:
+					(error instanceof DOMException || error instanceof Error) &&
+					error.name === 'NotAllowedError'
+						? 'directory-handle-permission-denied'
+						: 'directory-handle-unknown-error',
+				details: error,
+			})
+		);
+		return 'failed';
+	}
+
+	try {
+		await dispatch(
+			updateSiteMetadata({
+				slug: site.slug,
+				changes: {
+					opfsResetPending: undefined,
+				},
+			})
+		);
+	} catch (error) {
+		if (signal.aborted) {
+			return 'failed';
+		}
+		logger.error('Error clearing pending Playground reset marker', error);
+		dispatch(
+			setActiveSiteError({
+				error:
+					(error instanceof DOMException || error instanceof Error) &&
+					error.name === 'NotAllowedError'
+						? 'directory-handle-permission-denied'
+						: 'directory-handle-unknown-error',
+				details: error,
+			})
+		);
+		return 'failed';
+	}
+
+	return 'completed';
 }
 
 function logSupportedBlueprintEvents(blueprint: BlueprintDeclaration) {
@@ -419,22 +525,27 @@ async function syncInitialOpfsFilesInBackground({
 	siteSlug,
 	operation,
 	dispatch,
+	signal,
 }: {
 	playground: PlaygroundClient;
 	mountDescriptor: Omit<MountDescriptor, 'initialSyncDirection'>;
 	siteSlug: string;
 	operation: 'save' | 'autosave';
 	dispatch: PlaygroundDispatch;
+	signal: AbortSignal;
 }) {
 	let shouldReportProgress = true;
 	try {
+		// The first OPFS copy can outlive the iframe that started it. Once the
+		// viewport aborts, stale worker progress must not recreate client state
+		// that the unmount cleanup already removed.
 		await playground.mountOpfs(
 			{
 				...mountDescriptor,
 				initialSyncDirection: 'memfs-to-opfs',
 			},
 			(progress: SyncProgress) => {
-				if (!shouldReportProgress) {
+				if (!shouldReportProgress || signal.aborted) {
 					return;
 				}
 				dispatch(
@@ -451,6 +562,9 @@ async function syncInitialOpfsFilesInBackground({
 				);
 			}
 		);
+		if (signal.aborted) {
+			return;
+		}
 		await dispatch(
 			updateSiteMetadata({
 				slug: siteSlug,
@@ -460,6 +574,9 @@ async function syncInitialOpfsFilesInBackground({
 				},
 			})
 		);
+		if (signal.aborted) {
+			return;
+		}
 		dispatch(
 			updateClientInfo({
 				siteSlug,
@@ -469,6 +586,9 @@ async function syncInitialOpfsFilesInBackground({
 			})
 		);
 	} catch (error: unknown) {
+		if (signal.aborted) {
+			return;
+		}
 		logger.error('Error syncing saved Playground to OPFS', error);
 		dispatch(
 			updateClientInfo({
@@ -487,48 +607,4 @@ async function syncInitialOpfsFilesInBackground({
 		// queued progress message so it cannot overwrite the final UI state.
 		shouldReportProgress = false;
 	}
-}
-
-/**
- * Check if the given directory handle directory is a Playground directory.
- *
- * @TODO: Create a shared package like @wp-playground/wordpress for such utilities
- * and bring in the context detection logic from wp-now – only express it in terms of
- * either abstract FS operations or isomorphic PHP FS operations.
- * (we can't just use Node.js require('fs') in the browser, for example)
- *
- * @TODO: Reuse the "isWordPressInstalled" logic implemented in the boot protocol.
- *        Perhaps mount OPFS first, and only then check for the presence of the
- *        WordPress installation? Or, if not, perhaps implement a shared file access
- * 		  abstraction that can be used both with the PHP module and OPFS directory handles?
- *
- * @param dirHandle
- */
-export async function playgroundAvailableInOpfs(
-	dirHandle: FileSystemDirectoryHandle
-) {
-	// Run this loop just to trigger an exception if the directory handle is no good.
-	// eslint-disable-next-line @typescript-eslint/no-unused-vars
-	for await (const _ of dirHandle.keys()) {
-		break;
-	}
-
-	try {
-		/**
-		 * Assume it's a Playground directory if these files exist:
-		 * - wp-config.php
-		 * - wp-content/database/.ht.sqlite
-		 */
-		await dirHandle.getFileHandle('wp-config.php', { create: false });
-		const wpContent = await dirHandle.getDirectoryHandle('wp-content', {
-			create: false,
-		});
-		const database = await wpContent.getDirectoryHandle('database', {
-			create: false,
-		});
-		await database.getFileHandle('.ht.sqlite', { create: false });
-	} catch {
-		return false;
-	}
-	return true;
 }

--- a/packages/playground/website/src/lib/state/redux/site-lifecycle.spec.ts
+++ b/packages/playground/website/src/lib/state/redux/site-lifecycle.spec.ts
@@ -3,7 +3,6 @@ import {
 	getAutosavedSitesToPrune,
 	getSitePublicPersistence,
 	getSitesSortedByRecency,
-	hasInterruptedInitialOpfsSync,
 	isAutosavedSite,
 	wasSiteRecentlyInteractedWith,
 } from './site-lifecycle';
@@ -131,53 +130,6 @@ describe('autosaved site helpers', () => {
 					whenLastUsed: now - RECENT_AUTOSAVE_RESTORE_WINDOW_MS - 1,
 				}),
 				now
-			)
-		).toBe(false);
-	});
-
-	it('identifies stored OPFS sites with an interrupted initial sync', () => {
-		expect(
-			hasInterruptedInitialOpfsSync(
-				createSite('pending-opfs', {
-					loadedFromStorage: true,
-					storage: 'opfs',
-					initialOpfsSyncPending: true,
-				})
-			)
-		).toBe(true);
-		expect(
-			hasInterruptedInitialOpfsSync(
-				createSite('fresh-pending-opfs', {
-					storage: 'opfs',
-					initialOpfsSyncPending: true,
-				})
-			)
-		).toBe(false);
-		expect(
-			hasInterruptedInitialOpfsSync(
-				createSite('recreated-loaded-opfs', {
-					loadedFromStorage: false,
-					storage: 'opfs',
-					initialOpfsSyncPending: true,
-				})
-			)
-		).toBe(false);
-		expect(
-			hasInterruptedInitialOpfsSync(
-				createSite('finished-opfs', {
-					loadedFromStorage: true,
-					storage: 'opfs',
-					initialOpfsSyncPending: false,
-				})
-			)
-		).toBe(false);
-		expect(
-			hasInterruptedInitialOpfsSync(
-				createSite('temporary', {
-					loadedFromStorage: true,
-					storage: 'none',
-					initialOpfsSyncPending: true,
-				})
 			)
 		).toBe(false);
 	});

--- a/packages/playground/website/src/lib/state/redux/site-lifecycle.ts
+++ b/packages/playground/website/src/lib/state/redux/site-lifecycle.ts
@@ -81,8 +81,9 @@ export function isExplicitlySavedSite(site: SiteInfo) {
  * Indicates whether the restored site has an interrupted first OPFS sync.
  *
  * `initialOpfsSyncPending` is cleared only after a full MEMFS-to-OPFS copy.
- * While it remains set on a site loaded from storage, the OPFS directory may
- * contain enough files to look installed but not enough to boot reliably.
+ * While it remains set on a site loaded from storage, metadata says the first
+ * copy never completed. Boot must not mount that directory even if some
+ * WordPress files were already copied before the tab closed.
  */
 export function hasInterruptedInitialOpfsSync(site: SiteInfo) {
 	return (

--- a/packages/playground/website/src/lib/state/redux/site-lifecycle.ts
+++ b/packages/playground/website/src/lib/state/redux/site-lifecycle.ts
@@ -78,22 +78,6 @@ export function isExplicitlySavedSite(site: SiteInfo) {
 }
 
 /**
- * Indicates whether the restored site has an interrupted first OPFS sync.
- *
- * `initialOpfsSyncPending` is cleared only after a full MEMFS-to-OPFS copy.
- * While it remains set on a site loaded from storage, metadata says the first
- * copy never completed. Boot must not mount that directory even if some
- * WordPress files were already copied before the tab closed.
- */
-export function hasInterruptedInitialOpfsSync(site: SiteInfo) {
-	return (
-		site.metadata.storage === 'opfs' &&
-		site.loadedFromStorage === true &&
-		site.metadata.initialOpfsSyncPending === true
-	);
-}
-
-/**
  * Returns the persistence value exposed by the public site-management API.
  *
  * Persistence describes a stored Playground, so temporary Playgrounds do not

--- a/packages/playground/website/src/lib/state/redux/site-management-api-middleware.ts
+++ b/packages/playground/website/src/lib/state/redux/site-management-api-middleware.ts
@@ -396,9 +396,9 @@ export function createSitesAPI(
 		/**
 		 * Recreates the active autosaved Playground with new setup settings.
 		 *
-		 * Autosaved Playgrounds behave like recoverable unsaved work: changing
-		 * setup settings replaces the current WordPress files under the same
-		 * autosaved slug instead of creating another autosave.
+		 * Today this keeps the same sidebar entry and replaces the WordPress
+		 * files under that site's OPFS directory. The future Dock flow should
+		 * create a separate Playground for setup changes instead.
 		 *
 		 * @param settings Optional site settings.
 		 * @throws When no site is selected, the active site is not autosaved, or
@@ -411,17 +411,16 @@ export function createSitesAPI(
 			}
 			if (!isAutosavedSite(site)) {
 				throw new Error(
-					'Only autosaved Playgrounds can be recreated in place.'
+					'Only autosaved Playgrounds can replace their stored files.'
 				);
 			}
 			const setupUrl = getSetupUrlForNewSite(settings, {
 				baseUrl: getSetupUrlFromSite(site, window.location.href),
 				onlySetupParams: true,
 			});
-			await selectClientBySiteSlug(
-				getState(),
-				site.slug
-			)?.unmountOpfs('/wordpress');
+			await selectClientBySiteSlug(getState(), site.slug)?.unmountOpfs(
+				'/wordpress'
+			);
 			dispatch(removeClientInfo(site.slug));
 			await dispatch(resetAutosavedSiteSpec(site.slug, setupUrl));
 			redirectTo(setupUrl.toString());

--- a/packages/playground/website/src/lib/state/redux/slice-sites.spec.ts
+++ b/packages/playground/website/src/lib/state/redux/slice-sites.spec.ts
@@ -5,7 +5,7 @@ describe('stored site specs', () => {
 	let createSite: ReturnType<typeof vi.fn>;
 	let updateSiteStorage: ReturnType<typeof vi.fn>;
 	let persistBlueprintBundle: ReturnType<typeof vi.fn>;
-	let resetSiteFiles: ReturnType<typeof vi.fn>;
+	let removeWordPressFilesKeepMetadata: ReturnType<typeof vi.fn>;
 	let resolveRuntimeConfiguration: ReturnType<typeof vi.fn>;
 
 	beforeEach(() => {
@@ -13,7 +13,7 @@ describe('stored site specs', () => {
 		createSite = vi.fn();
 		updateSiteStorage = vi.fn();
 		persistBlueprintBundle = vi.fn();
-		resetSiteFiles = vi.fn();
+		removeWordPressFilesKeepMetadata = vi.fn();
 		resolveRuntimeConfiguration = vi.fn();
 
 		vi.doMock('@php-wasm/logger', () => ({
@@ -48,7 +48,7 @@ describe('stored site specs', () => {
 			opfsSiteStorage: {
 				create: createSite,
 				update: updateSiteStorage,
-				resetSiteFiles,
+				removeWordPressFilesKeepMetadata,
 			},
 		}));
 		vi.doMock('../playground-identity', () => ({
@@ -312,7 +312,7 @@ describe('stored site specs', () => {
 		).rejects.toThrow('Invalid setup');
 
 		expect(persistBlueprintBundle).not.toHaveBeenCalled();
-		expect(resetSiteFiles).not.toHaveBeenCalled();
+		expect(removeWordPressFilesKeepMetadata).not.toHaveBeenCalled();
 	});
 
 	it('does not persist a bundle for a new stored site before validating setup', async () => {

--- a/packages/playground/website/src/lib/state/redux/slice-sites.ts
+++ b/packages/playground/website/src/lib/state/redux/slice-sites.ts
@@ -647,7 +647,7 @@ export function setStoredSiteSpec(
  * changing PHP version or networking. Those should update site metadata and
  * reboot. Longer term, the Dock UI should create a new Playground for setup
  * changes and leave the previous Playground untouched. Until that UX exists,
- * this function writes `opfsResetPending` so a reload can finish deleting old
+ * this function writes `opfsSiteRemovalPending` so a reload can finish deleting old
  * WordPress files if the tab closes during the deletion.
  */
 export function resetAutosavedSiteSpec(

--- a/packages/playground/website/src/lib/state/redux/slice-sites.ts
+++ b/packages/playground/website/src/lib/state/redux/slice-sites.ts
@@ -7,6 +7,7 @@ import {
 import type { PlaygroundDispatch, PlaygroundReduxState } from './store';
 import { selectActiveSite, setActiveSite } from './store';
 import { opfsSiteStorage } from '../opfs/opfs-site-storage';
+import { resetAutosavedSiteFilesWithPendingMarker } from '../opfs/opfs-autosave-reset';
 import type { OriginalUrlParams } from '../original-url-params';
 import {
 	BlueprintReflection,
@@ -636,11 +637,19 @@ export function setStoredSiteSpec(
 }
 
 /**
- * Replaces the setup metadata and WordPress files for an autosaved Playground
- * without changing its slug or display name.
+ * Replaces an autosaved Playground's WordPress files with files from a new setup.
  *
- * Autosaves are recoverable unsaved work. Explicitly saved Playgrounds preserve
- * their WordPress files, so they must not use this reset path.
+ * This is used after the user clicks "Apply Settings & Recreate Playground"
+ * in the autosaved settings form. The site keeps the same slug and name in the
+ * sidebar, but the old WordPress directory is deleted and the next boot
+ * installs WordPress from `playgroundUrlWithQueryApiArgs`.
+ *
+ * Callers must not use this for edits that can keep the existing files, such as
+ * changing PHP version or networking. Those should update site metadata and
+ * reboot. Longer term, the Dock UI should create a new Playground for setup
+ * changes and leave the previous Playground untouched. Until that UX exists,
+ * this function writes `opfsResetPending` so a reload can finish deleting old
+ * WordPress files if the tab closes during the deletion.
  */
 export function resetAutosavedSiteSpec(
 	siteSlug: string,
@@ -656,7 +665,7 @@ export function resetAutosavedSiteSpec(
 		}
 		if (!isAutosavedSite(site)) {
 			throw new Error(
-				`Cannot reset ${siteSlug}; only autosaved Playgrounds can be recreated in place.`
+				`Cannot reset ${siteSlug}; only autosaved Playgrounds can replace their stored files.`
 			);
 		}
 
@@ -673,42 +682,50 @@ export function resetAutosavedSiteSpec(
 				type: 'opfs-site',
 			};
 		}
-		// Validate the new setup before deleting the old WordPress files so a
-		// broken Blueprint URL does not destroy the existing autosave.
-		// `isAutosavedSite()` requires OPFS storage; an autosaved site cannot be
-		// selected in a browser session where OPFS storage is unavailable.
-		await opfsSiteStorage!.resetSiteFiles(siteSlug);
 		const now = Date.now();
-		await dispatch(
-			updateSite({
-				slug: siteSlug,
-				changes: {
-					loadedFromStorage: false,
-					originalUrlParams: getOriginalUrlParams(
-						playgroundUrlWithQueryApiArgs
-					),
-					metadata: {
-						...site.metadata,
-						whenCreated: now,
-						whenLastUsed: now,
-						initialOpfsSyncPending: true,
-						/**
-						 * Recreating an autosaved Playground discards the old
-						 * WordPress files and boots from the updated setup.
-						 * Constants discovered from the previous runtime may no
-						 * longer exist in the recreated site, so they must be
-						 * rediscovered after the first OPFS sync.
-						 */
-						playgroundDefinedConstants: undefined,
-						sourceSetupUrlFingerprint:
-							getAutosaveFingerprintFromURL(
-								playgroundUrlWithQueryApiArgs
-							),
-						originalBlueprint: resolvedBlueprint.blueprint,
-						originalBlueprintSource,
-						runtimeConfiguration,
-					},
-				},
+		const changes = {
+			loadedFromStorage: false,
+			originalUrlParams: getOriginalUrlParams(
+				playgroundUrlWithQueryApiArgs
+			),
+			metadata: {
+				...site.metadata,
+				whenCreated: now,
+				whenLastUsed: now,
+				initialOpfsSyncPending: true,
+				/**
+				 * Recreating an autosaved Playground discards the old
+				 * WordPress files and boots from the updated setup.
+				 * Constants discovered from the previous runtime may no
+				 * longer exist in the recreated site, so they must be
+				 * rediscovered after the first OPFS sync.
+				 */
+				playgroundDefinedConstants: undefined,
+				sourceSetupUrlFingerprint: getAutosaveFingerprintFromURL(
+					playgroundUrlWithQueryApiArgs
+				),
+				originalBlueprint: resolvedBlueprint.blueprint,
+				originalBlueprintSource,
+				runtimeConfiguration,
+			},
+		};
+
+		// Resolve the new setup before deleting the old WordPress files so a
+		// broken Blueprint URL does not destroy the existing autosave. Keep
+		// Redux unchanged until the old files are gone; changing `whenCreated`
+		// remounts the iframe, and the old OPFS mount can still write files
+		// back into this site's OPFS directory until deletion finishes.
+		const completedChanges = await resetAutosavedSiteFilesWithPendingMarker(
+			siteSlug,
+			changes
+		);
+		// The helper already wrote these changes to OPFS before and after
+		// deleting files. Update Redux without writing the same metadata a
+		// third time.
+		dispatch(
+			sitesSlice.actions.updateSite({
+				id: siteSlug,
+				changes: completedChanges,
 			})
 		);
 	};
@@ -831,6 +848,17 @@ export interface SiteMetadata {
 	 * OPFS and clear this flag after a successful sync.
 	 */
 	initialOpfsSyncPending?: boolean;
+	/**
+	 * Crash-recovery marker for replacing autosaved WordPress files.
+	 *
+	 * The current autosaved settings/Blueprint flows can keep the same slug
+	 * while changing the setup. They write new setup metadata before deleting
+	 * old WordPress files, so a browser crash can otherwise leave old files
+	 * paired with new metadata. When this flag is present, boot must finish
+	 * deleting the old files before it decides whether to mount OPFS or install
+	 * WordPress from the new setup.
+	 */
+	opfsResetPending?: boolean;
 	/**
 	 * PHP constants discovered from the running Playground and persisted so
 	 * they can be replayed after reload without changing the live boot config.

--- a/packages/playground/website/src/lib/state/redux/slice-sites.ts
+++ b/packages/playground/website/src/lib/state/redux/slice-sites.ts
@@ -50,7 +50,6 @@ export {
 	getSiteRecencyTimestamp,
 	getSitesSortedByRecency,
 	getSitePublicPersistence,
-	hasInterruptedInitialOpfsSync,
 	isAutosavedSite,
 	isExplicitlySavedSite,
 	wasSiteRecentlyInteractedWith,
@@ -858,7 +857,7 @@ export interface SiteMetadata {
 	 * deleting the old files before it decides whether to mount OPFS or install
 	 * WordPress from the new setup.
 	 */
-	opfsResetPending?: boolean;
+	opfsSiteRemovalPending?: boolean;
 	/**
 	 * PHP constants discovered from the running Playground and persisted so
 	 * they can be replayed after reload without changing the live boot config.

--- a/packages/playground/website/src/lib/state/redux/slice-ui.ts
+++ b/packages/playground/website/src/lib/state/redux/slice-ui.ts
@@ -8,6 +8,7 @@ export type SiteError =
 	| 'directory-handle-permission-denied'
 	| 'directory-handle-directory-does-not-exist'
 	| 'directory-handle-unknown-error'
+	| 'browser-storage-cleanup-failed'
 	| 'initial-opfs-sync-interrupted'
 	// @TODO: Improve name?
 	| 'site-boot-failed'


### PR DESCRIPTION
## What it does

Displays a useful, human-friendly error message when the user tries to boot an OPFS-stored Playground site whose files are incomplete.

## Rationale

When a user saves a Playground to browser storage, it triggers a MEMFS-to-OPFS sync. Closing the tab prematurely will interrupt it in the middle, leaving us with only a subset of site files. That's not enough to boot a site and today, before this PR, Playground fails with an opaque error. This PR makes that error explicit.

This failure mode exists also for autosaved sites. Changing the settings, such as the PHP version or WordPress version wipes out the site files from OPFS and recreates them. We can avoid this error mode entirely in the longer-term by creating new autosaves without removing the old ones.

## Implementation

This PR adds `opfsSiteRemovalPending` to OPFS metadata. Autosaved reset flows set it before deleting old WordPress files, preserve metadata and the editable Blueprint bundle, then clear it after cleanup.

`bootSiteClient()` checks the marker before mounting OPFS. If cleanup was interrupted, it retries deletion first; if deletion fails, it stops and shows a browser storage cleanup error.

The boot path now derives OPFS boot mode from metadata instead of probing files, and ignores stale async callbacks after an iframe is removed.

## Testing instructions

```bash
npm exec nx run playground-website:typecheck
npm exec nx lint playground-website
npm exec nx test playground-website
git diff --check
```

## Screenshots

**Saved Playground did not finish saving**

![Start a new Playground to continue](https://gist.githubusercontent.com/adamziel/e4033a308efb71cbe22789eef70fbcaa/raw/8284b69570b2643e116b51124b66dd85f2a4b5ee/interrupted-initial-save.png)

**Cleanup still failed after automatic retries**

![Close other Playground tabs, then reload](https://gist.githubusercontent.com/adamziel/e4033a308efb71cbe22789eef70fbcaa/raw/8284b69570b2643e116b51124b66dd85f2a4b5ee/interrupted-reset-cleanup.png)
