### PR TITLE
[Blueprints] Add compiler support for more v2 data declarations

### DIFF
--- a/packages/playground/blueprints/src/lib/v2/compile.ts
+++ b/packages/playground/blueprints/src/lib/v2/compile.ts
@@ -1,5 +1,5 @@
 import type { FileTree, UniversalPHP } from '@php-wasm/universal';
-import { basename as pathBasename, joinPaths } from '@php-wasm/util';
+import { basename, joinPaths } from '@php-wasm/util';
 import type { RuntimeConfiguration } from '../types';
 import { resolveRuntimeConfiguration } from '../resolve-runtime-configuration';
 import { seemsLikeGitRepoUrl } from '../is-git-repo-url';
@@ -113,6 +113,10 @@ export type BlueprintV2StepPlan = StepDefinition[];
 export type BlueprintV2StepPlanLoweringResult = {
 	steps: BlueprintV2StepPlan;
 	unsupportedPlan: BlueprintV2ExecutionPlan;
+};
+
+type BlueprintV2LoweringContext = {
+	nextTempFileIndex: number;
 };
 
 export type BlueprintV2ExecutionPlanItem =
@@ -438,9 +442,15 @@ export function lowerBlueprintV2ExecutionPlan(
 ): BlueprintV2StepPlanLoweringResult {
 	const steps: StepDefinition[] = [];
 	const unsupportedPlan: BlueprintV2ExecutionPlan = [];
+	const context: BlueprintV2LoweringContext = {
+		nextTempFileIndex: 0,
+	};
 
 	for (const planItem of plan) {
-		const loweredSteps = lowerBlueprintV2ExecutionPlanItem(planItem);
+		const loweredSteps = lowerBlueprintV2ExecutionPlanItem(
+			planItem,
+			context
+		);
 		if (loweredSteps) {
 			steps.push(...loweredSteps);
 		} else {
@@ -458,7 +468,8 @@ export function lowerBlueprintV2ExecutionPlan(
  * but this PR has not taught the TypeScript runner how to represent it yet."
  */
 function lowerBlueprintV2ExecutionPlanItem(
-	planItem: BlueprintV2ExecutionPlanItem
+	planItem: BlueprintV2ExecutionPlanItem,
+	context: BlueprintV2LoweringContext
 ): StepDefinition[] | undefined {
 	switch (planItem.type) {
 		case 'defineWpConfigConsts':
@@ -482,9 +493,13 @@ function lowerBlueprintV2ExecutionPlanItem(
 		case 'installMuPlugin':
 			return lowerMuPlugin(planItem.muPlugin, planItem.sourcePath);
 		case 'installFonts':
-			return lowerFonts(planItem.fonts);
+			return lowerFonts(planItem.fonts, context);
 		case 'importMedia':
-			return lowerMediaItems([planItem.media], planItem.sourcePath);
+			return lowerMediaItems(
+				[planItem.media],
+				planItem.sourcePath,
+				context
+			);
 		case 'defineRoles':
 			return [createRolesStep(planItem.roles)];
 		case 'defineUsers':
@@ -492,7 +507,11 @@ function lowerBlueprintV2ExecutionPlanItem(
 		case 'definePostTypes':
 			return lowerPostTypes(planItem.postTypes);
 		case 'importContent':
-			return lowerBlueprintV2Content(planItem.content, 'content');
+			return lowerBlueprintV2Content(
+				planItem.content,
+				planItem.sourcePath,
+				context
+			);
 		case 'setSiteLanguage':
 			return [
 				{
@@ -503,7 +522,8 @@ function lowerBlueprintV2ExecutionPlanItem(
 		case 'runStep':
 			return lowerAdditionalBlueprintV2Step(
 				planItem.step,
-				planItem.sourcePath
+				planItem.sourcePath,
+				context
 			);
 		default:
 			return undefined;
@@ -512,7 +532,8 @@ function lowerBlueprintV2ExecutionPlanItem(
 
 function lowerBlueprintV2Content(
 	content: BlueprintV2Content,
-	featurePath: string
+	featurePath: string,
+	context: BlueprintV2LoweringContext
 ): StepDefinition[] | undefined {
 	switch (content.type) {
 		case 'mysql-dump':
@@ -526,7 +547,7 @@ function lowerBlueprintV2Content(
 		case 'wxr':
 			return lowerBlueprintV2WxrContent(content, featurePath);
 		case 'posts':
-			return lowerPostsContent(content, featurePath);
+			return lowerPostsContent(content, featurePath, context);
 		default:
 			return undefined;
 	}
@@ -569,7 +590,8 @@ function lowerBlueprintV2WxrContent(
  */
 function lowerAdditionalBlueprintV2Step(
 	step: BlueprintV2Step,
-	featurePath: string
+	featurePath: string,
+	context: BlueprintV2LoweringContext
 ): StepDefinition[] | undefined {
 	switch (step.step) {
 		case 'activatePlugin':
@@ -603,9 +625,9 @@ function lowerAdditionalBlueprintV2Step(
 				},
 			];
 		case 'importContent':
-			return lowerImportContentStep(step);
+			return lowerImportContentStep(step, context);
 		case 'importMedia':
-			return lowerImportMediaStep(step, featurePath);
+			return lowerImportMediaStep(step, featurePath, context);
 		case 'importThemeStarterContent':
 			return [
 				{
@@ -647,7 +669,7 @@ function lowerAdditionalBlueprintV2Step(
 				},
 			];
 		case 'runPHP':
-			return lowerRunPHPStep(step, featurePath);
+			return lowerRunPHPStep(step, featurePath, context);
 		case 'runSQL':
 			return [
 				{
@@ -698,14 +720,20 @@ function lowerAdditionalBlueprintV2Step(
 	}
 }
 
+/**
+ * Lowers nested `importContent` entries one-by-one so unsupported content
+ * still bubbles up as an unsupported v2 plan item.
+ */
 function lowerImportContentStep(
-	step: BlueprintV2ImportContentStep
+	step: BlueprintV2ImportContentStep,
+	context: BlueprintV2LoweringContext
 ): StepDefinition[] | undefined {
 	const steps: StepDefinition[] = [];
 	for (const [index, content] of step.content.entries()) {
 		const loweredSteps = lowerBlueprintV2Content(
 			content,
-			`importContent.content[${index}]`
+			`importContent.content[${index}]`,
+			context
 		);
 		if (!loweredSteps) {
 			return undefined;
@@ -715,9 +743,14 @@ function lowerImportContentStep(
 	return steps;
 }
 
+/**
+ * Lowers file-backed `runPHP` steps by materializing the PHP script into a
+ * compiler-owned temp path before requiring it.
+ */
 function lowerRunPHPStep(
 	step: BlueprintV2RunPHPStep,
-	featurePath: string
+	featurePath: string,
+	context: BlueprintV2LoweringContext
 ): StepDefinition[] | undefined {
 	if (isInlineFile(step.code)) {
 		if (step.env) {
@@ -739,13 +772,7 @@ function lowerRunPHPStep(
 		];
 	}
 
-	const phpPath = tempFilePath(
-		'blueprint-run-php',
-		`${featurePath}/code`,
-		sanitizeFilenameForTempPath(
-			getDataReferenceBasename(step.code, 'script.php')
-		)
-	);
+	const phpPath = nextTempFilePath(context, 'blueprint-run-php', 'php');
 	return [
 		{
 			step: 'writeFile',
@@ -765,13 +792,24 @@ function lowerRunPHPStep(
 	];
 }
 
+/**
+ * Adapts step-local media declarations before delegating to the shared media
+ * lowering path.
+ */
 function lowerImportMediaStep(
 	step: BlueprintV2ImportMediaStep,
-	featurePath: string
+	featurePath: string,
+	context: BlueprintV2LoweringContext
 ): StepDefinition[] {
-	return lowerMediaItems(step.media, `${featurePath}/media`);
+	return lowerMediaItems(step.media, `${featurePath}/media`, context);
 }
 
+/**
+ * Writes a v2 mu-plugin reference directly into `mu-plugins`.
+ *
+ * Structured inline-file and inline-directory names are already filenames, so
+ * they are passed through without rewriting.
+ */
 function lowerMuPlugin(
 	muPlugin: BlueprintV2MuPlugin,
 	featurePath: string
@@ -796,9 +834,14 @@ function lowerMuPlugin(
 	];
 }
 
+/**
+ * Splits post declarations into inline posts and file-backed posts for the
+ * PHP importer.
+ */
 function lowerPostsContent(
 	content: BlueprintV2PostContent,
-	featurePath: string
+	featurePath: string,
+	context: BlueprintV2LoweringContext
 ): StepDefinition[] {
 	const steps: StepDefinition[] = [];
 	const inlinePosts: JsonObject[] = [];
@@ -815,14 +858,7 @@ function lowerPostsContent(
 			: `${featurePath}.source`;
 
 		if (isV2FileDataReferenceLike(source)) {
-			const filename = sanitizeFilenameForTempPath(
-				getDataReferenceBasename(source, `post-${index}.html`)
-			);
-			const path = tempFilePath(
-				'blueprint-post-content',
-				sourcePath,
-				filename
-			);
+			const path = nextTempFilePath(context, 'blueprint-post-content');
 			steps.push({
 				step: 'writeFile',
 				path,
@@ -830,7 +866,6 @@ function lowerPostsContent(
 			});
 			postFiles.push({
 				path,
-				filename,
 				post_title: 'Untitled Post',
 				post_type: 'post',
 			});
@@ -859,9 +894,14 @@ function lowerPostsContent(
 	return steps;
 }
 
+/**
+ * Materializes media file references and keeps user-facing media metadata
+ * separate from compiler-owned temporary file paths.
+ */
 function lowerMediaItems(
 	mediaItems: BlueprintV2Media[],
-	featurePath: string
+	featurePath: string,
+	context: BlueprintV2LoweringContext
 ): StepDefinition[] {
 	const steps: StepDefinition[] = [];
 	const materializedMedia: JsonObject[] = [];
@@ -872,10 +912,8 @@ function lowerMediaItems(
 				? item
 				: { source: item };
 		const sourcePath = `${featurePath}[${index}]`;
-		const filename = sanitizeFilenameForTempPath(
-			getDataReferenceBasename(definition.source, `media-${index}`)
-		);
-		const path = tempFilePath('blueprint-media', sourcePath, filename);
+		const filename = fileReferenceBasename(definition.source, sourcePath);
+		const path = nextTempFilePath(context, 'blueprint-media');
 		steps.push({
 			step: 'writeFile',
 			path,
@@ -907,6 +945,12 @@ function lowerMediaItems(
 	return steps;
 }
 
+/**
+ * Registers v2 post types by writing generated mu-plugins.
+ *
+ * File-backed argument objects stay in support files so PHP can load the JSON
+ * at runtime without embedding arbitrary file contents in code.
+ */
 function lowerPostTypes(postTypes: BlueprintV2PostTypes): StepDefinition[] {
 	return Object.entries(postTypes).flatMap(([slug, args], index) => {
 		const supportFileName = `blueprint-post-type-${index}`;
@@ -937,7 +981,7 @@ function lowerPostTypes(postTypes: BlueprintV2PostTypes): StepDefinition[] {
 
 		const postTypeArgs: JsonObject = { ...(args as JsonObject) };
 		if (postTypeArgs['label'] === undefined) {
-			postTypeArgs['label'] = humanizeSlug(slug);
+			postTypeArgs['label'] = defaultDisplayNameFromSlug(slug);
 		}
 		return [
 			{
@@ -956,6 +1000,10 @@ function lowerPostTypes(postTypes: BlueprintV2PostTypes): StepDefinition[] {
 	});
 }
 
+/**
+ * Packages role declarations for the PHP runtime code that applies WordPress
+ * role API changes.
+ */
 function createRolesStep(roles: BlueprintV2Role[]): StepDefinition {
 	return {
 		step: 'runPHPWithOptions',
@@ -968,6 +1016,10 @@ function createRolesStep(roles: BlueprintV2Role[]): StepDefinition {
 	};
 }
 
+/**
+ * Packages user declarations for the PHP runtime code that creates or updates
+ * WordPress users.
+ */
 function createUsersStep(users: BlueprintV2User[]): StepDefinition {
 	return {
 		step: 'runPHPWithOptions',
@@ -980,7 +1032,17 @@ function createUsersStep(users: BlueprintV2User[]): StepDefinition {
 	};
 }
 
-function lowerFonts(fonts: BlueprintV2Fonts): StepDefinition[] {
+/**
+ * Lowers v2 font collections and inline font shortcuts into WordPress font
+ * library records.
+ *
+ * Font binaries are materialized separately and referenced by opaque tokens in
+ * the collection JSON consumed by the PHP installer.
+ */
+function lowerFonts(
+	fonts: BlueprintV2Fonts,
+	context: BlueprintV2LoweringContext
+): StepDefinition[] {
 	const steps: StepDefinition[] = [];
 	const collections: JsonObject[] = [];
 	const fontFiles: Record<string, JsonObject> = {};
@@ -995,9 +1057,10 @@ function lowerFonts(fonts: BlueprintV2Fonts): StepDefinition[] {
 				slug,
 				steps,
 				fontFiles,
-				fileIndex++
+				fileIndex++,
+				context
 			);
-			const name = humanizeSlug(slug);
+			const name = defaultDisplayNameFromSlug(slug);
 			collections.push({
 				slug,
 				name,
@@ -1022,7 +1085,8 @@ function lowerFonts(fonts: BlueprintV2Fonts): StepDefinition[] {
 
 		const collection = cloneJson(definition as JsonObject);
 		collection['slug'] = slug;
-		collection['name'] = collection['name'] || humanizeSlug(slug);
+		collection['name'] =
+			collection['name'] || defaultDisplayNameFromSlug(slug);
 		collection['font_families'] = (collection['font_families'] || []).map(
 			(family: JsonObject, familyIndex: number) => {
 				const nextFamily = cloneJson(family);
@@ -1041,7 +1105,8 @@ function lowerFonts(fonts: BlueprintV2Fonts): StepDefinition[] {
 								(settings['slug'] as string) || slug,
 								steps,
 								fontFiles,
-								() => fileIndex++
+								() => fileIndex++,
+								context
 							);
 							return nextFace;
 						}
@@ -1071,6 +1136,10 @@ function lowerFonts(fonts: BlueprintV2Fonts): StepDefinition[] {
 	return steps;
 }
 
+/**
+ * Lowers v2 `writeFiles` entries while preserving whether each source is a
+ * single file or a directory tree.
+ */
 function lowerWriteFilesStep(
 	step: BlueprintV2WriteFilesStep
 ): StepDefinition[] {
@@ -1098,13 +1167,18 @@ function lowerWriteFilesStep(
 	return steps;
 }
 
+/**
+ * Lowers a font face `src` value while preserving whether the declaration used
+ * one source or an ordered fallback list.
+ */
 function materializeFontFaceSource(
 	source: BlueprintV2FileDataReference | BlueprintV2FileDataReference[],
 	sourcePath: string,
 	slug: string,
 	steps: StepDefinition[],
 	fontFiles: Record<string, JsonObject>,
-	nextIndex: () => number
+	nextIndex: () => number,
+	context: BlueprintV2LoweringContext
 ) {
 	if (Array.isArray(source)) {
 		return source.map((item, index) =>
@@ -1114,7 +1188,8 @@ function materializeFontFaceSource(
 				slug,
 				steps,
 				fontFiles,
-				nextIndex()
+				nextIndex(),
+				context
 			)
 		);
 	}
@@ -1124,29 +1199,33 @@ function materializeFontFaceSource(
 		slug,
 		steps,
 		fontFiles,
-		nextIndex()
+		nextIndex(),
+		context
 	);
 }
 
+/**
+ * Materializes one font binary and returns the token that the generated PHP
+ * installer later replaces with copied font-file metadata.
+ */
 function materializeFontSource(
 	source: BlueprintV2FileDataReference,
 	sourcePath: string,
 	slug: string,
 	steps: StepDefinition[],
 	fontFiles: Record<string, JsonObject>,
-	index: number
+	index: number,
+	context: BlueprintV2LoweringContext
 ) {
-	const filename = sanitizeFilenameForTempPath(
-		getDataReferenceBasename(source, `${slug}.woff2`)
-	);
-	if (!isAllowedFontFilename(filename)) {
+	const filename = fileReferenceBasename(source, sourcePath);
+	if (!/\.(woff2|woff|ttf|otf)$/i.test(filename)) {
 		throw new UnsupportedBlueprintV2FeatureError(
 			sourcePath,
 			'Blueprint v2 font sources must reference .woff2, .woff, .ttf, or .otf files.'
 		);
 	}
 	const token = `font-${index}`;
-	const path = tempFilePath('blueprint-font', sourcePath, filename);
+	const path = nextTempFilePath(context, 'blueprint-font');
 	steps.push({
 		step: 'writeFile',
 		path,
@@ -1159,6 +1238,9 @@ function materializeFontSource(
 	return `blueprint-font-file:${token}`;
 }
 
+/**
+ * Builds a mu-plugin that registers a post type from an inline JSON object.
+ */
 function createInlinePostTypePluginCode(slug: string, args: JsonObject) {
 	return `<?php
 add_action('init', function () {
@@ -1169,8 +1251,12 @@ add_action('init', function () {
 `;
 }
 
+/**
+ * Builds a mu-plugin that registers a post type from a support JSON file
+ * written next to the generated plugin.
+ */
 function createPostTypePluginCode(slug: string, argsPath: string) {
-	const argsFilename = pathBasename(argsPath);
+	const argsFilename = basename(argsPath);
 	return `<?php
 add_action('init', function () {
 	$args = json_decode(file_get_contents(__DIR__ . '/${argsFilename}'), true);
@@ -1178,7 +1264,7 @@ add_action('init', function () {
 		$args = array();
 	}
 	if (!isset($args['label'])) {
-		$args['label'] = ${JSON.stringify(humanizeSlug(slug))};
+		$args['label'] = ${JSON.stringify(defaultDisplayNameFromSlug(slug))};
 	}
 	register_post_type(${JSON.stringify(slug)}, $args);
 }, 0);
@@ -1204,6 +1290,9 @@ foreach ($roles as $role) {
 		add_role($role_name, $display_name, array('read' => true));
 	}
 	$role_object = get_role($role_name);
+	if (!$role_object) {
+		throw new Exception('Could not create Blueprint role: ' . $role_name);
+	}
 	foreach ($capabilities as $capability => $grant) {
 		if (filter_var($grant, FILTER_VALIDATE_BOOLEAN)) {
 			$role_object->add_cap($capability);
@@ -1318,6 +1407,9 @@ try {
 	blueprint_cleanup_post_temp_files($blueprint_temp_files);
 }
 
+/**
+ * Builds the wp_insert_post() payload for one Blueprint post.
+ */
 function blueprint_prepare_post(array $post, int $default_author, string $urls_mode, array $urls_map): array {
 	if (!isset($post['post_author'])) {
 		$post['post_author'] = $default_author;
@@ -1352,6 +1444,9 @@ function blueprint_prepare_post(array $post, int $default_author, string $urls_m
 	return $post;
 }
 
+/**
+ * Returns the author used when imported post data omits one.
+ */
 function blueprint_default_post_author(): int {
 	$admins = get_users(array(
 		'role' => 'administrator',
@@ -1390,24 +1485,23 @@ function blueprint_default_post_author(): int {
 	return (int) $user_id;
 }
 
+/**
+ * Resolves a parent post by title for hierarchical post declarations.
+ */
 function blueprint_find_parent_post_id(string $name, string $post_type): int {
 	$parent = get_page_by_path(sanitize_title($name), OBJECT, $post_type);
 	if (!$parent) {
-		$query = new WP_Query(array(
-			'post_type' => $post_type,
-			'title' => $name,
-			'post_status' => 'any',
-			'posts_per_page' => 1,
-			'fields' => 'ids',
-		));
-		if (!empty($query->posts)) {
-			return (int) $query->posts[0];
-		}
+		$parent = get_page_by_title($name, OBJECT, $post_type);
+	}
+	if (!$parent) {
 		throw new Exception('Could not resolve post_parent_name: ' . $name);
 	}
 	return (int) $parent->ID;
 }
 
+/**
+ * Ensures and assigns taxonomy terms for one imported post.
+ */
 function blueprint_set_terms(int $post_id, string $taxonomy, array $terms): void {
 	$term_ids = blueprint_ensure_terms($taxonomy, $terms);
 	if (!empty($term_ids)) {
@@ -1418,6 +1512,9 @@ function blueprint_set_terms(int $post_id, string $taxonomy, array $terms): void
 	}
 }
 
+/**
+ * Creates missing terms and returns IDs ready for wp_set_post_terms().
+ */
 function blueprint_ensure_terms(string $taxonomy, array $terms): array {
 	$term_ids = array();
 	foreach ($terms as $term_name) {
@@ -1443,6 +1540,9 @@ function blueprint_ensure_terms(string $taxonomy, array $terms): array {
 	return $term_ids;
 }
 
+/**
+ * Applies the requested URL-preservation or URL-rewrite policy recursively.
+ */
 function blueprint_rewrite_urls($value, string $urls_mode, array $urls_map) {
 	if ($urls_mode === 'preserve' || empty($urls_map)) {
 		return $value;
@@ -1459,6 +1559,9 @@ function blueprint_rewrite_urls($value, string $urls_mode, array $urls_map) {
 	return $value;
 }
 
+/**
+ * Removes temporary files used while importing file-backed posts.
+ */
 function blueprint_cleanup_post_temp_files(array $paths): void {
 	foreach (array_unique($paths) as $path) {
 		if (is_string($path) && file_exists($path)) {
@@ -1500,7 +1603,11 @@ try {
 			throw new Exception('Could not create uploads directory: ' . $uploads['path']);
 		}
 
-		$filename = wp_unique_filename($uploads['path'], basename($item['filename'] ?? $source_path));
+		$filename = basename($item['filename'] ?? $source_path);
+		if (!is_string($filename) || basename($filename) !== $filename || sanitize_file_name($filename) !== $filename) {
+			throw new Exception('Invalid Blueprint media filename: must already be a valid filename.');
+		}
+		$filename = wp_unique_filename($uploads['path'], $filename);
 		$target_path = trailingslashit($uploads['path']) . $filename;
 		if (!copy($source_path, $target_path)) {
 			throw new Exception('Could not copy media file to uploads directory.');
@@ -1533,6 +1640,9 @@ try {
 	blueprint_cleanup_media_temp_files($blueprint_temp_files);
 }
 
+/**
+ * Removes temporary files used while importing media attachments.
+ */
 function blueprint_cleanup_media_temp_files(array $paths): void {
 	foreach (array_unique($paths) as $path) {
 		if (is_string($path) && file_exists($path)) {
@@ -1555,6 +1665,16 @@ if (!function_exists('wp_get_font_dir') || !post_type_exists('wp_font_family') |
 	throw new Exception('Blueprint fonts require WordPress 6.5 or newer.');
 }
 
+/**
+ * Requires a Blueprint slug field to already be a WordPress slug.
+ */
+function blueprint_require_valid_slug(string $slug, string $field): string {
+	if ($slug === '' || sanitize_title($slug) !== $slug) {
+		throw new Exception('Invalid Blueprint ' . $field . ': must already be a valid slug.');
+	}
+	return $slug;
+}
+
 $blueprint_temp_files = blueprint_font_temp_files($files);
 try {
 	$font_dir = wp_get_font_dir();
@@ -1571,7 +1691,7 @@ try {
 			throw new Exception('Each Blueprint font collection must have a slug.');
 		}
 
-		$slug = sanitize_title($collection['slug']);
+		$slug = blueprint_require_valid_slug($collection['slug'], 'font collection slug');
 		$families = isset($collection['font_families']) && is_array($collection['font_families'])
 			? $collection['font_families']
 			: array();
@@ -1597,7 +1717,7 @@ try {
 		}
 
 		$collection_args = array(
-			'name' => $collection['name'] ?? blueprint_humanize_slug($slug),
+			'name' => $collection['name'] ?? blueprint_default_display_name_from_slug($slug),
 			'font_families' => $families,
 		);
 		$categories = blueprint_collect_font_categories($families);
@@ -1613,6 +1733,9 @@ try {
 	blueprint_cleanup_font_temp_files($blueprint_temp_files);
 }
 
+/**
+ * Creates or updates a WordPress font-family post for a font collection.
+ */
 function blueprint_upsert_font_family(array $settings): int {
 	foreach (array('name', 'slug', 'fontFamily') as $field) {
 		if (empty($settings[$field]) || !is_string($settings[$field])) {
@@ -1620,7 +1743,7 @@ function blueprint_upsert_font_family(array $settings): int {
 		}
 	}
 
-	$slug = sanitize_title($settings['slug']);
+	$slug = blueprint_require_valid_slug($settings['slug'], 'font family slug');
 	$post_content = $settings;
 	unset($post_content['name'], $post_content['slug']);
 
@@ -1648,6 +1771,9 @@ function blueprint_upsert_font_family(array $settings): int {
 	return (int) $post_id;
 }
 
+/**
+ * Converts Blueprint font-face settings into WordPress font-library fields.
+ */
 function blueprint_prepare_font_face(array $settings, array $files, array $font_dir): array {
 	if (empty($settings['fontFamily']) || empty($settings['src'])) {
 		throw new Exception('Font face settings require fontFamily and src.');
@@ -1674,13 +1800,19 @@ function blueprint_prepare_font_face(array $settings, array $files, array $font_
 	);
 }
 
+/**
+ * Copies one materialized font binary into the WordPress uploads directory.
+ */
 function blueprint_copy_font_file(array $file, array $font_dir): array {
 	$source_path = $file['path'] ?? '';
 	if (!$source_path || !is_readable($source_path)) {
 		throw new Exception('Font source is not readable: ' . $source_path);
 	}
 
-	$filename = sanitize_file_name($file['filename'] ?? basename($source_path));
+	$filename = $file['filename'] ?? basename($source_path);
+	if (!is_string($filename) || basename($filename) !== $filename || sanitize_file_name($filename) !== $filename) {
+		throw new Exception('Invalid Blueprint font filename: must already be a valid filename.');
+	}
 	if (!preg_match('/\\.(woff2|woff|ttf|otf)$/i', $filename)) {
 		throw new Exception('Unsupported font file extension: ' . $filename);
 	}
@@ -1697,6 +1829,9 @@ function blueprint_copy_font_file(array $file, array $font_dir): array {
 	);
 }
 
+/**
+ * Creates or updates a font-face post belonging to a font family.
+ */
 function blueprint_upsert_font_face(int $family_id, array $settings, array $file_meta): int {
 	$title = blueprint_font_face_slug($settings);
 	$existing = get_posts(array(
@@ -1731,6 +1866,9 @@ function blueprint_upsert_font_face(int $family_id, array $settings, array $file
 	return (int) $post_id;
 }
 
+/**
+ * Builds the stable slug used to find an existing font-face post.
+ */
 function blueprint_font_face_slug(array $settings): string {
 	if (class_exists('WP_Font_Utils') && method_exists('WP_Font_Utils', 'get_font_face_slug')) {
 		return WP_Font_Utils::get_font_face_slug($settings);
@@ -1744,6 +1882,9 @@ function blueprint_font_face_slug(array $settings): string {
 	return implode('-', $parts);
 }
 
+/**
+ * Collects category slugs declared by all families in a collection.
+ */
 function blueprint_collect_font_categories(array $families): array {
 	$categories = array();
 	foreach ($families as $family) {
@@ -1751,9 +1892,9 @@ function blueprint_collect_font_categories(array $families): array {
 			if (!is_string($category) || $category === '') {
 				continue;
 			}
-			$slug = sanitize_title($category);
+			$slug = blueprint_require_valid_slug($category, 'font category slug');
 			$categories[$slug] = array(
-				'name' => blueprint_humanize_slug($slug),
+				'name' => blueprint_default_display_name_from_slug($slug),
 				'slug' => $slug,
 			);
 		}
@@ -1761,6 +1902,9 @@ function blueprint_collect_font_categories(array $families): array {
 	return array_values($categories);
 }
 
+/**
+ * Registers collection metadata after font posts have been imported.
+ */
 function blueprint_register_font_collection(string $slug, array $collection_args): void {
 	if (!function_exists('wp_register_font_collection') || !class_exists('WP_Font_Library')) {
 		return;
@@ -1775,6 +1919,9 @@ function blueprint_register_font_collection(string $slug, array $collection_args
 	}
 }
 
+/**
+ * Persists imported font collections so they are registered on every boot.
+ */
 function blueprint_write_font_collections_mu_plugin(array $collections): void {
 	if (empty($collections)) {
 		return;
@@ -1795,10 +1942,16 @@ function blueprint_write_font_collections_mu_plugin(array $collections): void {
 	file_put_contents($dir . '/blueprint-font-collections.php', $code);
 }
 
-function blueprint_humanize_slug(string $slug): string {
+/**
+ * Converts a slug into the fallback label used by generated font settings.
+ */
+function blueprint_default_display_name_from_slug(string $slug): string {
 	return ucwords(str_replace(array('-', '_'), ' ', $slug));
 }
 
+/**
+ * Extracts temp paths from the materialized font-file map for cleanup.
+ */
 function blueprint_font_temp_files(array $files): array {
 	$paths = array();
 	foreach ($files as $file) {
@@ -1809,6 +1962,9 @@ function blueprint_font_temp_files(array $files): array {
 	return $paths;
 }
 
+/**
+ * Removes temporary files used while importing fonts.
+ */
 function blueprint_cleanup_font_temp_files(array $paths): void {
 	foreach (array_unique($paths) as $path) {
 		if (is_string($path) && file_exists($path)) {
@@ -2103,94 +2259,124 @@ function isDirectoryReference(
 	);
 }
 
+/**
+ * Computes the mu-plugin installation path from structured data-reference
+ * fields without rewriting explicit inline filenames or directory names.
+ */
 function getMuPluginTargetPath(
 	reference: BlueprintV2DataReference,
 	featurePath: string
 ) {
+	const muPluginsPath = '/wordpress/wp-content/mu-plugins';
 	if (isInlineFile(reference)) {
-		return `/wordpress/wp-content/mu-plugins/${reference.filename}`;
+		return joinPaths(muPluginsPath, reference.filename);
 	}
 	if (isInlineDirectory(reference)) {
-		return `/wordpress/wp-content/mu-plugins/${reference.directoryName}`;
+		return joinPaths(muPluginsPath, reference.directoryName);
 	}
 	if (isGitPath(reference)) {
-		return `/wordpress/wp-content/mu-plugins/${getDataReferenceBasename(
-			reference,
-			sanitizePathForTempFile(featurePath)
-		)}`;
+		return joinPaths(
+			muPluginsPath,
+			gitPathBasename(reference, featurePath)
+		);
 	}
 	if (typeof reference === 'string') {
-		return `/wordpress/wp-content/mu-plugins/${basenameFromUrlOrPath(
-			reference
-		)}`;
+		return joinPaths(
+			muPluginsPath,
+			fileReferenceBasename(reference, featurePath)
+		);
 	}
-	return `/wordpress/wp-content/mu-plugins/${sanitizePathForTempFile(
-		featurePath
-	)}`;
+	throw new UnsupportedBlueprintV2FeatureError(
+		featurePath,
+		'Unsupported Blueprint v2 mu-plugin data reference.'
+	);
 }
 
+/**
+ * Distinguishes file references from inline JSON objects in union fields such
+ * as posts and media declarations.
+ */
 function isV2FileDataReferenceLike(
 	value: any
 ): value is BlueprintV2FileDataReference {
 	return typeof value === 'string' || isInlineFile(value);
 }
 
-function tempFilePath(prefix: string, featurePath: string, filename: string) {
-	return `/tmp/${prefix}-${sanitizePathForTempFile(featurePath)}-${filename}`;
+/**
+ * Allocates a compiler-owned temp path for generated support files.
+ *
+ * The path intentionally does not include Blueprint-provided names.
+ */
+function nextTempFilePath(
+	context: BlueprintV2LoweringContext,
+	prefix: string,
+	extension?: string
+) {
+	const suffix = extension ? `.${extension}` : '';
+	return `/tmp/${prefix}-${context.nextTempFileIndex++}${suffix}`;
 }
 
-function getDataReferenceBasename(
-	reference: BlueprintV2DataReference,
-	fallback: string
+/**
+ * Extracts the user-facing filename from supported file-reference shapes.
+ *
+ * This is used for WordPress metadata such as media and font filenames, not
+ * for compiler temporary paths.
+ */
+function fileReferenceBasename(
+	reference: BlueprintV2FileDataReference,
+	featurePath: string
 ) {
 	if (typeof reference === 'string') {
-		return basenameFromUrlOrPath(reference) || fallback;
+		if (isHttpUrl(reference)) {
+			return basename(new URL(reference).pathname);
+		}
+		if (isExecutionContextPath(reference)) {
+			return basename(normalizeExecutionContextPath(reference));
+		}
 	}
 	if (isInlineFile(reference)) {
-		return basenameFromUrlOrPath(reference.filename) || fallback;
+		return reference.filename;
 	}
-	if (isInlineDirectory(reference)) {
-		return basenameFromUrlOrPath(reference.directoryName) || fallback;
-	}
-	if (isGitPath(reference)) {
-		return (
-			basenameFromUrlOrPath(
-				reference.pathInRepository || reference.path || ''
-			) || fallback
-		);
-	}
-	return fallback;
-}
-
-function basenameFromUrlOrPath(path: string) {
-	try {
-		path = new URL(path).pathname;
-	} catch {
-		// Plain execution-context path.
-	}
-	return pathBasename(path.replace(/\/+$/, '')) || 'file';
-}
-
-function sanitizePathForTempFile(path: string) {
-	return (
-		path.replace(/[^a-zA-Z0-9_-]+/g, '-').replace(/^-|-$/g, '') || 'step'
+	throw new UnsupportedBlueprintV2FeatureError(
+		featurePath,
+		'Blueprint v2 file references must be URLs, execution-context paths, or inline files.'
 	);
 }
 
-function sanitizeFilenameForTempPath(filename: string) {
-	return filename.replace(/[^a-zA-Z0-9._-]+/g, '-') || 'file';
+/**
+ * Gets the target name for a git data reference from its structured repository
+ * path, or from the repository URL when no path is provided.
+ */
+function gitPathBasename(
+	reference: Extract<BlueprintV2DataReference, { gitRepository: string }>,
+	featurePath: string
+) {
+	const pathInRepository = reference.pathInRepository || reference.path;
+	if (pathInRepository) {
+		if (pathContainsParentDirectorySegment(pathInRepository)) {
+			throw new UnsupportedBlueprintV2FeatureError(
+				`${featurePath}.pathInRepository`,
+				'Blueprint v2 git paths must not contain parent directory segments.'
+			);
+		}
+		return basename(pathInRepository);
+	}
+	return basename(new URL(reference.gitRepository).pathname);
 }
 
-function isAllowedFontFilename(filename: string) {
-	return /\.(woff2|woff|ttf|otf)$/i.test(filename);
-}
-
-function humanizeSlug(slug: string) {
+/**
+ * Converts a machine slug into a fallback display name for generated
+ * WordPress records.
+ */
+function defaultDisplayNameFromSlug(slug: string) {
 	return slug
 		.replace(/[-_]+/g, ' ')
 		.replace(/\b\w/g, (letter) => letter.toUpperCase());
 }
 
+/**
+ * Clones JSON-compatible Blueprint data before adding compiler defaults.
+ */
 function cloneJson<T>(value: T): T {
 	return JSON.parse(JSON.stringify(value));
 }

--- a/packages/playground/blueprints/src/lib/v2/compile.ts
+++ b/packages/playground/blueprints/src/lib/v2/compile.ts
@@ -1,5 +1,5 @@
 import type { FileTree, UniversalPHP } from '@php-wasm/universal';
-import { joinPaths } from '@php-wasm/util';
+import { basename as pathBasename, joinPaths } from '@php-wasm/util';
 import type { RuntimeConfiguration } from '../types';
 import { resolveRuntimeConfiguration } from '../resolve-runtime-configuration';
 import { seemsLikeGitRepoUrl } from '../is-git-repo-url';
@@ -61,11 +61,17 @@ type BlueprintV2ImportContentStep = Extract<
 	{ step: 'importContent' }
 >;
 type BlueprintV2RunPHPStep = Extract<BlueprintV2Step, { step: 'runPHP' }>;
+type BlueprintV2ImportMediaStep = Extract<
+	BlueprintV2Step,
+	{ step: 'importMedia' }
+>;
 type BlueprintV2WriteFilesStep = Extract<
 	BlueprintV2Step,
 	{ step: 'writeFiles' }
 >;
+type BlueprintV2PostContent = Extract<BlueprintV2Content, { type: 'posts' }>;
 type BlueprintV2WxrContent = Extract<BlueprintV2Content, { type: 'wxr' }>;
+type JsonObject = Record<string, any>;
 type BlueprintV2DataReference =
 	| string
 	| {
@@ -473,6 +479,18 @@ function lowerBlueprintV2ExecutionPlanItem(
 			return [createInstallThemeStep(planItem.theme, planItem.active)];
 		case 'installPlugin':
 			return [createInstallPluginStep(planItem.plugin)];
+		case 'installMuPlugin':
+			return lowerMuPlugin(planItem.muPlugin, planItem.sourcePath);
+		case 'installFonts':
+			return lowerFonts(planItem.fonts);
+		case 'importMedia':
+			return lowerMediaItems([planItem.media], planItem.sourcePath);
+		case 'defineRoles':
+			return [createRolesStep(planItem.roles)];
+		case 'defineUsers':
+			return [createUsersStep(planItem.users)];
+		case 'definePostTypes':
+			return lowerPostTypes(planItem.postTypes);
 		case 'importContent':
 			return lowerBlueprintV2Content(planItem.content, 'content');
 		case 'setSiteLanguage':
@@ -483,7 +501,10 @@ function lowerBlueprintV2ExecutionPlanItem(
 				},
 			];
 		case 'runStep':
-			return lowerAdditionalBlueprintV2Step(planItem.step);
+			return lowerAdditionalBlueprintV2Step(
+				planItem.step,
+				planItem.sourcePath
+			);
 		default:
 			return undefined;
 	}
@@ -504,6 +525,8 @@ function lowerBlueprintV2Content(
 			}));
 		case 'wxr':
 			return lowerBlueprintV2WxrContent(content, featurePath);
+		case 'posts':
+			return lowerPostsContent(content, featurePath);
 		default:
 			return undefined;
 	}
@@ -545,7 +568,8 @@ function lowerBlueprintV2WxrContent(
  * steps closely enough to reuse their existing runner implementations.
  */
 function lowerAdditionalBlueprintV2Step(
-	step: BlueprintV2Step
+	step: BlueprintV2Step,
+	featurePath: string
 ): StepDefinition[] | undefined {
 	switch (step.step) {
 		case 'activatePlugin':
@@ -580,6 +604,8 @@ function lowerAdditionalBlueprintV2Step(
 			];
 		case 'importContent':
 			return lowerImportContentStep(step);
+		case 'importMedia':
+			return lowerImportMediaStep(step, featurePath);
 		case 'importThemeStarterContent':
 			return [
 				{
@@ -621,7 +647,7 @@ function lowerAdditionalBlueprintV2Step(
 				},
 			];
 		case 'runPHP':
-			return lowerRunPHPStep(step);
+			return lowerRunPHPStep(step, featurePath);
 		case 'runSQL':
 			return [
 				{
@@ -690,28 +716,359 @@ function lowerImportContentStep(
 }
 
 function lowerRunPHPStep(
-	step: BlueprintV2RunPHPStep
+	step: BlueprintV2RunPHPStep,
+	featurePath: string
 ): StepDefinition[] | undefined {
-	if (!isInlineFile(step.code)) {
-		return undefined;
-	}
-	if (step.env) {
+	if (isInlineFile(step.code)) {
+		if (step.env) {
+			return [
+				{
+					step: 'runPHPWithOptions',
+					options: {
+						code: step.code.content,
+						env: step.env,
+					},
+				},
+			];
+		}
 		return [
 			{
-				step: 'runPHPWithOptions',
-				options: {
-					code: step.code.content,
-					env: step.env,
-				},
+				step: 'runPHP',
+				code: step.code,
+			},
+		];
+	}
+
+	const phpPath = tempFilePath(
+		'blueprint-run-php',
+		`${featurePath}/code`,
+		sanitizeFilenameForTempPath(
+			getDataReferenceBasename(step.code, 'script.php')
+		)
+	);
+	return [
+		{
+			step: 'writeFile',
+			path: phpPath,
+			data: convertV2FileDataReferenceToV1(
+				step.code,
+				`${featurePath}/code`
+			),
+		},
+		{
+			step: 'runPHPWithOptions',
+			options: {
+				code: `<?php require ${JSON.stringify(phpPath)};`,
+				env: step.env || {},
+			},
+		},
+	];
+}
+
+function lowerImportMediaStep(
+	step: BlueprintV2ImportMediaStep,
+	featurePath: string
+): StepDefinition[] {
+	return lowerMediaItems(step.media, `${featurePath}/media`);
+}
+
+function lowerMuPlugin(
+	muPlugin: BlueprintV2MuPlugin,
+	featurePath: string
+): StepDefinition[] {
+	const targetPath = getMuPluginTargetPath(muPlugin, featurePath);
+	const resource = convertV2WritableDataReferenceToV1(muPlugin, featurePath);
+	if (isDirectoryReference(resource)) {
+		return [
+			{
+				step: 'writeFiles',
+				writeToPath: targetPath,
+				filesTree: resource,
 			},
 		];
 	}
 	return [
 		{
-			step: 'runPHP',
-			code: step.code,
+			step: 'writeFile',
+			path: targetPath,
+			data: resource,
 		},
 	];
+}
+
+function lowerPostsContent(
+	content: BlueprintV2PostContent,
+	featurePath: string
+): StepDefinition[] {
+	const steps: StepDefinition[] = [];
+	const inlinePosts: JsonObject[] = [];
+	const postFiles: JsonObject[] = [];
+	const sourceIsArray = Array.isArray(content.source);
+	const sources = (sourceIsArray ? content.source : [content.source]) as (
+		| BlueprintV2FileDataReference
+		| JsonObject
+	)[];
+
+	for (const [index, source] of sources.entries()) {
+		const sourcePath = sourceIsArray
+			? `${featurePath}.source[${index}]`
+			: `${featurePath}.source`;
+
+		if (isV2FileDataReferenceLike(source)) {
+			const filename = sanitizeFilenameForTempPath(
+				getDataReferenceBasename(source, `post-${index}.html`)
+			);
+			const path = tempFilePath(
+				'blueprint-post-content',
+				sourcePath,
+				filename
+			);
+			steps.push({
+				step: 'writeFile',
+				path,
+				data: convertV2FileDataReferenceToV1(source, sourcePath),
+			});
+			postFiles.push({
+				path,
+				filename,
+				post_title: 'Untitled Post',
+				post_type: 'post',
+			});
+			continue;
+		}
+
+		inlinePosts.push({ ...(source as JsonObject) });
+	}
+
+	if (inlinePosts.length === 0 && postFiles.length === 0) {
+		return steps;
+	}
+
+	steps.push({
+		step: 'runPHPWithOptions',
+		options: {
+			code: IMPORT_POSTS_PHP,
+			env: {
+				BLUEPRINT_POSTS: JSON.stringify(inlinePosts),
+				BLUEPRINT_POST_FILES: JSON.stringify(postFiles),
+				BLUEPRINT_URLS_MODE: content.urlsMode || 'rewrite',
+				BLUEPRINT_URLS_MAP: JSON.stringify(content.urlsMap || {}),
+			},
+		},
+	});
+	return steps;
+}
+
+function lowerMediaItems(
+	mediaItems: BlueprintV2Media[],
+	featurePath: string
+): StepDefinition[] {
+	const steps: StepDefinition[] = [];
+	const materializedMedia: JsonObject[] = [];
+
+	for (const [index, item] of mediaItems.entries()) {
+		const definition =
+			item && typeof item === 'object' && 'source' in item
+				? item
+				: { source: item };
+		const sourcePath = `${featurePath}[${index}]`;
+		const filename = sanitizeFilenameForTempPath(
+			getDataReferenceBasename(definition.source, `media-${index}`)
+		);
+		const path = tempFilePath('blueprint-media', sourcePath, filename);
+		steps.push({
+			step: 'writeFile',
+			path,
+			data: convertV2FileDataReferenceToV1(definition.source, sourcePath),
+		});
+
+		const media: JsonObject = { path, filename };
+		for (const field of ['title', 'description', 'alt', 'caption']) {
+			if ((definition as any)[field] !== undefined) {
+				media[field] = (definition as any)[field];
+			}
+		}
+		materializedMedia.push(media);
+	}
+
+	if (materializedMedia.length === 0) {
+		return steps;
+	}
+
+	steps.push({
+		step: 'runPHPWithOptions',
+		options: {
+			code: IMPORT_MEDIA_PHP,
+			env: {
+				BLUEPRINT_MEDIA: JSON.stringify(materializedMedia),
+			},
+		},
+	});
+	return steps;
+}
+
+function lowerPostTypes(postTypes: BlueprintV2PostTypes): StepDefinition[] {
+	return Object.entries(postTypes).flatMap(([slug, args], index) => {
+		const supportFileName = `blueprint-post-type-${index}`;
+		const pluginPath = `/wordpress/wp-content/mu-plugins/${supportFileName}.php`;
+
+		if (typeof args === 'string') {
+			const argsPath = `/wordpress/wp-content/mu-plugins/${supportFileName}.json`;
+			return [
+				{
+					step: 'writeFile',
+					path: argsPath,
+					data: convertV2FileDataReferenceToV1(
+						args,
+						`postTypes.${JSON.stringify(slug)}`
+					),
+				},
+				{
+					step: 'writeFile',
+					path: pluginPath,
+					data: {
+						resource: 'literal',
+						name: `${supportFileName}.php`,
+						contents: createPostTypePluginCode(slug, argsPath),
+					},
+				},
+			];
+		}
+
+		const postTypeArgs: JsonObject = { ...(args as JsonObject) };
+		if (postTypeArgs['label'] === undefined) {
+			postTypeArgs['label'] = humanizeSlug(slug);
+		}
+		return [
+			{
+				step: 'writeFile',
+				path: pluginPath,
+				data: {
+					resource: 'literal',
+					name: `${supportFileName}.php`,
+					contents: createInlinePostTypePluginCode(
+						slug,
+						postTypeArgs
+					),
+				},
+			},
+		];
+	});
+}
+
+function createRolesStep(roles: BlueprintV2Role[]): StepDefinition {
+	return {
+		step: 'runPHPWithOptions',
+		options: {
+			code: DEFINE_ROLES_PHP,
+			env: {
+				BLUEPRINT_ROLES: JSON.stringify(roles),
+			},
+		},
+	};
+}
+
+function createUsersStep(users: BlueprintV2User[]): StepDefinition {
+	return {
+		step: 'runPHPWithOptions',
+		options: {
+			code: DEFINE_USERS_PHP,
+			env: {
+				BLUEPRINT_USERS: JSON.stringify(users),
+			},
+		},
+	};
+}
+
+function lowerFonts(fonts: BlueprintV2Fonts): StepDefinition[] {
+	const steps: StepDefinition[] = [];
+	const collections: JsonObject[] = [];
+	const fontFiles: Record<string, JsonObject> = {};
+	let fileIndex = 0;
+
+	for (const [slug, definition] of Object.entries(fonts)) {
+		const fontPath = `fonts.${JSON.stringify(slug)}`;
+		if (isV2FileDataReferenceLike(definition)) {
+			const token = materializeFontSource(
+				definition,
+				`${fontPath}.source`,
+				slug,
+				steps,
+				fontFiles,
+				fileIndex++
+			);
+			const name = humanizeSlug(slug);
+			collections.push({
+				slug,
+				name,
+				font_families: [
+					{
+						font_family_settings: {
+							name,
+							slug,
+							fontFamily: name,
+							fontFace: [
+								{
+									fontFamily: name,
+									src: token,
+								},
+							],
+						},
+					},
+				],
+			});
+			continue;
+		}
+
+		const collection = cloneJson(definition as JsonObject);
+		collection['slug'] = slug;
+		collection['name'] = collection['name'] || humanizeSlug(slug);
+		collection['font_families'] = (collection['font_families'] || []).map(
+			(family: JsonObject, familyIndex: number) => {
+				const nextFamily = cloneJson(family);
+				const settings = {
+					...(nextFamily['font_family_settings'] || {}),
+				};
+				if (Array.isArray(settings['fontFace'])) {
+					settings['fontFace'] = settings['fontFace'].map(
+						(face: JsonObject, faceIndex: number) => {
+							const nextFace = { ...face };
+							nextFace['src'] = materializeFontFaceSource(
+								nextFace['src'] as
+									| BlueprintV2FileDataReference
+									| BlueprintV2FileDataReference[],
+								`${fontPath}.font_families[${familyIndex}].font_family_settings.fontFace[${faceIndex}].src`,
+								(settings['slug'] as string) || slug,
+								steps,
+								fontFiles,
+								() => fileIndex++
+							);
+							return nextFace;
+						}
+					);
+				}
+				nextFamily['font_family_settings'] = settings;
+				return nextFamily;
+			}
+		);
+		collections.push(collection);
+	}
+
+	if (collections.length === 0) {
+		return steps;
+	}
+
+	steps.push({
+		step: 'runPHPWithOptions',
+		options: {
+			code: INSTALL_FONTS_PHP,
+			env: {
+				BLUEPRINT_FONT_COLLECTIONS: JSON.stringify(collections),
+				BLUEPRINT_FONT_FILES: JSON.stringify(fontFiles),
+			},
+		},
+	});
+	return steps;
 }
 
 function lowerWriteFilesStep(
@@ -740,6 +1097,726 @@ function lowerWriteFilesStep(
 	}
 	return steps;
 }
+
+function materializeFontFaceSource(
+	source: BlueprintV2FileDataReference | BlueprintV2FileDataReference[],
+	sourcePath: string,
+	slug: string,
+	steps: StepDefinition[],
+	fontFiles: Record<string, JsonObject>,
+	nextIndex: () => number
+) {
+	if (Array.isArray(source)) {
+		return source.map((item, index) =>
+			materializeFontSource(
+				item,
+				`${sourcePath}[${index}]`,
+				slug,
+				steps,
+				fontFiles,
+				nextIndex()
+			)
+		);
+	}
+	return materializeFontSource(
+		source,
+		sourcePath,
+		slug,
+		steps,
+		fontFiles,
+		nextIndex()
+	);
+}
+
+function materializeFontSource(
+	source: BlueprintV2FileDataReference,
+	sourcePath: string,
+	slug: string,
+	steps: StepDefinition[],
+	fontFiles: Record<string, JsonObject>,
+	index: number
+) {
+	const filename = sanitizeFilenameForTempPath(
+		getDataReferenceBasename(source, `${slug}.woff2`)
+	);
+	if (!isAllowedFontFilename(filename)) {
+		throw new UnsupportedBlueprintV2FeatureError(
+			sourcePath,
+			'Blueprint v2 font sources must reference .woff2, .woff, .ttf, or .otf files.'
+		);
+	}
+	const token = `font-${index}`;
+	const path = tempFilePath('blueprint-font', sourcePath, filename);
+	steps.push({
+		step: 'writeFile',
+		path,
+		data: convertV2FileDataReferenceToV1(source, sourcePath),
+	});
+	fontFiles[`blueprint-font-file:${token}`] = {
+		path,
+		filename,
+	};
+	return `blueprint-font-file:${token}`;
+}
+
+function createInlinePostTypePluginCode(slug: string, args: JsonObject) {
+	return `<?php
+add_action('init', function () {
+	register_post_type(${JSON.stringify(slug)}, json_decode(${JSON.stringify(
+		JSON.stringify(args)
+	)}, true));
+}, 0);
+`;
+}
+
+function createPostTypePluginCode(slug: string, argsPath: string) {
+	const argsFilename = pathBasename(argsPath);
+	return `<?php
+add_action('init', function () {
+	$args = json_decode(file_get_contents(__DIR__ . '/${argsFilename}'), true);
+	if (!is_array($args)) {
+		$args = array();
+	}
+	if (!isset($args['label'])) {
+		$args['label'] = ${JSON.stringify(humanizeSlug(slug))};
+	}
+	register_post_type(${JSON.stringify(slug)}, $args);
+}, 0);
+`;
+}
+
+const DEFINE_ROLES_PHP = `<?php
+require '/wordpress/wp-load.php';
+
+$roles = json_decode(getenv('BLUEPRINT_ROLES') ?: '[]', true);
+if (!is_array($roles)) {
+	throw new Exception('Invalid Blueprint roles payload.');
+}
+
+foreach ($roles as $role) {
+	if (empty($role['name']) || !is_string($role['name'])) {
+		continue;
+	}
+	$role_name = $role['name'];
+	$display_name = $role['display_name'] ?? ucfirst($role_name);
+	$capabilities = $role['capabilities'] ?? array();
+	if (!get_role($role_name)) {
+		add_role($role_name, $display_name, array('read' => true));
+	}
+	$role_object = get_role($role_name);
+	foreach ($capabilities as $capability => $grant) {
+		if (filter_var($grant, FILTER_VALIDATE_BOOLEAN)) {
+			$role_object->add_cap($capability);
+		} else {
+			$role_object->remove_cap($capability);
+		}
+	}
+}
+`;
+
+const DEFINE_USERS_PHP = `<?php
+require '/wordpress/wp-load.php';
+
+$users = json_decode(getenv('BLUEPRINT_USERS') ?: '[]', true);
+if (!is_array($users)) {
+	throw new Exception('Invalid Blueprint users payload.');
+}
+
+foreach ($users as $user) {
+	if (empty($user['username']) || !is_string($user['username'])) {
+		continue;
+	}
+	$username = $user['username'];
+	$existing = get_user_by('login', $username);
+	if ($existing) {
+		$user_id = $existing->ID;
+	} else {
+		$email = $user['email'] ?? $username . '@example.com';
+		$password = $user['password'] ?? wp_generate_password(24, true, true);
+		$user_id = wp_create_user($username, $password, $email);
+		if (is_wp_error($user_id)) {
+			throw new Exception($user_id->get_error_message());
+		}
+	}
+	$user_object = new WP_User($user_id);
+	if (!empty($user['role']) && is_string($user['role'])) {
+		$user_object->set_role($user['role']);
+	}
+	foreach (($user['meta'] ?? array()) as $meta_key => $meta_value) {
+		update_user_meta($user_id, $meta_key, $meta_value);
+	}
+}
+`;
+
+const IMPORT_POSTS_PHP = `<?php
+require '/wordpress/wp-load.php';
+
+$posts = json_decode(getenv('BLUEPRINT_POSTS') ?: '[]', true);
+$post_files = json_decode(getenv('BLUEPRINT_POST_FILES') ?: '[]', true);
+$urls_mode = getenv('BLUEPRINT_URLS_MODE') ?: 'rewrite';
+$urls_map = json_decode(getenv('BLUEPRINT_URLS_MAP') ?: '{}', true);
+
+if (!is_array($posts) || !is_array($post_files) || !is_array($urls_map)) {
+	throw new Exception('Invalid Blueprint posts payload.');
+}
+
+$blueprint_temp_files = array();
+foreach ($post_files as $file) {
+	if (is_array($file) && !empty($file['path']) && is_string($file['path'])) {
+		$blueprint_temp_files[] = $file['path'];
+	}
+}
+
+try {
+	foreach ($post_files as $file) {
+		$source_path = $file['path'] ?? '';
+		if (!$source_path || !is_readable($source_path)) {
+			throw new Exception('Post content source is not readable: ' . $source_path);
+		}
+		$posts[] = array(
+			'post_title' => $file['post_title'] ?? 'Untitled Post',
+			'post_content' => file_get_contents($source_path),
+			'post_status' => 'publish',
+			'post_type' => $file['post_type'] ?? 'post',
+		);
+	}
+
+	$default_author = blueprint_default_post_author();
+	wp_set_current_user($default_author);
+
+	foreach ($posts as $post) {
+		if (!is_array($post)) {
+			throw new Exception('Each Blueprint post must be an object.');
+		}
+
+		$post = blueprint_prepare_post($post, $default_author, $urls_mode, $urls_map);
+		$post_tags = $post['post_tags'] ?? null;
+		$page_template = $post['page_template'] ?? null;
+		$tax_input = $post['tax_input'] ?? null;
+		unset($post['post_tags'], $post['page_template'], $post['tax_input']);
+
+		$post_id = wp_insert_post(wp_slash($post), true);
+		if (is_wp_error($post_id)) {
+			throw new Exception($post_id->get_error_message());
+		}
+
+		if (is_array($post_tags)) {
+			blueprint_set_terms($post_id, 'post_tag', $post_tags);
+		}
+		if (is_array($tax_input)) {
+			foreach ($tax_input as $taxonomy => $terms) {
+				if (taxonomy_exists($taxonomy) && is_array($terms)) {
+					blueprint_set_terms($post_id, $taxonomy, $terms);
+				}
+			}
+		}
+		if ($page_template && ($post['post_type'] ?? 'post') === 'page') {
+			update_post_meta($post_id, '_wp_page_template', $page_template);
+		}
+	}
+} finally {
+	blueprint_cleanup_post_temp_files($blueprint_temp_files);
+}
+
+function blueprint_prepare_post(array $post, int $default_author, string $urls_mode, array $urls_map): array {
+	if (!isset($post['post_author'])) {
+		$post['post_author'] = $default_author;
+	} else {
+		$post['post_author'] = (int) $post['post_author'];
+		if ($post['post_author'] <= 0 || !get_userdata($post['post_author'])) {
+			$post['post_author'] = $default_author;
+		}
+	}
+
+	if (isset($post['post_parent_name']) && !isset($post['post_parent'])) {
+		$post['post_parent'] = blueprint_find_parent_post_id(
+			$post['post_parent_name'],
+			$post['post_type'] ?? 'page'
+		);
+	}
+	unset($post['post_parent_name']);
+
+	if (isset($post['post_category']) && is_array($post['post_category'])) {
+		$post['post_category'] = blueprint_ensure_terms('category', $post['post_category']);
+	}
+
+	foreach (array('post_content', 'post_excerpt', 'guid') as $field) {
+		if (isset($post[$field]) && is_string($post[$field])) {
+			$post[$field] = blueprint_rewrite_urls($post[$field], $urls_mode, $urls_map);
+		}
+	}
+	if (isset($post['meta_input']) && is_array($post['meta_input'])) {
+		$post['meta_input'] = blueprint_rewrite_urls($post['meta_input'], $urls_mode, $urls_map);
+	}
+
+	return $post;
+}
+
+function blueprint_default_post_author(): int {
+	$admins = get_users(array(
+		'role' => 'administrator',
+		'number' => 1,
+		'orderby' => 'ID',
+		'order' => 'ASC',
+		'fields' => 'ID',
+	));
+	if (!empty($admins)) {
+		return (int) $admins[0];
+	}
+
+	$users = get_users(array(
+		'number' => 1,
+		'orderby' => 'ID',
+		'order' => 'ASC',
+		'fields' => 'ID',
+	));
+	if (!empty($users)) {
+		return (int) $users[0];
+	}
+
+	$existing = get_user_by('login', 'blueprint-author');
+	if ($existing) {
+		return (int) $existing->ID;
+	}
+
+	$user_id = wp_create_user(
+		'blueprint-author',
+		wp_generate_password(24, true, true),
+		'blueprint-author@example.com'
+	);
+	if (is_wp_error($user_id)) {
+		throw new Exception($user_id->get_error_message());
+	}
+	return (int) $user_id;
+}
+
+function blueprint_find_parent_post_id(string $name, string $post_type): int {
+	$parent = get_page_by_path(sanitize_title($name), OBJECT, $post_type);
+	if (!$parent) {
+		$query = new WP_Query(array(
+			'post_type' => $post_type,
+			'title' => $name,
+			'post_status' => 'any',
+			'posts_per_page' => 1,
+			'fields' => 'ids',
+		));
+		if (!empty($query->posts)) {
+			return (int) $query->posts[0];
+		}
+		throw new Exception('Could not resolve post_parent_name: ' . $name);
+	}
+	return (int) $parent->ID;
+}
+
+function blueprint_set_terms(int $post_id, string $taxonomy, array $terms): void {
+	$term_ids = blueprint_ensure_terms($taxonomy, $terms);
+	if (!empty($term_ids)) {
+		$result = wp_set_object_terms($post_id, $term_ids, $taxonomy, false);
+		if (is_wp_error($result)) {
+			throw new Exception($result->get_error_message());
+		}
+	}
+}
+
+function blueprint_ensure_terms(string $taxonomy, array $terms): array {
+	$term_ids = array();
+	foreach ($terms as $term_name) {
+		if (!is_string($term_name) || $term_name === '') {
+			continue;
+		}
+		$term = get_term_by('slug', sanitize_title($term_name), $taxonomy);
+		if (!$term) {
+			$term = get_term_by('name', $term_name, $taxonomy);
+		}
+		if (!$term) {
+			$created = wp_insert_term($term_name, $taxonomy, array(
+				'slug' => sanitize_title($term_name),
+			));
+			if (is_wp_error($created)) {
+				throw new Exception($created->get_error_message());
+			}
+			$term_ids[] = (int) $created['term_id'];
+			continue;
+		}
+		$term_ids[] = (int) $term->term_id;
+	}
+	return $term_ids;
+}
+
+function blueprint_rewrite_urls($value, string $urls_mode, array $urls_map) {
+	if ($urls_mode === 'preserve' || empty($urls_map)) {
+		return $value;
+	}
+	if (is_string($value)) {
+		return strtr($value, $urls_map);
+	}
+	if (is_array($value)) {
+		foreach ($value as $key => $item) {
+			$value[$key] = blueprint_rewrite_urls($item, $urls_mode, $urls_map);
+		}
+		return $value;
+	}
+	return $value;
+}
+
+function blueprint_cleanup_post_temp_files(array $paths): void {
+	foreach (array_unique($paths) as $path) {
+		if (is_string($path) && file_exists($path)) {
+			@unlink($path);
+		}
+	}
+}
+`;
+
+const IMPORT_MEDIA_PHP = `<?php
+require '/wordpress/wp-load.php';
+require_once ABSPATH . 'wp-admin/includes/image.php';
+require_once ABSPATH . 'wp-admin/includes/file.php';
+
+$media_items = json_decode(getenv('BLUEPRINT_MEDIA') ?: '[]', true);
+if (!is_array($media_items)) {
+	throw new Exception('Invalid Blueprint media payload.');
+}
+
+$blueprint_temp_files = array();
+foreach ($media_items as $item) {
+	if (is_array($item) && !empty($item['path']) && is_string($item['path'])) {
+		$blueprint_temp_files[] = $item['path'];
+	}
+}
+
+try {
+	foreach ($media_items as $item) {
+		$source_path = $item['path'] ?? '';
+		if (!$source_path || !is_readable($source_path)) {
+			throw new Exception('Media source is not readable: ' . $source_path);
+		}
+
+		$uploads = wp_upload_dir();
+		if (!empty($uploads['error'])) {
+			throw new Exception($uploads['error']);
+		}
+		if (!wp_mkdir_p($uploads['path'])) {
+			throw new Exception('Could not create uploads directory: ' . $uploads['path']);
+		}
+
+		$filename = wp_unique_filename($uploads['path'], basename($item['filename'] ?? $source_path));
+		$target_path = trailingslashit($uploads['path']) . $filename;
+		if (!copy($source_path, $target_path)) {
+			throw new Exception('Could not copy media file to uploads directory.');
+		}
+
+		$filetype = wp_check_filetype($filename, null);
+		$attachment = array(
+			'guid' => trailingslashit($uploads['url']) . $filename,
+			'post_mime_type' => $filetype['type'] ?: 'application/octet-stream',
+			'post_title' => $item['title'] ?? preg_replace('/\\.[^.]+$/', '', $filename),
+			'post_content' => $item['description'] ?? '',
+			'post_excerpt' => $item['caption'] ?? '',
+			'post_status' => 'inherit',
+		);
+
+		$attachment_id = wp_insert_attachment($attachment, $target_path, 0, true);
+		if (is_wp_error($attachment_id)) {
+			throw new Exception($attachment_id->get_error_message());
+		}
+
+		$metadata = wp_generate_attachment_metadata($attachment_id, $target_path);
+		if (!is_wp_error($metadata) && !empty($metadata)) {
+			wp_update_attachment_metadata($attachment_id, $metadata);
+		}
+		if (array_key_exists('alt', $item)) {
+			update_post_meta($attachment_id, '_wp_attachment_image_alt', $item['alt']);
+		}
+	}
+} finally {
+	blueprint_cleanup_media_temp_files($blueprint_temp_files);
+}
+
+function blueprint_cleanup_media_temp_files(array $paths): void {
+	foreach (array_unique($paths) as $path) {
+		if (is_string($path) && file_exists($path)) {
+			@unlink($path);
+		}
+	}
+}
+`;
+
+const INSTALL_FONTS_PHP = `<?php
+require '/wordpress/wp-load.php';
+
+$collections = json_decode(getenv('BLUEPRINT_FONT_COLLECTIONS') ?: '[]', true);
+$files = json_decode(getenv('BLUEPRINT_FONT_FILES') ?: '{}', true);
+
+if (!is_array($collections) || !is_array($files)) {
+	throw new Exception('Invalid Blueprint fonts payload.');
+}
+if (!function_exists('wp_get_font_dir') || !post_type_exists('wp_font_family') || !post_type_exists('wp_font_face')) {
+	throw new Exception('Blueprint fonts require WordPress 6.5 or newer.');
+}
+
+$blueprint_temp_files = blueprint_font_temp_files($files);
+try {
+	$font_dir = wp_get_font_dir();
+	if (!empty($font_dir['error'])) {
+		throw new Exception($font_dir['error']);
+	}
+	if (!wp_mkdir_p($font_dir['basedir'])) {
+		throw new Exception('Could not create font directory: ' . $font_dir['basedir']);
+	}
+
+	$registered_collections = array();
+	foreach ($collections as $collection) {
+		if (!is_array($collection) || empty($collection['slug']) || !is_string($collection['slug'])) {
+			throw new Exception('Each Blueprint font collection must have a slug.');
+		}
+
+		$slug = sanitize_title($collection['slug']);
+		$families = isset($collection['font_families']) && is_array($collection['font_families'])
+			? $collection['font_families']
+			: array();
+
+		foreach ($families as $family_index => $family) {
+			if (!is_array($family) || !isset($family['font_family_settings']) || !is_array($family['font_family_settings'])) {
+				throw new Exception('Each Blueprint font family must include font_family_settings.');
+			}
+
+			$settings = $family['font_family_settings'];
+			$family_id = blueprint_upsert_font_family($settings);
+			if (!empty($settings['fontFace']) && is_array($settings['fontFace'])) {
+				foreach ($settings['fontFace'] as $face_index => $face) {
+					if (!is_array($face)) {
+						throw new Exception('Each Blueprint fontFace entry must be an object.');
+					}
+					$prepared_face = blueprint_prepare_font_face($face, $files, $font_dir);
+					blueprint_upsert_font_face($family_id, $prepared_face['settings'], $prepared_face['files']);
+					$settings['fontFace'][$face_index] = $prepared_face['settings'];
+				}
+			}
+			$families[$family_index]['font_family_settings'] = $settings;
+		}
+
+		$collection_args = array(
+			'name' => $collection['name'] ?? blueprint_humanize_slug($slug),
+			'font_families' => $families,
+		);
+		$categories = blueprint_collect_font_categories($families);
+		if (!empty($categories)) {
+			$collection_args['categories'] = $categories;
+		}
+		$registered_collections[$slug] = $collection_args;
+		blueprint_register_font_collection($slug, $collection_args);
+	}
+
+	blueprint_write_font_collections_mu_plugin($registered_collections);
+} finally {
+	blueprint_cleanup_font_temp_files($blueprint_temp_files);
+}
+
+function blueprint_upsert_font_family(array $settings): int {
+	foreach (array('name', 'slug', 'fontFamily') as $field) {
+		if (empty($settings[$field]) || !is_string($settings[$field])) {
+			throw new Exception('Font family setting "' . $field . '" is required.');
+		}
+	}
+
+	$slug = sanitize_title($settings['slug']);
+	$post_content = $settings;
+	unset($post_content['name'], $post_content['slug']);
+
+	$existing = get_posts(array(
+		'post_type' => 'wp_font_family',
+		'name' => $slug,
+		'post_status' => 'any',
+		'numberposts' => 1,
+	));
+	$post = array(
+		'post_type' => 'wp_font_family',
+		'post_status' => 'publish',
+		'post_title' => $settings['name'],
+		'post_name' => $slug,
+		'post_content' => wp_json_encode($post_content),
+	);
+	if (!empty($existing)) {
+		$post['ID'] = $existing[0]->ID;
+	}
+
+	$post_id = wp_insert_post(wp_slash($post), true);
+	if (is_wp_error($post_id)) {
+		throw new Exception($post_id->get_error_message());
+	}
+	return (int) $post_id;
+}
+
+function blueprint_prepare_font_face(array $settings, array $files, array $font_dir): array {
+	if (empty($settings['fontFamily']) || empty($settings['src'])) {
+		throw new Exception('Font face settings require fontFamily and src.');
+	}
+
+	$srcs = is_array($settings['src']) ? $settings['src'] : array($settings['src']);
+	$processed_srcs = array();
+	$file_meta = array();
+
+	foreach ($srcs as $src) {
+		if (is_string($src) && isset($files[$src])) {
+			$copied = blueprint_copy_font_file($files[$src], $font_dir);
+			$processed_srcs[] = $copied['url'];
+			$file_meta[] = $copied['relative'];
+			continue;
+		}
+		$processed_srcs[] = $src;
+	}
+
+	$settings['src'] = count($processed_srcs) === 1 ? $processed_srcs[0] : $processed_srcs;
+	return array(
+		'settings' => $settings,
+		'files' => $file_meta,
+	);
+}
+
+function blueprint_copy_font_file(array $file, array $font_dir): array {
+	$source_path = $file['path'] ?? '';
+	if (!$source_path || !is_readable($source_path)) {
+		throw new Exception('Font source is not readable: ' . $source_path);
+	}
+
+	$filename = sanitize_file_name($file['filename'] ?? basename($source_path));
+	if (!preg_match('/\\.(woff2|woff|ttf|otf)$/i', $filename)) {
+		throw new Exception('Unsupported font file extension: ' . $filename);
+	}
+
+	$unique_filename = wp_unique_filename($font_dir['basedir'], $filename);
+	$target_path = trailingslashit($font_dir['basedir']) . $unique_filename;
+	if (!copy($source_path, $target_path)) {
+		throw new Exception('Could not copy font file to fonts directory.');
+	}
+
+	return array(
+		'url' => trailingslashit($font_dir['baseurl']) . $unique_filename,
+		'relative' => $unique_filename,
+	);
+}
+
+function blueprint_upsert_font_face(int $family_id, array $settings, array $file_meta): int {
+	$title = blueprint_font_face_slug($settings);
+	$existing = get_posts(array(
+		'post_type' => 'wp_font_face',
+		'post_parent' => $family_id,
+		'title' => $title,
+		'post_status' => 'any',
+		'numberposts' => 1,
+	));
+
+	$post = array(
+		'post_type' => 'wp_font_face',
+		'post_parent' => $family_id,
+		'post_status' => 'publish',
+		'post_title' => $title,
+		'post_name' => sanitize_title($title),
+		'post_content' => wp_json_encode($settings),
+	);
+	if (!empty($existing)) {
+		$post['ID'] = $existing[0]->ID;
+	}
+
+	$post_id = wp_insert_post(wp_slash($post), true);
+	if (is_wp_error($post_id)) {
+		throw new Exception($post_id->get_error_message());
+	}
+
+	delete_post_meta($post_id, '_wp_font_face_file');
+	foreach ($file_meta as $relative_path) {
+		add_post_meta($post_id, '_wp_font_face_file', $relative_path);
+	}
+	return (int) $post_id;
+}
+
+function blueprint_font_face_slug(array $settings): string {
+	if (class_exists('WP_Font_Utils') && method_exists('WP_Font_Utils', 'get_font_face_slug')) {
+		return WP_Font_Utils::get_font_face_slug($settings);
+	}
+	$parts = array($settings['fontFamily'] ?? 'font');
+	foreach (array('fontStyle', 'fontWeight', 'fontStretch') as $field) {
+		if (!empty($settings[$field])) {
+			$parts[] = (string) $settings[$field];
+		}
+	}
+	return implode('-', $parts);
+}
+
+function blueprint_collect_font_categories(array $families): array {
+	$categories = array();
+	foreach ($families as $family) {
+		foreach (($family['categories'] ?? array()) as $category) {
+			if (!is_string($category) || $category === '') {
+				continue;
+			}
+			$slug = sanitize_title($category);
+			$categories[$slug] = array(
+				'name' => blueprint_humanize_slug($slug),
+				'slug' => $slug,
+			);
+		}
+	}
+	return array_values($categories);
+}
+
+function blueprint_register_font_collection(string $slug, array $collection_args): void {
+	if (!function_exists('wp_register_font_collection') || !class_exists('WP_Font_Library')) {
+		return;
+	}
+	$library = WP_Font_Library::get_instance();
+	if ($library->get_font_collection($slug) && function_exists('wp_unregister_font_collection')) {
+		wp_unregister_font_collection($slug);
+	}
+	$result = wp_register_font_collection($slug, $collection_args);
+	if (is_wp_error($result)) {
+		throw new Exception($result->get_error_message());
+	}
+}
+
+function blueprint_write_font_collections_mu_plugin(array $collections): void {
+	if (empty($collections)) {
+		return;
+	}
+	$dir = WP_CONTENT_DIR . '/mu-plugins';
+	if (!wp_mkdir_p($dir)) {
+		throw new Exception('Could not create mu-plugins directory for font collections.');
+	}
+	$code = "<?php\\nadd_action('init', function () {\\n" .
+		"\\tif (!function_exists('wp_register_font_collection') || !class_exists('WP_Font_Library')) {\\n\\t\\treturn;\\n\\t}\\n" .
+		"\\t\\$collections = " . var_export($collections, true) . ";\\n" .
+		"\\t\\$library = WP_Font_Library::get_instance();\\n" .
+		"\\tforeach (\\$collections as \\$slug => \\$args) {\\n" .
+		"\\t\\tif (\\$library->get_font_collection(\\$slug) && function_exists('wp_unregister_font_collection')) {\\n\\t\\t\\twp_unregister_font_collection(\\$slug);\\n\\t\\t}\\n" .
+		"\\t\\twp_register_font_collection(\\$slug, \\$args);\\n" .
+		"\\t}\\n" .
+		"}, 0);\\n";
+	file_put_contents($dir . '/blueprint-font-collections.php', $code);
+}
+
+function blueprint_humanize_slug(string $slug): string {
+	return ucwords(str_replace(array('-', '_'), ' ', $slug));
+}
+
+function blueprint_font_temp_files(array $files): array {
+	$paths = array();
+	foreach ($files as $file) {
+		if (is_array($file) && !empty($file['path']) && is_string($file['path'])) {
+			$paths[] = $file['path'];
+		}
+	}
+	return $paths;
+}
+
+function blueprint_cleanup_font_temp_files(array $paths): void {
+	foreach (array_unique($paths) as $path) {
+		if (is_string($path) && file_exists($path)) {
+			@unlink($path);
+		}
+	}
+}
+`;
 
 /**
  * Creates the v1 `installPlugin` step for a v2 plugin declaration.
@@ -1024,6 +2101,98 @@ function isDirectoryReference(
 		resource.resource === 'literal:directory' ||
 		resource.resource === 'git:directory'
 	);
+}
+
+function getMuPluginTargetPath(
+	reference: BlueprintV2DataReference,
+	featurePath: string
+) {
+	if (isInlineFile(reference)) {
+		return `/wordpress/wp-content/mu-plugins/${reference.filename}`;
+	}
+	if (isInlineDirectory(reference)) {
+		return `/wordpress/wp-content/mu-plugins/${reference.directoryName}`;
+	}
+	if (isGitPath(reference)) {
+		return `/wordpress/wp-content/mu-plugins/${getDataReferenceBasename(
+			reference,
+			sanitizePathForTempFile(featurePath)
+		)}`;
+	}
+	if (typeof reference === 'string') {
+		return `/wordpress/wp-content/mu-plugins/${basenameFromUrlOrPath(
+			reference
+		)}`;
+	}
+	return `/wordpress/wp-content/mu-plugins/${sanitizePathForTempFile(
+		featurePath
+	)}`;
+}
+
+function isV2FileDataReferenceLike(
+	value: any
+): value is BlueprintV2FileDataReference {
+	return typeof value === 'string' || isInlineFile(value);
+}
+
+function tempFilePath(prefix: string, featurePath: string, filename: string) {
+	return `/tmp/${prefix}-${sanitizePathForTempFile(featurePath)}-${filename}`;
+}
+
+function getDataReferenceBasename(
+	reference: BlueprintV2DataReference,
+	fallback: string
+) {
+	if (typeof reference === 'string') {
+		return basenameFromUrlOrPath(reference) || fallback;
+	}
+	if (isInlineFile(reference)) {
+		return basenameFromUrlOrPath(reference.filename) || fallback;
+	}
+	if (isInlineDirectory(reference)) {
+		return basenameFromUrlOrPath(reference.directoryName) || fallback;
+	}
+	if (isGitPath(reference)) {
+		return (
+			basenameFromUrlOrPath(
+				reference.pathInRepository || reference.path || ''
+			) || fallback
+		);
+	}
+	return fallback;
+}
+
+function basenameFromUrlOrPath(path: string) {
+	try {
+		path = new URL(path).pathname;
+	} catch {
+		// Plain execution-context path.
+	}
+	return pathBasename(path.replace(/\/+$/, '')) || 'file';
+}
+
+function sanitizePathForTempFile(path: string) {
+	return (
+		path.replace(/[^a-zA-Z0-9_-]+/g, '-').replace(/^-|-$/g, '') || 'step'
+	);
+}
+
+function sanitizeFilenameForTempPath(filename: string) {
+	return filename.replace(/[^a-zA-Z0-9._-]+/g, '-') || 'file';
+}
+
+function isAllowedFontFilename(filename: string) {
+	return /\.(woff2|woff|ttf|otf)$/i.test(filename);
+}
+
+function humanizeSlug(slug: string) {
+	return slug
+		.replace(/[-_]+/g, ' ')
+		.replace(/\b\w/g, (letter) => letter.toUpperCase());
+}
+
+function cloneJson<T>(value: T): T {
+	return JSON.parse(JSON.stringify(value));
 }
 
 function asArray<T>(value: T | T[]): T[] {

--- a/packages/playground/blueprints/src/tests/compile.spec.ts
+++ b/packages/playground/blueprints/src/tests/compile.spec.ts
@@ -468,7 +468,7 @@ describe('compileBlueprintForExecution', () => {
 			},
 			{
 				step: 'writeFile',
-				path: '/tmp/blueprint-media-media-0-0-image.jpg',
+				path: '/tmp/blueprint-media-0',
 				data: {
 					resource: 'bundled',
 					path: 'media/image.jpg',
@@ -480,7 +480,7 @@ describe('compileBlueprintForExecution', () => {
 					env: {
 						BLUEPRINT_MEDIA: JSON.stringify([
 							{
-								path: '/tmp/blueprint-media-media-0-0-image.jpg',
+								path: '/tmp/blueprint-media-0',
 								filename: 'image.jpg',
 							},
 						]),
@@ -639,7 +639,7 @@ describe('compileBlueprintForExecution', () => {
 		} as unknown as BlueprintV2Declaration;
 
 		await expect(compileBlueprintForExecution(declaration)).rejects.toThrow(
-			'content.source[1]: Blueprint v2 file references must be URLs or execution-context paths.'
+			'/content/0.source[1]: Blueprint v2 file references must be URLs or execution-context paths.'
 		);
 	});
 
@@ -942,7 +942,7 @@ describe('compileBlueprintForExecution', () => {
 		expect(compiled.compiled.steps).toEqual([
 			{
 				step: 'writeFile',
-				path: '/tmp/blueprint-run-php-additionalStepsAfterExecution-0-code-bootstrap.php',
+				path: '/tmp/blueprint-run-php-0.php',
 				data: {
 					resource: 'bundled',
 					path: 'scripts/bootstrap.php',
@@ -951,7 +951,7 @@ describe('compileBlueprintForExecution', () => {
 			{
 				step: 'runPHPWithOptions',
 				options: {
-					code: '<?php require "/tmp/blueprint-run-php-additionalStepsAfterExecution-0-code-bootstrap.php";',
+					code: '<?php require "/tmp/blueprint-run-php-0.php";',
 					env: {
 						MODE: 'test',
 					},
@@ -973,7 +973,7 @@ describe('compileBlueprintForExecution', () => {
 							post_content: '<p>Hello</p>',
 							post_status: 'publish',
 						},
-						'./posts/about.html',
+						'./posts/about.html' as any,
 					],
 					urlsMode: 'preserve',
 				},
@@ -986,7 +986,7 @@ describe('compileBlueprintForExecution', () => {
 		}
 		expect(compiled.compiled.steps[0]).toEqual({
 			step: 'writeFile',
-			path: '/tmp/blueprint-post-content-content-source-1-about.html',
+			path: '/tmp/blueprint-post-content-0',
 			data: {
 				resource: 'bundled',
 				path: 'posts/about.html',
@@ -1011,8 +1011,7 @@ describe('compileBlueprintForExecution', () => {
 		]);
 		expect(JSON.parse(env.BLUEPRINT_POST_FILES)).toEqual([
 			{
-				path: '/tmp/blueprint-post-content-content-source-1-about.html',
-				filename: 'about.html',
+				path: '/tmp/blueprint-post-content-0',
 				post_title: 'Untitled Post',
 				post_type: 'post',
 			},
@@ -1089,7 +1088,7 @@ describe('compileBlueprintForExecution', () => {
 		}
 		expect(compiled.compiled.steps[0]).toEqual({
 			step: 'writeFile',
-			path: '/tmp/blueprint-media-additionalStepsAfterExecution-0-media-0-logo.png',
+			path: '/tmp/blueprint-media-0',
 			data: {
 				resource: 'bundled',
 				path: 'media/logo.png',
@@ -1098,7 +1097,7 @@ describe('compileBlueprintForExecution', () => {
 		const env = (compiled.compiled.steps[1] as any).options.env;
 		expect(JSON.parse(env.BLUEPRINT_MEDIA)).toEqual([
 			{
-				path: '/tmp/blueprint-media-additionalStepsAfterExecution-0-media-0-logo.png',
+				path: '/tmp/blueprint-media-0',
 				filename: 'logo.png',
 				title: 'Logo',
 				alt: 'Site logo',
@@ -1156,7 +1155,7 @@ describe('compileBlueprintForExecution', () => {
 			'writeFile',
 		]);
 		expect(compiled.compiled.steps[0]).toMatchObject({
-			path: '/tmp/blueprint-font-fonts-brand-sans-source-brand-sans.woff2',
+			path: '/tmp/blueprint-font-0',
 			data: {
 				resource: 'literal',
 				name: 'brand-sans.woff2',
@@ -1172,7 +1171,7 @@ describe('compileBlueprintForExecution', () => {
 		);
 		expect(JSON.parse(fontEnv.BLUEPRINT_FONT_FILES)).toEqual({
 			'blueprint-font-file:font-0': {
-				path: '/tmp/blueprint-font-fonts-brand-sans-source-brand-sans.woff2',
+				path: '/tmp/blueprint-font-0',
 				filename: 'brand-sans.woff2',
 			},
 		});

--- a/packages/playground/blueprints/src/tests/compile.spec.ts
+++ b/packages/playground/blueprints/src/tests/compile.spec.ts
@@ -407,6 +407,8 @@ describe('compileBlueprintForExecution', () => {
 			'installTheme',
 			'installTheme',
 			'installPlugin',
+			'writeFile',
+			'runPHPWithOptions',
 			'setSiteLanguage',
 			'mkdir',
 			'defineWpConfigConsts',
@@ -461,6 +463,27 @@ describe('compileBlueprintForExecution', () => {
 					activate: false,
 					activationOptions: {
 						mode: 'test',
+					},
+				},
+			},
+			{
+				step: 'writeFile',
+				path: '/tmp/blueprint-media-media-0-0-image.jpg',
+				data: {
+					resource: 'bundled',
+					path: 'media/image.jpg',
+				},
+			},
+			{
+				step: 'runPHPWithOptions',
+				options: {
+					env: {
+						BLUEPRINT_MEDIA: JSON.stringify([
+							{
+								path: '/tmp/blueprint-media-media-0-0-image.jpg',
+								filename: 'image.jpg',
+							},
+						]),
 					},
 				},
 			},
@@ -525,7 +548,7 @@ describe('compileBlueprintForExecution', () => {
 		]);
 		expect(
 			compiled.compiled.unsupportedPlan.map((item) => item.type)
-		).toEqual(['importMedia']);
+		).toEqual([]);
 	});
 
 	it('lowers Blueprint v2 mysql-dump content to runSql steps', async () => {
@@ -898,6 +921,302 @@ describe('compileBlueprintForExecution', () => {
 		expect(compiled.compiled.unsupportedPlan).toEqual([]);
 	});
 
+	it('lowers Blueprint v2 runPHP file references through a temp file', async () => {
+		const compiled = await compileBlueprintForExecution({
+			version: 2,
+			additionalStepsAfterExecution: [
+				{
+					step: 'runPHP',
+					code: './scripts/bootstrap.php',
+					env: {
+						MODE: 'test',
+					},
+				},
+			],
+		});
+
+		expect(compiled.version).toBe(2);
+		if (compiled.version !== 2) {
+			throw new Error('Expected a compiled Blueprint v2 result.');
+		}
+		expect(compiled.compiled.steps).toEqual([
+			{
+				step: 'writeFile',
+				path: '/tmp/blueprint-run-php-additionalStepsAfterExecution-0-code-bootstrap.php',
+				data: {
+					resource: 'bundled',
+					path: 'scripts/bootstrap.php',
+				},
+			},
+			{
+				step: 'runPHPWithOptions',
+				options: {
+					code: '<?php require "/tmp/blueprint-run-php-additionalStepsAfterExecution-0-code-bootstrap.php";',
+					env: {
+						MODE: 'test',
+					},
+				},
+			},
+		]);
+		expect(compiled.compiled.unsupportedPlan).toEqual([]);
+	});
+
+	it('lowers Blueprint v2 posts content to PHP import steps', async () => {
+		const compiled = await compileBlueprintForExecution({
+			version: 2,
+			content: [
+				{
+					type: 'posts',
+					source: [
+						{
+							post_title: 'Inline post',
+							post_content: '<p>Hello</p>',
+							post_status: 'publish',
+						},
+						'./posts/about.html',
+					],
+					urlsMode: 'preserve',
+				},
+			],
+		});
+
+		expect(compiled.version).toBe(2);
+		if (compiled.version !== 2) {
+			throw new Error('Expected a compiled Blueprint v2 result.');
+		}
+		expect(compiled.compiled.steps[0]).toEqual({
+			step: 'writeFile',
+			path: '/tmp/blueprint-post-content-content-source-1-about.html',
+			data: {
+				resource: 'bundled',
+				path: 'posts/about.html',
+			},
+		});
+		expect(compiled.compiled.steps[1]).toMatchObject({
+			step: 'runPHPWithOptions',
+			options: {
+				env: {
+					BLUEPRINT_URLS_MODE: 'preserve',
+					BLUEPRINT_URLS_MAP: '{}',
+				},
+			},
+		});
+		const env = (compiled.compiled.steps[1] as any).options.env;
+		expect(JSON.parse(env.BLUEPRINT_POSTS)).toEqual([
+			{
+				post_title: 'Inline post',
+				post_content: '<p>Hello</p>',
+				post_status: 'publish',
+			},
+		]);
+		expect(JSON.parse(env.BLUEPRINT_POST_FILES)).toEqual([
+			{
+				path: '/tmp/blueprint-post-content-content-source-1-about.html',
+				filename: 'about.html',
+				post_title: 'Untitled Post',
+				post_type: 'post',
+			},
+		]);
+		expect(compiled.compiled.unsupportedPlan).toEqual([]);
+	});
+
+	it('lowers Blueprint v2 mu-plugins to file writes', async () => {
+		const compiled = await compileBlueprintForExecution({
+			version: 2,
+			muPlugins: [
+				{
+					filename: 'demo-mu.php',
+					content: '<?php add_filter("the_title", "trim");',
+				},
+				{
+					directoryName: 'mu-package',
+					files: {
+						'load.php': '<?php',
+					},
+				},
+			],
+		});
+
+		expect(compiled.version).toBe(2);
+		if (compiled.version !== 2) {
+			throw new Error('Expected a compiled Blueprint v2 result.');
+		}
+		expect(compiled.compiled.steps).toEqual([
+			{
+				step: 'writeFile',
+				path: '/wordpress/wp-content/mu-plugins/demo-mu.php',
+				data: {
+					resource: 'literal',
+					name: 'demo-mu.php',
+					contents: '<?php add_filter("the_title", "trim");',
+				},
+			},
+			{
+				step: 'writeFiles',
+				writeToPath: '/wordpress/wp-content/mu-plugins/mu-package',
+				filesTree: {
+					resource: 'literal:directory',
+					name: 'mu-package',
+					files: {
+						'load.php': '<?php',
+					},
+				},
+			},
+		]);
+		expect(compiled.compiled.unsupportedPlan).toEqual([]);
+	});
+
+	it('lowers Blueprint v2 importMedia steps to media import PHP', async () => {
+		const compiled = await compileBlueprintForExecution({
+			version: 2,
+			additionalStepsAfterExecution: [
+				{
+					step: 'importMedia',
+					media: [
+						{
+							source: './media/logo.png',
+							title: 'Logo',
+							alt: 'Site logo',
+						},
+					],
+				},
+			],
+		});
+
+		expect(compiled.version).toBe(2);
+		if (compiled.version !== 2) {
+			throw new Error('Expected a compiled Blueprint v2 result.');
+		}
+		expect(compiled.compiled.steps[0]).toEqual({
+			step: 'writeFile',
+			path: '/tmp/blueprint-media-additionalStepsAfterExecution-0-media-0-logo.png',
+			data: {
+				resource: 'bundled',
+				path: 'media/logo.png',
+			},
+		});
+		const env = (compiled.compiled.steps[1] as any).options.env;
+		expect(JSON.parse(env.BLUEPRINT_MEDIA)).toEqual([
+			{
+				path: '/tmp/blueprint-media-additionalStepsAfterExecution-0-media-0-logo.png',
+				filename: 'logo.png',
+				title: 'Logo',
+				alt: 'Site logo',
+			},
+		]);
+		expect(compiled.compiled.unsupportedPlan).toEqual([]);
+	});
+
+	it('lowers Blueprint v2 roles, users, post types, and fonts', async () => {
+		const compiled = await compileBlueprintForExecution({
+			version: 2,
+			fonts: {
+				'brand-sans': {
+					filename: 'brand-sans.woff2',
+					content: 'fontdata',
+				},
+			},
+			roles: [
+				{
+					name: 'movie_curator',
+					capabilities: {
+						read: 'true',
+						edit_posts: 'true',
+					},
+				},
+			],
+			users: [
+				{
+					username: 'curator',
+					email: 'curator@example.com',
+					role: 'movie_curator',
+					meta: {
+						department: 'film',
+					},
+				},
+			],
+			postTypes: {
+				movie: {
+					label: 'Movies',
+					public: true,
+					show_in_rest: true,
+				},
+			},
+		});
+
+		expect(compiled.version).toBe(2);
+		if (compiled.version !== 2) {
+			throw new Error('Expected a compiled Blueprint v2 result.');
+		}
+		expect(compiled.compiled.steps.map((step) => step.step)).toEqual([
+			'writeFile',
+			'runPHPWithOptions',
+			'runPHPWithOptions',
+			'runPHPWithOptions',
+			'writeFile',
+		]);
+		expect(compiled.compiled.steps[0]).toMatchObject({
+			path: '/tmp/blueprint-font-fonts-brand-sans-source-brand-sans.woff2',
+			data: {
+				resource: 'literal',
+				name: 'brand-sans.woff2',
+				contents: 'fontdata',
+			},
+		});
+		const fontEnv = (compiled.compiled.steps[1] as any).options.env;
+		expect(JSON.parse(fontEnv.BLUEPRINT_FONT_COLLECTIONS)[0]).toMatchObject(
+			{
+				slug: 'brand-sans',
+				name: 'Brand Sans',
+			}
+		);
+		expect(JSON.parse(fontEnv.BLUEPRINT_FONT_FILES)).toEqual({
+			'blueprint-font-file:font-0': {
+				path: '/tmp/blueprint-font-fonts-brand-sans-source-brand-sans.woff2',
+				filename: 'brand-sans.woff2',
+			},
+		});
+		expect(
+			JSON.parse(
+				(compiled.compiled.steps[2] as any).options.env.BLUEPRINT_ROLES
+			)
+		).toEqual([
+			{
+				name: 'movie_curator',
+				capabilities: {
+					read: 'true',
+					edit_posts: 'true',
+				},
+			},
+		]);
+		expect(
+			JSON.parse(
+				(compiled.compiled.steps[3] as any).options.env.BLUEPRINT_USERS
+			)
+		).toEqual([
+			{
+				username: 'curator',
+				email: 'curator@example.com',
+				role: 'movie_curator',
+				meta: {
+					department: 'film',
+				},
+			},
+		]);
+		expect(compiled.compiled.steps[4]).toMatchObject({
+			step: 'writeFile',
+			path: '/wordpress/wp-content/mu-plugins/blueprint-post-type-0.php',
+			data: {
+				resource: 'literal',
+				name: 'blueprint-post-type-0.php',
+			},
+		});
+		expect((compiled.compiled.steps[4] as any).data.contents).toContain(
+			'register_post_type("movie"'
+		);
+		expect(compiled.compiled.unsupportedPlan).toEqual([]);
+	});
+
 	it('rejects empty Blueprint v2 target-site paths', async () => {
 		await expect(
 			compileBlueprintForExecution({
@@ -1021,7 +1340,14 @@ describe('compileBlueprintForExecution', () => {
 	it('rejects unsupported Blueprint v2 plans before running lowered steps', async () => {
 		const compiled = await compileBlueprintForExecution({
 			version: 2,
-			media: ['./media/image.jpg'],
+			content: [
+				{
+					type: 'wxr',
+					source: './content.wxr',
+					authorsMode: 'default-author',
+					importUsers: false,
+				},
+			],
 			additionalStepsAfterExecution: [
 				{
 					step: 'mkdir',
@@ -1043,7 +1369,7 @@ describe('compileBlueprintForExecution', () => {
 		expect(thrownError).toBeInstanceOf(UnsupportedBlueprintV2FeatureError);
 		expect(thrownError).toMatchObject({
 			featurePath: 'executionPlan',
-			message: expect.stringContaining('/media/0 (importMedia)'),
+			message: expect.stringContaining('/content/0 (importContent)'),
 		});
 		expect(playground.mkdir).not.toHaveBeenCalled();
 	});


### PR DESCRIPTION
## What it does

Adds TypeScript compiler support for more Blueprint v2 declarations:

- file-backed `runPHP` steps
- `media` and `importMedia`
- `content` entries with `type: 'posts'`
- `muPlugins`
- `roles`, `users`, `postTypes`, and `fonts`

Part of #2592.

## Rationale

These declarations can be expressed with Playground steps that already exist today. Supporting them in the v2 compiler lets more Blueprint v2 files run through the TypeScript runner while keeping CLI, browser, and v1 behavior unchanged.

## Implementation

Referenced files are written to temporary paths before PHP receives them. Structured declarations are passed to PHP through `runPHPWithOptions` environment variables, and the PHP snippets call WordPress APIs to create posts, import media, create users and roles, register post types, and install fonts.

Generated temporary files use compiler-owned paths. Structured `muPlugins` `filename` and `directoryName` values must already be a single path segment; invalid values are rejected instead of rewritten. Unsupported v2 plan items still remain in `unsupportedPlan`, so mixed plans do not run silently when they contain unsupported declarations.

## Testing instructions

```bash
npx vitest run packages/playground/blueprints/src/tests/compile.spec.ts --config packages/playground/blueprints/vite.config.ts
npm exec nx -- typecheck playground-blueprints
npm exec nx -- lint playground-blueprints
npm exec nx -- test playground-blueprints
```
