### PR TITLE
[Blueprints] Add runtime coverage for supported v2 declarations

### DIFF
--- a/packages/playground/blueprints/src/tests/v2/runtime-smoke.spec.ts
+++ b/packages/playground/blueprints/src/tests/v2/runtime-smoke.spec.ts
@@ -8,21 +8,31 @@ import {
 } from '@wp-playground/wordpress-builds';
 import { InMemoryFilesystem } from '@wp-playground/storage';
 import { readFile } from 'fs/promises';
-import { describe, beforeEach, afterEach, expect, it } from 'vitest';
+import { describe, beforeAll, beforeEach, afterEach, expect, it } from 'vitest';
 import { compileBlueprintForExecution } from '../../lib/compile';
 import type { BlueprintV2Declaration } from '../../lib/v2/blueprint-v2-declaration';
 
 describe('Blueprint v2 runtime smoke tests', () => {
 	let php: PHP;
 	let handler: PHPRequestHandler;
+	let wordPressZip: Awaited<ReturnType<typeof getWordPressModule>>;
+	let sqliteIntegrationPluginZip: Awaited<
+		ReturnType<typeof getSqliteDriverModule>
+	>;
+
+	beforeAll(async () => {
+		[wordPressZip, sqliteIntegrationPluginZip] = await Promise.all([
+			getWordPressModule(),
+			getSqliteDriverModule(),
+		]);
+	});
 
 	beforeEach(async () => {
 		handler = await bootWordPressAndRequestHandler({
-			createPhpRuntime: async () =>
-				await loadNodeRuntime(RecommendedPHPVersion),
+			createPhpRuntime: () => loadNodeRuntime(RecommendedPHPVersion),
 			siteUrl: 'http://playground-domain/',
-			wordPressZip: await getWordPressModule(),
-			sqliteIntegrationPluginZip: await getSqliteDriverModule(),
+			wordPressZip,
+			sqliteIntegrationPluginZip,
 		});
 		php = await handler.getPrimaryPhp();
 	});

--- a/packages/playground/blueprints/src/tests/v2/runtime-smoke.spec.ts
+++ b/packages/playground/blueprints/src/tests/v2/runtime-smoke.spec.ts
@@ -1,0 +1,218 @@
+import type { PHP, PHPRequestHandler } from '@php-wasm/universal';
+import { bootWordPressAndRequestHandler } from '@wp-playground/wordpress';
+import { loadNodeRuntime } from '@php-wasm/node';
+import { RecommendedPHPVersion } from '@wp-playground/common';
+import {
+	getSqliteDriverModule,
+	getWordPressModule,
+} from '@wp-playground/wordpress-builds';
+import { InMemoryFilesystem } from '@wp-playground/storage';
+import { readFile } from 'fs/promises';
+import { describe, beforeEach, afterEach, expect, it } from 'vitest';
+import { compileBlueprintForExecution } from '../../lib/compile';
+import type { BlueprintV2Declaration } from '../../lib/v2/blueprint-v2-declaration';
+
+describe('Blueprint v2 runtime smoke tests', () => {
+	let php: PHP;
+	let handler: PHPRequestHandler;
+
+	beforeEach(async () => {
+		handler = await bootWordPressAndRequestHandler({
+			createPhpRuntime: async () =>
+				await loadNodeRuntime(RecommendedPHPVersion),
+			siteUrl: 'http://playground-domain/',
+			wordPressZip: await getWordPressModule(),
+			sqliteIntegrationPluginZip: await getSqliteDriverModule(),
+		});
+		php = await handler.getPrimaryPhp();
+	});
+
+	afterEach(async () => {
+		php.exit();
+		await handler[Symbol.asyncDispose]();
+	});
+
+	it('creates roles and users', async () => {
+		await applyBlueprint({
+			version: 2,
+			roles: [
+				{
+					name: 'v2_runtime_editor',
+					capabilities: {
+						read: 'true',
+						edit_posts: 'true',
+					},
+				},
+			],
+			users: [
+				{
+					username: 'v2_runtime_user',
+					email: 'v2-runtime-user@example.com',
+					role: 'v2_runtime_editor',
+					meta: {
+						from_blueprint: 'yes',
+					},
+				},
+			],
+		});
+
+		const result = await runWordPressJson({
+			code: `
+				$user = get_user_by('login', 'v2_runtime_user');
+				echo json_encode([
+					'exists' => (bool) $user,
+					'roles' => $user ? array_values($user->roles) : [],
+					'can_edit_posts' => $user ? user_can($user, 'edit_posts') : false,
+					'meta' => $user ? get_user_meta($user->ID, 'from_blueprint', true) : null,
+				]);
+			`,
+		});
+
+		expect(result).toEqual({
+			exists: true,
+			roles: ['v2_runtime_editor'],
+			can_edit_posts: true,
+			meta: 'yes',
+		});
+	});
+
+	it('imports inline posts', async () => {
+		await applyBlueprint({
+			version: 2,
+			content: [
+				{
+					type: 'posts',
+					source: [
+						{
+							post_title: 'V2 Runtime Post',
+							post_name: 'v2-runtime-post',
+							post_content: '<p>Imported from Blueprint v2.</p>',
+							post_status: 'publish',
+						},
+					],
+				},
+			],
+		});
+
+		const result = await runWordPressJson({
+			code: `
+				$post = get_page_by_path('v2-runtime-post', OBJECT, 'post');
+				echo json_encode([
+					'exists' => (bool) $post,
+					'title' => $post ? $post->post_title : null,
+					'content' => $post ? $post->post_content : null,
+					'status' => $post ? $post->post_status : null,
+				]);
+			`,
+		});
+
+		expect(result).toEqual({
+			exists: true,
+			title: 'V2 Runtime Post',
+			content: '<p>Imported from Blueprint v2.</p>',
+			status: 'publish',
+		});
+	});
+
+	it('imports bundled media files', async () => {
+		const image = await readFile(
+			new URL('../fixtures/demo.png', import.meta.url)
+		);
+		const bundle = new InMemoryFilesystem({
+			'blueprint.json': JSON.stringify({
+				version: 2,
+				media: [
+					{
+						source: './media/demo.png',
+						title: 'V2 Runtime Image',
+						alt: 'Imported by a v2 Blueprint runtime test',
+					},
+				],
+			}),
+			media: {
+				'demo.png': image,
+			},
+		});
+
+		await applyBlueprint(bundle);
+
+		const result = await runWordPressJson({
+			code: `
+				$attachments = get_posts([
+					'post_type' => 'attachment',
+					'post_status' => 'inherit',
+					'numberposts' => -1,
+				]);
+				$match = null;
+				foreach ($attachments as $attachment) {
+					if ($attachment->post_title === 'V2 Runtime Image') {
+						$match = $attachment;
+						break;
+					}
+				}
+				echo json_encode([
+					'exists' => (bool) $match,
+					'mime_type' => $match ? $match->post_mime_type : null,
+					'alt' => $match ? get_post_meta($match->ID, '_wp_attachment_image_alt', true) : null,
+				]);
+			`,
+		});
+
+		expect(result).toEqual({
+			exists: true,
+			mime_type: 'image/png',
+			alt: 'Imported by a v2 Blueprint runtime test',
+		});
+	});
+
+	it('registers post types through generated mu-plugins', async () => {
+		await applyBlueprint({
+			version: 2,
+			postTypes: {
+				movie: {
+					label: 'Movies',
+					public: true,
+					show_in_rest: true,
+				},
+			},
+		});
+
+		const result = await runWordPressJson({
+			code: `
+				echo json_encode([
+					'exists' => post_type_exists('movie'),
+					'label' => post_type_exists('movie') ? get_post_type_object('movie')->label : null,
+				]);
+			`,
+		});
+
+		expect(result).toEqual({
+			exists: true,
+			label: 'Movies',
+		});
+	});
+
+	/**
+	 * Compiles and executes one v2 Blueprint against the booted WordPress site.
+	 */
+	async function applyBlueprint(
+		blueprint: BlueprintV2Declaration | InMemoryFilesystem
+	) {
+		const compiled = await compileBlueprintForExecution(blueprint);
+		expect(compiled.version).toBe(2);
+		await compiled.run(php);
+	}
+
+	/**
+	 * Loads WordPress and evaluates a small assertion script that returns JSON.
+	 */
+	async function runWordPressJson({ code }: { code: string }) {
+		const response = await php.run({
+			code: `<?php
+			require '/wordpress/wp-load.php';
+			${code}
+			`,
+		});
+		return response.json;
+	}
+});


### PR DESCRIPTION
## What it does

Adds runtime smoke tests for Blueprint v2 declarations that the TypeScript compiler already supports.

The tests run real v2 Blueprints and verify WordPress state after execution, covering representative declarations such as users/roles, posts, media, and post types.

## Rationale

Compiler tests already verify the generated step records. These tests prove those steps also work when executed through the Playground runtime and WordPress APIs.

## Implementation

Uses small v2 Blueprint fixtures in the existing blueprints test package. Each test applies one focused declaration set and asserts the resulting WordPress state.

## Testing instructions

```bash
npx vitest run packages/playground/blueprints/src/tests/v2/runtime-smoke.spec.ts --config packages/playground/blueprints/vite.config.ts
npm exec nx -- lint playground-blueprints
npm exec nx -- typecheck playground-blueprints
npm exec nx -- test playground-blueprints
```
