### PR TITLE
[Website] Classify saved Playground states

### DIFF
--- a/packages/playground/website/src/components/saved-playgrounds-overlay/is-valid-blueprint-draft.spec.ts
+++ b/packages/playground/website/src/components/saved-playgrounds-overlay/is-valid-blueprint-draft.spec.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { isValidBlueprintDraft } from './is-valid-blueprint-draft';
+
+describe('isValidBlueprintDraft', () => {
+	it('accepts JSON objects', () => {
+		expect(isValidBlueprintDraft('{"steps":[]}')).toBe(true);
+	});
+
+	it('rejects valid JSON values that are not objects', () => {
+		expect(isValidBlueprintDraft('[]')).toBe(false);
+		expect(isValidBlueprintDraft('null')).toBe(false);
+		expect(isValidBlueprintDraft('"blueprint"')).toBe(false);
+		expect(isValidBlueprintDraft('42')).toBe(false);
+	});
+
+	it('rejects empty or invalid JSON', () => {
+		expect(isValidBlueprintDraft('')).toBe(false);
+		expect(isValidBlueprintDraft('{')).toBe(false);
+	});
+});

--- a/packages/playground/website/src/components/saved-playgrounds-overlay/is-valid-blueprint-draft.ts
+++ b/packages/playground/website/src/components/saved-playgrounds-overlay/is-valid-blueprint-draft.ts
@@ -1,0 +1,20 @@
+/**
+ * Whether a "Write a Blueprint" draft is something we can boot a Playground
+ * from. A Blueprint must be a JSON object — valid JSON that parses to a string,
+ * number, boolean, null, or array would pass `JSON.parse` but crash the boot
+ * resolver, so those must not enable the Create button.
+ */
+export function isValidBlueprintDraft(text: string): boolean {
+	if (text.trim().length === 0) {
+		return false;
+	}
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(text);
+	} catch {
+		return false;
+	}
+	return (
+		typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)
+	);
+}

--- a/packages/playground/website/src/components/saved-playgrounds-overlay/storage-actions.spec.ts
+++ b/packages/playground/website/src/components/saved-playgrounds-overlay/storage-actions.spec.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { getPlaygroundStorageActions } from './storage-actions';
+
+describe('getPlaygroundStorageActions', () => {
+	it('allows local-directory saves even when OPFS is unavailable', () => {
+		expect(
+			getPlaygroundStorageActions({
+				isTemporary: true,
+				isAutosave: false,
+				isOpfsAvailable: false,
+				localFsAvailability: 'available',
+			})
+		).toEqual({
+			canStoreInBrowser: false,
+			canSaveToLocal: true,
+		});
+	});
+
+	it('hides save actions for already-stored Playgrounds', () => {
+		expect(
+			getPlaygroundStorageActions({
+				isTemporary: false,
+				isAutosave: false,
+				isOpfsAvailable: true,
+				localFsAvailability: 'available',
+			})
+		).toEqual({
+			canStoreInBrowser: false,
+			canSaveToLocal: false,
+		});
+	});
+
+	it('requires OPFS only for storing in browser storage', () => {
+		expect(
+			getPlaygroundStorageActions({
+				isTemporary: false,
+				isAutosave: true,
+				isOpfsAvailable: true,
+				localFsAvailability: 'not-available',
+			})
+		).toEqual({
+			canStoreInBrowser: true,
+			canSaveToLocal: false,
+		});
+	});
+});

--- a/packages/playground/website/src/components/saved-playgrounds-overlay/storage-actions.ts
+++ b/packages/playground/website/src/components/saved-playgrounds-overlay/storage-actions.ts
@@ -1,0 +1,26 @@
+import type { LocalFsAvailability } from '../../lib/hooks/use-local-fs-availability';
+
+/**
+ * Classifies which save actions should be shown for a Playground.
+ *
+ * Temporary and autosaved Playgrounds can still be persisted somewhere else.
+ * Explicitly stored Playgrounds already have durable storage, so the overlay
+ * should not offer another browser-storage or local-directory save action.
+ */
+export function getPlaygroundStorageActions({
+	isTemporary,
+	isAutosave,
+	isOpfsAvailable,
+	localFsAvailability,
+}: {
+	isTemporary: boolean;
+	isAutosave: boolean;
+	isOpfsAvailable: boolean;
+	localFsAvailability: LocalFsAvailability | null;
+}) {
+	const canPersistSite = isTemporary || isAutosave;
+	return {
+		canStoreInBrowser: canPersistSite && isOpfsAvailable,
+		canSaveToLocal: canPersistSite && localFsAvailability === 'available',
+	};
+}

--- a/packages/playground/website/src/lib/opfs-sync-progress.spec.ts
+++ b/packages/playground/website/src/lib/opfs-sync-progress.spec.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { getOpfsSyncProgressPercent } from './opfs-sync-progress';
+
+describe('getOpfsSyncProgressPercent', () => {
+	it('returns 0 when progress is missing or total is not positive', () => {
+		expect(getOpfsSyncProgressPercent(undefined)).toBe(0);
+		expect(getOpfsSyncProgressPercent({ files: 10, total: 0 })).toBe(0);
+		expect(getOpfsSyncProgressPercent({ files: 10, total: -1 })).toBe(0);
+	});
+
+	it('rounds progress and clamps it into the visible progressbar range', () => {
+		expect(getOpfsSyncProgressPercent({ files: 1, total: 3 })).toBe(33);
+		expect(getOpfsSyncProgressPercent({ files: -1, total: 3 })).toBe(0);
+		expect(getOpfsSyncProgressPercent({ files: 4, total: 3 })).toBe(100);
+	});
+});

--- a/packages/playground/website/src/lib/opfs-sync-progress.spec.ts
+++ b/packages/playground/website/src/lib/opfs-sync-progress.spec.ts
@@ -6,6 +6,18 @@ describe('getOpfsSyncProgressPercent', () => {
 		expect(getOpfsSyncProgressPercent(undefined)).toBe(0);
 		expect(getOpfsSyncProgressPercent({ files: 10, total: 0 })).toBe(0);
 		expect(getOpfsSyncProgressPercent({ files: 10, total: -1 })).toBe(0);
+		expect(
+			getOpfsSyncProgressPercent({ files: Number.NaN, total: 10 })
+		).toBe(0);
+		expect(
+			getOpfsSyncProgressPercent({ files: 10, total: Number.NaN })
+		).toBe(0);
+		expect(
+			getOpfsSyncProgressPercent({
+				files: Number.POSITIVE_INFINITY,
+				total: 10,
+			})
+		).toBe(0);
 	});
 
 	it('rounds progress and clamps it into the visible progressbar range', () => {

--- a/packages/playground/website/src/lib/opfs-sync-progress.ts
+++ b/packages/playground/website/src/lib/opfs-sync-progress.ts
@@ -1,0 +1,15 @@
+/**
+ * Turns OPFS file-count progress into a bounded 0–100 percentage for save
+ * progress indicators. Returns 0 when progress is unavailable or hasn't started.
+ */
+export function getOpfsSyncProgressPercent(
+	progress: { files: number; total: number } | undefined | null
+): number {
+	if (!progress || progress.total <= 0) {
+		return 0;
+	}
+	return Math.max(
+		0,
+		Math.min(100, Math.round((progress.files / progress.total) * 100))
+	);
+}

--- a/packages/playground/website/src/lib/opfs-sync-progress.ts
+++ b/packages/playground/website/src/lib/opfs-sync-progress.ts
@@ -5,7 +5,12 @@
 export function getOpfsSyncProgressPercent(
 	progress: { files: number; total: number } | undefined | null
 ): number {
-	if (!progress || progress.total <= 0) {
+	if (
+		!progress ||
+		!Number.isFinite(progress.files) ||
+		!Number.isFinite(progress.total) ||
+		progress.total <= 0
+	) {
 		return 0;
 	}
 	return Math.max(


### PR DESCRIPTION
## What it does

Adds small, tested helpers for UI decisions shared by saved Playground surfaces:

- `isValidBlueprintDraft()` accepts only JSON objects for "Write a Blueprint" drafts, so valid non-object JSON cannot enable a Playground boot path that expects a Blueprint object.
- `getPlaygroundStorageActions()` classifies whether a Playground can be saved to browser storage or to a local directory based on its lifecycle and available storage APIs.
- `getOpfsSyncProgressPercent()` converts OPFS file-count sync progress into a bounded 0–100 value for progress indicators, returning `0` for missing or non-finite progress values.

This is part of the Dock UI work tracked in #3965.

## Rationale

The saved Playgrounds overlay, save-status UI, and Dock need to answer the same state questions. Keeping those decisions in focused helpers makes the invariants reviewable on their own before they are wired into larger UI changes.

The helpers are additive in this PR. They do not change the current saved Playgrounds overlay, save modal, or browser chrome behavior.

## Implementation

The helpers stay near the surfaces that will use them: Blueprint draft and storage-action classifiers live under `saved-playgrounds-overlay`, while OPFS progress formatting lives under `src/lib` because multiple save-status surfaces can use it.

## Testing instructions

```bash
npm exec nx test playground-website --testFile=is-valid-blueprint-draft.spec.ts --testFile=storage-actions.spec.ts --testFile=opfs-sync-progress.spec.ts
npm exec nx lint playground-website
npm exec nx typecheck playground-website
```
