### PR TITLE
[Blueprints] Report progress for v2 compiler steps

### DIFF
--- a/packages/playground/blueprints/src/lib/compile.ts
+++ b/packages/playground/blueprints/src/lib/compile.ts
@@ -52,7 +52,8 @@ export async function compileBlueprintForExecution(
 	if (isBlueprintV2Declaration(declaration)) {
 		return compileBlueprintV2ForExecution(
 			isRawJsonInput ? declaration : input,
-			declaration
+			declaration,
+			options
 		);
 	}
 	if (isRawJsonInput) {
@@ -65,13 +66,17 @@ export async function compileBlueprintForExecution(
 
 async function compileBlueprintV2ForExecution(
 	input: Blueprint | BlueprintBundle,
-	declaration: BlueprintV2Declaration
+	declaration: BlueprintV2Declaration,
+	options: CompileBlueprintForExecutionOptions
 ): Promise<CompiledBlueprintForExecution> {
 	const compiled = await compileBlueprintV2(
 		declaration,
 		isBlueprintBundle(input)
-			? { streamBundledFile: (...args: [any]) => input.read(...args) }
-			: {}
+			? {
+					progress: options.progress,
+					streamBundledFile: (...args: [any]) => input.read(...args),
+				}
+			: { progress: options.progress }
 	);
 	return {
 		version: 2,

--- a/packages/playground/blueprints/src/lib/v1/compile.ts
+++ b/packages/playground/blueprints/src/lib/v1/compile.ts
@@ -703,7 +703,8 @@ function compileStep<S extends StepDefinition>(
 	}: CompileStepArgsOptions
 ): { run: CompiledV1Step; step: S; resources: Array<Resource<any>> } {
 	const stepProgress = rootProgressTracker.stage(
-		(step.progress?.weight || 1) / totalProgressWeight
+		(step.progress?.weight || 1) / totalProgressWeight,
+		step.progress?.caption
 	);
 
 	const args: any = {};
@@ -722,6 +723,9 @@ function compileStep<S extends StepDefinition>(
 
 	const run = async (playground: UniversalPHP) => {
 		try {
+			if (step.progress?.caption) {
+				stepProgress.setCaption(step.progress.caption);
+			}
 			stepProgress.fillSlowly();
 			return await keyedStepHandlers[step.step](
 				playground,

--- a/packages/playground/blueprints/src/lib/v2/compile.ts
+++ b/packages/playground/blueprints/src/lib/v2/compile.ts
@@ -452,13 +452,157 @@ export function lowerBlueprintV2ExecutionPlan(
 			context
 		);
 		if (loweredSteps) {
-			steps.push(...loweredSteps);
+			steps.push(...addProgressMetadata(loweredSteps, planItem));
 		} else {
 			unsupportedPlan.push(planItem);
 		}
 	}
 
 	return { steps, unsupportedPlan };
+}
+
+/**
+ * Assigns progress metadata to the v1 steps produced by one v2 plan item.
+ *
+ * Some v2 declarations expand into multiple v1 steps. Splitting one unit of
+ * progress across those steps keeps the tracker aligned with user-facing v2
+ * declarations instead of leaking the internal lowering shape.
+ */
+function addProgressMetadata(
+	steps: StepDefinition[],
+	planItem: BlueprintV2ExecutionPlanItem
+): StepDefinition[] {
+	if (steps.length === 0) {
+		return steps;
+	}
+	const caption = getProgressCaption(planItem);
+	const weight = 1 / steps.length;
+	return steps.map((step) => ({
+		...step,
+		progress: {
+			...step.progress,
+			caption: step.progress?.caption ?? caption,
+			weight: step.progress?.weight ?? weight,
+		},
+	}));
+}
+
+/**
+ * Returns the progress caption for a single v2 execution-plan item.
+ *
+ * Keep this switch exhaustive. A new execution-plan item should fail type
+ * checks here until the runner decides what progress text to report for it.
+ */
+function getProgressCaption(planItem: BlueprintV2ExecutionPlanItem): string {
+	switch (planItem.type) {
+		case 'defineWpConfigConsts':
+			return 'Defining constants';
+		case 'setSiteOptions':
+			return 'Setting site options';
+		case 'installMuPlugin':
+			return 'Installing must-use plugin';
+		case 'installTheme':
+			return planItem.active
+				? 'Installing active theme'
+				: 'Installing theme';
+		case 'installPlugin':
+			return 'Installing plugin';
+		case 'installFonts':
+			return 'Installing fonts';
+		case 'importMedia':
+			return 'Importing media';
+		case 'setSiteLanguage':
+			return 'Setting site language';
+		case 'defineRoles':
+			return 'Creating roles';
+		case 'defineUsers':
+			return 'Creating users';
+		case 'definePostTypes':
+			return 'Registering post types';
+		case 'importContent':
+			return getContentProgressCaption(planItem.content);
+		case 'runStep':
+			return getAdditionalStepProgressCaption(planItem.step);
+	}
+	return assertNever(planItem);
+}
+
+/**
+ * Makes discriminated-union switches fail at compile time when they miss a
+ * case. The thrown error is only a runtime fallback for malformed input.
+ */
+function assertNever(value: never): never {
+	throw new Error(`Unexpected Blueprint v2 progress item: ${value}`);
+}
+
+/**
+ * Returns the progress caption for v2 content imports.
+ *
+ * Keep this switch exhaustive. Adding a new content type should require an
+ * explicit caption decision instead of silently falling back to generic text.
+ */
+function getContentProgressCaption(content: BlueprintV2Content): string {
+	switch (content.type) {
+		case 'mysql-dump':
+			return 'Importing SQL content';
+		case 'posts':
+			return 'Importing posts';
+		case 'wxr':
+			return 'Importing WXR content';
+	}
+	return assertNever(content);
+}
+
+/**
+ * Returns the progress caption for `additionalStepsAfterExecution` entries.
+ *
+ * Keep this switch exhaustive. These are direct v1-style steps embedded in v2,
+ * so new supported step types need a visible progress label here as well.
+ */
+function getAdditionalStepProgressCaption(step: BlueprintV2Step): string {
+	switch (step.step) {
+		case 'activatePlugin':
+			return 'Activating plugin';
+		case 'activateTheme':
+			return 'Activating theme';
+		case 'cp':
+			return 'Copying files';
+		case 'defineConstants':
+			return 'Defining constants';
+		case 'importContent':
+			return 'Importing content';
+		case 'importMedia':
+			return 'Importing media';
+		case 'importThemeStarterContent':
+			return 'Importing theme starter content';
+		case 'installPlugin':
+			return 'Installing plugin';
+		case 'installTheme':
+			return 'Installing theme';
+		case 'mkdir':
+			return 'Creating directory';
+		case 'mv':
+			return 'Moving files';
+		case 'rm':
+			return 'Removing file';
+		case 'rmdir':
+			return 'Removing directory';
+		case 'runPHP':
+			return 'Running PHP';
+		case 'runSQL':
+			return 'Executing SQL queries';
+		case 'setSiteLanguage':
+			return 'Setting site language';
+		case 'setSiteOptions':
+			return 'Setting site options';
+		case 'unzip':
+			return 'Extracting ZIP file';
+		case 'wp-cli':
+			return 'Running WP-CLI';
+		case 'writeFiles':
+			return 'Writing files';
+	}
+	return assertNever(step);
 }
 
 /**

--- a/packages/playground/blueprints/src/tests/compile.spec.ts
+++ b/packages/playground/blueprints/src/tests/compile.spec.ts
@@ -1,9 +1,23 @@
 import { InMemoryFilesystem } from '@wp-playground/storage';
+import { ProgressTracker } from '@php-wasm/progress';
 import { vi } from 'vitest';
 import { compileBlueprintForExecution } from '../lib/compile';
 import type { BlueprintV1Declaration } from '../lib/v1/types';
 import type { BlueprintV2Declaration } from '../lib/v2/blueprint-v2-declaration';
-import { UnsupportedBlueprintV2FeatureError } from '../lib/v2/compile';
+import {
+	lowerBlueprintV2ExecutionPlan,
+	UnsupportedBlueprintV2FeatureError,
+} from '../lib/v2/compile';
+
+function withoutProgress(step: any) {
+	const rest = { ...step };
+	delete rest.progress;
+	return rest;
+}
+
+function withoutProgressFromSteps(steps: any[]) {
+	return steps.map(withoutProgress);
+}
 
 describe('compileBlueprintForExecution', () => {
 	it('compiles Blueprint v1 declarations through the v1 compiler', async () => {
@@ -551,6 +565,103 @@ describe('compileBlueprintForExecution', () => {
 		).toEqual([]);
 	});
 
+	it('adds useful progress metadata to Blueprint v2 generated steps', async () => {
+		const compiled = await compileBlueprintForExecution({
+			version: 2,
+			media: ['./media/image.jpg'],
+			additionalStepsAfterExecution: [
+				{
+					step: 'mkdir',
+					path: 'site:wp-content/uploads/from-v2',
+				},
+			],
+		});
+
+		expect(compiled.version).toBe(2);
+		if (compiled.version !== 2) {
+			throw new Error('Expected a compiled Blueprint v2 result.');
+		}
+		expect(
+			compiled.compiled.steps.map((step) => ({
+				step: step.step,
+				progress: step.progress,
+			}))
+		).toEqual([
+			{
+				step: 'writeFile',
+				progress: {
+					caption: 'Importing media',
+					weight: 0.5,
+				},
+			},
+			{
+				step: 'runPHPWithOptions',
+				progress: {
+					caption: 'Importing media',
+					weight: 0.5,
+				},
+			},
+			{
+				step: 'mkdir',
+				progress: {
+					caption: 'Creating directory',
+					weight: 1,
+				},
+			},
+		]);
+	});
+
+	it('does not add progress metadata when a Blueprint v2 plan item produces no steps', () => {
+		const result = lowerBlueprintV2ExecutionPlan([
+			{
+				type: 'runStep',
+				step: {
+					step: 'writeFiles',
+					files: {},
+				},
+				sourcePath: '/additionalStepsAfterExecution/0',
+			},
+		]);
+
+		expect(result).toEqual({
+			steps: [],
+			unsupportedPlan: [],
+		});
+	});
+
+	it('reports Blueprint v2 progress through the provided progress tracker', async () => {
+		const progress = new ProgressTracker();
+		const events: Array<{ progress: number; caption: string }> = [];
+		progress.addEventListener('progress', (event: any) => {
+			events.push({
+				progress: event.detail.progress,
+				caption: event.detail.caption,
+			});
+		});
+		const compiled = await compileBlueprintForExecution(
+			{
+				version: 2,
+				additionalStepsAfterExecution: [
+					{
+						step: 'mkdir',
+						path: 'site:wp-content/uploads/from-v2',
+					},
+				],
+			},
+			{ progress }
+		);
+
+		await compiled.run({
+			mkdir: vi.fn(),
+		} as any);
+
+		expect(events).toContainEqual({
+			progress: 0,
+			caption: 'Creating directory',
+		});
+		expect(events.at(-1)?.progress).toBe(100);
+	});
+
 	it('lowers Blueprint v2 mysql-dump content to runSql steps', async () => {
 		const compiled = await compileBlueprintForExecution({
 			version: 2,
@@ -573,7 +684,7 @@ describe('compileBlueprintForExecution', () => {
 		if (compiled.version !== 2) {
 			throw new Error('Expected a compiled Blueprint v2 result.');
 		}
-		expect(compiled.compiled.steps).toEqual([
+		expect(withoutProgressFromSteps(compiled.compiled.steps)).toEqual([
 			{
 				step: 'runSql',
 				sql: {
@@ -615,7 +726,7 @@ describe('compileBlueprintForExecution', () => {
 		if (compiled.version !== 2) {
 			throw new Error('Expected a compiled Blueprint v2 result.');
 		}
-		expect(compiled.compiled.steps).toEqual([
+		expect(withoutProgressFromSteps(compiled.compiled.steps)).toEqual([
 			{
 				step: 'runSql',
 				sql: {
@@ -669,7 +780,7 @@ describe('compileBlueprintForExecution', () => {
 		if (compiled.version !== 2) {
 			throw new Error('Expected a compiled Blueprint v2 result.');
 		}
-		expect(compiled.compiled.steps).toEqual([
+		expect(withoutProgressFromSteps(compiled.compiled.steps)).toEqual([
 			{
 				step: 'importWxr',
 				file: {
@@ -770,7 +881,7 @@ describe('compileBlueprintForExecution', () => {
 		if (compiled.version !== 2) {
 			throw new Error('Expected a compiled Blueprint v2 result.');
 		}
-		expect(compiled.compiled.steps).toEqual([
+		expect(withoutProgressFromSteps(compiled.compiled.steps)).toEqual([
 			{
 				step: 'runSql',
 				sql: {
@@ -824,7 +935,7 @@ describe('compileBlueprintForExecution', () => {
 		if (compiled.version !== 2) {
 			throw new Error('Expected a compiled Blueprint v2 result.');
 		}
-		expect(compiled.compiled.steps).toEqual([
+		expect(withoutProgressFromSteps(compiled.compiled.steps)).toEqual([
 			{
 				step: 'writeFile',
 				path: '/wordpress/wp-content/uploads/readme.txt',
@@ -892,7 +1003,7 @@ describe('compileBlueprintForExecution', () => {
 		if (compiled.version !== 2) {
 			throw new Error('Expected a compiled Blueprint v2 result.');
 		}
-		expect(compiled.compiled.steps).toEqual([
+		expect(withoutProgressFromSteps(compiled.compiled.steps)).toEqual([
 			{
 				step: 'unzip',
 				zipFile: {
@@ -939,7 +1050,7 @@ describe('compileBlueprintForExecution', () => {
 		if (compiled.version !== 2) {
 			throw new Error('Expected a compiled Blueprint v2 result.');
 		}
-		expect(compiled.compiled.steps).toEqual([
+		expect(withoutProgressFromSteps(compiled.compiled.steps)).toEqual([
 			{
 				step: 'writeFile',
 				path: '/tmp/blueprint-run-php-0.php',
@@ -984,7 +1095,7 @@ describe('compileBlueprintForExecution', () => {
 		if (compiled.version !== 2) {
 			throw new Error('Expected a compiled Blueprint v2 result.');
 		}
-		expect(compiled.compiled.steps[0]).toEqual({
+		expect(withoutProgress(compiled.compiled.steps[0])).toEqual({
 			step: 'writeFile',
 			path: '/tmp/blueprint-post-content-0',
 			data: {
@@ -1040,7 +1151,7 @@ describe('compileBlueprintForExecution', () => {
 		if (compiled.version !== 2) {
 			throw new Error('Expected a compiled Blueprint v2 result.');
 		}
-		expect(compiled.compiled.steps).toEqual([
+		expect(withoutProgressFromSteps(compiled.compiled.steps)).toEqual([
 			{
 				step: 'writeFile',
 				path: '/wordpress/wp-content/mu-plugins/demo-mu.php',
@@ -1086,7 +1197,7 @@ describe('compileBlueprintForExecution', () => {
 		if (compiled.version !== 2) {
 			throw new Error('Expected a compiled Blueprint v2 result.');
 		}
-		expect(compiled.compiled.steps[0]).toEqual({
+		expect(withoutProgress(compiled.compiled.steps[0])).toEqual({
 			step: 'writeFile',
 			path: '/tmp/blueprint-media-0',
 			data: {


### PR DESCRIPTION
## What it does

Reports Blueprint v2 execution progress.

The v2 CLI handler already creates a `ProgressTracker`, but the compiler path did not consistently feed useful captions into it. Multi-step v2 declarations, such as media imports, also looked like separate unrelated operations instead of one user-facing task.

Part of #2592.

## Implementation

Adds progress metadata when v2 plan items become executable steps. If one v2 declaration creates multiple support steps, the declaration weight is split across those steps so progress still tracks the original Blueprint shape.

Also forwards the caller-provided `progress` tracker through `compileBlueprintForExecution()` for v2 declarations, and makes the shared step runner honor `step.progress.caption` before fast steps complete.

## Testing instructions

CI
