### PR TITLE
[PHP] Preserve empty directories in tar.zst core bundles

### DIFF
--- a/packages/playground/wordpress-builds/build/build-tar-zst.mjs
+++ b/packages/playground/wordpress-builds/build/build-tar-zst.mjs
@@ -110,6 +110,7 @@ function readTreeIntoFileMap(root) {
 			const rel = prefix ? `${prefix}/${entry.name}` : entry.name;
 			if (entry.isDirectory()) {
 				walk(abs, rel);
+				fileMap[`${rel}/`] = new Uint8Array();
 			} else if (entry.isFile()) {
 				// `wordpress-static.zip` is served from
 				// packages/playground/wordpress-builds/public/wp-<version>/ for
@@ -153,18 +154,23 @@ function buildOne(slug, windowLog, deleteZip = false) {
 		});
 		const fileMap = readTreeIntoFileMap(tmp);
 		const entries = normalizeEntries(fileMap);
+		const files = entries.filter((entry) => entry.type !== 'dir');
+		const dirCount = entries.length - files.length;
 		const uncompressedBytes = entries.reduce(
-			(n, e) => n + e.data.length,
+			(n, e) => n + (e.type === 'dir' ? 0 : e.data.length),
 			0
 		);
 		const tar = createUstarTar(entries, { mtime: 0 });
 		const compressed = compressTarZst(tar, windowLog);
+		const tarMib = (tar.length / 1048576).toFixed(2);
+		const compressedMib = (compressed.length / 1048576).toFixed(2);
 		const outPath = path.join(WP_DIR, `wp-${slug}.tar.zst`);
 		writeFileSync(outPath, compressed);
 		const sha256 = createHash('sha256').update(compressed).digest('hex');
 		const meta = {
 			slug,
-			fileCount: entries.length,
+			fileCount: files.length,
+			dirCount,
 			size: compressed.length,
 			sha256,
 			uncompressedBytes,
@@ -172,8 +178,9 @@ function buildOne(slug, windowLog, deleteZip = false) {
 			windowLog,
 		};
 		console.log(
-			`wp-${slug}: ${entries.length} files, tar ${(tar.length / 1048576).toFixed(2)} MiB ` +
-				`→ tar.zst ${(compressed.length / 1048576).toFixed(2)} MiB (wlog ${windowLog}), sha256 ${sha256.slice(0, 12)}…`
+			`wp-${slug}: ${files.length} files, ${dirCount} dirs, ` +
+				`tar ${tarMib} MiB → tar.zst ${compressedMib} MiB ` +
+				`(wlog ${windowLog}), sha256 ${sha256.slice(0, 12)}…`
 		);
 		if (deleteZip) {
 			// The zip is now a transient build source; tar.zst is the shipped
@@ -198,8 +205,7 @@ function validateZipListing(zipPath) {
 		if (name.startsWith('/')) {
 			throw new Error(`Unsafe ZIP entry path (absolute): ${name}`);
 		}
-		if (name.endsWith('/')) continue;
-		sanitizeArchivePath(name);
+		sanitizeArchivePath(name.endsWith('/') ? name.slice(0, -1) : name);
 	}
 }
 
@@ -249,8 +255,12 @@ function verify(versions) {
 		process.exit(1);
 	}
 	for (const [slug, meta] of Object.entries(readArtifactMeta(versions))) {
+		const dirCount = meta.dirCount ?? 0;
+		const dirCountLabel = dirCount === 1 ? '1 dir' : `${dirCount} dirs`;
 		console.log(
-			`OK  wp-${slug}.tar.zst (${meta.size} bytes, ${meta.fileCount} files, ${meta.sha256.slice(0, 12)}…)`
+			`OK  wp-${slug}.tar.zst (` +
+				`${meta.size} bytes, ${meta.fileCount} files, ` +
+				`${dirCountLabel}, ${meta.sha256.slice(0, 12)}…)`
 		);
 	}
 }
@@ -338,10 +348,13 @@ function readOneArtifactMeta(slug) {
 		throw new Error(`Missing committed artifact: ${tarZst}`);
 	}
 	const bytes = readFileSync(tarZst);
+	const entries = readUstarTar(zlib.zstdDecompressSync(bytes));
+	const fileCount = entries.filter((entry) => entry.type !== 'dir').length;
 	return {
 		size: statSync(tarZst).size,
 		sha256: createHash('sha256').update(bytes).digest('hex'),
-		fileCount: readUstarTar(zlib.zstdDecompressSync(bytes)).length,
+		fileCount,
+		dirCount: entries.length - fileCount,
 	};
 }
 

--- a/packages/playground/wordpress-builds/build/lib/tar-ustar.mjs
+++ b/packages/playground/wordpress-builds/build/lib/tar-ustar.mjs
@@ -18,7 +18,8 @@
 // file-count parity with the ZIP baseline.
 //
 // Determinism policy: entries are emitted in a fixed byte-wise sort with
-// mtime=0, uid=gid=0, empty uname/gname, and a fixed mode.
+// mtime=0, uid=gid=0, empty uname/gname, and fixed modes. Files use typeflag
+// '0'; empty directories that no file re-creates use typeflag '5'.
 //
 // Reused semantics: entry-name sanitization mirrors sanitizeTarPath() in the
 // runtime extractor: reject backslashes, absolute paths, and ".." segments;
@@ -49,21 +50,53 @@ export function sanitizeArchivePath(name) {
 }
 
 /**
- * Turn a { path -> Uint8Array } map into a sorted, sanitized, files-only entry
- * list ready for createUstarTar(). Directory keys (trailing "/") are dropped;
- * unsafe file paths throw. The sort is a stable byte-wise comparison on the
- * sanitized name so two runs over the same input yield an identical archive.
+ * Turn a { path -> Uint8Array } map into a sorted, sanitized entry list ready
+ * for createUstarTar(). Each entry is tagged `{ type: "file", name, data }` or
+ * `{ type: "dir", name }`.
+ *
+ * Directory members (trailing "/") are preserved only when no file will create
+ * them implicitly. That keeps explicitly empty directories from disappearing
+ * while avoiding redundant directory headers for every file parent.
+ *
+ * Unsafe paths throw for both files and directories. The sort is a stable
+ * byte-wise comparison on the sanitized name so two runs over the same input
+ * yield an identical archive.
  */
 export function normalizeEntries(fileMap) {
-	const entries = [];
+	const files = [];
+	const dirCandidates = [];
 	for (const rawName of Object.keys(fileMap)) {
 		const isDirectory = rawName.endsWith('/');
 		const name = sanitizeArchivePath(
 			isDirectory ? rawName.slice(0, -1) : rawName
 		);
-		if (isDirectory) continue; // directory member, skip
 		if (!name) continue;
-		entries.push({ name, data: fileMap[rawName] });
+		if (isDirectory) {
+			dirCandidates.push(name);
+		} else {
+			files.push({ type: 'file', name, data: fileMap[rawName] });
+		}
+	}
+
+	// Every ancestor directory of a kept file is created implicitly by the
+	// extractor; collect them so we never emit a redundant directory member.
+	const impliedDirs = new Set();
+	for (const file of files) {
+		let index = file.name.lastIndexOf('/');
+		while (index > 0) {
+			const dir = file.name.slice(0, index);
+			if (impliedDirs.has(dir)) break;
+			impliedDirs.add(dir);
+			index = dir.lastIndexOf('/');
+		}
+	}
+
+	const seenDirs = new Set();
+	const entries = [...files];
+	for (const name of dirCandidates) {
+		if (impliedDirs.has(name) || seenDirs.has(name)) continue;
+		seenDirs.add(name);
+		entries.push({ type: 'dir', name });
 	}
 	// Byte-wise (codepoint) sort — NOT localeCompare, which is locale-sensitive
 	// and would make the archive non-reproducible across environments.
@@ -238,8 +271,9 @@ function readOctal(block, offset, length) {
 
 /**
  * Minimal tar reader that understands USTAR entries (incl. the prefix/name
- * split) and GNU `././@LongLink` names. Returns [{ name, data }] for files.
- * Used by tests to prove round-trip fidelity.
+ * split) and GNU `././@LongLink` names. Returns `{ name, data }` for files and
+ * `{ name, type: "dir" }` for directories. Used by tests to prove round-trip
+ * fidelity.
  */
 export function readUstarTar(buffer) {
 	const buf = Buffer.isBuffer(buffer) ? buffer : Buffer.from(buffer);
@@ -265,11 +299,13 @@ export function readUstarTar(buffer) {
 			pendingName = data.toString('utf8').replace(/\0.*$/, '');
 			continue;
 		}
-		if (typeflag === '5') continue; // directory
-		if (typeflag !== '0' && typeflag !== '\0') continue; // non-file types
-
 		const name = pendingName ?? (prefix ? `${prefix}/${rawName}` : rawName);
 		pendingName = null;
+		if (typeflag === '5' || name.endsWith('/')) {
+			entries.push({ name: name.replace(/\/+$/, ''), type: 'dir' });
+			continue;
+		}
+		if (typeflag !== '0' && typeflag !== '\0') continue; // non-file types
 		entries.push({ name, data: Uint8Array.prototype.slice.call(data) });
 	}
 	return entries;

--- a/packages/playground/wordpress-builds/src/test/get-wordpress-module-details.spec.ts
+++ b/packages/playground/wordpress-builds/src/test/get-wordpress-module-details.spec.ts
@@ -36,12 +36,15 @@ describe('getWordPressModuleDetails()', () => {
 		);
 		const compressedBytes = new Uint8Array(readFileSync(bundlePath));
 		const entries = readUstarTar(await decompressZstd(compressedBytes));
+		const files = entries.filter(
+			(entry: { type?: string }) => entry.type !== 'dir'
+		);
 
 		expect(module.size).toBe(statSync(bundlePath).size);
 		expect(module.sha256).toBe(
 			createHash('sha256').update(compressedBytes).digest('hex')
 		);
-		expect(module.fileCount).toBe(entries.length);
+		expect(module.fileCount).toBe(files.length);
 	});
 
 	it('keeps remote trunk modules classified as ZIPs without local metadata', () => {
@@ -72,6 +75,8 @@ describe('getWordPressModuleDetails()', () => {
 async function decompressZstd(compressedBytes: Uint8Array) {
 	const decoder = new ZSTDDecoder();
 	await decoder.init();
-	const chunks = [...decoder.decodeStreaming([compressedBytes])] as Uint8Array[];
+	const chunks = [
+		...decoder.decodeStreaming([compressedBytes]),
+	] as Uint8Array[];
 	return Buffer.concat(chunks.map((chunk) => Buffer.from(chunk)));
 }

--- a/packages/playground/wordpress-builds/src/test/wordpress-zip-assets.spec.ts
+++ b/packages/playground/wordpress-builds/src/test/wordpress-zip-assets.spec.ts
@@ -1,7 +1,11 @@
 import { readdirSync, readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 // eslint-disable-next-line @nx/enforce-module-boundaries -- in-package build helper
-import { normalizeEntries, readUstarTar } from '../../build/lib/tar-ustar.mjs';
+import {
+	createUstarTar,
+	normalizeEntries,
+	readUstarTar,
+} from '../../build/lib/tar-ustar.mjs';
 // zstddec (WASM) decodes the tar.zst on any Node version; node:zlib zstd would
 // need Node >= 22.15, but the CI unit-test job runs Node 20.
 import { ZSTDDecoder } from 'zstddec/stream';
@@ -19,6 +23,46 @@ describe('WordPress core bundle assets', () => {
 				[name]: new Uint8Array(),
 			})
 		).toThrow(message);
+	});
+
+	it('preserves only explicit directories with no file descendants', () => {
+		const entries = normalizeEntries({
+			'wp-content/': new Uint8Array(),
+			'wp-content/plugins/': new Uint8Array(),
+			'wp-content/plugins/akismet/akismet.php': new TextEncoder().encode(
+				'<?php'
+			),
+			'wp-content/upgrade/': new Uint8Array(),
+		});
+
+		expect(
+			entries.map((entry: { name: string; type?: string }) => ({
+				name: entry.name,
+				type: entry.type ?? 'file',
+			}))
+		).toEqual([
+			{ name: 'wp-content/plugins/akismet/akismet.php', type: 'file' },
+			{ name: 'wp-content/upgrade', type: 'dir' },
+		]);
+	});
+
+	it('round-trips explicit directory entries without counting them as files', () => {
+		const entries = normalizeEntries({
+			'wp-content/cache/': new Uint8Array(),
+			'wp-includes/version.php': new TextEncoder().encode('<?php'),
+		});
+		const tarEntries = readUstarTar(createUstarTar(entries)) as Array<{
+			name: string;
+			type?: string;
+		}>;
+
+		expect(tarEntries).toEqual([
+			{ name: 'wp-content/cache', type: 'dir' },
+			{ name: 'wp-includes/version.php', data: expect.any(Uint8Array) },
+		]);
+		expect(tarEntries.filter((entry) => entry.type !== 'dir')).toHaveLength(
+			1
+		);
 	});
 
 	it('ships CSS files that WordPress core reads from PHP', async () => {

--- a/packages/playground/wordpress/src/streaming-tar-extract.spec.ts
+++ b/packages/playground/wordpress/src/streaming-tar-extract.spec.ts
@@ -329,22 +329,19 @@ describe('StreamingTarParser', () => {
 		{
 			fixture: 'bsdtar-ustar.tar',
 			description: 'libarchive bsdtar --format=ustar',
-			expectedPath:
-				'wp-content/themes/' + 'p'.repeat(120) + '/style.css',
+			expectedPath: 'wp-content/themes/' + 'p'.repeat(120) + '/style.css',
 			expectedContents: 'body{color:red}\n',
 		},
 		{
 			fixture: 'bsdtar-gnutar.tar',
 			description: 'libarchive bsdtar --format=gnutar',
-			expectedPath:
-				'wp-content/plugins/' + 'q'.repeat(180) + '/main.php',
+			expectedPath: 'wp-content/plugins/' + 'q'.repeat(180) + '/main.php',
 			expectedContents: '<?php echo "plugin";\n',
 		},
 		{
 			fixture: 'bsdtar-pax.tar',
 			description: 'libarchive bsdtar --format=pax',
-			expectedPath:
-				'wp-content/plugins/' + 'q'.repeat(180) + '/main.php',
+			expectedPath: 'wp-content/plugins/' + 'q'.repeat(180) + '/main.php',
 			expectedContents: '<?php echo "plugin";\n',
 		},
 	])(
@@ -507,9 +504,7 @@ describe('StreamingTarParser', () => {
 
 	it('throws when a USTAR prefix path escapes the extraction root', () => {
 		expect(() =>
-			collect(
-				buildTar([{ name: 'escape.txt', prefix: '..', data: 'x' }])
-			)
+			collect(buildTar([{ name: 'escape.txt', prefix: '..', data: 'x' }]))
 		).toThrow(/path traversal/);
 	});
 
@@ -548,7 +543,6 @@ describe('StreamingTarParser', () => {
 	});
 });
 
-
 describe('extractTarStreamToPhp', () => {
 	it('writes files and creates parent directories in MEMFS', async () => {
 		const { php, files, dirs } = fakePhp();
@@ -564,6 +558,18 @@ describe('extractTarStreamToPhp', () => {
 		expect(text(files.get('/wordpress/wp-includes/version.php'))).toBe('v');
 		expect(dirs.has('/wordpress/wp-includes')).toBe(true);
 		expect(stats.fileCount).toBe(2);
+	});
+
+	it('creates explicit empty directories in MEMFS', async () => {
+		const { php, dirs } = fakePhp();
+		const stream = streamOf(
+			buildTar([{ name: 'wp-content/upgrade', type: 'dir' }])
+		);
+		const stats = await extractTarStreamToPhp(stream, php, '/wordpress');
+
+		expect(dirs.has('/wordpress/wp-content/upgrade')).toBe(true);
+		expect(stats.dirCount).toBe(1);
+		expect(stats.fileCount).toBe(0);
 	});
 
 	it('respects overwriteFiles=false by skipping existing files', async () => {
@@ -600,9 +606,7 @@ describe('extractTarStreamToPhp', () => {
 
 	it('keeps targetRoot=/ writes absolute', async () => {
 		const { php, files } = fakePhp();
-		const stream = streamOf(
-			buildTar([{ name: 'index.php', data: 'x' }])
-		);
+		const stream = streamOf(buildTar([{ name: 'index.php', data: 'x' }]));
 
 		await extractTarStreamToPhp(stream, php, '/');
 
@@ -610,7 +614,6 @@ describe('extractTarStreamToPhp', () => {
 		expect(files.has('index.php')).toBe(false);
 	});
 });
-
 
 async function collectStream(stream: ReadableStream<Uint8Array>) {
 	const entries: TarEntry[] = [];
@@ -685,7 +688,10 @@ async function withoutNativeDecompressionStream<T>(callback: () => Promise<T>) {
 describe('createDecodedTarStream + zstddec fallback', () => {
 	it('streams a .tar.zst fixture through zstddec into the tar parser', async () => {
 		await withoutNativeDecompressionStream(async () => {
-			const stream = await createDecodedTarStream(ZSTD_TAR_FIXTURE, 'zstd');
+			const stream = await createDecodedTarStream(
+				ZSTD_TAR_FIXTURE,
+				'zstd'
+			);
 			const { entries, stats } = await collectStream(stream);
 			const binary = Buffer.alloc(3000);
 			for (let i = 0; i < binary.length; i += 1) {


### PR DESCRIPTION
## What it does

Preserves explicit empty directory entries when converting WordPress core ZIP bundles to `tar.zst`, so future trimmed bundles do not silently drop directories that are semantically required at runtime.

## Rationale

The `tar.zst` build path converted extracted ZIP contents into a files-only tar entry list. Parent directories are normally recreated while extracting file entries, but an explicit ZIP directory with no kept file descendants disappears entirely.

That does not affect the currently committed WordPress core bundles, which verify with `0` directory entries, but it can become a regression if future trimming leaves a required directory empty. This follows the same failure mode reported in the Moodle Playground follow-up on #3913.

## Implementation

`normalizeEntries()` now keeps explicit directory members only when no regular file will recreate them. Redundant parent directory headers are still omitted, and `fileCount` remains regular-files-only for the runtime parity check.

The tar test reader now surfaces directory entries so metadata verification and tests can distinguish files from directories. The runtime extractor already created typeflag-`5` directories; this PR adds a focused regression test for that behavior.

## Testing instructions

```bash
npx nx test playground-wordpress-builds --testFile=wordpress-zip-assets.spec.ts
npx nx test playground-wordpress --testFile=streaming-tar-extract.spec.ts
node packages/playground/wordpress-builds/build/build-tar-zst.mjs --verify
npx nx run-many -t lint -p playground-wordpress-builds,playground-wordpress
```
