### PR TITLE
[Website] Reuse FilePickerTree imports in the shared explorer

### DIFF
--- a/packages/playground/components/e2e/tests/playground-file-editor.spec.ts
+++ b/packages/playground/components/e2e/tests/playground-file-editor.spec.ts
@@ -28,6 +28,68 @@ async function readHarnessFile(page: Page, path: string) {
 	}, path);
 }
 
+/** Drops one nested host directory on the file explorer background. */
+async function dropHarnessDirectory(page: Page, content: string) {
+	await page
+		.locator('[class*="fileExplorerContainer"]')
+		.first()
+		.evaluate((container, fileContent) => {
+			const file = new File([fileContent], 'note.txt', {
+				type: 'text/plain',
+			});
+			const fileEntry = {
+				isFile: true,
+				isDirectory: false,
+				name: file.name,
+				file: (resolve: (value: File) => void) => resolve(file),
+			};
+			let nestedRead = false;
+			const nestedDirectory = {
+				isFile: false,
+				isDirectory: true,
+				name: 'nested',
+				createReader: () => ({
+					readEntries: (resolve: (entries: unknown[]) => void) => {
+						resolve(nestedRead ? [] : [fileEntry]);
+						nestedRead = true;
+					},
+				}),
+			};
+			let rootRead = false;
+			const droppedDirectory = {
+				isFile: false,
+				isDirectory: true,
+				name: 'dropped-folder',
+				createReader: () => ({
+					readEntries: (resolve: (entries: unknown[]) => void) => {
+						resolve(rootRead ? [] : [nestedDirectory]);
+						rootRead = true;
+					},
+				}),
+			};
+			let dropDataIsReadable = true;
+			const dropEvent = new Event('drop', {
+				bubbles: true,
+				cancelable: true,
+			});
+			Object.defineProperty(dropEvent, 'dataTransfer', {
+				value: {
+					types: ['Files'],
+					items: [
+						{
+							kind: 'file',
+							webkitGetAsEntry: () =>
+								dropDataIsReadable ? droppedDirectory : null,
+						},
+					],
+					files: [],
+				},
+			});
+			container.dispatchEvent(dropEvent);
+			dropDataIsReadable = false;
+		}, content);
+}
+
 test.beforeEach(async ({ page }) => {
 	await gotoHarness(page);
 });
@@ -37,6 +99,31 @@ test('opens the initial file', async ({ page }) => {
 	await expect(page.locator('.cm-content')).toContainText(
 		"<?php echo 'Hello';"
 	);
+});
+
+test('imports a local directory dropped on the explorer background', async ({
+	page,
+}) => {
+	const content = 'Dropped from a nested local directory';
+	const importedPath = '/wordpress/workspace/dropped-folder/nested/note.txt';
+
+	await expect(
+		page.getByRole('button', { name: 'Upload files' })
+	).toBeVisible();
+	await dropHarnessDirectory(page, content);
+
+	await expect
+		.poll(async () => {
+			try {
+				return await readHarnessFile(page, importedPath);
+			} catch {
+				return null;
+			}
+		})
+		.toBe(content);
+	await expect(
+		page.locator('button[data-path="/wordpress/workspace/dropped-folder"]')
+	).toBeVisible();
 });
 
 test('autosaves editor changes into the harness filesystem', async ({

--- a/packages/playground/components/e2e/tests/playground-file-picker.spec.ts
+++ b/packages/playground/components/e2e/tests/playground-file-picker.spec.ts
@@ -309,6 +309,60 @@ test('renaming a directory keeps it expanded with its children', async ({
 	).toBeVisible();
 });
 
+test('preserves backslashes and spaces in renamed entries', async ({
+	page,
+}) => {
+	await expandToPath(page, 'wordpress/wp-content/themes');
+	await nodeButton(page, 'wordpress/wp-content/themes').click({
+		button: 'right',
+	});
+	await page.getByRole('menuitem', { name: 'Rename' }).click();
+	const input = renameInput(page, 'wordpress/wp-content/themes');
+	const name = ' themes\\ ';
+	const renamedPath = `/wordpress/wp-content/${name}`;
+	await input.fill(name);
+	await input.press('Enter');
+
+	await expect
+		.poll(() =>
+			page.evaluate((path) => {
+				return Array.from(
+					document.querySelectorAll<HTMLElement>('[data-path]')
+				).some((element) => element.dataset.path === path);
+			}, renamedPath)
+		)
+		.toBe(true);
+	await expect(
+		page.evaluate((path) => {
+			return window.__filePickerHarness!.filesystem.isDir(path);
+		}, renamedPath)
+	).resolves.toBe(true);
+	await expect
+		.poll(() =>
+			page.evaluate(
+				() => (document.activeElement as HTMLElement)?.dataset.path
+			)
+		)
+		.toBe(renamedPath);
+
+	await page.keyboard.press('ArrowRight');
+	await expect
+		.poll(() =>
+			page.evaluate(
+				() => (document.activeElement as HTMLElement)?.dataset.path
+			)
+		)
+		.toBe(`${renamedPath}/twentytwentyone`);
+	await page.keyboard.press('ArrowLeft');
+	await expect
+		.poll(() =>
+			page.evaluate(
+				() => (document.activeElement as HTMLElement)?.dataset.path
+			)
+		)
+		.toBe(renamedPath);
+});
+
 test('escape cancels an in-progress rename', async ({ page }) => {
 	await expandToPath(page, 'wordpress/workspace');
 	await nodeButton(page, 'wordpress/workspace/index.php').click({

--- a/packages/playground/components/src/FilePickerTree/index.tsx
+++ b/packages/playground/components/src/FilePickerTree/index.tsx
@@ -1,4 +1,10 @@
-import { basename, dirname, joinPaths } from '@php-wasm/util';
+import {
+	basename,
+	dirname,
+	isParentOf,
+	joinPaths,
+	normalizePath,
+} from '@php-wasm/util';
 import type { AsyncWritableFilesystem } from '@wp-playground/storage';
 import {
 	Button,
@@ -74,6 +80,8 @@ export type FileNode = {
 
 export type FilePickerTreeProps = {
 	withContextMenu?: boolean;
+	/** Disables filesystem mutations while preserving selection and previews. */
+	readOnly?: boolean;
 	filesystem: AsyncWritableFilesystem;
 	root?: string; // default '/wordpress'
 	initialSelectedPath?: string;
@@ -94,15 +102,21 @@ export type FilePickerTreeHandle = {
 	// Filesystem helpers
 	createFile: (absSelectedPath?: string) => Promise<void>;
 	createFolder: (absSelectedPath?: string) => Promise<void>;
+	/** Imports captured file-input entries into an existing tree directory. */
+	importFiles: (
+		files: readonly File[],
+		destinationDir: string
+	) => Promise<void>;
+	/** Imports a drop payload into an existing tree directory. */
+	importDataTransfer: (
+		dataTransfer: DataTransfer,
+		destinationDir: string
+	) => Promise<void>;
 };
 
 function buildPathChain(path: string): string[] {
 	if (!path) return [];
-	const normalized =
-		path
-			.replaceAll(/\\+/g, '/')
-			.replace(/\/{2,}/g, '/')
-			.replace(/\/$/, '') || path;
+	const normalized = normalizePath(path);
 	const hasLeadingSlash = normalized.startsWith('/');
 	const parts = normalized.split('/').filter(Boolean);
 	const chain: string[] = [];
@@ -117,20 +131,6 @@ function buildPathChain(path: string): string[] {
 		chain.push(current);
 	}
 	return chain;
-}
-
-function isDescendantPath(ancestor: string, candidate: string) {
-	if (!ancestor || !candidate) return false;
-	if (ancestor === candidate) return false;
-	const normalizedAncestor =
-		ancestor === '/' ? '/' : ancestor.replace(/\/{2,}/g, '/');
-	const normalizedCandidate = candidate.replace(/\/{2,}/g, '/');
-	if (normalizedAncestor === '/') {
-		return (
-			normalizedCandidate.startsWith('/') && normalizedCandidate !== '/'
-		);
-	}
-	return normalizedCandidate.startsWith(`${normalizedAncestor}/`);
 }
 
 function remapSinglePath(value: string | null, from: string, to: string) {
@@ -148,6 +148,7 @@ export const FilePickerTree = forwardRef<
 >(function FilePickerTree(
 	{
 		withContextMenu = true,
+		readOnly = false,
 		filesystem,
 		root = '/wordpress',
 		initialSelectedPath,
@@ -156,19 +157,7 @@ export const FilePickerTree = forwardRef<
 	},
 	ref
 ) {
-	const normalizedRoot = useMemo(() => {
-		let p = (root || '/').replace(/\\+/g, '/');
-		if (!p.startsWith('/')) p = `/${p}`;
-		p = p.replace(/\/{2,}/g, '/');
-		if (p.length > 1 && p.endsWith('/')) p = p.slice(0, -1);
-		return p || '/';
-	}, [root]);
-
-	const isValidNameSegment = (name: string) => {
-		if (!name) return false;
-		if (name === '.' || name === '..') return false;
-		return !/[\\/]/.test(name);
-	};
+	const normalizedRoot = useMemo(() => joinPaths('/', root || '/'), [root]);
 
 	const [expanded, setExpanded] = useState<ExpandedNodePaths>(() => {
 		if (!initialSelectedPath) {
@@ -227,7 +216,7 @@ export const FilePickerTree = forwardRef<
 
 	const focusDomNode = (path: string) => {
 		const focusTarget = containerRef.current?.querySelector(
-			`[data-path="${path}"]`
+			`[data-path="${CSS.escape(path)}"]`
 		) as HTMLElement | null;
 		if (focusTarget && typeof focusTarget.focus === 'function') {
 			focusTarget.focus();
@@ -239,8 +228,9 @@ export const FilePickerTree = forwardRef<
 	};
 
 	const generatePath = (node: FileNode, parentPath = ''): string => {
-		const raw = parentPath ? `${parentPath}/${node.name}` : node.name;
-		return raw.replaceAll(/\\+/g, '/').replace(/\/{2,}/g, '/');
+		return parentPath
+			? joinPaths(parentPath, node.name)
+			: joinPaths('/', node.name);
 	};
 
 	const getResolvedChildren = (
@@ -421,20 +411,12 @@ export const FilePickerTree = forwardRef<
 		if (!from || !to || from === to) {
 			return;
 		}
-		const fromPrefix = from === '/' ? '/' : `${from}/`;
-		const remapKey = (key: string): string | null => {
-			if (key === from) return to;
-			if (key.startsWith(fromPrefix)) {
-				return to + key.slice(from.length);
-			}
-			return null;
-		};
 
 		setExpanded((prev) => {
 			let changed = false;
 			const next: ExpandedNodePaths = { ...prev };
 			for (const key of Object.keys(prev)) {
-				const mapped = remapKey(key);
+				const mapped = remapSinglePath(key, from, to);
 				if (mapped && mapped !== key) {
 					next[mapped] = prev[key];
 					delete next[key];
@@ -448,7 +430,7 @@ export const FilePickerTree = forwardRef<
 			let changed = false;
 			const next = { ...prev } as Record<string, FileNode[]>;
 			for (const key of Object.keys(prev)) {
-				const mapped = remapKey(key);
+				const mapped = remapSinglePath(key, from, to);
 				if (mapped && mapped !== key) {
 					next[mapped] = prev[key];
 					delete next[key];
@@ -458,16 +440,8 @@ export const FilePickerTree = forwardRef<
 			return changed ? next : prev;
 		});
 
-		setSelectedPath((prev) => {
-			if (!prev) return prev;
-			const mapped = remapKey(prev);
-			return mapped ?? prev;
-		});
-		setFocusedPath((prev) => {
-			if (!prev) return prev;
-			const mapped = remapKey(prev);
-			return mapped ?? prev;
-		});
+		setSelectedPath((prev) => remapSinglePath(prev, from, to));
+		setFocusedPath((prev) => remapSinglePath(prev, from, to));
 	};
 
 	const resetDragState = () => {
@@ -502,7 +476,7 @@ export const FilePickerTree = forwardRef<
 		tempPath: string;
 	} | null>(null);
 
-	const effectiveRenamingPath = renamingAbsolutePath;
+	const effectiveRenamingPath = readOnly ? null : renamingAbsolutePath;
 
 	useImperativeHandle(
 		ref,
@@ -540,13 +514,23 @@ export const FilePickerTree = forwardRef<
 			refresh: async (path: string) => await refreshChildren(path),
 			remapPath: remapPathState,
 			createFile: async (absSelectedPath?: string) => {
+				if (readOnly) return;
 				await createNode(absSelectedPath, 'file', 'untitled.php');
 			},
 			createFolder: async (absSelectedPath?: string) => {
+				if (readOnly) return;
 				await createNode(absSelectedPath, 'folder', 'New Folder');
 			},
+			importFiles: async (files, destinationDir) => {
+				if (readOnly) return;
+				await importFiles(files, destinationDir);
+			},
+			importDataTransfer: async (dataTransfer, destinationDir) => {
+				if (readOnly) return;
+				await importDataTransfer(dataTransfer, destinationDir);
+			},
 		}),
-		[selectedPath, refreshChildren, remapPathState, expandToPath]
+		[selectedPath, refreshChildren, remapPathState, expandToPath, readOnly]
 	);
 
 	const hasInitializedRef = useRef(false);
@@ -690,10 +674,7 @@ export const FilePickerTree = forwardRef<
 			return { allowed: false, state: 'invalid', destination: null };
 		}
 		if (sourcePath) {
-			if (destinationDir === sourcePath) {
-				return { allowed: false, state: 'invalid', destination: null };
-			}
-			if (isDescendantPath(sourcePath, destinationDir)) {
+			if (isParentOf(sourcePath, destinationDir)) {
 				return { allowed: false, state: 'invalid', destination: null };
 			}
 		}
@@ -809,7 +790,10 @@ export const FilePickerTree = forwardRef<
 			if (sourcePath) {
 				await moveNode(sourcePath, evaluation.destination);
 			} else {
-				await importExternalItems(event, evaluation.destination);
+				await importDataTransfer(
+					event.dataTransfer,
+					evaluation.destination
+				);
 			}
 		} finally {
 			resetDragState();
@@ -1037,18 +1021,32 @@ export const FilePickerTree = forwardRef<
 		}
 	};
 
-	const importExternalItems = async (
-		event: React.DragEvent,
+	/** Imports files selected by the browser's file input into one directory. */
+	const importFiles = (files: readonly File[], destinationDir: string) => {
+		return importExternalItems([], files, destinationDir);
+	};
+
+	/** Captures a drop payload before the browser protects its data store. */
+	const importDataTransfer = (
+		dataTransfer: DataTransfer,
 		destinationDir: string
 	) => {
-		if (!filesystem) return;
-		const items = event.dataTransfer?.items
-			? Array.from(event.dataTransfer.items)
-			: [];
+		const items = Array.from(dataTransfer.items);
 		const entries = items
 			.filter((item) => item.kind === 'file')
 			.map((item) => getEntryFromItem(item))
 			.filter((entry): entry is FileSystemEntryLike => Boolean(entry));
+		const files = Array.from(dataTransfer.files);
+		return importExternalItems(entries, files, destinationDir);
+	};
+
+	/** Writes captured files or directory entries through the tree's importer. */
+	const importExternalItems = async (
+		entries: FileSystemEntryLike[],
+		files: readonly File[],
+		destinationDir: string
+	) => {
+		if (!filesystem) return;
 		if (entries.length > 0) {
 			for (const entry of entries) {
 				if (entry.isFile) {
@@ -1064,9 +1062,6 @@ export const FilePickerTree = forwardRef<
 				}
 			}
 		} else {
-			const files = event.dataTransfer?.files
-				? Array.from(event.dataTransfer.files)
-				: [];
 			for (const file of files) {
 				await importFileBlob(file, destinationDir);
 			}
@@ -1189,11 +1184,16 @@ export const FilePickerTree = forwardRef<
 
 	// Filesystem-mode rename handlers
 	const handleRename = async (path: string, newName: string) => {
+		if (readOnly) return;
 		const pending = pendingCreateRef.current;
 		const isPending = pending?.tempPath === path;
 		const parent = dirname(path);
-		const sanitized = (newName || '').trim();
-		if (!isValidNameSegment(sanitized)) {
+		if (
+			!newName ||
+			newName === '.' ||
+			newName === '..' ||
+			basename(newName) !== newName
+		) {
 			if (isPending) {
 				try {
 					if (pending.type === 'folder') {
@@ -1211,7 +1211,7 @@ export const FilePickerTree = forwardRef<
 			setRenamingAbsolutePath(isPending ? null : path);
 			return;
 		}
-		let candidate = joinPaths(parent, sanitized);
+		let candidate = joinPaths(parent, newName);
 		let candidateNormalized = candidate;
 		if (candidateNormalized === path) {
 			setRenamingAbsolutePath(null);
@@ -1234,7 +1234,7 @@ export const FilePickerTree = forwardRef<
 				try {
 					const unique = await findAvailableName(
 						parent === '/' ? '/' : parent,
-						sanitized
+						newName
 					);
 					candidate = joinPaths(parent, unique);
 					candidateNormalized = candidate;
@@ -1327,23 +1327,25 @@ export const FilePickerTree = forwardRef<
 						selectPath={selectPath}
 						generatePath={generatePath}
 						getChildren={getResolvedChildren}
-						onContextMenu={handleInternalContextMenu}
+						onContextMenu={
+							readOnly ? undefined : handleInternalContextMenu
+						}
 						renamingPath={effectiveRenamingPath}
 						onRename={handleRename}
 						onRenameCancel={handleRenameCancelInternal}
 						dropIndicator={dropIndicator}
-						onDragStart={handleNodeDragStart}
-						onDragEnd={handleNodeDragEnd}
-						onDragEnter={handleNodeDragEnter}
-						onDragOver={handleNodeDragOver}
-						onDragLeave={handleNodeDragLeave}
-						onDrop={handleNodeDrop}
+						onDragStart={readOnly ? undefined : handleNodeDragStart}
+						onDragEnd={readOnly ? undefined : handleNodeDragEnd}
+						onDragEnter={readOnly ? undefined : handleNodeDragEnter}
+						onDragOver={readOnly ? undefined : handleNodeDragOver}
+						onDragLeave={readOnly ? undefined : handleNodeDragLeave}
+						onDrop={readOnly ? undefined : handleNodeDrop}
 						rootPath={normalizedRoot}
 						onDoubleClickFile={onDoubleClickFile}
 					/>
 				))}
 			</TreeGrid>
-			{contextMenu && (
+			{!readOnly && contextMenu && (
 				<Popover
 					placement="bottom-start"
 					onClose={() => setContextMenu(null)}
@@ -1521,7 +1523,8 @@ const NodeRow: React.FC<{
 	const isDropTargetValid = isDropTarget && dropIndicator?.state === 'valid';
 	const isDropTargetInvalid =
 		isDropTarget && dropIndicator?.state === 'invalid';
-	const isDraggable = !isRenaming && path !== rootPath;
+	const isDraggable =
+		Boolean(onDragStart) && !isRenaming && path !== rootPath;
 	const clickTimeoutRef = useRef<number | null>(null);
 
 	const dragHandlers = {
@@ -1564,7 +1567,7 @@ const NodeRow: React.FC<{
 			} else {
 				(
 					document.querySelector(
-						`[data-path="${parentPath}"]`
+						`[data-path="${CSS.escape(parentPath)}"]`
 					) as HTMLButtonElement
 				)?.focus();
 			}
@@ -1579,7 +1582,7 @@ const NodeRow: React.FC<{
 					);
 					(
 						document.querySelector(
-							`[data-path="${firstChildPath}"]`
+							`[data-path="${CSS.escape(firstChildPath)}"]`
 						) as HTMLButtonElement
 					)?.focus();
 				}
@@ -1622,7 +1625,7 @@ const NodeRow: React.FC<{
 	const handleRenameSubmit = (event: React.FormEvent) => {
 		event.preventDefault();
 		renameHandledRef.current = true;
-		onRename?.(path, renameValue.trim());
+		onRename?.(path, renameValue);
 	};
 
 	const handleRenameKeyDown = (

--- a/packages/playground/components/src/PlaygroundFileEditor/file-explorer-sidebar.tsx
+++ b/packages/playground/components/src/PlaygroundFileEditor/file-explorer-sidebar.tsx
@@ -1,4 +1,5 @@
 import React, {
+	useEffect,
 	useMemo,
 	useRef,
 	useState,
@@ -6,7 +7,8 @@ import React, {
 	type SetStateAction,
 } from 'react';
 import { Icon } from '@wordpress/components';
-import { file as folderIcon, page as fileIcon } from '@wordpress/icons';
+import { file as folderIcon, page as fileIcon, upload } from '@wordpress/icons';
+import classNames from 'classnames';
 import styles from './file-explorer.module.css';
 import {
 	FilePickerTree,
@@ -14,7 +16,7 @@ import {
 } from '@wp-playground/components';
 import type { AsyncWritableFilesystem } from '@wp-playground/storage';
 import { logger } from '@php-wasm/logger';
-import { dirname, normalizePath } from '@php-wasm/util';
+import { basename, dirname } from '@php-wasm/util';
 import { BinaryFilePreview } from '@wp-playground/components';
 import {
 	seemsLikeBinary,
@@ -41,6 +43,7 @@ export type FileExplorerSidebarProps = {
 		message: string | JSX.Element
 	) => Promise<void> | void;
 	documentRoot: string;
+	readOnly?: boolean;
 };
 
 /**
@@ -55,22 +58,35 @@ export function FileExplorerSidebar({
 	onSelectionCleared,
 	onShowMessage,
 	documentRoot,
+	readOnly = false,
 }: FileExplorerSidebarProps) {
 	const treeRef = useRef<FilePickerTreeHandle | null>(null);
+	const uploadInputRef = useRef<HTMLInputElement | null>(null);
 
 	const treeInitialPath = useMemo(() => {
-		return normalizePath(
-			currentPath
-				? dirname(normalizePath(currentPath))
-				: (selectedDirPath ?? documentRoot)
-		);
+		return currentPath
+			? dirname(currentPath)
+			: (selectedDirPath ?? documentRoot);
 		// Prevent tree from jumping unexpectedly when selectedDirPath changes.
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [currentPath, documentRoot]);
 
-	const [lastSelectedPath, setLastSelectedPath] = useState<string | null>(
-		null
-	);
+	const [isDraggingSidebar, setIsDraggingSidebar] = useState(false);
+
+	// `currentPath` already owns the visible file. Mirror it into the tree
+	// instead of introducing another focus-path prop that could drift.
+	useEffect(() => {
+		if (!currentPath || !treeRef.current) {
+			return;
+		}
+		setSelectedDirPath(dirname(currentPath));
+		treeRef.current.focusPath(currentPath, {
+			select: true,
+			domFocus: false,
+			notify: false,
+		});
+		void treeRef.current.expandToPath(currentPath);
+	}, [currentPath, setSelectedDirPath]);
 
 	/**
 	 * Opens a selected file as editable text, binary preview, or too-large notice.
@@ -94,7 +110,7 @@ export function FileExplorerSidebar({
 				return;
 			}
 			const data = previewRead.data;
-			const filename = path.split('/').pop() || 'download';
+			const filename = basename(path) || 'download';
 
 			if (seemsLikeBinary(data)) {
 				const mimeType = getMimeType(filename);
@@ -144,54 +160,146 @@ export function FileExplorerSidebar({
 		}
 	};
 
+	/** Sends file-input uploads through the tree's existing import path. */
+	const handleUploadInputChange = (
+		event: React.ChangeEvent<HTMLInputElement>
+	) => {
+		const files = Array.from(event.target.files ?? []);
+		event.target.value = '';
+		if (files.length === 0) {
+			return;
+		}
+		void treeRef.current
+			?.importFiles(files, selectedDirPath ?? documentRoot)
+			.catch((error) => logger.error('Failed to import files', error));
+	};
+
+	/** Sends a host drop through the same recursive importer used by tree rows. */
+	const handleSidebarDrop = (event: React.DragEvent) => {
+		if (
+			event.dataTransfer.types.includes(
+				'application/x-wp-playground-path'
+			)
+		) {
+			return;
+		}
+		event.preventDefault();
+		if (readOnly) {
+			return;
+		}
+		void treeRef.current
+			?.importDataTransfer(
+				event.dataTransfer,
+				selectedDirPath ?? documentRoot
+			)
+			.catch((error) =>
+				logger.error('Failed to import dropped files', error)
+			);
+	};
+
 	return (
-		<div className={styles['fileExplorerContainer']}>
+		<div
+			className={classNames(styles['fileExplorerContainer'], {
+				[styles['dropActive']]: isDraggingSidebar,
+			})}
+			onDragEnter={(event) => {
+				if (
+					event.dataTransfer.types.includes(
+						'application/x-wp-playground-path'
+					)
+				) {
+					return;
+				}
+				event.preventDefault();
+				if (!readOnly) {
+					setIsDraggingSidebar(true);
+				}
+			}}
+			onDragOver={(event) => {
+				if (
+					event.dataTransfer.types.includes(
+						'application/x-wp-playground-path'
+					)
+				) {
+					return;
+				}
+				event.preventDefault();
+				event.dataTransfer.dropEffect = readOnly ? 'none' : 'copy';
+			}}
+			onDragLeave={(event) => {
+				const related = event.relatedTarget as Node | null;
+				if (!related || !event.currentTarget.contains(related)) {
+					setIsDraggingSidebar(false);
+				}
+			}}
+			onDropCapture={() => setIsDraggingSidebar(false)}
+			onDrop={handleSidebarDrop}
+		>
 			<div className={styles['fileExplorerHeader']}>
 				<span className={styles['fileExplorerTitle']}>Files</span>
-				<div className={styles['fileExplorerActions']}>
-					<button
-						className={styles['fileExplorerButton']}
-						type="button"
-						onClick={() => {
-							if (!treeRef.current) {
-								return;
-							}
-							void treeRef.current.createFile(
-								lastSelectedPath ?? undefined
-							);
-						}}
-						title="Create new file"
-					>
-						<Icon icon={fileIcon} size={16} />
-						New File
-					</button>
-					<button
-						className={styles['fileExplorerButton']}
-						type="button"
-						onClick={() => {
-							if (!treeRef.current) {
-								return;
-							}
-							void treeRef.current.createFolder(
-								lastSelectedPath ?? undefined
-							);
-						}}
-						title="Create new folder"
-					>
-						<Icon icon={folderIcon} size={16} />
-						New Folder
-					</button>
-				</div>
+				{!readOnly ? (
+					<div className={styles['fileExplorerActions']}>
+						<button
+							className={styles['fileExplorerButton']}
+							type="button"
+							onClick={() => {
+								if (!treeRef.current) {
+									return;
+								}
+								void treeRef.current.createFile();
+							}}
+							title="Create new file"
+						>
+							<Icon icon={fileIcon} size={16} />
+							New File
+						</button>
+						<button
+							className={styles['fileExplorerButton']}
+							type="button"
+							onClick={() => {
+								if (!treeRef.current) {
+									return;
+								}
+								void treeRef.current.createFolder();
+							}}
+							title="Create new folder"
+						>
+							<Icon icon={folderIcon} size={16} />
+							New Folder
+						</button>
+						<button
+							className={classNames(
+								styles['fileExplorerButton'],
+								styles['fileExplorerIconButton'],
+								styles['fileExplorerUploadButton']
+							)}
+							type="button"
+							onClick={() => uploadInputRef.current?.click()}
+							aria-label="Upload files"
+							title="Upload files"
+						>
+							<Icon icon={upload} size={16} />
+						</button>
+						<input
+							ref={uploadInputRef}
+							type="file"
+							multiple
+							style={{ display: 'none' }}
+							onChange={handleUploadInputChange}
+						/>
+					</div>
+				) : null}
 			</div>
 			<div className={styles['fileExplorerTree']}>
 				<FilePickerTree
 					ref={treeRef}
+					readOnly={readOnly}
 					filesystem={filesystem}
 					root={documentRoot}
 					initialSelectedPath={treeInitialPath}
 					onSelect={async (path) => {
-						setLastSelectedPath(path);
 						if (!path) {
+							setSelectedDirPath(documentRoot);
 							await onSelectionCleared();
 							return;
 						}
@@ -203,6 +311,7 @@ export function FileExplorerSidebar({
 						} catch {
 							// If we cannot determine whether it is a directory, treat as file.
 						}
+						setSelectedDirPath(dirname(path));
 						// For files, open them but don't move focus to the editor
 						await handleOpenFile(path, false);
 					}}


### PR DESCRIPTION
## What it does

Adds an Upload button to the reusable file editor and lets users drop files or local
directories on the blank area around its file tree. Imports go into the selected
directory, and dropped directories keep their nested files and subdirectories.

This PR also:

- adds a `readOnly` option that keeps browsing and previews available while hiding
  or disabling changes to the filesystem;
- selects and expands to the file currently open in the editor; and
- uses the existing POSIX path helpers without trimming rename input or treating
  `\` as a separator. Empty names, `.`, `..`, and names containing `/` are still
  rejected.

The Blueprint editor switch remains in #3990.

## Rationale

The file browser has two parts. `FileExplorerSidebar` renders the header, Upload
button, and space around the tree. `FilePickerTree` renders the rows and performs
filesystem operations.

Before this PR, dropping a local directory on a tree row worked because the drop
reached `FilePickerTree`. Dropping the same directory on the surrounding sidebar did
not reach that code. This PR makes the tree's import operation available to the
sidebar, so the Upload button, tree-row drops, and background drops all behave the
same way.

The browser only exposes a drop payload while the drop handler is running, so the
sidebar captures its entries and files before starting the asynchronous import.

## Testing instructions

```bash
npm exec nx -- run-many -t test,typecheck,lint,build \
  --projects=playground-components
npm exec nx -- run playground-components:e2e -- --workers=1
```

Manual check:

1. Run `npm exec nx -- run playground-components:dev -- --host 127.0.0.1 --port 5174` and open `http://127.0.0.1:5174/playwright-file-editor.html`.
2. Select `/wordpress/workspace/subdir`, upload a text file, and confirm it appears there.
3. Drop a nested local directory on the blank explorer background and confirm its hierarchy appears under the selected directory.
4. Rename a throwaway entry with surrounding spaces and a backslash and confirm the name is not rewritten.
