### PR TITLE
[Blueprints] Support v2 WXR author options

### DIFF
--- a/packages/playground/blueprints/public/blueprint-schema-validator.js
+++ b/packages/playground/blueprints/public/blueprint-schema-validator.js
@@ -610,6 +610,25 @@ const schema11 = {
 								'The fallback local user for imported authors that cannot be mapped.',
 							default: 'admin',
 						},
+						authorsMode: {
+							type: 'string',
+							enum: ['create', 'default-author', 'map'],
+							description:
+								'How to assign imported WXR authors to local WordPress users.',
+							default: 'default-author',
+						},
+						authorsMap: {
+							type: 'object',
+							additionalProperties: { type: 'string' },
+							description:
+								'Remote WXR author usernames keyed to existing local usernames.',
+						},
+						importUsers: {
+							type: 'boolean',
+							description:
+								'Whether to create local users for imported WXR authors.',
+							default: false,
+						},
 						importer: {
 							type: 'string',
 							enum: ['data-liberation', 'default'],
@@ -4683,6 +4702,25 @@ const schema33 = {
 					description:
 						'The fallback local user for imported authors that cannot be mapped.',
 					default: 'admin',
+				},
+				authorsMode: {
+					type: 'string',
+					enum: ['create', 'default-author', 'map'],
+					description:
+						'How to assign imported WXR authors to local WordPress users.',
+					default: 'default-author',
+				},
+				authorsMap: {
+					type: 'object',
+					additionalProperties: { type: 'string' },
+					description:
+						'Remote WXR author usernames keyed to existing local usernames.',
+				},
+				importUsers: {
+					type: 'boolean',
+					description:
+						'Whether to create local users for imported WXR authors.',
+					default: false,
 				},
 				importer: {
 					type: 'string',
@@ -10795,16 +10833,9 @@ function validate28(
 									const _errs98 = errors;
 									for (const key13 in data) {
 										if (
-											!(
-												key13 === 'progress' ||
-												key13 === 'step' ||
-												key13 === 'file' ||
-												key13 === 'fetchAttachments' ||
-												key13 === 'rewriteUrls' ||
-												key13 === 'importComments' ||
-												key13 ===
-													'defaultAuthorUsername' ||
-												key13 === 'importer'
+											!func2.call(
+												schema33.oneOf[6].properties,
+												key13
 											)
 										) {
 											validate28.errors = [
@@ -11191,11 +11222,11 @@ function validate28(
 																}
 																if (valid21) {
 																	if (
-																		data.importer !==
+																		data.authorsMode !==
 																		undefined
 																	) {
 																		let data44 =
-																			data.importer;
+																			data.authorsMode;
 																		const _errs117 =
 																			errors;
 																		if (
@@ -11207,9 +11238,9 @@ function validate28(
 																					{
 																						instancePath:
 																							instancePath +
-																							'/importer',
+																							'/authorsMode',
 																						schemaPath:
-																							'#/oneOf/6/properties/importer/type',
+																							'#/oneOf/6/properties/authorsMode/type',
 																						keyword:
 																							'type',
 																						params: {
@@ -11224,9 +11255,11 @@ function validate28(
 																		if (
 																			!(
 																				data44 ===
-																					'data-liberation' ||
+																					'create' ||
 																				data44 ===
-																					'default'
+																					'default-author' ||
+																				data44 ===
+																					'map'
 																			)
 																		) {
 																			validate28.errors =
@@ -11234,9 +11267,9 @@ function validate28(
 																					{
 																						instancePath:
 																							instancePath +
-																							'/importer',
+																							'/authorsMode',
 																						schemaPath:
-																							'#/oneOf/6/properties/importer/enum',
+																							'#/oneOf/6/properties/authorsMode/enum',
 																						keyword:
 																							'enum',
 																						params: {
@@ -11244,7 +11277,7 @@ function validate28(
 																								schema33
 																									.oneOf[6]
 																									.properties
-																									.importer
+																									.authorsMode
 																									.enum,
 																						},
 																						message:
@@ -11258,6 +11291,215 @@ function validate28(
 																			errors;
 																	} else {
 																		var valid21 = true;
+																	}
+																	if (
+																		valid21
+																	) {
+																		if (
+																			data.authorsMap !==
+																			undefined
+																		) {
+																			let data45 =
+																				data.authorsMap;
+																			const _errs119 =
+																				errors;
+																			if (
+																				errors ===
+																				_errs119
+																			) {
+																				if (
+																					data45 &&
+																					typeof data45 ==
+																						'object' &&
+																					!Array.isArray(
+																						data45
+																					)
+																				) {
+																					for (const key15 in data45) {
+																						const _errs122 =
+																							errors;
+																						if (
+																							typeof data45[
+																								key15
+																							] !==
+																							'string'
+																						) {
+																							validate28.errors =
+																								[
+																									{
+																										instancePath:
+																											instancePath +
+																											'/authorsMap/' +
+																											key15
+																												.replace(
+																													/~/g,
+																													'~0'
+																												)
+																												.replace(
+																													/\//g,
+																													'~1'
+																												),
+																										schemaPath:
+																											'#/oneOf/6/properties/authorsMap/additionalProperties/type',
+																										keyword:
+																											'type',
+																										params: {
+																											type: 'string',
+																										},
+																										message:
+																											'must be string',
+																									},
+																								];
+																							return false;
+																						}
+																						var valid23 =
+																							_errs122 ===
+																							errors;
+																						if (
+																							!valid23
+																						) {
+																							break;
+																						}
+																					}
+																				} else {
+																					validate28.errors =
+																						[
+																							{
+																								instancePath:
+																									instancePath +
+																									'/authorsMap',
+																								schemaPath:
+																									'#/oneOf/6/properties/authorsMap/type',
+																								keyword:
+																									'type',
+																								params: {
+																									type: 'object',
+																								},
+																								message:
+																									'must be object',
+																							},
+																						];
+																					return false;
+																				}
+																			}
+																			var valid21 =
+																				_errs119 ===
+																				errors;
+																		} else {
+																			var valid21 = true;
+																		}
+																		if (
+																			valid21
+																		) {
+																			if (
+																				data.importUsers !==
+																				undefined
+																			) {
+																				const _errs124 =
+																					errors;
+																				if (
+																					typeof data.importUsers !==
+																					'boolean'
+																				) {
+																					validate28.errors =
+																						[
+																							{
+																								instancePath:
+																									instancePath +
+																									'/importUsers',
+																								schemaPath:
+																									'#/oneOf/6/properties/importUsers/type',
+																								keyword:
+																									'type',
+																								params: {
+																									type: 'boolean',
+																								},
+																								message:
+																									'must be boolean',
+																							},
+																						];
+																					return false;
+																				}
+																				var valid21 =
+																					_errs124 ===
+																					errors;
+																			} else {
+																				var valid21 = true;
+																			}
+																			if (
+																				valid21
+																			) {
+																				if (
+																					data.importer !==
+																					undefined
+																				) {
+																					let data48 =
+																						data.importer;
+																					const _errs126 =
+																						errors;
+																					if (
+																						typeof data48 !==
+																						'string'
+																					) {
+																						validate28.errors =
+																							[
+																								{
+																									instancePath:
+																										instancePath +
+																										'/importer',
+																									schemaPath:
+																										'#/oneOf/6/properties/importer/type',
+																									keyword:
+																										'type',
+																									params: {
+																										type: 'string',
+																									},
+																									message:
+																										'must be string',
+																								},
+																							];
+																						return false;
+																					}
+																					if (
+																						!(
+																							data48 ===
+																								'data-liberation' ||
+																							data48 ===
+																								'default'
+																						)
+																					) {
+																						validate28.errors =
+																							[
+																								{
+																									instancePath:
+																										instancePath +
+																										'/importer',
+																									schemaPath:
+																										'#/oneOf/6/properties/importer/enum',
+																									keyword:
+																										'enum',
+																									params: {
+																										allowedValues:
+																											schema33
+																												.oneOf[6]
+																												.properties
+																												.importer
+																												.enum,
+																									},
+																									message:
+																										'must be equal to one of the allowed values',
+																								},
+																							];
+																						return false;
+																					}
+																					var valid21 =
+																						_errs126 ===
+																						errors;
+																				} else {
+																					var valid21 = true;
+																				}
+																			}
+																		}
 																	}
 																}
 															}
@@ -11282,8 +11524,8 @@ function validate28(
 							}
 						}
 					} else if (tag0 === 'importThemeStarterContent') {
-						const _errs119 = errors;
-						if (errors === _errs119) {
+						const _errs128 = errors;
+						if (errors === _errs128) {
 							if (
 								data &&
 								typeof data == 'object' &&
@@ -11310,13 +11552,13 @@ function validate28(
 									];
 									return false;
 								} else {
-									const _errs121 = errors;
-									for (const key15 in data) {
+									const _errs130 = errors;
+									for (const key16 in data) {
 										if (
 											!(
-												key15 === 'progress' ||
-												key15 === 'step' ||
-												key15 === 'themeSlug'
+												key16 === 'progress' ||
+												key16 === 'step' ||
+												key16 === 'themeSlug'
 											)
 										) {
 											validate28.errors = [
@@ -11328,7 +11570,7 @@ function validate28(
 														'additionalProperties',
 													params: {
 														additionalProperty:
-															key15,
+															key16,
 													},
 													message:
 														'must NOT have additional properties',
@@ -11338,23 +11580,23 @@ function validate28(
 											break;
 										}
 									}
-									if (_errs121 === errors) {
+									if (_errs130 === errors) {
 										if (data.progress !== undefined) {
-											let data45 = data.progress;
-											const _errs122 = errors;
-											if (errors === _errs122) {
+											let data49 = data.progress;
+											const _errs131 = errors;
+											if (errors === _errs131) {
 												if (
-													data45 &&
-													typeof data45 == 'object' &&
-													!Array.isArray(data45)
+													data49 &&
+													typeof data49 == 'object' &&
+													!Array.isArray(data49)
 												) {
-													const _errs124 = errors;
-													for (const key16 in data45) {
+													const _errs133 = errors;
+													for (const key17 in data49) {
 														if (
 															!(
-																key16 ===
+																key17 ===
 																	'weight' ||
-																key16 ===
+																key17 ===
 																	'caption'
 															)
 														) {
@@ -11370,7 +11612,7 @@ function validate28(
 																			'additionalProperties',
 																		params: {
 																			additionalProperty:
-																				key16,
+																				key17,
 																		},
 																		message:
 																			'must NOT have additional properties',
@@ -11380,21 +11622,21 @@ function validate28(
 															break;
 														}
 													}
-													if (_errs124 === errors) {
+													if (_errs133 === errors) {
 														if (
-															data45.weight !==
+															data49.weight !==
 															undefined
 														) {
-															let data46 =
-																data45.weight;
-															const _errs125 =
+															let data50 =
+																data49.weight;
+															const _errs134 =
 																errors;
 															if (
 																!(
-																	typeof data46 ==
+																	typeof data50 ==
 																		'number' &&
 																	isFinite(
-																		data46
+																		data50
 																	)
 																)
 															) {
@@ -11417,21 +11659,21 @@ function validate28(
 																	];
 																return false;
 															}
-															var valid25 =
-																_errs125 ===
+															var valid26 =
+																_errs134 ===
 																errors;
 														} else {
-															var valid25 = true;
+															var valid26 = true;
 														}
-														if (valid25) {
+														if (valid26) {
 															if (
-																data45.caption !==
+																data49.caption !==
 																undefined
 															) {
-																const _errs127 =
+																const _errs136 =
 																	errors;
 																if (
-																	typeof data45.caption !==
+																	typeof data49.caption !==
 																	'string'
 																) {
 																	validate28.errors =
@@ -11453,11 +11695,11 @@ function validate28(
 																		];
 																	return false;
 																}
-																var valid25 =
-																	_errs127 ===
+																var valid26 =
+																	_errs136 ===
 																	errors;
 															} else {
-																var valid25 = true;
+																var valid26 = true;
 															}
 														}
 													}
@@ -11480,16 +11722,16 @@ function validate28(
 													return false;
 												}
 											}
-											var valid24 = _errs122 === errors;
+											var valid25 = _errs131 === errors;
 										} else {
-											var valid24 = true;
+											var valid25 = true;
 										}
-										if (valid24) {
+										if (valid25) {
 											if (data.step !== undefined) {
-												let data48 = data.step;
-												const _errs129 = errors;
+												let data52 = data.step;
+												const _errs138 = errors;
 												if (
-													typeof data48 !== 'string'
+													typeof data52 !== 'string'
 												) {
 													validate28.errors = [
 														{
@@ -11510,7 +11752,7 @@ function validate28(
 												}
 												if (
 													'importThemeStarterContent' !==
-													data48
+													data52
 												) {
 													validate28.errors = [
 														{
@@ -11530,16 +11772,16 @@ function validate28(
 													];
 													return false;
 												}
-												var valid24 =
-													_errs129 === errors;
+												var valid25 =
+													_errs138 === errors;
 											} else {
-												var valid24 = true;
+												var valid25 = true;
 											}
-											if (valid24) {
+											if (valid25) {
 												if (
 													data.themeSlug !== undefined
 												) {
-													const _errs131 = errors;
+													const _errs140 = errors;
 													if (
 														typeof data.themeSlug !==
 														'string'
@@ -11561,10 +11803,10 @@ function validate28(
 														];
 														return false;
 													}
-													var valid24 =
-														_errs131 === errors;
+													var valid25 =
+														_errs140 === errors;
 												} else {
-													var valid24 = true;
+													var valid25 = true;
 												}
 											}
 										}
@@ -11584,8 +11826,8 @@ function validate28(
 							}
 						}
 					} else if (tag0 === 'importWordPressFiles') {
-						const _errs133 = errors;
-						if (errors === _errs133) {
+						const _errs142 = errors;
+						if (errors === _errs142) {
 							if (
 								data &&
 								typeof data == 'object' &&
@@ -11614,14 +11856,14 @@ function validate28(
 									];
 									return false;
 								} else {
-									const _errs135 = errors;
-									for (const key17 in data) {
+									const _errs144 = errors;
+									for (const key18 in data) {
 										if (
 											!(
-												key17 === 'progress' ||
-												key17 === 'step' ||
-												key17 === 'wordPressFilesZip' ||
-												key17 === 'pathInZip'
+												key18 === 'progress' ||
+												key18 === 'step' ||
+												key18 === 'wordPressFilesZip' ||
+												key18 === 'pathInZip'
 											)
 										) {
 											validate28.errors = [
@@ -11633,7 +11875,7 @@ function validate28(
 														'additionalProperties',
 													params: {
 														additionalProperty:
-															key17,
+															key18,
 													},
 													message:
 														'must NOT have additional properties',
@@ -11643,23 +11885,23 @@ function validate28(
 											break;
 										}
 									}
-									if (_errs135 === errors) {
+									if (_errs144 === errors) {
 										if (data.progress !== undefined) {
-											let data50 = data.progress;
-											const _errs136 = errors;
-											if (errors === _errs136) {
+											let data54 = data.progress;
+											const _errs145 = errors;
+											if (errors === _errs145) {
 												if (
-													data50 &&
-													typeof data50 == 'object' &&
-													!Array.isArray(data50)
+													data54 &&
+													typeof data54 == 'object' &&
+													!Array.isArray(data54)
 												) {
-													const _errs138 = errors;
-													for (const key18 in data50) {
+													const _errs147 = errors;
+													for (const key19 in data54) {
 														if (
 															!(
-																key18 ===
+																key19 ===
 																	'weight' ||
-																key18 ===
+																key19 ===
 																	'caption'
 															)
 														) {
@@ -11675,7 +11917,7 @@ function validate28(
 																			'additionalProperties',
 																		params: {
 																			additionalProperty:
-																				key18,
+																				key19,
 																		},
 																		message:
 																			'must NOT have additional properties',
@@ -11685,21 +11927,21 @@ function validate28(
 															break;
 														}
 													}
-													if (_errs138 === errors) {
+													if (_errs147 === errors) {
 														if (
-															data50.weight !==
+															data54.weight !==
 															undefined
 														) {
-															let data51 =
-																data50.weight;
-															const _errs139 =
+															let data55 =
+																data54.weight;
+															const _errs148 =
 																errors;
 															if (
 																!(
-																	typeof data51 ==
+																	typeof data55 ==
 																		'number' &&
 																	isFinite(
-																		data51
+																		data55
 																	)
 																)
 															) {
@@ -11722,21 +11964,21 @@ function validate28(
 																	];
 																return false;
 															}
-															var valid28 =
-																_errs139 ===
+															var valid29 =
+																_errs148 ===
 																errors;
 														} else {
-															var valid28 = true;
+															var valid29 = true;
 														}
-														if (valid28) {
+														if (valid29) {
 															if (
-																data50.caption !==
+																data54.caption !==
 																undefined
 															) {
-																const _errs141 =
+																const _errs150 =
 																	errors;
 																if (
-																	typeof data50.caption !==
+																	typeof data54.caption !==
 																	'string'
 																) {
 																	validate28.errors =
@@ -11758,11 +12000,11 @@ function validate28(
 																		];
 																	return false;
 																}
-																var valid28 =
-																	_errs141 ===
+																var valid29 =
+																	_errs150 ===
 																	errors;
 															} else {
-																var valid28 = true;
+																var valid29 = true;
 															}
 														}
 													}
@@ -11785,16 +12027,16 @@ function validate28(
 													return false;
 												}
 											}
-											var valid27 = _errs136 === errors;
+											var valid28 = _errs145 === errors;
 										} else {
-											var valid27 = true;
+											var valid28 = true;
 										}
-										if (valid27) {
+										if (valid28) {
 											if (data.step !== undefined) {
-												let data53 = data.step;
-												const _errs143 = errors;
+												let data57 = data.step;
+												const _errs152 = errors;
 												if (
-													typeof data53 !== 'string'
+													typeof data57 !== 'string'
 												) {
 													validate28.errors = [
 														{
@@ -11815,7 +12057,7 @@ function validate28(
 												}
 												if (
 													'importWordPressFiles' !==
-													data53
+													data57
 												) {
 													validate28.errors = [
 														{
@@ -11835,17 +12077,17 @@ function validate28(
 													];
 													return false;
 												}
-												var valid27 =
-													_errs143 === errors;
+												var valid28 =
+													_errs152 === errors;
 											} else {
-												var valid27 = true;
+												var valid28 = true;
 											}
-											if (valid27) {
+											if (valid28) {
 												if (
 													data.wordPressFilesZip !==
 													undefined
 												) {
-													const _errs145 = errors;
+													const _errs154 = errors;
 													if (
 														!validate16(
 															data.wordPressFilesZip,
@@ -11869,17 +12111,17 @@ function validate28(
 																	);
 														errors = vErrors.length;
 													}
-													var valid27 =
-														_errs145 === errors;
+													var valid28 =
+														_errs154 === errors;
 												} else {
-													var valid27 = true;
+													var valid28 = true;
 												}
-												if (valid27) {
+												if (valid28) {
 													if (
 														data.pathInZip !==
 														undefined
 													) {
-														const _errs146 = errors;
+														const _errs155 = errors;
 														if (
 															typeof data.pathInZip !==
 															'string'
@@ -11903,10 +12145,10 @@ function validate28(
 																];
 															return false;
 														}
-														var valid27 =
-															_errs146 === errors;
+														var valid28 =
+															_errs155 === errors;
 													} else {
-														var valid27 = true;
+														var valid28 = true;
 													}
 												}
 											}
@@ -11927,8 +12169,8 @@ function validate28(
 							}
 						}
 					} else if (tag0 === 'installPlugin') {
-						const _errs148 = errors;
-						if (errors === _errs148) {
+						const _errs157 = errors;
+						if (errors === _errs157) {
 							if (
 								data &&
 								typeof data == 'object' &&
@@ -11957,17 +12199,17 @@ function validate28(
 									];
 									return false;
 								} else {
-									const _errs150 = errors;
-									for (const key19 in data) {
+									const _errs159 = errors;
+									for (const key20 in data) {
 										if (
 											!(
-												key19 === 'progress' ||
-												key19 ===
+												key20 === 'progress' ||
+												key20 ===
 													'ifAlreadyInstalled' ||
-												key19 === 'step' ||
-												key19 === 'pluginData' ||
-												key19 === 'pluginZipFile' ||
-												key19 === 'options'
+												key20 === 'step' ||
+												key20 === 'pluginData' ||
+												key20 === 'pluginZipFile' ||
+												key20 === 'options'
 											)
 										) {
 											validate28.errors = [
@@ -11979,7 +12221,7 @@ function validate28(
 														'additionalProperties',
 													params: {
 														additionalProperty:
-															key19,
+															key20,
 													},
 													message:
 														'must NOT have additional properties',
@@ -11989,23 +12231,23 @@ function validate28(
 											break;
 										}
 									}
-									if (_errs150 === errors) {
+									if (_errs159 === errors) {
 										if (data.progress !== undefined) {
-											let data56 = data.progress;
-											const _errs151 = errors;
-											if (errors === _errs151) {
+											let data60 = data.progress;
+											const _errs160 = errors;
+											if (errors === _errs160) {
 												if (
-													data56 &&
-													typeof data56 == 'object' &&
-													!Array.isArray(data56)
+													data60 &&
+													typeof data60 == 'object' &&
+													!Array.isArray(data60)
 												) {
-													const _errs153 = errors;
-													for (const key20 in data56) {
+													const _errs162 = errors;
+													for (const key21 in data60) {
 														if (
 															!(
-																key20 ===
+																key21 ===
 																	'weight' ||
-																key20 ===
+																key21 ===
 																	'caption'
 															)
 														) {
@@ -12021,7 +12263,7 @@ function validate28(
 																			'additionalProperties',
 																		params: {
 																			additionalProperty:
-																				key20,
+																				key21,
 																		},
 																		message:
 																			'must NOT have additional properties',
@@ -12031,21 +12273,21 @@ function validate28(
 															break;
 														}
 													}
-													if (_errs153 === errors) {
+													if (_errs162 === errors) {
 														if (
-															data56.weight !==
+															data60.weight !==
 															undefined
 														) {
-															let data57 =
-																data56.weight;
-															const _errs154 =
+															let data61 =
+																data60.weight;
+															const _errs163 =
 																errors;
 															if (
 																!(
-																	typeof data57 ==
+																	typeof data61 ==
 																		'number' &&
 																	isFinite(
-																		data57
+																		data61
 																	)
 																)
 															) {
@@ -12068,21 +12310,21 @@ function validate28(
 																	];
 																return false;
 															}
-															var valid31 =
-																_errs154 ===
+															var valid32 =
+																_errs163 ===
 																errors;
 														} else {
-															var valid31 = true;
+															var valid32 = true;
 														}
-														if (valid31) {
+														if (valid32) {
 															if (
-																data56.caption !==
+																data60.caption !==
 																undefined
 															) {
-																const _errs156 =
+																const _errs165 =
 																	errors;
 																if (
-																	typeof data56.caption !==
+																	typeof data60.caption !==
 																	'string'
 																) {
 																	validate28.errors =
@@ -12104,11 +12346,11 @@ function validate28(
 																		];
 																	return false;
 																}
-																var valid31 =
-																	_errs156 ===
+																var valid32 =
+																	_errs165 ===
 																	errors;
 															} else {
-																var valid31 = true;
+																var valid32 = true;
 															}
 														}
 													}
@@ -12131,20 +12373,20 @@ function validate28(
 													return false;
 												}
 											}
-											var valid30 = _errs151 === errors;
+											var valid31 = _errs160 === errors;
 										} else {
-											var valid30 = true;
+											var valid31 = true;
 										}
-										if (valid30) {
+										if (valid31) {
 											if (
 												data.ifAlreadyInstalled !==
 												undefined
 											) {
-												let data59 =
+												let data63 =
 													data.ifAlreadyInstalled;
-												const _errs158 = errors;
+												const _errs167 = errors;
 												if (
-													typeof data59 !== 'string'
+													typeof data63 !== 'string'
 												) {
 													validate28.errors = [
 														{
@@ -12165,10 +12407,10 @@ function validate28(
 												}
 												if (
 													!(
-														data59 ===
+														data63 ===
 															'overwrite' ||
-														data59 === 'skip' ||
-														data59 === 'error'
+														data63 === 'skip' ||
+														data63 === 'error'
 													)
 												) {
 													validate28.errors = [
@@ -12193,17 +12435,17 @@ function validate28(
 													];
 													return false;
 												}
-												var valid30 =
-													_errs158 === errors;
+												var valid31 =
+													_errs167 === errors;
 											} else {
-												var valid30 = true;
+												var valid31 = true;
 											}
-											if (valid30) {
+											if (valid31) {
 												if (data.step !== undefined) {
-													let data60 = data.step;
-													const _errs160 = errors;
+													let data64 = data.step;
+													const _errs169 = errors;
 													if (
-														typeof data60 !==
+														typeof data64 !==
 														'string'
 													) {
 														validate28.errors = [
@@ -12225,7 +12467,7 @@ function validate28(
 													}
 													if (
 														'installPlugin' !==
-														data60
+														data64
 													) {
 														validate28.errors = [
 															{
@@ -12246,25 +12488,25 @@ function validate28(
 														];
 														return false;
 													}
-													var valid30 =
-														_errs160 === errors;
+													var valid31 =
+														_errs169 === errors;
 												} else {
-													var valid30 = true;
+													var valid31 = true;
 												}
-												if (valid30) {
+												if (valid31) {
 													if (
 														data.pluginData !==
 														undefined
 													) {
-														let data61 =
+														let data65 =
 															data.pluginData;
-														const _errs162 = errors;
-														const _errs163 = errors;
-														let valid32 = false;
-														const _errs164 = errors;
+														const _errs171 = errors;
+														const _errs172 = errors;
+														let valid33 = false;
+														const _errs173 = errors;
 														if (
 															!validate16(
-																data61,
+																data65,
 																{
 																	instancePath:
 																		instancePath +
@@ -12287,15 +12529,15 @@ function validate28(
 																vErrors.length;
 														}
 														var _valid0 =
-															_errs164 === errors;
-														valid32 =
-															valid32 || _valid0;
-														if (!valid32) {
-															const _errs165 =
+															_errs173 === errors;
+														valid33 =
+															valid33 || _valid0;
+														if (!valid33) {
+															const _errs174 =
 																errors;
 															if (
 																!validate18(
-																	data61,
+																	data65,
 																	{
 																		instancePath:
 																			instancePath +
@@ -12319,13 +12561,13 @@ function validate28(
 																	vErrors.length;
 															}
 															var _valid0 =
-																_errs165 ===
+																_errs174 ===
 																errors;
-															valid32 =
-																valid32 ||
+															valid33 =
+																valid33 ||
 																_valid0;
 														}
-														if (!valid32) {
+														if (!valid33) {
 															const err0 = {
 																instancePath:
 																	instancePath +
@@ -12354,30 +12596,30 @@ function validate28(
 																vErrors;
 															return false;
 														} else {
-															errors = _errs163;
+															errors = _errs172;
 															if (
 																vErrors !== null
 															) {
-																if (_errs163) {
+																if (_errs172) {
 																	vErrors.length =
-																		_errs163;
+																		_errs172;
 																} else {
 																	vErrors =
 																		null;
 																}
 															}
 														}
-														var valid30 =
-															_errs162 === errors;
+														var valid31 =
+															_errs171 === errors;
 													} else {
-														var valid30 = true;
+														var valid31 = true;
 													}
-													if (valid30) {
+													if (valid31) {
 														if (
 															data.pluginZipFile !==
 															undefined
 														) {
-															const _errs166 =
+															const _errs175 =
 																errors;
 															if (
 																!validate16(
@@ -12404,49 +12646,49 @@ function validate28(
 																errors =
 																	vErrors.length;
 															}
-															var valid30 =
-																_errs166 ===
+															var valid31 =
+																_errs175 ===
 																errors;
 														} else {
-															var valid30 = true;
+															var valid31 = true;
 														}
-														if (valid30) {
+														if (valid31) {
 															if (
 																data.options !==
 																undefined
 															) {
-																let data63 =
+																let data67 =
 																	data.options;
-																const _errs167 =
+																const _errs176 =
 																	errors;
-																const _errs168 =
+																const _errs177 =
 																	errors;
 																if (
 																	errors ===
-																	_errs168
+																	_errs177
 																) {
 																	if (
-																		data63 &&
-																		typeof data63 ==
+																		data67 &&
+																		typeof data67 ==
 																			'object' &&
 																		!Array.isArray(
-																			data63
+																			data67
 																		)
 																	) {
-																		const _errs170 =
+																		const _errs179 =
 																			errors;
-																		for (const key21 in data63) {
+																		for (const key22 in data67) {
 																			if (
 																				!(
-																					key21 ===
+																					key22 ===
 																						'activate' ||
-																					key21 ===
+																					key22 ===
 																						'activationOptions' ||
-																					key21 ===
+																					key22 ===
 																						'onError' ||
-																					key21 ===
+																					key22 ===
 																						'targetFolderName' ||
-																					key21 ===
+																					key22 ===
 																						'humanReadableName'
 																				)
 																			) {
@@ -12462,7 +12704,7 @@ function validate28(
 																								'additionalProperties',
 																							params: {
 																								additionalProperty:
-																									key21,
+																									key22,
 																							},
 																							message:
 																								'must NOT have additional properties',
@@ -12473,17 +12715,17 @@ function validate28(
 																			}
 																		}
 																		if (
-																			_errs170 ===
+																			_errs179 ===
 																			errors
 																		) {
 																			if (
-																				data63.activate !==
+																				data67.activate !==
 																				undefined
 																			) {
-																				const _errs171 =
+																				const _errs180 =
 																					errors;
 																				if (
-																					typeof data63.activate !==
+																					typeof data67.activate !==
 																					'boolean'
 																				) {
 																					validate28.errors =
@@ -12505,43 +12747,43 @@ function validate28(
 																						];
 																					return false;
 																				}
-																				var valid34 =
-																					_errs171 ===
+																				var valid35 =
+																					_errs180 ===
 																					errors;
 																			} else {
-																				var valid34 = true;
+																				var valid35 = true;
 																			}
 																			if (
-																				valid34
+																				valid35
 																			) {
 																				if (
-																					data63.activationOptions !==
+																					data67.activationOptions !==
 																					undefined
 																				) {
-																					let data65 =
-																						data63.activationOptions;
-																					const _errs173 =
+																					let data69 =
+																						data67.activationOptions;
+																					const _errs182 =
 																						errors;
 																					if (
 																						errors ===
-																						_errs173
+																						_errs182
 																					) {
 																						if (
-																							data65 &&
-																							typeof data65 ==
+																							data69 &&
+																							typeof data69 ==
 																								'object' &&
 																							!Array.isArray(
-																								data65
+																								data69
 																							)
 																						) {
-																							for (const key22 in data65) {
-																								const _errs176 =
+																							for (const key23 in data69) {
+																								const _errs185 =
 																									errors;
-																								var valid35 =
-																									_errs176 ===
+																								var valid36 =
+																									_errs185 ===
 																									errors;
 																								if (
-																									!valid35
+																									!valid36
 																								) {
 																									break;
 																								}
@@ -12567,25 +12809,25 @@ function validate28(
 																							return false;
 																						}
 																					}
-																					var valid34 =
-																						_errs173 ===
+																					var valid35 =
+																						_errs182 ===
 																						errors;
 																				} else {
-																					var valid34 = true;
+																					var valid35 = true;
 																				}
 																				if (
-																					valid34
+																					valid35
 																				) {
 																					if (
-																						data63.onError !==
+																						data67.onError !==
 																						undefined
 																					) {
-																						let data67 =
-																							data63.onError;
-																						const _errs177 =
+																						let data71 =
+																							data67.onError;
+																						const _errs186 =
 																							errors;
 																						if (
-																							typeof data67 !==
+																							typeof data71 !==
 																							'string'
 																						) {
 																							validate28.errors =
@@ -12609,9 +12851,9 @@ function validate28(
 																						}
 																						if (
 																							!(
-																								data67 ===
+																								data71 ===
 																									'skip-plugin' ||
-																								data67 ===
+																								data71 ===
 																									'throw'
 																							)
 																						) {
@@ -12638,23 +12880,23 @@ function validate28(
 																								];
 																							return false;
 																						}
-																						var valid34 =
-																							_errs177 ===
+																						var valid35 =
+																							_errs186 ===
 																							errors;
 																					} else {
-																						var valid34 = true;
+																						var valid35 = true;
 																					}
 																					if (
-																						valid34
+																						valid35
 																					) {
 																						if (
-																							data63.targetFolderName !==
+																							data67.targetFolderName !==
 																							undefined
 																						) {
-																							const _errs179 =
+																							const _errs188 =
 																								errors;
 																							if (
-																								typeof data63.targetFolderName !==
+																								typeof data67.targetFolderName !==
 																								'string'
 																							) {
 																								validate28.errors =
@@ -12676,23 +12918,23 @@ function validate28(
 																									];
 																								return false;
 																							}
-																							var valid34 =
-																								_errs179 ===
+																							var valid35 =
+																								_errs188 ===
 																								errors;
 																						} else {
-																							var valid34 = true;
+																							var valid35 = true;
 																						}
 																						if (
-																							valid34
+																							valid35
 																						) {
 																							if (
-																								data63.humanReadableName !==
+																								data67.humanReadableName !==
 																								undefined
 																							) {
-																								const _errs181 =
+																								const _errs190 =
 																									errors;
 																								if (
-																									typeof data63.humanReadableName !==
+																									typeof data67.humanReadableName !==
 																									'string'
 																								) {
 																									validate28.errors =
@@ -12714,11 +12956,11 @@ function validate28(
 																										];
 																									return false;
 																								}
-																								var valid34 =
-																									_errs181 ===
+																								var valid35 =
+																									_errs190 ===
 																									errors;
 																							} else {
-																								var valid34 = true;
+																								var valid35 = true;
 																							}
 																						}
 																					}
@@ -12746,11 +12988,11 @@ function validate28(
 																		return false;
 																	}
 																}
-																var valid30 =
-																	_errs167 ===
+																var valid31 =
+																	_errs176 ===
 																	errors;
 															} else {
-																var valid30 = true;
+																var valid31 = true;
 															}
 														}
 													}
@@ -12773,8 +13015,8 @@ function validate28(
 							}
 						}
 					} else if (tag0 === 'installTheme') {
-						const _errs183 = errors;
-						if (errors === _errs183) {
+						const _errs192 = errors;
+						if (errors === _errs192) {
 							if (
 								data &&
 								typeof data == 'object' &&
@@ -12803,17 +13045,17 @@ function validate28(
 									];
 									return false;
 								} else {
-									const _errs185 = errors;
-									for (const key23 in data) {
+									const _errs194 = errors;
+									for (const key24 in data) {
 										if (
 											!(
-												key23 === 'progress' ||
-												key23 ===
+												key24 === 'progress' ||
+												key24 ===
 													'ifAlreadyInstalled' ||
-												key23 === 'step' ||
-												key23 === 'themeData' ||
-												key23 === 'themeZipFile' ||
-												key23 === 'options'
+												key24 === 'step' ||
+												key24 === 'themeData' ||
+												key24 === 'themeZipFile' ||
+												key24 === 'options'
 											)
 										) {
 											validate28.errors = [
@@ -12825,7 +13067,7 @@ function validate28(
 														'additionalProperties',
 													params: {
 														additionalProperty:
-															key23,
+															key24,
 													},
 													message:
 														'must NOT have additional properties',
@@ -12835,23 +13077,23 @@ function validate28(
 											break;
 										}
 									}
-									if (_errs185 === errors) {
+									if (_errs194 === errors) {
 										if (data.progress !== undefined) {
-											let data70 = data.progress;
-											const _errs186 = errors;
-											if (errors === _errs186) {
+											let data74 = data.progress;
+											const _errs195 = errors;
+											if (errors === _errs195) {
 												if (
-													data70 &&
-													typeof data70 == 'object' &&
-													!Array.isArray(data70)
+													data74 &&
+													typeof data74 == 'object' &&
+													!Array.isArray(data74)
 												) {
-													const _errs188 = errors;
-													for (const key24 in data70) {
+													const _errs197 = errors;
+													for (const key25 in data74) {
 														if (
 															!(
-																key24 ===
+																key25 ===
 																	'weight' ||
-																key24 ===
+																key25 ===
 																	'caption'
 															)
 														) {
@@ -12867,7 +13109,7 @@ function validate28(
 																			'additionalProperties',
 																		params: {
 																			additionalProperty:
-																				key24,
+																				key25,
 																		},
 																		message:
 																			'must NOT have additional properties',
@@ -12877,21 +13119,21 @@ function validate28(
 															break;
 														}
 													}
-													if (_errs188 === errors) {
+													if (_errs197 === errors) {
 														if (
-															data70.weight !==
+															data74.weight !==
 															undefined
 														) {
-															let data71 =
-																data70.weight;
-															const _errs189 =
+															let data75 =
+																data74.weight;
+															const _errs198 =
 																errors;
 															if (
 																!(
-																	typeof data71 ==
+																	typeof data75 ==
 																		'number' &&
 																	isFinite(
-																		data71
+																		data75
 																	)
 																)
 															) {
@@ -12914,21 +13156,21 @@ function validate28(
 																	];
 																return false;
 															}
-															var valid38 =
-																_errs189 ===
+															var valid39 =
+																_errs198 ===
 																errors;
 														} else {
-															var valid38 = true;
+															var valid39 = true;
 														}
-														if (valid38) {
+														if (valid39) {
 															if (
-																data70.caption !==
+																data74.caption !==
 																undefined
 															) {
-																const _errs191 =
+																const _errs200 =
 																	errors;
 																if (
-																	typeof data70.caption !==
+																	typeof data74.caption !==
 																	'string'
 																) {
 																	validate28.errors =
@@ -12950,11 +13192,11 @@ function validate28(
 																		];
 																	return false;
 																}
-																var valid38 =
-																	_errs191 ===
+																var valid39 =
+																	_errs200 ===
 																	errors;
 															} else {
-																var valid38 = true;
+																var valid39 = true;
 															}
 														}
 													}
@@ -12977,20 +13219,20 @@ function validate28(
 													return false;
 												}
 											}
-											var valid37 = _errs186 === errors;
+											var valid38 = _errs195 === errors;
 										} else {
-											var valid37 = true;
+											var valid38 = true;
 										}
-										if (valid37) {
+										if (valid38) {
 											if (
 												data.ifAlreadyInstalled !==
 												undefined
 											) {
-												let data73 =
+												let data77 =
 													data.ifAlreadyInstalled;
-												const _errs193 = errors;
+												const _errs202 = errors;
 												if (
-													typeof data73 !== 'string'
+													typeof data77 !== 'string'
 												) {
 													validate28.errors = [
 														{
@@ -13011,10 +13253,10 @@ function validate28(
 												}
 												if (
 													!(
-														data73 ===
+														data77 ===
 															'overwrite' ||
-														data73 === 'skip' ||
-														data73 === 'error'
+														data77 === 'skip' ||
+														data77 === 'error'
 													)
 												) {
 													validate28.errors = [
@@ -13039,17 +13281,17 @@ function validate28(
 													];
 													return false;
 												}
-												var valid37 =
-													_errs193 === errors;
+												var valid38 =
+													_errs202 === errors;
 											} else {
-												var valid37 = true;
+												var valid38 = true;
 											}
-											if (valid37) {
+											if (valid38) {
 												if (data.step !== undefined) {
-													let data74 = data.step;
-													const _errs195 = errors;
+													let data78 = data.step;
+													const _errs204 = errors;
 													if (
-														typeof data74 !==
+														typeof data78 !==
 														'string'
 													) {
 														validate28.errors = [
@@ -13071,7 +13313,7 @@ function validate28(
 													}
 													if (
 														'installTheme' !==
-														data74
+														data78
 													) {
 														validate28.errors = [
 															{
@@ -13092,25 +13334,25 @@ function validate28(
 														];
 														return false;
 													}
-													var valid37 =
-														_errs195 === errors;
+													var valid38 =
+														_errs204 === errors;
 												} else {
-													var valid37 = true;
+													var valid38 = true;
 												}
-												if (valid37) {
+												if (valid38) {
 													if (
 														data.themeData !==
 														undefined
 													) {
-														let data75 =
+														let data79 =
 															data.themeData;
-														const _errs197 = errors;
-														const _errs198 = errors;
-														let valid39 = false;
-														const _errs199 = errors;
+														const _errs206 = errors;
+														const _errs207 = errors;
+														let valid40 = false;
+														const _errs208 = errors;
 														if (
 															!validate16(
-																data75,
+																data79,
 																{
 																	instancePath:
 																		instancePath +
@@ -13133,15 +13375,15 @@ function validate28(
 																vErrors.length;
 														}
 														var _valid1 =
-															_errs199 === errors;
-														valid39 =
-															valid39 || _valid1;
-														if (!valid39) {
-															const _errs200 =
+															_errs208 === errors;
+														valid40 =
+															valid40 || _valid1;
+														if (!valid40) {
+															const _errs209 =
 																errors;
 															if (
 																!validate18(
-																	data75,
+																	data79,
 																	{
 																		instancePath:
 																			instancePath +
@@ -13165,13 +13407,13 @@ function validate28(
 																	vErrors.length;
 															}
 															var _valid1 =
-																_errs200 ===
+																_errs209 ===
 																errors;
-															valid39 =
-																valid39 ||
+															valid40 =
+																valid40 ||
 																_valid1;
 														}
-														if (!valid39) {
+														if (!valid40) {
 															const err1 = {
 																instancePath:
 																	instancePath +
@@ -13200,30 +13442,30 @@ function validate28(
 																vErrors;
 															return false;
 														} else {
-															errors = _errs198;
+															errors = _errs207;
 															if (
 																vErrors !== null
 															) {
-																if (_errs198) {
+																if (_errs207) {
 																	vErrors.length =
-																		_errs198;
+																		_errs207;
 																} else {
 																	vErrors =
 																		null;
 																}
 															}
 														}
-														var valid37 =
-															_errs197 === errors;
+														var valid38 =
+															_errs206 === errors;
 													} else {
-														var valid37 = true;
+														var valid38 = true;
 													}
-													if (valid37) {
+													if (valid38) {
 														if (
 															data.themeZipFile !==
 															undefined
 														) {
-															const _errs201 =
+															const _errs210 =
 																errors;
 															if (
 																!validate16(
@@ -13250,49 +13492,49 @@ function validate28(
 																errors =
 																	vErrors.length;
 															}
-															var valid37 =
-																_errs201 ===
+															var valid38 =
+																_errs210 ===
 																errors;
 														} else {
-															var valid37 = true;
+															var valid38 = true;
 														}
-														if (valid37) {
+														if (valid38) {
 															if (
 																data.options !==
 																undefined
 															) {
-																let data77 =
+																let data81 =
 																	data.options;
-																const _errs202 =
+																const _errs211 =
 																	errors;
-																const _errs203 =
+																const _errs212 =
 																	errors;
 																if (
 																	errors ===
-																	_errs203
+																	_errs212
 																) {
 																	if (
-																		data77 &&
-																		typeof data77 ==
+																		data81 &&
+																		typeof data81 ==
 																			'object' &&
 																		!Array.isArray(
-																			data77
+																			data81
 																		)
 																	) {
-																		const _errs205 =
+																		const _errs214 =
 																			errors;
-																		for (const key25 in data77) {
+																		for (const key26 in data81) {
 																			if (
 																				!(
-																					key25 ===
+																					key26 ===
 																						'activate' ||
-																					key25 ===
+																					key26 ===
 																						'importStarterContent' ||
-																					key25 ===
+																					key26 ===
 																						'onError' ||
-																					key25 ===
+																					key26 ===
 																						'targetFolderName' ||
-																					key25 ===
+																					key26 ===
 																						'humanReadableName'
 																				)
 																			) {
@@ -13308,7 +13550,7 @@ function validate28(
 																								'additionalProperties',
 																							params: {
 																								additionalProperty:
-																									key25,
+																									key26,
 																							},
 																							message:
 																								'must NOT have additional properties',
@@ -13319,17 +13561,17 @@ function validate28(
 																			}
 																		}
 																		if (
-																			_errs205 ===
+																			_errs214 ===
 																			errors
 																		) {
 																			if (
-																				data77.activate !==
+																				data81.activate !==
 																				undefined
 																			) {
-																				const _errs206 =
+																				const _errs215 =
 																					errors;
 																				if (
-																					typeof data77.activate !==
+																					typeof data81.activate !==
 																					'boolean'
 																				) {
 																					validate28.errors =
@@ -13351,23 +13593,23 @@ function validate28(
 																						];
 																					return false;
 																				}
-																				var valid41 =
-																					_errs206 ===
+																				var valid42 =
+																					_errs215 ===
 																					errors;
 																			} else {
-																				var valid41 = true;
+																				var valid42 = true;
 																			}
 																			if (
-																				valid41
+																				valid42
 																			) {
 																				if (
-																					data77.importStarterContent !==
+																					data81.importStarterContent !==
 																					undefined
 																				) {
-																					const _errs208 =
+																					const _errs217 =
 																						errors;
 																					if (
-																						typeof data77.importStarterContent !==
+																						typeof data81.importStarterContent !==
 																						'boolean'
 																					) {
 																						validate28.errors =
@@ -13389,25 +13631,25 @@ function validate28(
 																							];
 																						return false;
 																					}
-																					var valid41 =
-																						_errs208 ===
+																					var valid42 =
+																						_errs217 ===
 																						errors;
 																				} else {
-																					var valid41 = true;
+																					var valid42 = true;
 																				}
 																				if (
-																					valid41
+																					valid42
 																				) {
 																					if (
-																						data77.onError !==
+																						data81.onError !==
 																						undefined
 																					) {
-																						let data80 =
-																							data77.onError;
-																						const _errs210 =
+																						let data84 =
+																							data81.onError;
+																						const _errs219 =
 																							errors;
 																						if (
-																							typeof data80 !==
+																							typeof data84 !==
 																							'string'
 																						) {
 																							validate28.errors =
@@ -13431,9 +13673,9 @@ function validate28(
 																						}
 																						if (
 																							!(
-																								data80 ===
+																								data84 ===
 																									'skip-theme' ||
-																								data80 ===
+																								data84 ===
 																									'throw'
 																							)
 																						) {
@@ -13460,23 +13702,23 @@ function validate28(
 																								];
 																							return false;
 																						}
-																						var valid41 =
-																							_errs210 ===
+																						var valid42 =
+																							_errs219 ===
 																							errors;
 																					} else {
-																						var valid41 = true;
+																						var valid42 = true;
 																					}
 																					if (
-																						valid41
+																						valid42
 																					) {
 																						if (
-																							data77.targetFolderName !==
+																							data81.targetFolderName !==
 																							undefined
 																						) {
-																							const _errs212 =
+																							const _errs221 =
 																								errors;
 																							if (
-																								typeof data77.targetFolderName !==
+																								typeof data81.targetFolderName !==
 																								'string'
 																							) {
 																								validate28.errors =
@@ -13498,23 +13740,23 @@ function validate28(
 																									];
 																								return false;
 																							}
-																							var valid41 =
-																								_errs212 ===
+																							var valid42 =
+																								_errs221 ===
 																								errors;
 																						} else {
-																							var valid41 = true;
+																							var valid42 = true;
 																						}
 																						if (
-																							valid41
+																							valid42
 																						) {
 																							if (
-																								data77.humanReadableName !==
+																								data81.humanReadableName !==
 																								undefined
 																							) {
-																								const _errs214 =
+																								const _errs223 =
 																									errors;
 																								if (
-																									typeof data77.humanReadableName !==
+																									typeof data81.humanReadableName !==
 																									'string'
 																								) {
 																									validate28.errors =
@@ -13536,11 +13778,11 @@ function validate28(
 																										];
 																									return false;
 																								}
-																								var valid41 =
-																									_errs214 ===
+																								var valid42 =
+																									_errs223 ===
 																									errors;
 																							} else {
-																								var valid41 = true;
+																								var valid42 = true;
 																							}
 																						}
 																					}
@@ -13568,11 +13810,11 @@ function validate28(
 																		return false;
 																	}
 																}
-																var valid37 =
-																	_errs202 ===
+																var valid38 =
+																	_errs211 ===
 																	errors;
 															} else {
-																var valid37 = true;
+																var valid38 = true;
 															}
 														}
 													}
@@ -13595,8 +13837,8 @@ function validate28(
 							}
 						}
 					} else if (tag0 === 'login') {
-						const _errs216 = errors;
-						if (errors === _errs216) {
+						const _errs225 = errors;
+						if (errors === _errs225) {
 							if (
 								data &&
 								typeof data == 'object' &&
@@ -13623,14 +13865,14 @@ function validate28(
 									];
 									return false;
 								} else {
-									const _errs218 = errors;
-									for (const key26 in data) {
+									const _errs227 = errors;
+									for (const key27 in data) {
 										if (
 											!(
-												key26 === 'progress' ||
-												key26 === 'step' ||
-												key26 === 'username' ||
-												key26 === 'password'
+												key27 === 'progress' ||
+												key27 === 'step' ||
+												key27 === 'username' ||
+												key27 === 'password'
 											)
 										) {
 											validate28.errors = [
@@ -13642,7 +13884,7 @@ function validate28(
 														'additionalProperties',
 													params: {
 														additionalProperty:
-															key26,
+															key27,
 													},
 													message:
 														'must NOT have additional properties',
@@ -13652,23 +13894,23 @@ function validate28(
 											break;
 										}
 									}
-									if (_errs218 === errors) {
+									if (_errs227 === errors) {
 										if (data.progress !== undefined) {
-											let data83 = data.progress;
-											const _errs219 = errors;
-											if (errors === _errs219) {
+											let data87 = data.progress;
+											const _errs228 = errors;
+											if (errors === _errs228) {
 												if (
-													data83 &&
-													typeof data83 == 'object' &&
-													!Array.isArray(data83)
+													data87 &&
+													typeof data87 == 'object' &&
+													!Array.isArray(data87)
 												) {
-													const _errs221 = errors;
-													for (const key27 in data83) {
+													const _errs230 = errors;
+													for (const key28 in data87) {
 														if (
 															!(
-																key27 ===
+																key28 ===
 																	'weight' ||
-																key27 ===
+																key28 ===
 																	'caption'
 															)
 														) {
@@ -13684,7 +13926,7 @@ function validate28(
 																			'additionalProperties',
 																		params: {
 																			additionalProperty:
-																				key27,
+																				key28,
 																		},
 																		message:
 																			'must NOT have additional properties',
@@ -13694,21 +13936,21 @@ function validate28(
 															break;
 														}
 													}
-													if (_errs221 === errors) {
+													if (_errs230 === errors) {
 														if (
-															data83.weight !==
+															data87.weight !==
 															undefined
 														) {
-															let data84 =
-																data83.weight;
-															const _errs222 =
+															let data88 =
+																data87.weight;
+															const _errs231 =
 																errors;
 															if (
 																!(
-																	typeof data84 ==
+																	typeof data88 ==
 																		'number' &&
 																	isFinite(
-																		data84
+																		data88
 																	)
 																)
 															) {
@@ -13731,21 +13973,21 @@ function validate28(
 																	];
 																return false;
 															}
-															var valid44 =
-																_errs222 ===
+															var valid45 =
+																_errs231 ===
 																errors;
 														} else {
-															var valid44 = true;
+															var valid45 = true;
 														}
-														if (valid44) {
+														if (valid45) {
 															if (
-																data83.caption !==
+																data87.caption !==
 																undefined
 															) {
-																const _errs224 =
+																const _errs233 =
 																	errors;
 																if (
-																	typeof data83.caption !==
+																	typeof data87.caption !==
 																	'string'
 																) {
 																	validate28.errors =
@@ -13767,11 +14009,11 @@ function validate28(
 																		];
 																	return false;
 																}
-																var valid44 =
-																	_errs224 ===
+																var valid45 =
+																	_errs233 ===
 																	errors;
 															} else {
-																var valid44 = true;
+																var valid45 = true;
 															}
 														}
 													}
@@ -13794,16 +14036,16 @@ function validate28(
 													return false;
 												}
 											}
-											var valid43 = _errs219 === errors;
+											var valid44 = _errs228 === errors;
 										} else {
-											var valid43 = true;
+											var valid44 = true;
 										}
-										if (valid43) {
+										if (valid44) {
 											if (data.step !== undefined) {
-												let data86 = data.step;
-												const _errs226 = errors;
+												let data90 = data.step;
+												const _errs235 = errors;
 												if (
-													typeof data86 !== 'string'
+													typeof data90 !== 'string'
 												) {
 													validate28.errors = [
 														{
@@ -13822,7 +14064,7 @@ function validate28(
 													];
 													return false;
 												}
-												if ('login' !== data86) {
+												if ('login' !== data90) {
 													validate28.errors = [
 														{
 															instancePath:
@@ -13841,16 +14083,16 @@ function validate28(
 													];
 													return false;
 												}
-												var valid43 =
-													_errs226 === errors;
+												var valid44 =
+													_errs235 === errors;
 											} else {
-												var valid43 = true;
+												var valid44 = true;
 											}
-											if (valid43) {
+											if (valid44) {
 												if (
 													data.username !== undefined
 												) {
-													const _errs228 = errors;
+													const _errs237 = errors;
 													if (
 														typeof data.username !==
 														'string'
@@ -13872,17 +14114,17 @@ function validate28(
 														];
 														return false;
 													}
-													var valid43 =
-														_errs228 === errors;
+													var valid44 =
+														_errs237 === errors;
 												} else {
-													var valid43 = true;
+													var valid44 = true;
 												}
-												if (valid43) {
+												if (valid44) {
 													if (
 														data.password !==
 														undefined
 													) {
-														const _errs230 = errors;
+														const _errs239 = errors;
 														if (
 															typeof data.password !==
 															'string'
@@ -13906,10 +14148,10 @@ function validate28(
 																];
 															return false;
 														}
-														var valid43 =
-															_errs230 === errors;
+														var valid44 =
+															_errs239 === errors;
 													} else {
-														var valid43 = true;
+														var valid44 = true;
 													}
 												}
 											}
@@ -13930,8 +14172,8 @@ function validate28(
 							}
 						}
 					} else if (tag0 === 'mkdir') {
-						const _errs232 = errors;
-						if (errors === _errs232) {
+						const _errs241 = errors;
+						if (errors === _errs241) {
 							if (
 								data &&
 								typeof data == 'object' &&
@@ -13960,13 +14202,13 @@ function validate28(
 									];
 									return false;
 								} else {
-									const _errs234 = errors;
-									for (const key28 in data) {
+									const _errs243 = errors;
+									for (const key29 in data) {
 										if (
 											!(
-												key28 === 'progress' ||
-												key28 === 'step' ||
-												key28 === 'path'
+												key29 === 'progress' ||
+												key29 === 'step' ||
+												key29 === 'path'
 											)
 										) {
 											validate28.errors = [
@@ -13978,7 +14220,7 @@ function validate28(
 														'additionalProperties',
 													params: {
 														additionalProperty:
-															key28,
+															key29,
 													},
 													message:
 														'must NOT have additional properties',
@@ -13988,23 +14230,23 @@ function validate28(
 											break;
 										}
 									}
-									if (_errs234 === errors) {
+									if (_errs243 === errors) {
 										if (data.progress !== undefined) {
-											let data89 = data.progress;
-											const _errs235 = errors;
-											if (errors === _errs235) {
+											let data93 = data.progress;
+											const _errs244 = errors;
+											if (errors === _errs244) {
 												if (
-													data89 &&
-													typeof data89 == 'object' &&
-													!Array.isArray(data89)
+													data93 &&
+													typeof data93 == 'object' &&
+													!Array.isArray(data93)
 												) {
-													const _errs237 = errors;
-													for (const key29 in data89) {
+													const _errs246 = errors;
+													for (const key30 in data93) {
 														if (
 															!(
-																key29 ===
+																key30 ===
 																	'weight' ||
-																key29 ===
+																key30 ===
 																	'caption'
 															)
 														) {
@@ -14020,7 +14262,7 @@ function validate28(
 																			'additionalProperties',
 																		params: {
 																			additionalProperty:
-																				key29,
+																				key30,
 																		},
 																		message:
 																			'must NOT have additional properties',
@@ -14030,21 +14272,21 @@ function validate28(
 															break;
 														}
 													}
-													if (_errs237 === errors) {
+													if (_errs246 === errors) {
 														if (
-															data89.weight !==
+															data93.weight !==
 															undefined
 														) {
-															let data90 =
-																data89.weight;
-															const _errs238 =
+															let data94 =
+																data93.weight;
+															const _errs247 =
 																errors;
 															if (
 																!(
-																	typeof data90 ==
+																	typeof data94 ==
 																		'number' &&
 																	isFinite(
-																		data90
+																		data94
 																	)
 																)
 															) {
@@ -14067,21 +14309,21 @@ function validate28(
 																	];
 																return false;
 															}
-															var valid47 =
-																_errs238 ===
+															var valid48 =
+																_errs247 ===
 																errors;
 														} else {
-															var valid47 = true;
+															var valid48 = true;
 														}
-														if (valid47) {
+														if (valid48) {
 															if (
-																data89.caption !==
+																data93.caption !==
 																undefined
 															) {
-																const _errs240 =
+																const _errs249 =
 																	errors;
 																if (
-																	typeof data89.caption !==
+																	typeof data93.caption !==
 																	'string'
 																) {
 																	validate28.errors =
@@ -14103,11 +14345,11 @@ function validate28(
 																		];
 																	return false;
 																}
-																var valid47 =
-																	_errs240 ===
+																var valid48 =
+																	_errs249 ===
 																	errors;
 															} else {
-																var valid47 = true;
+																var valid48 = true;
 															}
 														}
 													}
@@ -14130,16 +14372,16 @@ function validate28(
 													return false;
 												}
 											}
-											var valid46 = _errs235 === errors;
+											var valid47 = _errs244 === errors;
 										} else {
-											var valid46 = true;
+											var valid47 = true;
 										}
-										if (valid46) {
+										if (valid47) {
 											if (data.step !== undefined) {
-												let data92 = data.step;
-												const _errs242 = errors;
+												let data96 = data.step;
+												const _errs251 = errors;
 												if (
-													typeof data92 !== 'string'
+													typeof data96 !== 'string'
 												) {
 													validate28.errors = [
 														{
@@ -14158,7 +14400,7 @@ function validate28(
 													];
 													return false;
 												}
-												if ('mkdir' !== data92) {
+												if ('mkdir' !== data96) {
 													validate28.errors = [
 														{
 															instancePath:
@@ -14177,14 +14419,14 @@ function validate28(
 													];
 													return false;
 												}
-												var valid46 =
-													_errs242 === errors;
+												var valid47 =
+													_errs251 === errors;
 											} else {
-												var valid46 = true;
+												var valid47 = true;
 											}
-											if (valid46) {
+											if (valid47) {
 												if (data.path !== undefined) {
-													const _errs244 = errors;
+													const _errs253 = errors;
 													if (
 														typeof data.path !==
 														'string'
@@ -14206,10 +14448,10 @@ function validate28(
 														];
 														return false;
 													}
-													var valid46 =
-														_errs244 === errors;
+													var valid47 =
+														_errs253 === errors;
 												} else {
-													var valid46 = true;
+													var valid47 = true;
 												}
 											}
 										}
@@ -14229,8 +14471,8 @@ function validate28(
 							}
 						}
 					} else if (tag0 === 'mv') {
-						const _errs246 = errors;
-						if (errors === _errs246) {
+						const _errs255 = errors;
+						if (errors === _errs255) {
 							if (
 								data &&
 								typeof data == 'object' &&
@@ -14261,14 +14503,14 @@ function validate28(
 									];
 									return false;
 								} else {
-									const _errs248 = errors;
-									for (const key30 in data) {
+									const _errs257 = errors;
+									for (const key31 in data) {
 										if (
 											!(
-												key30 === 'progress' ||
-												key30 === 'step' ||
-												key30 === 'fromPath' ||
-												key30 === 'toPath'
+												key31 === 'progress' ||
+												key31 === 'step' ||
+												key31 === 'fromPath' ||
+												key31 === 'toPath'
 											)
 										) {
 											validate28.errors = [
@@ -14280,7 +14522,7 @@ function validate28(
 														'additionalProperties',
 													params: {
 														additionalProperty:
-															key30,
+															key31,
 													},
 													message:
 														'must NOT have additional properties',
@@ -14290,23 +14532,23 @@ function validate28(
 											break;
 										}
 									}
-									if (_errs248 === errors) {
+									if (_errs257 === errors) {
 										if (data.progress !== undefined) {
-											let data94 = data.progress;
-											const _errs249 = errors;
-											if (errors === _errs249) {
+											let data98 = data.progress;
+											const _errs258 = errors;
+											if (errors === _errs258) {
 												if (
-													data94 &&
-													typeof data94 == 'object' &&
-													!Array.isArray(data94)
+													data98 &&
+													typeof data98 == 'object' &&
+													!Array.isArray(data98)
 												) {
-													const _errs251 = errors;
-													for (const key31 in data94) {
+													const _errs260 = errors;
+													for (const key32 in data98) {
 														if (
 															!(
-																key31 ===
+																key32 ===
 																	'weight' ||
-																key31 ===
+																key32 ===
 																	'caption'
 															)
 														) {
@@ -14322,7 +14564,7 @@ function validate28(
 																			'additionalProperties',
 																		params: {
 																			additionalProperty:
-																				key31,
+																				key32,
 																		},
 																		message:
 																			'must NOT have additional properties',
@@ -14332,21 +14574,21 @@ function validate28(
 															break;
 														}
 													}
-													if (_errs251 === errors) {
+													if (_errs260 === errors) {
 														if (
-															data94.weight !==
+															data98.weight !==
 															undefined
 														) {
-															let data95 =
-																data94.weight;
-															const _errs252 =
+															let data99 =
+																data98.weight;
+															const _errs261 =
 																errors;
 															if (
 																!(
-																	typeof data95 ==
+																	typeof data99 ==
 																		'number' &&
 																	isFinite(
-																		data95
+																		data99
 																	)
 																)
 															) {
@@ -14369,21 +14611,21 @@ function validate28(
 																	];
 																return false;
 															}
-															var valid50 =
-																_errs252 ===
+															var valid51 =
+																_errs261 ===
 																errors;
 														} else {
-															var valid50 = true;
+															var valid51 = true;
 														}
-														if (valid50) {
+														if (valid51) {
 															if (
-																data94.caption !==
+																data98.caption !==
 																undefined
 															) {
-																const _errs254 =
+																const _errs263 =
 																	errors;
 																if (
-																	typeof data94.caption !==
+																	typeof data98.caption !==
 																	'string'
 																) {
 																	validate28.errors =
@@ -14405,11 +14647,11 @@ function validate28(
 																		];
 																	return false;
 																}
-																var valid50 =
-																	_errs254 ===
+																var valid51 =
+																	_errs263 ===
 																	errors;
 															} else {
-																var valid50 = true;
+																var valid51 = true;
 															}
 														}
 													}
@@ -14432,16 +14674,16 @@ function validate28(
 													return false;
 												}
 											}
-											var valid49 = _errs249 === errors;
+											var valid50 = _errs258 === errors;
 										} else {
-											var valid49 = true;
+											var valid50 = true;
 										}
-										if (valid49) {
+										if (valid50) {
 											if (data.step !== undefined) {
-												let data97 = data.step;
-												const _errs256 = errors;
+												let data101 = data.step;
+												const _errs265 = errors;
 												if (
-													typeof data97 !== 'string'
+													typeof data101 !== 'string'
 												) {
 													validate28.errors = [
 														{
@@ -14460,7 +14702,7 @@ function validate28(
 													];
 													return false;
 												}
-												if ('mv' !== data97) {
+												if ('mv' !== data101) {
 													validate28.errors = [
 														{
 															instancePath:
@@ -14479,16 +14721,16 @@ function validate28(
 													];
 													return false;
 												}
-												var valid49 =
-													_errs256 === errors;
+												var valid50 =
+													_errs265 === errors;
 											} else {
-												var valid49 = true;
+												var valid50 = true;
 											}
-											if (valid49) {
+											if (valid50) {
 												if (
 													data.fromPath !== undefined
 												) {
-													const _errs258 = errors;
+													const _errs267 = errors;
 													if (
 														typeof data.fromPath !==
 														'string'
@@ -14510,17 +14752,17 @@ function validate28(
 														];
 														return false;
 													}
-													var valid49 =
-														_errs258 === errors;
+													var valid50 =
+														_errs267 === errors;
 												} else {
-													var valid49 = true;
+													var valid50 = true;
 												}
-												if (valid49) {
+												if (valid50) {
 													if (
 														data.toPath !==
 														undefined
 													) {
-														const _errs260 = errors;
+														const _errs269 = errors;
 														if (
 															typeof data.toPath !==
 															'string'
@@ -14544,10 +14786,10 @@ function validate28(
 																];
 															return false;
 														}
-														var valid49 =
-															_errs260 === errors;
+														var valid50 =
+															_errs269 === errors;
 													} else {
-														var valid49 = true;
+														var valid50 = true;
 													}
 												}
 											}
@@ -14568,8 +14810,8 @@ function validate28(
 							}
 						}
 					} else if (tag0 === 'resetData') {
-						const _errs262 = errors;
-						if (errors === _errs262) {
+						const _errs271 = errors;
+						if (errors === _errs271) {
 							if (
 								data &&
 								typeof data == 'object' &&
@@ -14596,12 +14838,12 @@ function validate28(
 									];
 									return false;
 								} else {
-									const _errs264 = errors;
-									for (const key32 in data) {
+									const _errs273 = errors;
+									for (const key33 in data) {
 										if (
 											!(
-												key32 === 'progress' ||
-												key32 === 'step'
+												key33 === 'progress' ||
+												key33 === 'step'
 											)
 										) {
 											validate28.errors = [
@@ -14613,7 +14855,7 @@ function validate28(
 														'additionalProperties',
 													params: {
 														additionalProperty:
-															key32,
+															key33,
 													},
 													message:
 														'must NOT have additional properties',
@@ -14623,24 +14865,24 @@ function validate28(
 											break;
 										}
 									}
-									if (_errs264 === errors) {
+									if (_errs273 === errors) {
 										if (data.progress !== undefined) {
-											let data100 = data.progress;
-											const _errs265 = errors;
-											if (errors === _errs265) {
+											let data104 = data.progress;
+											const _errs274 = errors;
+											if (errors === _errs274) {
 												if (
-													data100 &&
-													typeof data100 ==
+													data104 &&
+													typeof data104 ==
 														'object' &&
-													!Array.isArray(data100)
+													!Array.isArray(data104)
 												) {
-													const _errs267 = errors;
-													for (const key33 in data100) {
+													const _errs276 = errors;
+													for (const key34 in data104) {
 														if (
 															!(
-																key33 ===
+																key34 ===
 																	'weight' ||
-																key33 ===
+																key34 ===
 																	'caption'
 															)
 														) {
@@ -14656,7 +14898,7 @@ function validate28(
 																			'additionalProperties',
 																		params: {
 																			additionalProperty:
-																				key33,
+																				key34,
 																		},
 																		message:
 																			'must NOT have additional properties',
@@ -14666,21 +14908,21 @@ function validate28(
 															break;
 														}
 													}
-													if (_errs267 === errors) {
+													if (_errs276 === errors) {
 														if (
-															data100.weight !==
+															data104.weight !==
 															undefined
 														) {
-															let data101 =
-																data100.weight;
-															const _errs268 =
+															let data105 =
+																data104.weight;
+															const _errs277 =
 																errors;
 															if (
 																!(
-																	typeof data101 ==
+																	typeof data105 ==
 																		'number' &&
 																	isFinite(
-																		data101
+																		data105
 																	)
 																)
 															) {
@@ -14703,21 +14945,21 @@ function validate28(
 																	];
 																return false;
 															}
-															var valid53 =
-																_errs268 ===
+															var valid54 =
+																_errs277 ===
 																errors;
 														} else {
-															var valid53 = true;
+															var valid54 = true;
 														}
-														if (valid53) {
+														if (valid54) {
 															if (
-																data100.caption !==
+																data104.caption !==
 																undefined
 															) {
-																const _errs270 =
+																const _errs279 =
 																	errors;
 																if (
-																	typeof data100.caption !==
+																	typeof data104.caption !==
 																	'string'
 																) {
 																	validate28.errors =
@@ -14739,11 +14981,11 @@ function validate28(
 																		];
 																	return false;
 																}
-																var valid53 =
-																	_errs270 ===
+																var valid54 =
+																	_errs279 ===
 																	errors;
 															} else {
-																var valid53 = true;
+																var valid54 = true;
 															}
 														}
 													}
@@ -14766,16 +15008,16 @@ function validate28(
 													return false;
 												}
 											}
-											var valid52 = _errs265 === errors;
+											var valid53 = _errs274 === errors;
 										} else {
-											var valid52 = true;
+											var valid53 = true;
 										}
-										if (valid52) {
+										if (valid53) {
 											if (data.step !== undefined) {
-												let data103 = data.step;
-												const _errs272 = errors;
+												let data107 = data.step;
+												const _errs281 = errors;
 												if (
-													typeof data103 !== 'string'
+													typeof data107 !== 'string'
 												) {
 													validate28.errors = [
 														{
@@ -14794,7 +15036,7 @@ function validate28(
 													];
 													return false;
 												}
-												if ('resetData' !== data103) {
+												if ('resetData' !== data107) {
 													validate28.errors = [
 														{
 															instancePath:
@@ -14813,10 +15055,10 @@ function validate28(
 													];
 													return false;
 												}
-												var valid52 =
-													_errs272 === errors;
+												var valid53 =
+													_errs281 === errors;
 											} else {
-												var valid52 = true;
+												var valid53 = true;
 											}
 										}
 									}
@@ -14835,8 +15077,8 @@ function validate28(
 							}
 						}
 					} else if (tag0 === 'request') {
-						const _errs274 = errors;
-						if (errors === _errs274) {
+						const _errs283 = errors;
+						if (errors === _errs283) {
 							if (
 								data &&
 								typeof data == 'object' &&
@@ -14865,13 +15107,13 @@ function validate28(
 									];
 									return false;
 								} else {
-									const _errs276 = errors;
-									for (const key34 in data) {
+									const _errs285 = errors;
+									for (const key35 in data) {
 										if (
 											!(
-												key34 === 'progress' ||
-												key34 === 'step' ||
-												key34 === 'request'
+												key35 === 'progress' ||
+												key35 === 'step' ||
+												key35 === 'request'
 											)
 										) {
 											validate28.errors = [
@@ -14883,7 +15125,7 @@ function validate28(
 														'additionalProperties',
 													params: {
 														additionalProperty:
-															key34,
+															key35,
 													},
 													message:
 														'must NOT have additional properties',
@@ -14893,24 +15135,24 @@ function validate28(
 											break;
 										}
 									}
-									if (_errs276 === errors) {
+									if (_errs285 === errors) {
 										if (data.progress !== undefined) {
-											let data104 = data.progress;
-											const _errs277 = errors;
-											if (errors === _errs277) {
+											let data108 = data.progress;
+											const _errs286 = errors;
+											if (errors === _errs286) {
 												if (
-													data104 &&
-													typeof data104 ==
+													data108 &&
+													typeof data108 ==
 														'object' &&
-													!Array.isArray(data104)
+													!Array.isArray(data108)
 												) {
-													const _errs279 = errors;
-													for (const key35 in data104) {
+													const _errs288 = errors;
+													for (const key36 in data108) {
 														if (
 															!(
-																key35 ===
+																key36 ===
 																	'weight' ||
-																key35 ===
+																key36 ===
 																	'caption'
 															)
 														) {
@@ -14926,7 +15168,7 @@ function validate28(
 																			'additionalProperties',
 																		params: {
 																			additionalProperty:
-																				key35,
+																				key36,
 																		},
 																		message:
 																			'must NOT have additional properties',
@@ -14936,21 +15178,21 @@ function validate28(
 															break;
 														}
 													}
-													if (_errs279 === errors) {
+													if (_errs288 === errors) {
 														if (
-															data104.weight !==
+															data108.weight !==
 															undefined
 														) {
-															let data105 =
-																data104.weight;
-															const _errs280 =
+															let data109 =
+																data108.weight;
+															const _errs289 =
 																errors;
 															if (
 																!(
-																	typeof data105 ==
+																	typeof data109 ==
 																		'number' &&
 																	isFinite(
-																		data105
+																		data109
 																	)
 																)
 															) {
@@ -14973,21 +15215,21 @@ function validate28(
 																	];
 																return false;
 															}
-															var valid56 =
-																_errs280 ===
+															var valid57 =
+																_errs289 ===
 																errors;
 														} else {
-															var valid56 = true;
+															var valid57 = true;
 														}
-														if (valid56) {
+														if (valid57) {
 															if (
-																data104.caption !==
+																data108.caption !==
 																undefined
 															) {
-																const _errs282 =
+																const _errs291 =
 																	errors;
 																if (
-																	typeof data104.caption !==
+																	typeof data108.caption !==
 																	'string'
 																) {
 																	validate28.errors =
@@ -15009,11 +15251,11 @@ function validate28(
 																		];
 																	return false;
 																}
-																var valid56 =
-																	_errs282 ===
+																var valid57 =
+																	_errs291 ===
 																	errors;
 															} else {
-																var valid56 = true;
+																var valid57 = true;
 															}
 														}
 													}
@@ -15036,16 +15278,16 @@ function validate28(
 													return false;
 												}
 											}
-											var valid55 = _errs277 === errors;
+											var valid56 = _errs286 === errors;
 										} else {
-											var valid55 = true;
+											var valid56 = true;
 										}
-										if (valid55) {
+										if (valid56) {
 											if (data.step !== undefined) {
-												let data107 = data.step;
-												const _errs284 = errors;
+												let data111 = data.step;
+												const _errs293 = errors;
 												if (
-													typeof data107 !== 'string'
+													typeof data111 !== 'string'
 												) {
 													validate28.errors = [
 														{
@@ -15064,7 +15306,7 @@ function validate28(
 													];
 													return false;
 												}
-												if ('request' !== data107) {
+												if ('request' !== data111) {
 													validate28.errors = [
 														{
 															instancePath:
@@ -15083,16 +15325,16 @@ function validate28(
 													];
 													return false;
 												}
-												var valid55 =
-													_errs284 === errors;
+												var valid56 =
+													_errs293 === errors;
 											} else {
-												var valid55 = true;
+												var valid56 = true;
 											}
-											if (valid55) {
+											if (valid56) {
 												if (
 													data.request !== undefined
 												) {
-													const _errs286 = errors;
+													const _errs295 = errors;
 													if (
 														!validate37(
 															data.request,
@@ -15116,10 +15358,10 @@ function validate28(
 																	);
 														errors = vErrors.length;
 													}
-													var valid55 =
-														_errs286 === errors;
+													var valid56 =
+														_errs295 === errors;
 												} else {
-													var valid55 = true;
+													var valid56 = true;
 												}
 											}
 										}
@@ -15139,8 +15381,8 @@ function validate28(
 							}
 						}
 					} else if (tag0 === 'rm') {
-						const _errs287 = errors;
-						if (errors === _errs287) {
+						const _errs296 = errors;
+						if (errors === _errs296) {
 							if (
 								data &&
 								typeof data == 'object' &&
@@ -15169,13 +15411,13 @@ function validate28(
 									];
 									return false;
 								} else {
-									const _errs289 = errors;
-									for (const key36 in data) {
+									const _errs298 = errors;
+									for (const key37 in data) {
 										if (
 											!(
-												key36 === 'progress' ||
-												key36 === 'step' ||
-												key36 === 'path'
+												key37 === 'progress' ||
+												key37 === 'step' ||
+												key37 === 'path'
 											)
 										) {
 											validate28.errors = [
@@ -15187,7 +15429,7 @@ function validate28(
 														'additionalProperties',
 													params: {
 														additionalProperty:
-															key36,
+															key37,
 													},
 													message:
 														'must NOT have additional properties',
@@ -15197,24 +15439,24 @@ function validate28(
 											break;
 										}
 									}
-									if (_errs289 === errors) {
+									if (_errs298 === errors) {
 										if (data.progress !== undefined) {
-											let data109 = data.progress;
-											const _errs290 = errors;
-											if (errors === _errs290) {
+											let data113 = data.progress;
+											const _errs299 = errors;
+											if (errors === _errs299) {
 												if (
-													data109 &&
-													typeof data109 ==
+													data113 &&
+													typeof data113 ==
 														'object' &&
-													!Array.isArray(data109)
+													!Array.isArray(data113)
 												) {
-													const _errs292 = errors;
-													for (const key37 in data109) {
+													const _errs301 = errors;
+													for (const key38 in data113) {
 														if (
 															!(
-																key37 ===
+																key38 ===
 																	'weight' ||
-																key37 ===
+																key38 ===
 																	'caption'
 															)
 														) {
@@ -15230,7 +15472,7 @@ function validate28(
 																			'additionalProperties',
 																		params: {
 																			additionalProperty:
-																				key37,
+																				key38,
 																		},
 																		message:
 																			'must NOT have additional properties',
@@ -15240,21 +15482,21 @@ function validate28(
 															break;
 														}
 													}
-													if (_errs292 === errors) {
+													if (_errs301 === errors) {
 														if (
-															data109.weight !==
+															data113.weight !==
 															undefined
 														) {
-															let data110 =
-																data109.weight;
-															const _errs293 =
+															let data114 =
+																data113.weight;
+															const _errs302 =
 																errors;
 															if (
 																!(
-																	typeof data110 ==
+																	typeof data114 ==
 																		'number' &&
 																	isFinite(
-																		data110
+																		data114
 																	)
 																)
 															) {
@@ -15277,21 +15519,21 @@ function validate28(
 																	];
 																return false;
 															}
-															var valid59 =
-																_errs293 ===
+															var valid60 =
+																_errs302 ===
 																errors;
 														} else {
-															var valid59 = true;
+															var valid60 = true;
 														}
-														if (valid59) {
+														if (valid60) {
 															if (
-																data109.caption !==
+																data113.caption !==
 																undefined
 															) {
-																const _errs295 =
+																const _errs304 =
 																	errors;
 																if (
-																	typeof data109.caption !==
+																	typeof data113.caption !==
 																	'string'
 																) {
 																	validate28.errors =
@@ -15313,11 +15555,11 @@ function validate28(
 																		];
 																	return false;
 																}
-																var valid59 =
-																	_errs295 ===
+																var valid60 =
+																	_errs304 ===
 																	errors;
 															} else {
-																var valid59 = true;
+																var valid60 = true;
 															}
 														}
 													}
@@ -15340,16 +15582,16 @@ function validate28(
 													return false;
 												}
 											}
-											var valid58 = _errs290 === errors;
+											var valid59 = _errs299 === errors;
 										} else {
-											var valid58 = true;
+											var valid59 = true;
 										}
-										if (valid58) {
+										if (valid59) {
 											if (data.step !== undefined) {
-												let data112 = data.step;
-												const _errs297 = errors;
+												let data116 = data.step;
+												const _errs306 = errors;
 												if (
-													typeof data112 !== 'string'
+													typeof data116 !== 'string'
 												) {
 													validate28.errors = [
 														{
@@ -15368,7 +15610,7 @@ function validate28(
 													];
 													return false;
 												}
-												if ('rm' !== data112) {
+												if ('rm' !== data116) {
 													validate28.errors = [
 														{
 															instancePath:
@@ -15387,14 +15629,14 @@ function validate28(
 													];
 													return false;
 												}
-												var valid58 =
-													_errs297 === errors;
+												var valid59 =
+													_errs306 === errors;
 											} else {
-												var valid58 = true;
+												var valid59 = true;
 											}
-											if (valid58) {
+											if (valid59) {
 												if (data.path !== undefined) {
-													const _errs299 = errors;
+													const _errs308 = errors;
 													if (
 														typeof data.path !==
 														'string'
@@ -15416,10 +15658,10 @@ function validate28(
 														];
 														return false;
 													}
-													var valid58 =
-														_errs299 === errors;
+													var valid59 =
+														_errs308 === errors;
 												} else {
-													var valid58 = true;
+													var valid59 = true;
 												}
 											}
 										}
@@ -15439,8 +15681,8 @@ function validate28(
 							}
 						}
 					} else if (tag0 === 'rmdir') {
-						const _errs301 = errors;
-						if (errors === _errs301) {
+						const _errs310 = errors;
+						if (errors === _errs310) {
 							if (
 								data &&
 								typeof data == 'object' &&
@@ -15469,13 +15711,13 @@ function validate28(
 									];
 									return false;
 								} else {
-									const _errs303 = errors;
-									for (const key38 in data) {
+									const _errs312 = errors;
+									for (const key39 in data) {
 										if (
 											!(
-												key38 === 'progress' ||
-												key38 === 'step' ||
-												key38 === 'path'
+												key39 === 'progress' ||
+												key39 === 'step' ||
+												key39 === 'path'
 											)
 										) {
 											validate28.errors = [
@@ -15487,7 +15729,7 @@ function validate28(
 														'additionalProperties',
 													params: {
 														additionalProperty:
-															key38,
+															key39,
 													},
 													message:
 														'must NOT have additional properties',
@@ -15497,24 +15739,24 @@ function validate28(
 											break;
 										}
 									}
-									if (_errs303 === errors) {
+									if (_errs312 === errors) {
 										if (data.progress !== undefined) {
-											let data114 = data.progress;
-											const _errs304 = errors;
-											if (errors === _errs304) {
+											let data118 = data.progress;
+											const _errs313 = errors;
+											if (errors === _errs313) {
 												if (
-													data114 &&
-													typeof data114 ==
+													data118 &&
+													typeof data118 ==
 														'object' &&
-													!Array.isArray(data114)
+													!Array.isArray(data118)
 												) {
-													const _errs306 = errors;
-													for (const key39 in data114) {
+													const _errs315 = errors;
+													for (const key40 in data118) {
 														if (
 															!(
-																key39 ===
+																key40 ===
 																	'weight' ||
-																key39 ===
+																key40 ===
 																	'caption'
 															)
 														) {
@@ -15530,7 +15772,7 @@ function validate28(
 																			'additionalProperties',
 																		params: {
 																			additionalProperty:
-																				key39,
+																				key40,
 																		},
 																		message:
 																			'must NOT have additional properties',
@@ -15540,21 +15782,21 @@ function validate28(
 															break;
 														}
 													}
-													if (_errs306 === errors) {
+													if (_errs315 === errors) {
 														if (
-															data114.weight !==
+															data118.weight !==
 															undefined
 														) {
-															let data115 =
-																data114.weight;
-															const _errs307 =
+															let data119 =
+																data118.weight;
+															const _errs316 =
 																errors;
 															if (
 																!(
-																	typeof data115 ==
+																	typeof data119 ==
 																		'number' &&
 																	isFinite(
-																		data115
+																		data119
 																	)
 																)
 															) {
@@ -15577,21 +15819,21 @@ function validate28(
 																	];
 																return false;
 															}
-															var valid62 =
-																_errs307 ===
+															var valid63 =
+																_errs316 ===
 																errors;
 														} else {
-															var valid62 = true;
+															var valid63 = true;
 														}
-														if (valid62) {
+														if (valid63) {
 															if (
-																data114.caption !==
+																data118.caption !==
 																undefined
 															) {
-																const _errs309 =
+																const _errs318 =
 																	errors;
 																if (
-																	typeof data114.caption !==
+																	typeof data118.caption !==
 																	'string'
 																) {
 																	validate28.errors =
@@ -15613,11 +15855,11 @@ function validate28(
 																		];
 																	return false;
 																}
-																var valid62 =
-																	_errs309 ===
+																var valid63 =
+																	_errs318 ===
 																	errors;
 															} else {
-																var valid62 = true;
+																var valid63 = true;
 															}
 														}
 													}
@@ -15640,16 +15882,16 @@ function validate28(
 													return false;
 												}
 											}
-											var valid61 = _errs304 === errors;
+											var valid62 = _errs313 === errors;
 										} else {
-											var valid61 = true;
+											var valid62 = true;
 										}
-										if (valid61) {
+										if (valid62) {
 											if (data.step !== undefined) {
-												let data117 = data.step;
-												const _errs311 = errors;
+												let data121 = data.step;
+												const _errs320 = errors;
 												if (
-													typeof data117 !== 'string'
+													typeof data121 !== 'string'
 												) {
 													validate28.errors = [
 														{
@@ -15668,7 +15910,7 @@ function validate28(
 													];
 													return false;
 												}
-												if ('rmdir' !== data117) {
+												if ('rmdir' !== data121) {
 													validate28.errors = [
 														{
 															instancePath:
@@ -15687,14 +15929,14 @@ function validate28(
 													];
 													return false;
 												}
-												var valid61 =
-													_errs311 === errors;
+												var valid62 =
+													_errs320 === errors;
 											} else {
-												var valid61 = true;
+												var valid62 = true;
 											}
-											if (valid61) {
+											if (valid62) {
 												if (data.path !== undefined) {
-													const _errs313 = errors;
+													const _errs322 = errors;
 													if (
 														typeof data.path !==
 														'string'
@@ -15716,10 +15958,10 @@ function validate28(
 														];
 														return false;
 													}
-													var valid61 =
-														_errs313 === errors;
+													var valid62 =
+														_errs322 === errors;
 												} else {
-													var valid61 = true;
+													var valid62 = true;
 												}
 											}
 										}
@@ -15739,8 +15981,8 @@ function validate28(
 							}
 						}
 					} else if (tag0 === 'runPHP') {
-						const _errs315 = errors;
-						if (errors === _errs315) {
+						const _errs324 = errors;
+						if (errors === _errs324) {
 							if (
 								data &&
 								typeof data == 'object' &&
@@ -15769,13 +16011,13 @@ function validate28(
 									];
 									return false;
 								} else {
-									const _errs317 = errors;
-									for (const key40 in data) {
+									const _errs326 = errors;
+									for (const key41 in data) {
 										if (
 											!(
-												key40 === 'progress' ||
-												key40 === 'step' ||
-												key40 === 'code'
+												key41 === 'progress' ||
+												key41 === 'step' ||
+												key41 === 'code'
 											)
 										) {
 											validate28.errors = [
@@ -15787,7 +16029,7 @@ function validate28(
 														'additionalProperties',
 													params: {
 														additionalProperty:
-															key40,
+															key41,
 													},
 													message:
 														'must NOT have additional properties',
@@ -15797,24 +16039,24 @@ function validate28(
 											break;
 										}
 									}
-									if (_errs317 === errors) {
+									if (_errs326 === errors) {
 										if (data.progress !== undefined) {
-											let data119 = data.progress;
-											const _errs318 = errors;
-											if (errors === _errs318) {
+											let data123 = data.progress;
+											const _errs327 = errors;
+											if (errors === _errs327) {
 												if (
-													data119 &&
-													typeof data119 ==
+													data123 &&
+													typeof data123 ==
 														'object' &&
-													!Array.isArray(data119)
+													!Array.isArray(data123)
 												) {
-													const _errs320 = errors;
-													for (const key41 in data119) {
+													const _errs329 = errors;
+													for (const key42 in data123) {
 														if (
 															!(
-																key41 ===
+																key42 ===
 																	'weight' ||
-																key41 ===
+																key42 ===
 																	'caption'
 															)
 														) {
@@ -15830,7 +16072,7 @@ function validate28(
 																			'additionalProperties',
 																		params: {
 																			additionalProperty:
-																				key41,
+																				key42,
 																		},
 																		message:
 																			'must NOT have additional properties',
@@ -15840,21 +16082,21 @@ function validate28(
 															break;
 														}
 													}
-													if (_errs320 === errors) {
+													if (_errs329 === errors) {
 														if (
-															data119.weight !==
+															data123.weight !==
 															undefined
 														) {
-															let data120 =
-																data119.weight;
-															const _errs321 =
+															let data124 =
+																data123.weight;
+															const _errs330 =
 																errors;
 															if (
 																!(
-																	typeof data120 ==
+																	typeof data124 ==
 																		'number' &&
 																	isFinite(
-																		data120
+																		data124
 																	)
 																)
 															) {
@@ -15877,21 +16119,21 @@ function validate28(
 																	];
 																return false;
 															}
-															var valid65 =
-																_errs321 ===
+															var valid66 =
+																_errs330 ===
 																errors;
 														} else {
-															var valid65 = true;
+															var valid66 = true;
 														}
-														if (valid65) {
+														if (valid66) {
 															if (
-																data119.caption !==
+																data123.caption !==
 																undefined
 															) {
-																const _errs323 =
+																const _errs332 =
 																	errors;
 																if (
-																	typeof data119.caption !==
+																	typeof data123.caption !==
 																	'string'
 																) {
 																	validate28.errors =
@@ -15913,11 +16155,11 @@ function validate28(
 																		];
 																	return false;
 																}
-																var valid65 =
-																	_errs323 ===
+																var valid66 =
+																	_errs332 ===
 																	errors;
 															} else {
-																var valid65 = true;
+																var valid66 = true;
 															}
 														}
 													}
@@ -15940,16 +16182,16 @@ function validate28(
 													return false;
 												}
 											}
-											var valid64 = _errs318 === errors;
+											var valid65 = _errs327 === errors;
 										} else {
-											var valid64 = true;
+											var valid65 = true;
 										}
-										if (valid64) {
+										if (valid65) {
 											if (data.step !== undefined) {
-												let data122 = data.step;
-												const _errs325 = errors;
+												let data126 = data.step;
+												const _errs334 = errors;
 												if (
-													typeof data122 !== 'string'
+													typeof data126 !== 'string'
 												) {
 													validate28.errors = [
 														{
@@ -15968,7 +16210,7 @@ function validate28(
 													];
 													return false;
 												}
-												if ('runPHP' !== data122) {
+												if ('runPHP' !== data126) {
 													validate28.errors = [
 														{
 															instancePath:
@@ -15987,20 +16229,20 @@ function validate28(
 													];
 													return false;
 												}
-												var valid64 =
-													_errs325 === errors;
+												var valid65 =
+													_errs334 === errors;
 											} else {
-												var valid64 = true;
+												var valid65 = true;
 											}
-											if (valid64) {
+											if (valid65) {
 												if (data.code !== undefined) {
-													let data123 = data.code;
-													const _errs327 = errors;
-													const _errs328 = errors;
-													let valid66 = false;
-													const _errs329 = errors;
+													let data127 = data.code;
+													const _errs336 = errors;
+													const _errs337 = errors;
+													let valid67 = false;
+													const _errs338 = errors;
 													if (
-														typeof data123 !==
+														typeof data127 !==
 														'string'
 													) {
 														const err2 = {
@@ -16024,29 +16266,29 @@ function validate28(
 														errors++;
 													}
 													var _valid2 =
-														_errs329 === errors;
-													valid66 =
-														valid66 || _valid2;
-													if (!valid66) {
-														const _errs331 = errors;
+														_errs338 === errors;
+													valid67 =
+														valid67 || _valid2;
+													if (!valid67) {
+														const _errs340 = errors;
 														if (
-															errors === _errs331
+															errors === _errs340
 														) {
 															if (
-																data123 &&
-																typeof data123 ==
+																data127 &&
+																typeof data127 ==
 																	'object' &&
 																!Array.isArray(
-																	data123
+																	data127
 																)
 															) {
 																let missing20;
 																if (
-																	(data123.filename ===
+																	(data127.filename ===
 																		undefined &&
 																		(missing20 =
 																			'filename')) ||
-																	(data123.content ===
+																	(data127.content ===
 																		undefined &&
 																		(missing20 =
 																			'content'))
@@ -16084,14 +16326,14 @@ function validate28(
 																	}
 																	errors++;
 																} else {
-																	const _errs333 =
+																	const _errs342 =
 																		errors;
-																	for (const key42 in data123) {
+																	for (const key43 in data127) {
 																		if (
 																			!(
-																				key42 ===
+																				key43 ===
 																					'filename' ||
-																				key42 ===
+																				key43 ===
 																					'content'
 																			)
 																		) {
@@ -16106,7 +16348,7 @@ function validate28(
 																						'additionalProperties',
 																					params: {
 																						additionalProperty:
-																							key42,
+																							key43,
 																					},
 																					message:
 																						'must NOT have additional properties',
@@ -16129,17 +16371,17 @@ function validate28(
 																		}
 																	}
 																	if (
-																		_errs333 ===
+																		_errs342 ===
 																		errors
 																	) {
 																		if (
-																			data123.filename !==
+																			data127.filename !==
 																			undefined
 																		) {
-																			const _errs334 =
+																			const _errs343 =
 																				errors;
 																			if (
-																				typeof data123.filename !==
+																				typeof data127.filename !==
 																				'string'
 																			) {
 																				const err5 =
@@ -16172,23 +16414,23 @@ function validate28(
 																				}
 																				errors++;
 																			}
-																			var valid67 =
-																				_errs334 ===
+																			var valid68 =
+																				_errs343 ===
 																				errors;
 																		} else {
-																			var valid67 = true;
+																			var valid68 = true;
 																		}
 																		if (
-																			valid67
+																			valid68
 																		) {
 																			if (
-																				data123.content !==
+																				data127.content !==
 																				undefined
 																			) {
-																				const _errs336 =
+																				const _errs345 =
 																					errors;
 																				if (
-																					typeof data123.content !==
+																					typeof data127.content !==
 																					'string'
 																				) {
 																					const err6 =
@@ -16221,11 +16463,11 @@ function validate28(
 																					}
 																					errors++;
 																				}
-																				var valid67 =
-																					_errs336 ===
+																				var valid68 =
+																					_errs345 ===
 																					errors;
 																			} else {
-																				var valid67 = true;
+																				var valid68 = true;
 																			}
 																		}
 																	}
@@ -16261,11 +16503,11 @@ function validate28(
 															}
 														}
 														var _valid2 =
-															_errs331 === errors;
-														valid66 =
-															valid66 || _valid2;
+															_errs340 === errors;
+														valid67 =
+															valid67 || _valid2;
 													}
-													if (!valid66) {
+													if (!valid67) {
 														const err8 = {
 															instancePath:
 																instancePath +
@@ -16287,20 +16529,20 @@ function validate28(
 															vErrors;
 														return false;
 													} else {
-														errors = _errs328;
+														errors = _errs337;
 														if (vErrors !== null) {
-															if (_errs328) {
+															if (_errs337) {
 																vErrors.length =
-																	_errs328;
+																	_errs337;
 															} else {
 																vErrors = null;
 															}
 														}
 													}
-													var valid64 =
-														_errs327 === errors;
+													var valid65 =
+														_errs336 === errors;
 												} else {
-													var valid64 = true;
+													var valid65 = true;
 												}
 											}
 										}
@@ -16320,8 +16562,8 @@ function validate28(
 							}
 						}
 					} else if (tag0 === 'runPHPWithOptions') {
-						const _errs338 = errors;
-						if (errors === _errs338) {
+						const _errs347 = errors;
+						if (errors === _errs347) {
 							if (
 								data &&
 								typeof data == 'object' &&
@@ -16350,13 +16592,13 @@ function validate28(
 									];
 									return false;
 								} else {
-									const _errs340 = errors;
-									for (const key43 in data) {
+									const _errs349 = errors;
+									for (const key44 in data) {
 										if (
 											!(
-												key43 === 'progress' ||
-												key43 === 'step' ||
-												key43 === 'options'
+												key44 === 'progress' ||
+												key44 === 'step' ||
+												key44 === 'options'
 											)
 										) {
 											validate28.errors = [
@@ -16368,7 +16610,7 @@ function validate28(
 														'additionalProperties',
 													params: {
 														additionalProperty:
-															key43,
+															key44,
 													},
 													message:
 														'must NOT have additional properties',
@@ -16378,24 +16620,24 @@ function validate28(
 											break;
 										}
 									}
-									if (_errs340 === errors) {
+									if (_errs349 === errors) {
 										if (data.progress !== undefined) {
-											let data126 = data.progress;
-											const _errs341 = errors;
-											if (errors === _errs341) {
+											let data130 = data.progress;
+											const _errs350 = errors;
+											if (errors === _errs350) {
 												if (
-													data126 &&
-													typeof data126 ==
+													data130 &&
+													typeof data130 ==
 														'object' &&
-													!Array.isArray(data126)
+													!Array.isArray(data130)
 												) {
-													const _errs343 = errors;
-													for (const key44 in data126) {
+													const _errs352 = errors;
+													for (const key45 in data130) {
 														if (
 															!(
-																key44 ===
+																key45 ===
 																	'weight' ||
-																key44 ===
+																key45 ===
 																	'caption'
 															)
 														) {
@@ -16411,7 +16653,7 @@ function validate28(
 																			'additionalProperties',
 																		params: {
 																			additionalProperty:
-																				key44,
+																				key45,
 																		},
 																		message:
 																			'must NOT have additional properties',
@@ -16421,21 +16663,21 @@ function validate28(
 															break;
 														}
 													}
-													if (_errs343 === errors) {
+													if (_errs352 === errors) {
 														if (
-															data126.weight !==
+															data130.weight !==
 															undefined
 														) {
-															let data127 =
-																data126.weight;
-															const _errs344 =
+															let data131 =
+																data130.weight;
+															const _errs353 =
 																errors;
 															if (
 																!(
-																	typeof data127 ==
+																	typeof data131 ==
 																		'number' &&
 																	isFinite(
-																		data127
+																		data131
 																	)
 																)
 															) {
@@ -16458,21 +16700,21 @@ function validate28(
 																	];
 																return false;
 															}
-															var valid70 =
-																_errs344 ===
+															var valid71 =
+																_errs353 ===
 																errors;
 														} else {
-															var valid70 = true;
+															var valid71 = true;
 														}
-														if (valid70) {
+														if (valid71) {
 															if (
-																data126.caption !==
+																data130.caption !==
 																undefined
 															) {
-																const _errs346 =
+																const _errs355 =
 																	errors;
 																if (
-																	typeof data126.caption !==
+																	typeof data130.caption !==
 																	'string'
 																) {
 																	validate28.errors =
@@ -16494,11 +16736,11 @@ function validate28(
 																		];
 																	return false;
 																}
-																var valid70 =
-																	_errs346 ===
+																var valid71 =
+																	_errs355 ===
 																	errors;
 															} else {
-																var valid70 = true;
+																var valid71 = true;
 															}
 														}
 													}
@@ -16521,16 +16763,16 @@ function validate28(
 													return false;
 												}
 											}
-											var valid69 = _errs341 === errors;
+											var valid70 = _errs350 === errors;
 										} else {
-											var valid69 = true;
+											var valid70 = true;
 										}
-										if (valid69) {
+										if (valid70) {
 											if (data.step !== undefined) {
-												let data129 = data.step;
-												const _errs348 = errors;
+												let data133 = data.step;
+												const _errs357 = errors;
 												if (
-													typeof data129 !== 'string'
+													typeof data133 !== 'string'
 												) {
 													validate28.errors = [
 														{
@@ -16551,7 +16793,7 @@ function validate28(
 												}
 												if (
 													'runPHPWithOptions' !==
-													data129
+													data133
 												) {
 													validate28.errors = [
 														{
@@ -16571,16 +16813,16 @@ function validate28(
 													];
 													return false;
 												}
-												var valid69 =
-													_errs348 === errors;
+												var valid70 =
+													_errs357 === errors;
 											} else {
-												var valid69 = true;
+												var valid70 = true;
 											}
-											if (valid69) {
+											if (valid70) {
 												if (
 													data.options !== undefined
 												) {
-													const _errs350 = errors;
+													const _errs359 = errors;
 													if (
 														!validate39(
 															data.options,
@@ -16604,10 +16846,10 @@ function validate28(
 																	);
 														errors = vErrors.length;
 													}
-													var valid69 =
-														_errs350 === errors;
+													var valid70 =
+														_errs359 === errors;
 												} else {
-													var valid69 = true;
+													var valid70 = true;
 												}
 											}
 										}
@@ -16627,8 +16869,8 @@ function validate28(
 							}
 						}
 					} else if (tag0 === 'runWpInstallationWizard') {
-						const _errs351 = errors;
-						if (errors === _errs351) {
+						const _errs360 = errors;
+						if (errors === _errs360) {
 							if (
 								data &&
 								typeof data == 'object' &&
@@ -16657,13 +16899,13 @@ function validate28(
 									];
 									return false;
 								} else {
-									const _errs353 = errors;
-									for (const key45 in data) {
+									const _errs362 = errors;
+									for (const key46 in data) {
 										if (
 											!(
-												key45 === 'progress' ||
-												key45 === 'step' ||
-												key45 === 'options'
+												key46 === 'progress' ||
+												key46 === 'step' ||
+												key46 === 'options'
 											)
 										) {
 											validate28.errors = [
@@ -16675,7 +16917,7 @@ function validate28(
 														'additionalProperties',
 													params: {
 														additionalProperty:
-															key45,
+															key46,
 													},
 													message:
 														'must NOT have additional properties',
@@ -16685,24 +16927,24 @@ function validate28(
 											break;
 										}
 									}
-									if (_errs353 === errors) {
+									if (_errs362 === errors) {
 										if (data.progress !== undefined) {
-											let data131 = data.progress;
-											const _errs354 = errors;
-											if (errors === _errs354) {
+											let data135 = data.progress;
+											const _errs363 = errors;
+											if (errors === _errs363) {
 												if (
-													data131 &&
-													typeof data131 ==
+													data135 &&
+													typeof data135 ==
 														'object' &&
-													!Array.isArray(data131)
+													!Array.isArray(data135)
 												) {
-													const _errs356 = errors;
-													for (const key46 in data131) {
+													const _errs365 = errors;
+													for (const key47 in data135) {
 														if (
 															!(
-																key46 ===
+																key47 ===
 																	'weight' ||
-																key46 ===
+																key47 ===
 																	'caption'
 															)
 														) {
@@ -16718,7 +16960,7 @@ function validate28(
 																			'additionalProperties',
 																		params: {
 																			additionalProperty:
-																				key46,
+																				key47,
 																		},
 																		message:
 																			'must NOT have additional properties',
@@ -16728,21 +16970,21 @@ function validate28(
 															break;
 														}
 													}
-													if (_errs356 === errors) {
+													if (_errs365 === errors) {
 														if (
-															data131.weight !==
+															data135.weight !==
 															undefined
 														) {
-															let data132 =
-																data131.weight;
-															const _errs357 =
+															let data136 =
+																data135.weight;
+															const _errs366 =
 																errors;
 															if (
 																!(
-																	typeof data132 ==
+																	typeof data136 ==
 																		'number' &&
 																	isFinite(
-																		data132
+																		data136
 																	)
 																)
 															) {
@@ -16765,21 +17007,21 @@ function validate28(
 																	];
 																return false;
 															}
-															var valid73 =
-																_errs357 ===
+															var valid74 =
+																_errs366 ===
 																errors;
 														} else {
-															var valid73 = true;
+															var valid74 = true;
 														}
-														if (valid73) {
+														if (valid74) {
 															if (
-																data131.caption !==
+																data135.caption !==
 																undefined
 															) {
-																const _errs359 =
+																const _errs368 =
 																	errors;
 																if (
-																	typeof data131.caption !==
+																	typeof data135.caption !==
 																	'string'
 																) {
 																	validate28.errors =
@@ -16801,11 +17043,11 @@ function validate28(
 																		];
 																	return false;
 																}
-																var valid73 =
-																	_errs359 ===
+																var valid74 =
+																	_errs368 ===
 																	errors;
 															} else {
-																var valid73 = true;
+																var valid74 = true;
 															}
 														}
 													}
@@ -16828,16 +17070,16 @@ function validate28(
 													return false;
 												}
 											}
-											var valid72 = _errs354 === errors;
+											var valid73 = _errs363 === errors;
 										} else {
-											var valid72 = true;
+											var valid73 = true;
 										}
-										if (valid72) {
+										if (valid73) {
 											if (data.step !== undefined) {
-												let data134 = data.step;
-												const _errs361 = errors;
+												let data138 = data.step;
+												const _errs370 = errors;
 												if (
-													typeof data134 !== 'string'
+													typeof data138 !== 'string'
 												) {
 													validate28.errors = [
 														{
@@ -16858,7 +17100,7 @@ function validate28(
 												}
 												if (
 													'runWpInstallationWizard' !==
-													data134
+													data138
 												) {
 													validate28.errors = [
 														{
@@ -16878,35 +17120,35 @@ function validate28(
 													];
 													return false;
 												}
-												var valid72 =
-													_errs361 === errors;
+												var valid73 =
+													_errs370 === errors;
 											} else {
-												var valid72 = true;
+												var valid73 = true;
 											}
-											if (valid72) {
+											if (valid73) {
 												if (
 													data.options !== undefined
 												) {
-													let data135 = data.options;
-													const _errs363 = errors;
-													const _errs364 = errors;
-													if (errors === _errs364) {
+													let data139 = data.options;
+													const _errs372 = errors;
+													const _errs373 = errors;
+													if (errors === _errs373) {
 														if (
-															data135 &&
-															typeof data135 ==
+															data139 &&
+															typeof data139 ==
 																'object' &&
 															!Array.isArray(
-																data135
+																data139
 															)
 														) {
-															const _errs366 =
+															const _errs375 =
 																errors;
-															for (const key47 in data135) {
+															for (const key48 in data139) {
 																if (
 																	!(
-																		key47 ===
+																		key48 ===
 																			'adminUsername' ||
-																		key47 ===
+																		key48 ===
 																			'adminPassword'
 																	)
 																) {
@@ -16922,7 +17164,7 @@ function validate28(
 																					'additionalProperties',
 																				params: {
 																					additionalProperty:
-																						key47,
+																						key48,
 																				},
 																				message:
 																					'must NOT have additional properties',
@@ -16933,17 +17175,17 @@ function validate28(
 																}
 															}
 															if (
-																_errs366 ===
+																_errs375 ===
 																errors
 															) {
 																if (
-																	data135.adminUsername !==
+																	data139.adminUsername !==
 																	undefined
 																) {
-																	const _errs367 =
+																	const _errs376 =
 																		errors;
 																	if (
-																		typeof data135.adminUsername !==
+																		typeof data139.adminUsername !==
 																		'string'
 																	) {
 																		validate28.errors =
@@ -16965,21 +17207,21 @@ function validate28(
 																			];
 																		return false;
 																	}
-																	var valid75 =
-																		_errs367 ===
+																	var valid76 =
+																		_errs376 ===
 																		errors;
 																} else {
-																	var valid75 = true;
+																	var valid76 = true;
 																}
-																if (valid75) {
+																if (valid76) {
 																	if (
-																		data135.adminPassword !==
+																		data139.adminPassword !==
 																		undefined
 																	) {
-																		const _errs369 =
+																		const _errs378 =
 																			errors;
 																		if (
-																			typeof data135.adminPassword !==
+																			typeof data139.adminPassword !==
 																			'string'
 																		) {
 																			validate28.errors =
@@ -17001,11 +17243,11 @@ function validate28(
 																				];
 																			return false;
 																		}
-																		var valid75 =
-																			_errs369 ===
+																		var valid76 =
+																			_errs378 ===
 																			errors;
 																	} else {
-																		var valid75 = true;
+																		var valid76 = true;
 																	}
 																}
 															}
@@ -17030,10 +17272,10 @@ function validate28(
 															return false;
 														}
 													}
-													var valid72 =
-														_errs363 === errors;
+													var valid73 =
+														_errs372 === errors;
 												} else {
-													var valid72 = true;
+													var valid73 = true;
 												}
 											}
 										}
@@ -17053,8 +17295,8 @@ function validate28(
 							}
 						}
 					} else if (tag0 === 'runSql') {
-						const _errs371 = errors;
-						if (errors === _errs371) {
+						const _errs380 = errors;
+						if (errors === _errs380) {
 							if (
 								data &&
 								typeof data == 'object' &&
@@ -17083,13 +17325,13 @@ function validate28(
 									];
 									return false;
 								} else {
-									const _errs373 = errors;
-									for (const key48 in data) {
+									const _errs382 = errors;
+									for (const key49 in data) {
 										if (
 											!(
-												key48 === 'progress' ||
-												key48 === 'step' ||
-												key48 === 'sql'
+												key49 === 'progress' ||
+												key49 === 'step' ||
+												key49 === 'sql'
 											)
 										) {
 											validate28.errors = [
@@ -17101,7 +17343,7 @@ function validate28(
 														'additionalProperties',
 													params: {
 														additionalProperty:
-															key48,
+															key49,
 													},
 													message:
 														'must NOT have additional properties',
@@ -17111,24 +17353,24 @@ function validate28(
 											break;
 										}
 									}
-									if (_errs373 === errors) {
+									if (_errs382 === errors) {
 										if (data.progress !== undefined) {
-											let data138 = data.progress;
-											const _errs374 = errors;
-											if (errors === _errs374) {
+											let data142 = data.progress;
+											const _errs383 = errors;
+											if (errors === _errs383) {
 												if (
-													data138 &&
-													typeof data138 ==
+													data142 &&
+													typeof data142 ==
 														'object' &&
-													!Array.isArray(data138)
+													!Array.isArray(data142)
 												) {
-													const _errs376 = errors;
-													for (const key49 in data138) {
+													const _errs385 = errors;
+													for (const key50 in data142) {
 														if (
 															!(
-																key49 ===
+																key50 ===
 																	'weight' ||
-																key49 ===
+																key50 ===
 																	'caption'
 															)
 														) {
@@ -17144,7 +17386,7 @@ function validate28(
 																			'additionalProperties',
 																		params: {
 																			additionalProperty:
-																				key49,
+																				key50,
 																		},
 																		message:
 																			'must NOT have additional properties',
@@ -17154,21 +17396,21 @@ function validate28(
 															break;
 														}
 													}
-													if (_errs376 === errors) {
+													if (_errs385 === errors) {
 														if (
-															data138.weight !==
+															data142.weight !==
 															undefined
 														) {
-															let data139 =
-																data138.weight;
-															const _errs377 =
+															let data143 =
+																data142.weight;
+															const _errs386 =
 																errors;
 															if (
 																!(
-																	typeof data139 ==
+																	typeof data143 ==
 																		'number' &&
 																	isFinite(
-																		data139
+																		data143
 																	)
 																)
 															) {
@@ -17191,21 +17433,21 @@ function validate28(
 																	];
 																return false;
 															}
-															var valid78 =
-																_errs377 ===
+															var valid79 =
+																_errs386 ===
 																errors;
 														} else {
-															var valid78 = true;
+															var valid79 = true;
 														}
-														if (valid78) {
+														if (valid79) {
 															if (
-																data138.caption !==
+																data142.caption !==
 																undefined
 															) {
-																const _errs379 =
+																const _errs388 =
 																	errors;
 																if (
-																	typeof data138.caption !==
+																	typeof data142.caption !==
 																	'string'
 																) {
 																	validate28.errors =
@@ -17227,11 +17469,11 @@ function validate28(
 																		];
 																	return false;
 																}
-																var valid78 =
-																	_errs379 ===
+																var valid79 =
+																	_errs388 ===
 																	errors;
 															} else {
-																var valid78 = true;
+																var valid79 = true;
 															}
 														}
 													}
@@ -17254,16 +17496,16 @@ function validate28(
 													return false;
 												}
 											}
-											var valid77 = _errs374 === errors;
+											var valid78 = _errs383 === errors;
 										} else {
-											var valid77 = true;
+											var valid78 = true;
 										}
-										if (valid77) {
+										if (valid78) {
 											if (data.step !== undefined) {
-												let data141 = data.step;
-												const _errs381 = errors;
+												let data145 = data.step;
+												const _errs390 = errors;
 												if (
-													typeof data141 !== 'string'
+													typeof data145 !== 'string'
 												) {
 													validate28.errors = [
 														{
@@ -17282,7 +17524,7 @@ function validate28(
 													];
 													return false;
 												}
-												if ('runSql' !== data141) {
+												if ('runSql' !== data145) {
 													validate28.errors = [
 														{
 															instancePath:
@@ -17301,14 +17543,14 @@ function validate28(
 													];
 													return false;
 												}
-												var valid77 =
-													_errs381 === errors;
+												var valid78 =
+													_errs390 === errors;
 											} else {
-												var valid77 = true;
+												var valid78 = true;
 											}
-											if (valid77) {
+											if (valid78) {
 												if (data.sql !== undefined) {
-													const _errs383 = errors;
+													const _errs392 = errors;
 													if (
 														!validate16(data.sql, {
 															instancePath:
@@ -17328,10 +17570,10 @@ function validate28(
 																	);
 														errors = vErrors.length;
 													}
-													var valid77 =
-														_errs383 === errors;
+													var valid78 =
+														_errs392 === errors;
 												} else {
-													var valid77 = true;
+													var valid78 = true;
 												}
 											}
 										}
@@ -17351,8 +17593,8 @@ function validate28(
 							}
 						}
 					} else if (tag0 === 'setSiteOptions') {
-						const _errs384 = errors;
-						if (errors === _errs384) {
+						const _errs393 = errors;
+						if (errors === _errs393) {
 							if (
 								data &&
 								typeof data == 'object' &&
@@ -17381,13 +17623,13 @@ function validate28(
 									];
 									return false;
 								} else {
-									const _errs386 = errors;
-									for (const key50 in data) {
+									const _errs395 = errors;
+									for (const key51 in data) {
 										if (
 											!(
-												key50 === 'progress' ||
-												key50 === 'step' ||
-												key50 === 'options'
+												key51 === 'progress' ||
+												key51 === 'step' ||
+												key51 === 'options'
 											)
 										) {
 											validate28.errors = [
@@ -17399,7 +17641,7 @@ function validate28(
 														'additionalProperties',
 													params: {
 														additionalProperty:
-															key50,
+															key51,
 													},
 													message:
 														'must NOT have additional properties',
@@ -17409,24 +17651,24 @@ function validate28(
 											break;
 										}
 									}
-									if (_errs386 === errors) {
+									if (_errs395 === errors) {
 										if (data.progress !== undefined) {
-											let data143 = data.progress;
-											const _errs387 = errors;
-											if (errors === _errs387) {
+											let data147 = data.progress;
+											const _errs396 = errors;
+											if (errors === _errs396) {
 												if (
-													data143 &&
-													typeof data143 ==
+													data147 &&
+													typeof data147 ==
 														'object' &&
-													!Array.isArray(data143)
+													!Array.isArray(data147)
 												) {
-													const _errs389 = errors;
-													for (const key51 in data143) {
+													const _errs398 = errors;
+													for (const key52 in data147) {
 														if (
 															!(
-																key51 ===
+																key52 ===
 																	'weight' ||
-																key51 ===
+																key52 ===
 																	'caption'
 															)
 														) {
@@ -17442,7 +17684,7 @@ function validate28(
 																			'additionalProperties',
 																		params: {
 																			additionalProperty:
-																				key51,
+																				key52,
 																		},
 																		message:
 																			'must NOT have additional properties',
@@ -17452,21 +17694,21 @@ function validate28(
 															break;
 														}
 													}
-													if (_errs389 === errors) {
+													if (_errs398 === errors) {
 														if (
-															data143.weight !==
+															data147.weight !==
 															undefined
 														) {
-															let data144 =
-																data143.weight;
-															const _errs390 =
+															let data148 =
+																data147.weight;
+															const _errs399 =
 																errors;
 															if (
 																!(
-																	typeof data144 ==
+																	typeof data148 ==
 																		'number' &&
 																	isFinite(
-																		data144
+																		data148
 																	)
 																)
 															) {
@@ -17489,21 +17731,21 @@ function validate28(
 																	];
 																return false;
 															}
-															var valid81 =
-																_errs390 ===
+															var valid82 =
+																_errs399 ===
 																errors;
 														} else {
-															var valid81 = true;
+															var valid82 = true;
 														}
-														if (valid81) {
+														if (valid82) {
 															if (
-																data143.caption !==
+																data147.caption !==
 																undefined
 															) {
-																const _errs392 =
+																const _errs401 =
 																	errors;
 																if (
-																	typeof data143.caption !==
+																	typeof data147.caption !==
 																	'string'
 																) {
 																	validate28.errors =
@@ -17525,11 +17767,11 @@ function validate28(
 																		];
 																	return false;
 																}
-																var valid81 =
-																	_errs392 ===
+																var valid82 =
+																	_errs401 ===
 																	errors;
 															} else {
-																var valid81 = true;
+																var valid82 = true;
 															}
 														}
 													}
@@ -17552,16 +17794,16 @@ function validate28(
 													return false;
 												}
 											}
-											var valid80 = _errs387 === errors;
+											var valid81 = _errs396 === errors;
 										} else {
-											var valid80 = true;
+											var valid81 = true;
 										}
-										if (valid80) {
+										if (valid81) {
 											if (data.step !== undefined) {
-												let data146 = data.step;
-												const _errs394 = errors;
+												let data150 = data.step;
+												const _errs403 = errors;
 												if (
-													typeof data146 !== 'string'
+													typeof data150 !== 'string'
 												) {
 													validate28.errors = [
 														{
@@ -17581,7 +17823,7 @@ function validate28(
 													return false;
 												}
 												if (
-													'setSiteOptions' !== data146
+													'setSiteOptions' !== data150
 												) {
 													validate28.errors = [
 														{
@@ -17601,33 +17843,33 @@ function validate28(
 													];
 													return false;
 												}
-												var valid80 =
-													_errs394 === errors;
+												var valid81 =
+													_errs403 === errors;
 											} else {
-												var valid80 = true;
+												var valid81 = true;
 											}
-											if (valid80) {
+											if (valid81) {
 												if (
 													data.options !== undefined
 												) {
-													let data147 = data.options;
-													const _errs396 = errors;
-													if (errors === _errs396) {
+													let data151 = data.options;
+													const _errs405 = errors;
+													if (errors === _errs405) {
 														if (
-															data147 &&
-															typeof data147 ==
+															data151 &&
+															typeof data151 ==
 																'object' &&
 															!Array.isArray(
-																data147
+																data151
 															)
 														) {
-															for (const key52 in data147) {
-																const _errs399 =
+															for (const key53 in data151) {
+																const _errs408 =
 																	errors;
-																var valid82 =
-																	_errs399 ===
+																var valid83 =
+																	_errs408 ===
 																	errors;
-																if (!valid82) {
+																if (!valid83) {
 																	break;
 																}
 															}
@@ -17652,10 +17894,10 @@ function validate28(
 															return false;
 														}
 													}
-													var valid80 =
-														_errs396 === errors;
+													var valid81 =
+														_errs405 === errors;
 												} else {
-													var valid80 = true;
+													var valid81 = true;
 												}
 											}
 										}
@@ -17675,8 +17917,8 @@ function validate28(
 							}
 						}
 					} else if (tag0 === 'unzip') {
-						const _errs400 = errors;
-						if (errors === _errs400) {
+						const _errs409 = errors;
+						if (errors === _errs409) {
 							if (
 								data &&
 								typeof data == 'object' &&
@@ -17705,15 +17947,15 @@ function validate28(
 									];
 									return false;
 								} else {
-									const _errs402 = errors;
-									for (const key53 in data) {
+									const _errs411 = errors;
+									for (const key54 in data) {
 										if (
 											!(
-												key53 === 'progress' ||
-												key53 === 'step' ||
-												key53 === 'zipFile' ||
-												key53 === 'zipPath' ||
-												key53 === 'extractToPath'
+												key54 === 'progress' ||
+												key54 === 'step' ||
+												key54 === 'zipFile' ||
+												key54 === 'zipPath' ||
+												key54 === 'extractToPath'
 											)
 										) {
 											validate28.errors = [
@@ -17725,7 +17967,7 @@ function validate28(
 														'additionalProperties',
 													params: {
 														additionalProperty:
-															key53,
+															key54,
 													},
 													message:
 														'must NOT have additional properties',
@@ -17735,24 +17977,24 @@ function validate28(
 											break;
 										}
 									}
-									if (_errs402 === errors) {
+									if (_errs411 === errors) {
 										if (data.progress !== undefined) {
-											let data149 = data.progress;
-											const _errs403 = errors;
-											if (errors === _errs403) {
+											let data153 = data.progress;
+											const _errs412 = errors;
+											if (errors === _errs412) {
 												if (
-													data149 &&
-													typeof data149 ==
+													data153 &&
+													typeof data153 ==
 														'object' &&
-													!Array.isArray(data149)
+													!Array.isArray(data153)
 												) {
-													const _errs405 = errors;
-													for (const key54 in data149) {
+													const _errs414 = errors;
+													for (const key55 in data153) {
 														if (
 															!(
-																key54 ===
+																key55 ===
 																	'weight' ||
-																key54 ===
+																key55 ===
 																	'caption'
 															)
 														) {
@@ -17768,7 +18010,7 @@ function validate28(
 																			'additionalProperties',
 																		params: {
 																			additionalProperty:
-																				key54,
+																				key55,
 																		},
 																		message:
 																			'must NOT have additional properties',
@@ -17778,21 +18020,21 @@ function validate28(
 															break;
 														}
 													}
-													if (_errs405 === errors) {
+													if (_errs414 === errors) {
 														if (
-															data149.weight !==
+															data153.weight !==
 															undefined
 														) {
-															let data150 =
-																data149.weight;
-															const _errs406 =
+															let data154 =
+																data153.weight;
+															const _errs415 =
 																errors;
 															if (
 																!(
-																	typeof data150 ==
+																	typeof data154 ==
 																		'number' &&
 																	isFinite(
-																		data150
+																		data154
 																	)
 																)
 															) {
@@ -17815,21 +18057,21 @@ function validate28(
 																	];
 																return false;
 															}
-															var valid85 =
-																_errs406 ===
+															var valid86 =
+																_errs415 ===
 																errors;
 														} else {
-															var valid85 = true;
+															var valid86 = true;
 														}
-														if (valid85) {
+														if (valid86) {
 															if (
-																data149.caption !==
+																data153.caption !==
 																undefined
 															) {
-																const _errs408 =
+																const _errs417 =
 																	errors;
 																if (
-																	typeof data149.caption !==
+																	typeof data153.caption !==
 																	'string'
 																) {
 																	validate28.errors =
@@ -17851,11 +18093,11 @@ function validate28(
 																		];
 																	return false;
 																}
-																var valid85 =
-																	_errs408 ===
+																var valid86 =
+																	_errs417 ===
 																	errors;
 															} else {
-																var valid85 = true;
+																var valid86 = true;
 															}
 														}
 													}
@@ -17878,16 +18120,16 @@ function validate28(
 													return false;
 												}
 											}
-											var valid84 = _errs403 === errors;
+											var valid85 = _errs412 === errors;
 										} else {
-											var valid84 = true;
+											var valid85 = true;
 										}
-										if (valid84) {
+										if (valid85) {
 											if (data.step !== undefined) {
-												let data152 = data.step;
-												const _errs410 = errors;
+												let data156 = data.step;
+												const _errs419 = errors;
 												if (
-													typeof data152 !== 'string'
+													typeof data156 !== 'string'
 												) {
 													validate28.errors = [
 														{
@@ -17906,7 +18148,7 @@ function validate28(
 													];
 													return false;
 												}
-												if ('unzip' !== data152) {
+												if ('unzip' !== data156) {
 													validate28.errors = [
 														{
 															instancePath:
@@ -17925,16 +18167,16 @@ function validate28(
 													];
 													return false;
 												}
-												var valid84 =
-													_errs410 === errors;
+												var valid85 =
+													_errs419 === errors;
 											} else {
-												var valid84 = true;
+												var valid85 = true;
 											}
-											if (valid84) {
+											if (valid85) {
 												if (
 													data.zipFile !== undefined
 												) {
-													const _errs412 = errors;
+													const _errs421 = errors;
 													if (
 														!validate16(
 															data.zipFile,
@@ -17958,17 +18200,17 @@ function validate28(
 																	);
 														errors = vErrors.length;
 													}
-													var valid84 =
-														_errs412 === errors;
+													var valid85 =
+														_errs421 === errors;
 												} else {
-													var valid84 = true;
+													var valid85 = true;
 												}
-												if (valid84) {
+												if (valid85) {
 													if (
 														data.zipPath !==
 														undefined
 													) {
-														const _errs413 = errors;
+														const _errs422 = errors;
 														if (
 															typeof data.zipPath !==
 															'string'
@@ -17992,17 +18234,17 @@ function validate28(
 																];
 															return false;
 														}
-														var valid84 =
-															_errs413 === errors;
+														var valid85 =
+															_errs422 === errors;
 													} else {
-														var valid84 = true;
+														var valid85 = true;
 													}
-													if (valid84) {
+													if (valid85) {
 														if (
 															data.extractToPath !==
 															undefined
 														) {
-															const _errs415 =
+															const _errs424 =
 																errors;
 															if (
 																typeof data.extractToPath !==
@@ -18027,11 +18269,11 @@ function validate28(
 																	];
 																return false;
 															}
-															var valid84 =
-																_errs415 ===
+															var valid85 =
+																_errs424 ===
 																errors;
 														} else {
-															var valid84 = true;
+															var valid85 = true;
 														}
 													}
 												}
@@ -18053,8 +18295,8 @@ function validate28(
 							}
 						}
 					} else if (tag0 === 'updateUserMeta') {
-						const _errs417 = errors;
-						if (errors === _errs417) {
+						const _errs426 = errors;
+						if (errors === _errs426) {
 							if (
 								data &&
 								typeof data == 'object' &&
@@ -18085,14 +18327,14 @@ function validate28(
 									];
 									return false;
 								} else {
-									const _errs419 = errors;
-									for (const key55 in data) {
+									const _errs428 = errors;
+									for (const key56 in data) {
 										if (
 											!(
-												key55 === 'progress' ||
-												key55 === 'step' ||
-												key55 === 'meta' ||
-												key55 === 'userId'
+												key56 === 'progress' ||
+												key56 === 'step' ||
+												key56 === 'meta' ||
+												key56 === 'userId'
 											)
 										) {
 											validate28.errors = [
@@ -18104,7 +18346,7 @@ function validate28(
 														'additionalProperties',
 													params: {
 														additionalProperty:
-															key55,
+															key56,
 													},
 													message:
 														'must NOT have additional properties',
@@ -18114,24 +18356,24 @@ function validate28(
 											break;
 										}
 									}
-									if (_errs419 === errors) {
+									if (_errs428 === errors) {
 										if (data.progress !== undefined) {
-											let data156 = data.progress;
-											const _errs420 = errors;
-											if (errors === _errs420) {
+											let data160 = data.progress;
+											const _errs429 = errors;
+											if (errors === _errs429) {
 												if (
-													data156 &&
-													typeof data156 ==
+													data160 &&
+													typeof data160 ==
 														'object' &&
-													!Array.isArray(data156)
+													!Array.isArray(data160)
 												) {
-													const _errs422 = errors;
-													for (const key56 in data156) {
+													const _errs431 = errors;
+													for (const key57 in data160) {
 														if (
 															!(
-																key56 ===
+																key57 ===
 																	'weight' ||
-																key56 ===
+																key57 ===
 																	'caption'
 															)
 														) {
@@ -18147,7 +18389,7 @@ function validate28(
 																			'additionalProperties',
 																		params: {
 																			additionalProperty:
-																				key56,
+																				key57,
 																		},
 																		message:
 																			'must NOT have additional properties',
@@ -18157,21 +18399,21 @@ function validate28(
 															break;
 														}
 													}
-													if (_errs422 === errors) {
+													if (_errs431 === errors) {
 														if (
-															data156.weight !==
+															data160.weight !==
 															undefined
 														) {
-															let data157 =
-																data156.weight;
-															const _errs423 =
+															let data161 =
+																data160.weight;
+															const _errs432 =
 																errors;
 															if (
 																!(
-																	typeof data157 ==
+																	typeof data161 ==
 																		'number' &&
 																	isFinite(
-																		data157
+																		data161
 																	)
 																)
 															) {
@@ -18194,21 +18436,21 @@ function validate28(
 																	];
 																return false;
 															}
-															var valid88 =
-																_errs423 ===
+															var valid89 =
+																_errs432 ===
 																errors;
 														} else {
-															var valid88 = true;
+															var valid89 = true;
 														}
-														if (valid88) {
+														if (valid89) {
 															if (
-																data156.caption !==
+																data160.caption !==
 																undefined
 															) {
-																const _errs425 =
+																const _errs434 =
 																	errors;
 																if (
-																	typeof data156.caption !==
+																	typeof data160.caption !==
 																	'string'
 																) {
 																	validate28.errors =
@@ -18230,11 +18472,11 @@ function validate28(
 																		];
 																	return false;
 																}
-																var valid88 =
-																	_errs425 ===
+																var valid89 =
+																	_errs434 ===
 																	errors;
 															} else {
-																var valid88 = true;
+																var valid89 = true;
 															}
 														}
 													}
@@ -18257,16 +18499,16 @@ function validate28(
 													return false;
 												}
 											}
-											var valid87 = _errs420 === errors;
+											var valid88 = _errs429 === errors;
 										} else {
-											var valid87 = true;
+											var valid88 = true;
 										}
-										if (valid87) {
+										if (valid88) {
 											if (data.step !== undefined) {
-												let data159 = data.step;
-												const _errs427 = errors;
+												let data163 = data.step;
+												const _errs436 = errors;
 												if (
-													typeof data159 !== 'string'
+													typeof data163 !== 'string'
 												) {
 													validate28.errors = [
 														{
@@ -18286,7 +18528,7 @@ function validate28(
 													return false;
 												}
 												if (
-													'updateUserMeta' !== data159
+													'updateUserMeta' !== data163
 												) {
 													validate28.errors = [
 														{
@@ -18306,31 +18548,31 @@ function validate28(
 													];
 													return false;
 												}
-												var valid87 =
-													_errs427 === errors;
+												var valid88 =
+													_errs436 === errors;
 											} else {
-												var valid87 = true;
+												var valid88 = true;
 											}
-											if (valid87) {
+											if (valid88) {
 												if (data.meta !== undefined) {
-													let data160 = data.meta;
-													const _errs429 = errors;
-													if (errors === _errs429) {
+													let data164 = data.meta;
+													const _errs438 = errors;
+													if (errors === _errs438) {
 														if (
-															data160 &&
-															typeof data160 ==
+															data164 &&
+															typeof data164 ==
 																'object' &&
 															!Array.isArray(
-																data160
+																data164
 															)
 														) {
-															for (const key57 in data160) {
-																const _errs432 =
+															for (const key58 in data164) {
+																const _errs441 =
 																	errors;
-																var valid89 =
-																	_errs432 ===
+																var valid90 =
+																	_errs441 ===
 																	errors;
-																if (!valid89) {
+																if (!valid90) {
 																	break;
 																}
 															}
@@ -18355,25 +18597,25 @@ function validate28(
 															return false;
 														}
 													}
-													var valid87 =
-														_errs429 === errors;
+													var valid88 =
+														_errs438 === errors;
 												} else {
-													var valid87 = true;
+													var valid88 = true;
 												}
-												if (valid87) {
+												if (valid88) {
 													if (
 														data.userId !==
 														undefined
 													) {
-														let data162 =
+														let data166 =
 															data.userId;
-														const _errs433 = errors;
+														const _errs442 = errors;
 														if (
 															!(
-																typeof data162 ==
+																typeof data166 ==
 																	'number' &&
 																isFinite(
-																	data162
+																	data166
 																)
 															)
 														) {
@@ -18396,10 +18638,10 @@ function validate28(
 																];
 															return false;
 														}
-														var valid87 =
-															_errs433 === errors;
+														var valid88 =
+															_errs442 === errors;
 													} else {
-														var valid87 = true;
+														var valid88 = true;
 													}
 												}
 											}
@@ -18420,8 +18662,8 @@ function validate28(
 							}
 						}
 					} else if (tag0 === 'writeFile') {
-						const _errs435 = errors;
-						if (errors === _errs435) {
+						const _errs444 = errors;
+						if (errors === _errs444) {
 							if (
 								data &&
 								typeof data == 'object' &&
@@ -18452,14 +18694,14 @@ function validate28(
 									];
 									return false;
 								} else {
-									const _errs437 = errors;
-									for (const key58 in data) {
+									const _errs446 = errors;
+									for (const key59 in data) {
 										if (
 											!(
-												key58 === 'progress' ||
-												key58 === 'step' ||
-												key58 === 'path' ||
-												key58 === 'data'
+												key59 === 'progress' ||
+												key59 === 'step' ||
+												key59 === 'path' ||
+												key59 === 'data'
 											)
 										) {
 											validate28.errors = [
@@ -18471,7 +18713,7 @@ function validate28(
 														'additionalProperties',
 													params: {
 														additionalProperty:
-															key58,
+															key59,
 													},
 													message:
 														'must NOT have additional properties',
@@ -18481,24 +18723,24 @@ function validate28(
 											break;
 										}
 									}
-									if (_errs437 === errors) {
+									if (_errs446 === errors) {
 										if (data.progress !== undefined) {
-											let data163 = data.progress;
-											const _errs438 = errors;
-											if (errors === _errs438) {
+											let data167 = data.progress;
+											const _errs447 = errors;
+											if (errors === _errs447) {
 												if (
-													data163 &&
-													typeof data163 ==
+													data167 &&
+													typeof data167 ==
 														'object' &&
-													!Array.isArray(data163)
+													!Array.isArray(data167)
 												) {
-													const _errs440 = errors;
-													for (const key59 in data163) {
+													const _errs449 = errors;
+													for (const key60 in data167) {
 														if (
 															!(
-																key59 ===
+																key60 ===
 																	'weight' ||
-																key59 ===
+																key60 ===
 																	'caption'
 															)
 														) {
@@ -18514,7 +18756,7 @@ function validate28(
 																			'additionalProperties',
 																		params: {
 																			additionalProperty:
-																				key59,
+																				key60,
 																		},
 																		message:
 																			'must NOT have additional properties',
@@ -18524,21 +18766,21 @@ function validate28(
 															break;
 														}
 													}
-													if (_errs440 === errors) {
+													if (_errs449 === errors) {
 														if (
-															data163.weight !==
+															data167.weight !==
 															undefined
 														) {
-															let data164 =
-																data163.weight;
-															const _errs441 =
+															let data168 =
+																data167.weight;
+															const _errs450 =
 																errors;
 															if (
 																!(
-																	typeof data164 ==
+																	typeof data168 ==
 																		'number' &&
 																	isFinite(
-																		data164
+																		data168
 																	)
 																)
 															) {
@@ -18561,21 +18803,21 @@ function validate28(
 																	];
 																return false;
 															}
-															var valid92 =
-																_errs441 ===
+															var valid93 =
+																_errs450 ===
 																errors;
 														} else {
-															var valid92 = true;
+															var valid93 = true;
 														}
-														if (valid92) {
+														if (valid93) {
 															if (
-																data163.caption !==
+																data167.caption !==
 																undefined
 															) {
-																const _errs443 =
+																const _errs452 =
 																	errors;
 																if (
-																	typeof data163.caption !==
+																	typeof data167.caption !==
 																	'string'
 																) {
 																	validate28.errors =
@@ -18597,11 +18839,11 @@ function validate28(
 																		];
 																	return false;
 																}
-																var valid92 =
-																	_errs443 ===
+																var valid93 =
+																	_errs452 ===
 																	errors;
 															} else {
-																var valid92 = true;
+																var valid93 = true;
 															}
 														}
 													}
@@ -18624,16 +18866,16 @@ function validate28(
 													return false;
 												}
 											}
-											var valid91 = _errs438 === errors;
+											var valid92 = _errs447 === errors;
 										} else {
-											var valid91 = true;
+											var valid92 = true;
 										}
-										if (valid91) {
+										if (valid92) {
 											if (data.step !== undefined) {
-												let data166 = data.step;
-												const _errs445 = errors;
+												let data170 = data.step;
+												const _errs454 = errors;
 												if (
-													typeof data166 !== 'string'
+													typeof data170 !== 'string'
 												) {
 													validate28.errors = [
 														{
@@ -18652,7 +18894,7 @@ function validate28(
 													];
 													return false;
 												}
-												if ('writeFile' !== data166) {
+												if ('writeFile' !== data170) {
 													validate28.errors = [
 														{
 															instancePath:
@@ -18671,14 +18913,14 @@ function validate28(
 													];
 													return false;
 												}
-												var valid91 =
-													_errs445 === errors;
+												var valid92 =
+													_errs454 === errors;
 											} else {
-												var valid91 = true;
+												var valid92 = true;
 											}
-											if (valid91) {
+											if (valid92) {
 												if (data.path !== undefined) {
-													const _errs447 = errors;
+													const _errs456 = errors;
 													if (
 														typeof data.path !==
 														'string'
@@ -18700,23 +18942,23 @@ function validate28(
 														];
 														return false;
 													}
-													var valid91 =
-														_errs447 === errors;
+													var valid92 =
+														_errs456 === errors;
 												} else {
-													var valid91 = true;
+													var valid92 = true;
 												}
-												if (valid91) {
+												if (valid92) {
 													if (
 														data.data !== undefined
 													) {
-														let data168 = data.data;
-														const _errs449 = errors;
-														const _errs450 = errors;
-														let valid93 = false;
-														const _errs451 = errors;
+														let data172 = data.data;
+														const _errs458 = errors;
+														const _errs459 = errors;
+														let valid94 = false;
+														const _errs460 = errors;
 														if (
 															!validate16(
-																data168,
+																data172,
 																{
 																	instancePath:
 																		instancePath +
@@ -18739,14 +18981,14 @@ function validate28(
 																vErrors.length;
 														}
 														var _valid3 =
-															_errs451 === errors;
-														valid93 =
-															valid93 || _valid3;
-														if (!valid93) {
-															const _errs452 =
+															_errs460 === errors;
+														valid94 =
+															valid94 || _valid3;
+														if (!valid94) {
+															const _errs461 =
 																errors;
 															if (
-																typeof data168 !==
+																typeof data172 !==
 																'string'
 															) {
 																const err9 = {
@@ -18778,45 +19020,45 @@ function validate28(
 																errors++;
 															}
 															var _valid3 =
-																_errs452 ===
+																_errs461 ===
 																errors;
-															valid93 =
-																valid93 ||
+															valid94 =
+																valid94 ||
 																_valid3;
-															if (!valid93) {
-																const _errs454 =
+															if (!valid94) {
+																const _errs463 =
 																	errors;
 																if (
 																	errors ===
-																	_errs454
+																	_errs463
 																) {
 																	if (
-																		data168 &&
-																		typeof data168 ==
+																		data172 &&
+																		typeof data172 ==
 																			'object' &&
 																		!Array.isArray(
-																			data168
+																			data172
 																		)
 																	) {
 																		let missing28;
 																		if (
-																			(data168.BYTES_PER_ELEMENT ===
+																			(data172.BYTES_PER_ELEMENT ===
 																				undefined &&
 																				(missing28 =
 																					'BYTES_PER_ELEMENT')) ||
-																			(data168.buffer ===
+																			(data172.buffer ===
 																				undefined &&
 																				(missing28 =
 																					'buffer')) ||
-																			(data168.byteLength ===
+																			(data172.byteLength ===
 																				undefined &&
 																				(missing28 =
 																					'byteLength')) ||
-																			(data168.byteOffset ===
+																			(data172.byteOffset ===
 																				undefined &&
 																				(missing28 =
 																					'byteOffset')) ||
-																			(data168.length ===
+																			(data172.length ===
 																				undefined &&
 																				(missing28 =
 																					'length'))
@@ -18854,35 +19096,35 @@ function validate28(
 																			}
 																			errors++;
 																		} else {
-																			const _errs456 =
+																			const _errs465 =
 																				errors;
-																			for (const key60 in data168) {
+																			for (const key61 in data172) {
 																				if (
 																					!(
-																						key60 ===
+																						key61 ===
 																							'BYTES_PER_ELEMENT' ||
-																						key60 ===
+																						key61 ===
 																							'buffer' ||
-																						key60 ===
+																						key61 ===
 																							'byteLength' ||
-																						key60 ===
+																						key61 ===
 																							'byteOffset' ||
-																						key60 ===
+																						key61 ===
 																							'length'
 																					)
 																				) {
-																					let data169 =
-																						data168[
-																							key60
+																					let data173 =
+																						data172[
+																							key61
 																						];
-																					const _errs457 =
+																					const _errs466 =
 																						errors;
 																					if (
 																						!(
-																							typeof data169 ==
+																							typeof data173 ==
 																								'number' &&
 																							isFinite(
-																								data169
+																								data173
 																							)
 																						)
 																					) {
@@ -18891,7 +19133,7 @@ function validate28(
 																								instancePath:
 																									instancePath +
 																									'/data/' +
-																									key60
+																									key61
 																										.replace(
 																											/~/g,
 																											'~0'
@@ -18925,34 +19167,34 @@ function validate28(
 																						}
 																						errors++;
 																					}
-																					var valid94 =
-																						_errs457 ===
+																					var valid95 =
+																						_errs466 ===
 																						errors;
 																					if (
-																						!valid94
+																						!valid95
 																					) {
 																						break;
 																					}
 																				}
 																			}
 																			if (
-																				_errs456 ===
+																				_errs465 ===
 																				errors
 																			) {
 																				if (
-																					data168.BYTES_PER_ELEMENT !==
+																					data172.BYTES_PER_ELEMENT !==
 																					undefined
 																				) {
-																					let data170 =
-																						data168.BYTES_PER_ELEMENT;
-																					const _errs459 =
+																					let data174 =
+																						data172.BYTES_PER_ELEMENT;
+																					const _errs468 =
 																						errors;
 																					if (
 																						!(
-																							typeof data170 ==
+																							typeof data174 ==
 																								'number' &&
 																							isFinite(
-																								data170
+																								data174
 																							)
 																						)
 																					) {
@@ -18986,38 +19228,38 @@ function validate28(
 																						}
 																						errors++;
 																					}
-																					var valid95 =
-																						_errs459 ===
+																					var valid96 =
+																						_errs468 ===
 																						errors;
 																				} else {
-																					var valid95 = true;
+																					var valid96 = true;
 																				}
 																				if (
-																					valid95
+																					valid96
 																				) {
 																					if (
-																						data168.buffer !==
+																						data172.buffer !==
 																						undefined
 																					) {
-																						let data171 =
-																							data168.buffer;
-																						const _errs461 =
+																						let data175 =
+																							data172.buffer;
+																						const _errs470 =
 																							errors;
 																						if (
 																							errors ===
-																							_errs461
+																							_errs470
 																						) {
 																							if (
-																								data171 &&
-																								typeof data171 ==
+																								data175 &&
+																								typeof data175 ==
 																									'object' &&
 																								!Array.isArray(
-																									data171
+																									data175
 																								)
 																							) {
 																								let missing29;
 																								if (
-																									data171.byteLength ===
+																									data175.byteLength ===
 																										undefined &&
 																									(missing29 =
 																										'byteLength')
@@ -19055,12 +19297,12 @@ function validate28(
 																									}
 																									errors++;
 																								} else {
-																									const _errs463 =
+																									const _errs472 =
 																										errors;
-																									for (const key61 in data171) {
+																									for (const key62 in data175) {
 																										if (
 																											!(
-																												key61 ===
+																												key62 ===
 																												'byteLength'
 																											)
 																										) {
@@ -19075,7 +19317,7 @@ function validate28(
 																														'additionalProperties',
 																													params: {
 																														additionalProperty:
-																															key61,
+																															key62,
 																													},
 																													message:
 																														'must NOT have additional properties',
@@ -19098,21 +19340,21 @@ function validate28(
 																										}
 																									}
 																									if (
-																										_errs463 ===
+																										_errs472 ===
 																										errors
 																									) {
 																										if (
-																											data171.byteLength !==
+																											data175.byteLength !==
 																											undefined
 																										) {
-																											let data172 =
-																												data171.byteLength;
+																											let data176 =
+																												data175.byteLength;
 																											if (
 																												!(
-																													typeof data172 ==
+																													typeof data176 ==
 																														'number' &&
 																													isFinite(
-																														data172
+																														data176
 																													)
 																												)
 																											) {
@@ -19181,29 +19423,29 @@ function validate28(
 																								errors++;
 																							}
 																						}
-																						var valid95 =
-																							_errs461 ===
+																						var valid96 =
+																							_errs470 ===
 																							errors;
 																					} else {
-																						var valid95 = true;
+																						var valid96 = true;
 																					}
 																					if (
-																						valid95
+																						valid96
 																					) {
 																						if (
-																							data168.byteLength !==
+																							data172.byteLength !==
 																							undefined
 																						) {
-																							let data173 =
-																								data168.byteLength;
-																							const _errs466 =
+																							let data177 =
+																								data172.byteLength;
+																							const _errs475 =
 																								errors;
 																							if (
 																								!(
-																									typeof data173 ==
+																									typeof data177 ==
 																										'number' &&
 																									isFinite(
-																										data173
+																										data177
 																									)
 																								)
 																							) {
@@ -19237,29 +19479,29 @@ function validate28(
 																								}
 																								errors++;
 																							}
-																							var valid95 =
-																								_errs466 ===
+																							var valid96 =
+																								_errs475 ===
 																								errors;
 																						} else {
-																							var valid95 = true;
+																							var valid96 = true;
 																						}
 																						if (
-																							valid95
+																							valid96
 																						) {
 																							if (
-																								data168.byteOffset !==
+																								data172.byteOffset !==
 																								undefined
 																							) {
-																								let data174 =
-																									data168.byteOffset;
-																								const _errs468 =
+																								let data178 =
+																									data172.byteOffset;
+																								const _errs477 =
 																									errors;
 																								if (
 																									!(
-																										typeof data174 ==
+																										typeof data178 ==
 																											'number' &&
 																										isFinite(
-																											data174
+																											data178
 																										)
 																									)
 																								) {
@@ -19293,29 +19535,29 @@ function validate28(
 																									}
 																									errors++;
 																								}
-																								var valid95 =
-																									_errs468 ===
+																								var valid96 =
+																									_errs477 ===
 																									errors;
 																							} else {
-																								var valid95 = true;
+																								var valid96 = true;
 																							}
 																							if (
-																								valid95
+																								valid96
 																							) {
 																								if (
-																									data168.length !==
+																									data172.length !==
 																									undefined
 																								) {
-																									let data175 =
-																										data168.length;
-																									const _errs470 =
+																									let data179 =
+																										data172.length;
+																									const _errs479 =
 																										errors;
 																									if (
 																										!(
-																											typeof data175 ==
+																											typeof data179 ==
 																												'number' &&
 																											isFinite(
-																												data175
+																												data179
 																											)
 																										)
 																									) {
@@ -19349,11 +19591,11 @@ function validate28(
 																										}
 																										errors++;
 																									}
-																									var valid95 =
-																										_errs470 ===
+																									var valid96 =
+																										_errs479 ===
 																										errors;
 																								} else {
-																									var valid95 = true;
+																									var valid96 = true;
 																								}
 																							}
 																						}
@@ -19394,14 +19636,14 @@ function validate28(
 																	}
 																}
 																var _valid3 =
-																	_errs454 ===
+																	_errs463 ===
 																	errors;
-																valid93 =
-																	valid93 ||
+																valid94 =
+																	valid94 ||
 																	_valid3;
 															}
 														}
-														if (!valid93) {
+														if (!valid94) {
 															const err21 = {
 																instancePath:
 																	instancePath +
@@ -19430,23 +19672,23 @@ function validate28(
 																vErrors;
 															return false;
 														} else {
-															errors = _errs450;
+															errors = _errs459;
 															if (
 																vErrors !== null
 															) {
-																if (_errs450) {
+																if (_errs459) {
 																	vErrors.length =
-																		_errs450;
+																		_errs459;
 																} else {
 																	vErrors =
 																		null;
 																}
 															}
 														}
-														var valid91 =
-															_errs449 === errors;
+														var valid92 =
+															_errs458 === errors;
 													} else {
-														var valid91 = true;
+														var valid92 = true;
 													}
 												}
 											}
@@ -19467,8 +19709,8 @@ function validate28(
 							}
 						}
 					} else if (tag0 === 'writeFiles') {
-						const _errs472 = errors;
-						if (errors === _errs472) {
+						const _errs481 = errors;
+						if (errors === _errs481) {
 							if (
 								data &&
 								typeof data == 'object' &&
@@ -19499,14 +19741,14 @@ function validate28(
 									];
 									return false;
 								} else {
-									const _errs474 = errors;
-									for (const key62 in data) {
+									const _errs483 = errors;
+									for (const key63 in data) {
 										if (
 											!(
-												key62 === 'progress' ||
-												key62 === 'step' ||
-												key62 === 'writeToPath' ||
-												key62 === 'filesTree'
+												key63 === 'progress' ||
+												key63 === 'step' ||
+												key63 === 'writeToPath' ||
+												key63 === 'filesTree'
 											)
 										) {
 											validate28.errors = [
@@ -19518,7 +19760,7 @@ function validate28(
 														'additionalProperties',
 													params: {
 														additionalProperty:
-															key62,
+															key63,
 													},
 													message:
 														'must NOT have additional properties',
@@ -19528,24 +19770,24 @@ function validate28(
 											break;
 										}
 									}
-									if (_errs474 === errors) {
+									if (_errs483 === errors) {
 										if (data.progress !== undefined) {
-											let data176 = data.progress;
-											const _errs475 = errors;
-											if (errors === _errs475) {
+											let data180 = data.progress;
+											const _errs484 = errors;
+											if (errors === _errs484) {
 												if (
-													data176 &&
-													typeof data176 ==
+													data180 &&
+													typeof data180 ==
 														'object' &&
-													!Array.isArray(data176)
+													!Array.isArray(data180)
 												) {
-													const _errs477 = errors;
-													for (const key63 in data176) {
+													const _errs486 = errors;
+													for (const key64 in data180) {
 														if (
 															!(
-																key63 ===
+																key64 ===
 																	'weight' ||
-																key63 ===
+																key64 ===
 																	'caption'
 															)
 														) {
@@ -19561,7 +19803,7 @@ function validate28(
 																			'additionalProperties',
 																		params: {
 																			additionalProperty:
-																				key63,
+																				key64,
 																		},
 																		message:
 																			'must NOT have additional properties',
@@ -19571,21 +19813,21 @@ function validate28(
 															break;
 														}
 													}
-													if (_errs477 === errors) {
+													if (_errs486 === errors) {
 														if (
-															data176.weight !==
+															data180.weight !==
 															undefined
 														) {
-															let data177 =
-																data176.weight;
-															const _errs478 =
+															let data181 =
+																data180.weight;
+															const _errs487 =
 																errors;
 															if (
 																!(
-																	typeof data177 ==
+																	typeof data181 ==
 																		'number' &&
 																	isFinite(
-																		data177
+																		data181
 																	)
 																)
 															) {
@@ -19608,21 +19850,21 @@ function validate28(
 																	];
 																return false;
 															}
-															var valid99 =
-																_errs478 ===
+															var valid100 =
+																_errs487 ===
 																errors;
 														} else {
-															var valid99 = true;
+															var valid100 = true;
 														}
-														if (valid99) {
+														if (valid100) {
 															if (
-																data176.caption !==
+																data180.caption !==
 																undefined
 															) {
-																const _errs480 =
+																const _errs489 =
 																	errors;
 																if (
-																	typeof data176.caption !==
+																	typeof data180.caption !==
 																	'string'
 																) {
 																	validate28.errors =
@@ -19644,11 +19886,11 @@ function validate28(
 																		];
 																	return false;
 																}
-																var valid99 =
-																	_errs480 ===
+																var valid100 =
+																	_errs489 ===
 																	errors;
 															} else {
-																var valid99 = true;
+																var valid100 = true;
 															}
 														}
 													}
@@ -19671,16 +19913,16 @@ function validate28(
 													return false;
 												}
 											}
-											var valid98 = _errs475 === errors;
+											var valid99 = _errs484 === errors;
 										} else {
-											var valid98 = true;
+											var valid99 = true;
 										}
-										if (valid98) {
+										if (valid99) {
 											if (data.step !== undefined) {
-												let data179 = data.step;
-												const _errs482 = errors;
+												let data183 = data.step;
+												const _errs491 = errors;
 												if (
-													typeof data179 !== 'string'
+													typeof data183 !== 'string'
 												) {
 													validate28.errors = [
 														{
@@ -19699,7 +19941,7 @@ function validate28(
 													];
 													return false;
 												}
-												if ('writeFiles' !== data179) {
+												if ('writeFiles' !== data183) {
 													validate28.errors = [
 														{
 															instancePath:
@@ -19718,17 +19960,17 @@ function validate28(
 													];
 													return false;
 												}
-												var valid98 =
-													_errs482 === errors;
+												var valid99 =
+													_errs491 === errors;
 											} else {
-												var valid98 = true;
+												var valid99 = true;
 											}
-											if (valid98) {
+											if (valid99) {
 												if (
 													data.writeToPath !==
 													undefined
 												) {
-													const _errs484 = errors;
+													const _errs493 = errors;
 													if (
 														typeof data.writeToPath !==
 														'string'
@@ -19750,17 +19992,17 @@ function validate28(
 														];
 														return false;
 													}
-													var valid98 =
-														_errs484 === errors;
+													var valid99 =
+														_errs493 === errors;
 												} else {
-													var valid98 = true;
+													var valid99 = true;
 												}
-												if (valid98) {
+												if (valid99) {
 													if (
 														data.filesTree !==
 														undefined
 													) {
-														const _errs486 = errors;
+														const _errs495 = errors;
 														if (
 															!validate18(
 																data.filesTree,
@@ -19785,10 +20027,10 @@ function validate28(
 															errors =
 																vErrors.length;
 														}
-														var valid98 =
-															_errs486 === errors;
+														var valid99 =
+															_errs495 === errors;
 													} else {
-														var valid98 = true;
+														var valid99 = true;
 													}
 												}
 											}
@@ -19809,8 +20051,8 @@ function validate28(
 							}
 						}
 					} else if (tag0 === 'wp-cli') {
-						const _errs487 = errors;
-						if (errors === _errs487) {
+						const _errs496 = errors;
+						if (errors === _errs496) {
 							if (
 								data &&
 								typeof data == 'object' &&
@@ -19839,14 +20081,14 @@ function validate28(
 									];
 									return false;
 								} else {
-									const _errs489 = errors;
-									for (const key64 in data) {
+									const _errs498 = errors;
+									for (const key65 in data) {
 										if (
 											!(
-												key64 === 'progress' ||
-												key64 === 'step' ||
-												key64 === 'command' ||
-												key64 === 'wpCliPath'
+												key65 === 'progress' ||
+												key65 === 'step' ||
+												key65 === 'command' ||
+												key65 === 'wpCliPath'
 											)
 										) {
 											validate28.errors = [
@@ -19858,7 +20100,7 @@ function validate28(
 														'additionalProperties',
 													params: {
 														additionalProperty:
-															key64,
+															key65,
 													},
 													message:
 														'must NOT have additional properties',
@@ -19868,24 +20110,24 @@ function validate28(
 											break;
 										}
 									}
-									if (_errs489 === errors) {
+									if (_errs498 === errors) {
 										if (data.progress !== undefined) {
-											let data182 = data.progress;
-											const _errs490 = errors;
-											if (errors === _errs490) {
+											let data186 = data.progress;
+											const _errs499 = errors;
+											if (errors === _errs499) {
 												if (
-													data182 &&
-													typeof data182 ==
+													data186 &&
+													typeof data186 ==
 														'object' &&
-													!Array.isArray(data182)
+													!Array.isArray(data186)
 												) {
-													const _errs492 = errors;
-													for (const key65 in data182) {
+													const _errs501 = errors;
+													for (const key66 in data186) {
 														if (
 															!(
-																key65 ===
+																key66 ===
 																	'weight' ||
-																key65 ===
+																key66 ===
 																	'caption'
 															)
 														) {
@@ -19901,7 +20143,7 @@ function validate28(
 																			'additionalProperties',
 																		params: {
 																			additionalProperty:
-																				key65,
+																				key66,
 																		},
 																		message:
 																			'must NOT have additional properties',
@@ -19911,21 +20153,21 @@ function validate28(
 															break;
 														}
 													}
-													if (_errs492 === errors) {
+													if (_errs501 === errors) {
 														if (
-															data182.weight !==
+															data186.weight !==
 															undefined
 														) {
-															let data183 =
-																data182.weight;
-															const _errs493 =
+															let data187 =
+																data186.weight;
+															const _errs502 =
 																errors;
 															if (
 																!(
-																	typeof data183 ==
+																	typeof data187 ==
 																		'number' &&
 																	isFinite(
-																		data183
+																		data187
 																	)
 																)
 															) {
@@ -19948,21 +20190,21 @@ function validate28(
 																	];
 																return false;
 															}
-															var valid102 =
-																_errs493 ===
+															var valid103 =
+																_errs502 ===
 																errors;
 														} else {
-															var valid102 = true;
+															var valid103 = true;
 														}
-														if (valid102) {
+														if (valid103) {
 															if (
-																data182.caption !==
+																data186.caption !==
 																undefined
 															) {
-																const _errs495 =
+																const _errs504 =
 																	errors;
 																if (
-																	typeof data182.caption !==
+																	typeof data186.caption !==
 																	'string'
 																) {
 																	validate28.errors =
@@ -19984,11 +20226,11 @@ function validate28(
 																		];
 																	return false;
 																}
-																var valid102 =
-																	_errs495 ===
+																var valid103 =
+																	_errs504 ===
 																	errors;
 															} else {
-																var valid102 = true;
+																var valid103 = true;
 															}
 														}
 													}
@@ -20011,16 +20253,16 @@ function validate28(
 													return false;
 												}
 											}
-											var valid101 = _errs490 === errors;
+											var valid102 = _errs499 === errors;
 										} else {
-											var valid101 = true;
+											var valid102 = true;
 										}
-										if (valid101) {
+										if (valid102) {
 											if (data.step !== undefined) {
-												let data185 = data.step;
-												const _errs497 = errors;
+												let data189 = data.step;
+												const _errs506 = errors;
 												if (
-													typeof data185 !== 'string'
+													typeof data189 !== 'string'
 												) {
 													validate28.errors = [
 														{
@@ -20039,7 +20281,7 @@ function validate28(
 													];
 													return false;
 												}
-												if ('wp-cli' !== data185) {
+												if ('wp-cli' !== data189) {
 													validate28.errors = [
 														{
 															instancePath:
@@ -20058,22 +20300,22 @@ function validate28(
 													];
 													return false;
 												}
-												var valid101 =
-													_errs497 === errors;
+												var valid102 =
+													_errs506 === errors;
 											} else {
-												var valid101 = true;
+												var valid102 = true;
 											}
-											if (valid101) {
+											if (valid102) {
 												if (
 													data.command !== undefined
 												) {
-													let data186 = data.command;
-													const _errs499 = errors;
-													const _errs500 = errors;
-													let valid103 = false;
-													const _errs501 = errors;
+													let data190 = data.command;
+													const _errs508 = errors;
+													const _errs509 = errors;
+													let valid104 = false;
+													const _errs510 = errors;
 													if (
-														typeof data186 !==
+														typeof data190 !==
 														'string'
 													) {
 														const err22 = {
@@ -20097,31 +20339,31 @@ function validate28(
 														errors++;
 													}
 													var _valid4 =
-														_errs501 === errors;
-													valid103 =
-														valid103 || _valid4;
-													if (!valid103) {
-														const _errs503 = errors;
+														_errs510 === errors;
+													valid104 =
+														valid104 || _valid4;
+													if (!valid104) {
+														const _errs512 = errors;
 														if (
-															errors === _errs503
+															errors === _errs512
 														) {
 															if (
 																Array.isArray(
-																	data186
+																	data190
 																)
 															) {
-																var valid104 = true;
+																var valid105 = true;
 																const len0 =
-																	data186.length;
+																	data190.length;
 																for (
 																	let i0 = 0;
 																	i0 < len0;
 																	i0++
 																) {
-																	const _errs505 =
+																	const _errs514 =
 																		errors;
 																	if (
-																		typeof data186[
+																		typeof data190[
 																			i0
 																		] !==
 																		'string'
@@ -20157,11 +20399,11 @@ function validate28(
 																		}
 																		errors++;
 																	}
-																	var valid104 =
-																		_errs505 ===
+																	var valid105 =
+																		_errs514 ===
 																		errors;
 																	if (
-																		!valid104
+																		!valid105
 																	) {
 																		break;
 																	}
@@ -20197,11 +20439,11 @@ function validate28(
 															}
 														}
 														var _valid4 =
-															_errs503 === errors;
-														valid103 =
-															valid103 || _valid4;
+															_errs512 === errors;
+														valid104 =
+															valid104 || _valid4;
 													}
-													if (!valid103) {
+													if (!valid104) {
 														const err25 = {
 															instancePath:
 																instancePath +
@@ -20223,27 +20465,27 @@ function validate28(
 															vErrors;
 														return false;
 													} else {
-														errors = _errs500;
+														errors = _errs509;
 														if (vErrors !== null) {
-															if (_errs500) {
+															if (_errs509) {
 																vErrors.length =
-																	_errs500;
+																	_errs509;
 															} else {
 																vErrors = null;
 															}
 														}
 													}
-													var valid101 =
-														_errs499 === errors;
+													var valid102 =
+														_errs508 === errors;
 												} else {
-													var valid101 = true;
+													var valid102 = true;
 												}
-												if (valid101) {
+												if (valid102) {
 													if (
 														data.wpCliPath !==
 														undefined
 													) {
-														const _errs507 = errors;
+														const _errs516 = errors;
 														if (
 															typeof data.wpCliPath !==
 															'string'
@@ -20267,10 +20509,10 @@ function validate28(
 																];
 															return false;
 														}
-														var valid101 =
-															_errs507 === errors;
+														var valid102 =
+															_errs516 === errors;
 													} else {
-														var valid101 = true;
+														var valid102 = true;
 													}
 												}
 											}
@@ -20291,8 +20533,8 @@ function validate28(
 							}
 						}
 					} else if (tag0 === 'setSiteLanguage') {
-						const _errs509 = errors;
-						if (errors === _errs509) {
+						const _errs518 = errors;
+						if (errors === _errs518) {
 							if (
 								data &&
 								typeof data == 'object' &&
@@ -20321,13 +20563,13 @@ function validate28(
 									];
 									return false;
 								} else {
-									const _errs511 = errors;
-									for (const key66 in data) {
+									const _errs520 = errors;
+									for (const key67 in data) {
 										if (
 											!(
-												key66 === 'progress' ||
-												key66 === 'step' ||
-												key66 === 'language'
+												key67 === 'progress' ||
+												key67 === 'step' ||
+												key67 === 'language'
 											)
 										) {
 											validate28.errors = [
@@ -20339,7 +20581,7 @@ function validate28(
 														'additionalProperties',
 													params: {
 														additionalProperty:
-															key66,
+															key67,
 													},
 													message:
 														'must NOT have additional properties',
@@ -20349,24 +20591,24 @@ function validate28(
 											break;
 										}
 									}
-									if (_errs511 === errors) {
+									if (_errs520 === errors) {
 										if (data.progress !== undefined) {
-											let data189 = data.progress;
-											const _errs512 = errors;
-											if (errors === _errs512) {
+											let data193 = data.progress;
+											const _errs521 = errors;
+											if (errors === _errs521) {
 												if (
-													data189 &&
-													typeof data189 ==
+													data193 &&
+													typeof data193 ==
 														'object' &&
-													!Array.isArray(data189)
+													!Array.isArray(data193)
 												) {
-													const _errs514 = errors;
-													for (const key67 in data189) {
+													const _errs523 = errors;
+													for (const key68 in data193) {
 														if (
 															!(
-																key67 ===
+																key68 ===
 																	'weight' ||
-																key67 ===
+																key68 ===
 																	'caption'
 															)
 														) {
@@ -20382,7 +20624,7 @@ function validate28(
 																			'additionalProperties',
 																		params: {
 																			additionalProperty:
-																				key67,
+																				key68,
 																		},
 																		message:
 																			'must NOT have additional properties',
@@ -20392,21 +20634,21 @@ function validate28(
 															break;
 														}
 													}
-													if (_errs514 === errors) {
+													if (_errs523 === errors) {
 														if (
-															data189.weight !==
+															data193.weight !==
 															undefined
 														) {
-															let data190 =
-																data189.weight;
-															const _errs515 =
+															let data194 =
+																data193.weight;
+															const _errs524 =
 																errors;
 															if (
 																!(
-																	typeof data190 ==
+																	typeof data194 ==
 																		'number' &&
 																	isFinite(
-																		data190
+																		data194
 																	)
 																)
 															) {
@@ -20429,21 +20671,21 @@ function validate28(
 																	];
 																return false;
 															}
-															var valid107 =
-																_errs515 ===
+															var valid108 =
+																_errs524 ===
 																errors;
 														} else {
-															var valid107 = true;
+															var valid108 = true;
 														}
-														if (valid107) {
+														if (valid108) {
 															if (
-																data189.caption !==
+																data193.caption !==
 																undefined
 															) {
-																const _errs517 =
+																const _errs526 =
 																	errors;
 																if (
-																	typeof data189.caption !==
+																	typeof data193.caption !==
 																	'string'
 																) {
 																	validate28.errors =
@@ -20465,11 +20707,11 @@ function validate28(
 																		];
 																	return false;
 																}
-																var valid107 =
-																	_errs517 ===
+																var valid108 =
+																	_errs526 ===
 																	errors;
 															} else {
-																var valid107 = true;
+																var valid108 = true;
 															}
 														}
 													}
@@ -20492,16 +20734,16 @@ function validate28(
 													return false;
 												}
 											}
-											var valid106 = _errs512 === errors;
+											var valid107 = _errs521 === errors;
 										} else {
-											var valid106 = true;
+											var valid107 = true;
 										}
-										if (valid106) {
+										if (valid107) {
 											if (data.step !== undefined) {
-												let data192 = data.step;
-												const _errs519 = errors;
+												let data196 = data.step;
+												const _errs528 = errors;
 												if (
-													typeof data192 !== 'string'
+													typeof data196 !== 'string'
 												) {
 													validate28.errors = [
 														{
@@ -20522,7 +20764,7 @@ function validate28(
 												}
 												if (
 													'setSiteLanguage' !==
-													data192
+													data196
 												) {
 													validate28.errors = [
 														{
@@ -20542,16 +20784,16 @@ function validate28(
 													];
 													return false;
 												}
-												var valid106 =
-													_errs519 === errors;
+												var valid107 =
+													_errs528 === errors;
 											} else {
-												var valid106 = true;
+												var valid107 = true;
 											}
-											if (valid106) {
+											if (valid107) {
 												if (
 													data.language !== undefined
 												) {
-													const _errs521 = errors;
+													const _errs530 = errors;
 													if (
 														typeof data.language !==
 														'string'
@@ -20573,10 +20815,10 @@ function validate28(
 														];
 														return false;
 													}
-													var valid106 =
-														_errs521 === errors;
+													var valid107 =
+														_errs530 === errors;
 												} else {
-													var valid106 = true;
+													var valid107 = true;
 												}
 											}
 										}

--- a/packages/playground/blueprints/public/blueprint-schema.json
+++ b/packages/playground/blueprints/public/blueprint-schema.json
@@ -741,6 +741,24 @@
 							"description": "The fallback local user for imported authors that cannot be mapped.",
 							"default": "admin"
 						},
+						"authorsMode": {
+							"type": "string",
+							"enum": ["create", "default-author", "map"],
+							"description": "How to assign imported WXR authors to local WordPress users.",
+							"default": "default-author"
+						},
+						"authorsMap": {
+							"type": "object",
+							"additionalProperties": {
+								"type": "string"
+							},
+							"description": "Remote WXR author usernames keyed to existing local usernames."
+						},
+						"importUsers": {
+							"type": "boolean",
+							"description": "Whether to create local users for imported WXR authors.",
+							"default": false
+						},
 						"importer": {
 							"type": "string",
 							"enum": ["data-liberation", "default"],

--- a/packages/playground/blueprints/src/lib/steps/import-wxr.ts
+++ b/packages/playground/blueprints/src/lib/steps/import-wxr.ts
@@ -225,7 +225,7 @@ async function importWithDefaultImporter(
 		$user_map         = array();
 		$user_new         = array();
 
-		foreach (array_values($authors) as $index => $author) {
+		foreach ($authors as $index => $author) {
 			$remote_username = $author['author_login'] ?? '';
 			if (!is_string($remote_username) || $remote_username === '') {
 				continue;
@@ -264,8 +264,8 @@ async function importWithDefaultImporter(
 	/**
 	 * Finds the local user ID for an explicit WXR author map entry.
 	 */
-	function blueprint_wxr_author_id_for_username($local_username, string $remote_username): int {
-		if (!is_string($local_username) || $local_username === '') {
+	function blueprint_wxr_author_id_for_username(string $local_username, string $remote_username): int {
+		if ($local_username === '') {
 			throw new Exception(
 				sprintf('Invalid local user mapping for WXR author "%s".', $remote_username)
 			);

--- a/packages/playground/blueprints/src/lib/steps/import-wxr.ts
+++ b/packages/playground/blueprints/src/lib/steps/import-wxr.ts
@@ -45,6 +45,22 @@ export interface ImportWxrStep<ResourceType> {
 	 */
 	defaultAuthorUsername?: string;
 	/**
+	 * How to assign imported WXR authors to local WordPress users.
+	 *
+	 * @default "default-author"
+	 */
+	authorsMode?: 'create' | 'default-author' | 'map';
+	/**
+	 * Remote WXR author usernames keyed to existing local usernames.
+	 */
+	authorsMap?: Record<string, string>;
+	/**
+	 * Whether to create local users for imported WXR authors.
+	 *
+	 * @default false
+	 */
+	importUsers?: boolean;
+	/**
 	 * The importer to use. Possible values:
 	 *
 	 * - `default`: The importer from https://github.com/humanmade/WordPress-Importer
@@ -74,6 +90,9 @@ export const importWxr: StepHandler<ImportWxrStep<File>> = async (
 		rewriteUrls = true,
 		importComments = true,
 		defaultAuthorUsername = 'admin',
+		authorsMode = 'default-author',
+		authorsMap = {},
+		importUsers = false,
 	},
 	progress?
 ) => {
@@ -83,6 +102,9 @@ export const importWxr: StepHandler<ImportWxrStep<File>> = async (
 		rewriteUrls,
 		importComments,
 		fallbackAuthorUsername,
+		authorsMode,
+		authorsMap,
+		importUsers,
 	});
 };
 
@@ -95,6 +117,9 @@ async function importWithDefaultImporter(
 		rewriteUrls: boolean;
 		importComments: boolean;
 		fallbackAuthorUsername: string;
+		authorsMode: 'create' | 'default-author' | 'map';
+		authorsMap: Record<string, string>;
+		importUsers: boolean;
 	}
 ) {
 	progress?.tracker?.setCaption('Importing content');
@@ -144,9 +169,20 @@ async function importWithDefaultImporter(
 
 	$wp_import                  = new WP_Import();
 	$import_data                = $wp_import->parse( getenv('IMPORT_FILE') );
+	$authors_map                = json_decode(getenv('AUTHORS_MAP') ?: '{}', true);
+	if (!is_array($authors_map)) {
+		throw new Exception('Invalid WXR authors map payload.');
+	}
 
 	// Prepare the data to be used in process_author_mapping();
 	$wp_import->get_authors_from_import( $import_data );
+	$author_mapping_form = blueprint_prepare_wxr_author_mapping(
+		$wp_import->authors,
+		getenv('AUTHORS_MODE') ?: 'default-author',
+		$authors_map,
+		getenv('IMPORT_USERS') === 'true',
+		(int) $fallback_author->ID
+	);
 
 	if (getenv('IMPORT_COMMENTS') === 'false') {
 		add_filter('wp_import_post_comments', '__return_empty_array');
@@ -164,8 +200,9 @@ async function importWithDefaultImporter(
 		'step'   => 2,
 	);
 	$_POST = array(
-		'imported_authors'  => array(),
-		'user_map'          => array(),
+		'imported_authors'  => $author_mapping_form['imported_authors'],
+		'user_map'          => $author_mapping_form['user_map'],
+		'user_new'          => $author_mapping_form['user_new'],
 		'fetch_attachments' => $wp_import->fetch_attachments,
 	);
 
@@ -173,6 +210,79 @@ async function importWithDefaultImporter(
 	$wp_import->import( getenv('IMPORT_FILE'), [
 		'rewrite_urls' => getenv('REWRITE_URLS') === 'true',
 	] );
+
+	/**
+	 * Builds the importer form payload for WXR author assignment.
+	 */
+	function blueprint_prepare_wxr_author_mapping(
+		array $authors,
+		string $authors_mode,
+		array $authors_map,
+		bool $import_users,
+		int $fallback_author_id
+	): array {
+		$imported_authors = array();
+		$user_map         = array();
+		$user_new         = array();
+
+		foreach (array_values($authors) as $index => $author) {
+			$remote_username = $author['author_login'] ?? '';
+			if (!is_string($remote_username) || $remote_username === '') {
+				continue;
+			}
+
+			$imported_authors[$index] = $remote_username;
+			if (array_key_exists($remote_username, $authors_map)) {
+				$user_map[$index] = blueprint_wxr_author_id_for_username(
+					$authors_map[$remote_username],
+					$remote_username
+				);
+				continue;
+			}
+
+			if ($authors_mode === 'map') {
+				throw new Exception(
+					sprintf('Missing local user mapping for WXR author "%s".', $remote_username)
+				);
+			}
+
+			if ($authors_mode === 'create' && $import_users) {
+				$user_new[$index] = $remote_username;
+				continue;
+			}
+
+			$user_map[$index] = $fallback_author_id;
+		}
+
+		return array(
+			'imported_authors' => $imported_authors,
+			'user_map'         => $user_map,
+			'user_new'         => $user_new,
+		);
+	}
+
+	/**
+	 * Finds the local user ID for an explicit WXR author map entry.
+	 */
+	function blueprint_wxr_author_id_for_username($local_username, string $remote_username): int {
+		if (!is_string($local_username) || $local_username === '') {
+			throw new Exception(
+				sprintf('Invalid local user mapping for WXR author "%s".', $remote_username)
+			);
+		}
+
+		$local_user = get_user_by('login', $local_username);
+		if (!$local_user) {
+			throw new Exception(
+				sprintf(
+					'Could not find local user "%s" mapped from WXR author "%s".',
+					$local_username,
+					$remote_username
+				)
+			);
+		}
+		return (int) $local_user->ID;
+	}
 	`,
 		env: {
 			IMPORT_FILE: '/tmp/import.wxr',
@@ -180,6 +290,9 @@ async function importWithDefaultImporter(
 			REWRITE_URLS: options.rewriteUrls ? 'true' : 'false',
 			IMPORT_COMMENTS: options.importComments ? 'true' : 'false',
 			FALLBACK_AUTHOR_USERNAME: options.fallbackAuthorUsername,
+			AUTHORS_MODE: options.authorsMode,
+			AUTHORS_MAP: JSON.stringify(options.authorsMap),
+			IMPORT_USERS: options.importUsers ? 'true' : 'false',
 		},
 	});
 }

--- a/packages/playground/blueprints/src/lib/v2/compile.ts
+++ b/packages/playground/blueprints/src/lib/v2/compile.ts
@@ -557,14 +557,15 @@ function lowerBlueprintV2WxrContent(
 	content: BlueprintV2WxrContent,
 	featurePath: string
 ): StepDefinition[] | undefined {
-	if (
-		content.urlsMap ||
-		content.importUsers !== undefined ||
-		content.authorsMode !== 'default-author' ||
-		content.authorsMap
-	) {
+	if (content.urlsMap) {
 		return undefined;
 	}
+
+	const authorsMode =
+		content.authorsMode ??
+		(content.importUsers ? 'create' : 'default-author');
+	const importUsers =
+		content.importUsers ?? (authorsMode === 'create' ? true : false);
 
 	return asArray(content.source).map((source, index) => {
 		const step: StepDefinition = {
@@ -576,7 +577,12 @@ function lowerBlueprintV2WxrContent(
 			fetchAttachments: content.staticAssets !== 'hotlink',
 			rewriteUrls: content.urlsMode !== 'preserve',
 			importComments: content.importComments ?? false,
+			authorsMode,
+			importUsers,
 		};
+		if (content.authorsMap !== undefined) {
+			step.authorsMap = content.authorsMap;
+		}
 		if (content.defaultAuthorUsername !== undefined) {
 			step.defaultAuthorUsername = content.defaultAuthorUsername;
 		}

--- a/packages/playground/blueprints/src/tests/compile.spec.ts
+++ b/packages/playground/blueprints/src/tests/compile.spec.ts
@@ -679,6 +679,8 @@ describe('compileBlueprintForExecution', () => {
 				fetchAttachments: false,
 				rewriteUrls: false,
 				importComments: true,
+				authorsMode: 'default-author',
+				importUsers: false,
 				defaultAuthorUsername: 'editor',
 			},
 			{
@@ -691,13 +693,15 @@ describe('compileBlueprintForExecution', () => {
 				fetchAttachments: false,
 				rewriteUrls: false,
 				importComments: true,
+				authorsMode: 'default-author',
+				importUsers: false,
 				defaultAuthorUsername: 'editor',
 			},
 		]);
 		expect(compiled.compiled.unsupportedPlan).toEqual([]);
 	});
 
-	it('keeps WXR content with unsupported author behavior in the unsupported plan', async () => {
+	it('lowers Blueprint v2 WXR author maps to importWxr steps', async () => {
 		const compiled = await compileBlueprintForExecution({
 			version: 2,
 			content: [
@@ -716,21 +720,35 @@ describe('compileBlueprintForExecution', () => {
 		if (compiled.version !== 2) {
 			throw new Error('Expected a compiled Blueprint v2 result.');
 		}
-		expect(compiled.compiled.steps).toEqual([]);
-		expect(
-			compiled.compiled.unsupportedPlan.map((item) => item.type)
-		).toEqual(['importContent']);
+		expect(compiled.compiled.steps).toEqual([
+			{
+				step: 'importWxr',
+				file: {
+					resource: 'bundled',
+					path: 'content.wxr',
+				},
+				fetchAttachments: true,
+				rewriteUrls: true,
+				importComments: false,
+				authorsMode: 'map',
+				importUsers: false,
+				authorsMap: {
+					remote: 'admin',
+				},
+			},
+		]);
+		expect(compiled.compiled.unsupportedPlan).toEqual([]);
 	});
 
-	it('keeps WXR content with unsupported importer behavior in the unsupported plan', async () => {
+	it('lowers Blueprint v2 WXR user import options to importWxr steps', async () => {
 		const compiled = await compileBlueprintForExecution({
 			version: 2,
 			content: [
 				{
 					type: 'wxr',
 					source: './content.wxr',
-					authorsMode: 'default-author',
-					importUsers: false,
+					authorsMode: 'create',
+					importUsers: true,
 				},
 			],
 		});
@@ -739,10 +757,21 @@ describe('compileBlueprintForExecution', () => {
 		if (compiled.version !== 2) {
 			throw new Error('Expected a compiled Blueprint v2 result.');
 		}
-		expect(compiled.compiled.steps).toEqual([]);
-		expect(
-			compiled.compiled.unsupportedPlan.map((item) => item.type)
-		).toEqual(['importContent']);
+		expect(compiled.compiled.steps).toEqual([
+			{
+				step: 'importWxr',
+				file: {
+					resource: 'bundled',
+					path: 'content.wxr',
+				},
+				fetchAttachments: true,
+				rewriteUrls: true,
+				importComments: false,
+				authorsMode: 'create',
+				importUsers: true,
+			},
+		]);
+		expect(compiled.compiled.unsupportedPlan).toEqual([]);
 	});
 
 	it('lowers Blueprint v2 importContent steps through content lowering', async () => {
@@ -787,6 +816,8 @@ describe('compileBlueprintForExecution', () => {
 				fetchAttachments: true,
 				rewriteUrls: true,
 				importComments: false,
+				authorsMode: 'default-author',
+				importUsers: false,
 			},
 		]);
 		expect(compiled.compiled.unsupportedPlan).toEqual([]);
@@ -1344,7 +1375,9 @@ describe('compileBlueprintForExecution', () => {
 					type: 'wxr',
 					source: './content.wxr',
 					authorsMode: 'default-author',
-					importUsers: false,
+					urlsMap: {
+						'https://example.com': 'https://mapped.example',
+					},
 				},
 			],
 			additionalStepsAfterExecution: [

--- a/packages/playground/blueprints/src/tests/steps/import-wxr.spec.ts
+++ b/packages/playground/blueprints/src/tests/steps/import-wxr.spec.ts
@@ -696,7 +696,8 @@ describe('Blueprint step importWxr', () => {
 						createAuthorWxr(
 							'remote_author',
 							'Mapped Author Post',
-							'mapped-author-post'
+							'mapped-author-post',
+							501
 						),
 					],
 					'import.wxr'
@@ -733,7 +734,8 @@ describe('Blueprint step importWxr', () => {
 						createAuthorWxr(
 							'remote_author',
 							'Created Author Post',
-							'created-author-post'
+							'created-author-post',
+							502
 						),
 					],
 					'import.wxr'
@@ -793,7 +795,8 @@ describe('Blueprint step importWxr', () => {
 function createAuthorWxr(
 	authorLogin: string,
 	postTitle: string,
-	postSlug: string
+	postSlug: string,
+	importId: number
 ) {
 	return `<?xml version="1.0" encoding="UTF-8" ?>
 <rss version="2.0"
@@ -809,7 +812,7 @@ function createAuthorWxr(
 	<wp:base_site_url>https://example.com</wp:base_site_url>
 	<wp:base_blog_url>https://example.com</wp:base_blog_url>
 	<wp:author>
-		<wp:author_id>5</wp:author_id>
+		<wp:author_id>${importId}</wp:author_id>
 		<wp:author_login><![CDATA[${authorLogin}]]></wp:author_login>
 		<wp:author_email><![CDATA[${authorLogin}@example.com]]></wp:author_email>
 		<wp:author_display_name><![CDATA[${authorLogin}]]></wp:author_display_name>
@@ -821,11 +824,11 @@ function createAuthorWxr(
 		<link>https://example.com/${postSlug}/</link>
 		<pubDate>Wed, 01 Jan 2025 00:00:00 +0000</pubDate>
 		<dc:creator><![CDATA[${authorLogin}]]></dc:creator>
-		<guid isPermaLink="false">https://example.com/?p=5</guid>
+		<guid isPermaLink="false">https://example.com/?p=${importId}</guid>
 		<description></description>
 		<content:encoded><![CDATA[<p>Imported author post</p>]]></content:encoded>
 		<excerpt:encoded><![CDATA[]]></excerpt:encoded>
-		<wp:post_id>5</wp:post_id>
+		<wp:post_id>${importId}</wp:post_id>
 		<wp:post_date><![CDATA[2025-01-01 00:00:00]]></wp:post_date>
 		<wp:post_date_gmt><![CDATA[2025-01-01 00:00:00]]></wp:post_date_gmt>
 		<wp:post_modified><![CDATA[2025-01-01 00:00:00]]></wp:post_modified>

--- a/packages/playground/blueprints/src/tests/steps/import-wxr.spec.ts
+++ b/packages/playground/blueprints/src/tests/steps/import-wxr.spec.ts
@@ -672,6 +672,100 @@ describe('Blueprint step importWxr', () => {
 	);
 
 	it(
+		'Should map imported authors to configured local users',
+		async () => {
+			await php.run({
+				code: `<?php
+			require getenv('DOCROOT') . '/wp-load.php';
+			$user_id = wp_create_user(
+				'wxr_mapped_author',
+				'password',
+				'wxr_mapped_author@example.com'
+			);
+			$user = new WP_User($user_id);
+			$user->set_role('author');
+			`,
+				env: {
+					DOCROOT: handler.documentRoot,
+				},
+			});
+
+			await importWxr(php, {
+				file: new File(
+					[
+						createAuthorWxr(
+							'remote_author',
+							'Mapped Author Post',
+							'mapped-author-post'
+						),
+					],
+					'import.wxr'
+				),
+				authorsMode: 'map',
+				authorsMap: {
+					remote_author: 'wxr_mapped_author',
+				},
+			});
+
+			const result = await php.run({
+				code: `<?php
+			require getenv('DOCROOT') . '/wp-load.php';
+			$post = get_page_by_path('mapped-author-post', OBJECT, 'post');
+			$author = $post ? get_user_by('ID', $post->post_author) : null;
+			echo json_encode($author ? $author->user_login : null);
+			`,
+				env: {
+					DOCROOT: handler.documentRoot,
+				},
+			});
+
+			expect(result.json).toBe('wxr_mapped_author');
+		},
+		{ timeout: 30_000 }
+	);
+
+	it(
+		'Should create users for imported authors when requested',
+		async () => {
+			await importWxr(php, {
+				file: new File(
+					[
+						createAuthorWxr(
+							'remote_author',
+							'Created Author Post',
+							'created-author-post'
+						),
+					],
+					'import.wxr'
+				),
+				authorsMode: 'create',
+				importUsers: true,
+			});
+
+			const result = await php.run({
+				code: `<?php
+			require getenv('DOCROOT') . '/wp-load.php';
+			$post = get_page_by_path('created-author-post', OBJECT, 'post');
+			$author = $post ? get_user_by('ID', $post->post_author) : null;
+			echo json_encode([
+				'user_exists' => (bool) get_user_by('login', 'remote_author'),
+				'post_author' => $author ? $author->user_login : null,
+			]);
+			`,
+				env: {
+					DOCROOT: handler.documentRoot,
+				},
+			});
+
+			expect(result.json).toEqual({
+				user_exists: true,
+				post_author: 'remote_author',
+			});
+		},
+		{ timeout: 30_000 }
+	);
+
+	it(
 		'Should fail when the configured default author does not exist',
 		async () => {
 			const fileData = await readFile(
@@ -692,3 +786,60 @@ describe('Blueprint step importWxr', () => {
 		{ timeout: 30_000 }
 	);
 });
+
+/**
+ * Creates a minimal WXR file with one author and one post.
+ */
+function createAuthorWxr(
+	authorLogin: string,
+	postTitle: string,
+	postSlug: string
+) {
+	return `<?xml version="1.0" encoding="UTF-8" ?>
+<rss version="2.0"
+	xmlns:excerpt="http://wordpress.org/export/1.2/excerpt/"
+	xmlns:content="http://purl.org/rss/1.0/modules/content/"
+	xmlns:dc="http://purl.org/dc/elements/1.1/"
+	xmlns:wp="http://wordpress.org/export/1.2/"
+>
+<channel>
+	<title>Author import</title>
+	<link>https://example.com</link>
+	<wp:wxr_version>1.2</wp:wxr_version>
+	<wp:base_site_url>https://example.com</wp:base_site_url>
+	<wp:base_blog_url>https://example.com</wp:base_blog_url>
+	<wp:author>
+		<wp:author_id>5</wp:author_id>
+		<wp:author_login><![CDATA[${authorLogin}]]></wp:author_login>
+		<wp:author_email><![CDATA[${authorLogin}@example.com]]></wp:author_email>
+		<wp:author_display_name><![CDATA[${authorLogin}]]></wp:author_display_name>
+		<wp:author_first_name><![CDATA[]]></wp:author_first_name>
+		<wp:author_last_name><![CDATA[]]></wp:author_last_name>
+	</wp:author>
+	<item>
+		<title><![CDATA[${postTitle}]]></title>
+		<link>https://example.com/${postSlug}/</link>
+		<pubDate>Wed, 01 Jan 2025 00:00:00 +0000</pubDate>
+		<dc:creator><![CDATA[${authorLogin}]]></dc:creator>
+		<guid isPermaLink="false">https://example.com/?p=5</guid>
+		<description></description>
+		<content:encoded><![CDATA[<p>Imported author post</p>]]></content:encoded>
+		<excerpt:encoded><![CDATA[]]></excerpt:encoded>
+		<wp:post_id>5</wp:post_id>
+		<wp:post_date><![CDATA[2025-01-01 00:00:00]]></wp:post_date>
+		<wp:post_date_gmt><![CDATA[2025-01-01 00:00:00]]></wp:post_date_gmt>
+		<wp:post_modified><![CDATA[2025-01-01 00:00:00]]></wp:post_modified>
+		<wp:post_modified_gmt><![CDATA[2025-01-01 00:00:00]]></wp:post_modified_gmt>
+		<wp:comment_status><![CDATA[open]]></wp:comment_status>
+		<wp:ping_status><![CDATA[closed]]></wp:ping_status>
+		<wp:post_name><![CDATA[${postSlug}]]></wp:post_name>
+		<wp:status><![CDATA[publish]]></wp:status>
+		<wp:post_parent>0</wp:post_parent>
+		<wp:menu_order>0</wp:menu_order>
+		<wp:post_type><![CDATA[post]]></wp:post_type>
+		<wp:post_password><![CDATA[]]></wp:post_password>
+		<wp:is_sticky>0</wp:is_sticky>
+	</item>
+</channel>
+</rss>`;
+}

--- a/packages/playground/blueprints/src/tests/steps/import-wxr.spec.ts
+++ b/packages/playground/blueprints/src/tests/steps/import-wxr.spec.ts
@@ -50,6 +50,51 @@ describe('Blueprint step importWxr', () => {
 		});
 	};
 
+	const createAuthorUsers = async (usernames: string[]) => {
+		await php.run({
+			code: `<?php
+			require getenv('DOCROOT') . '/wp-load.php';
+			foreach (json_decode(getenv('USERNAMES'), true) as $username) {
+				if (get_user_by('login', $username)) {
+					continue;
+				}
+				$user_id = wp_create_user(
+					$username,
+					'password',
+					$username . '@example.com'
+				);
+				$user = new WP_User($user_id);
+				$user->set_role('author');
+			}
+			`,
+			env: {
+				DOCROOT: handler.documentRoot,
+				USERNAMES: JSON.stringify(usernames),
+			},
+		});
+	};
+
+	const getPostAuthorLogins = async (postSlugs: string[]) => {
+		const result = await php.run({
+			code: `<?php
+			require getenv('DOCROOT') . '/wp-load.php';
+			$post_author_logins = [];
+			foreach (json_decode(getenv('POST_SLUGS'), true) as $post_slug) {
+				$post = get_page_by_path($post_slug, OBJECT, 'post');
+				$author = $post ? get_user_by('ID', $post->post_author) : null;
+				$post_author_logins[$post_slug] = $author ? $author->user_login : null;
+			}
+			echo json_encode($post_author_logins);
+			`,
+			env: {
+				DOCROOT: handler.documentRoot,
+				POST_SLUGS: JSON.stringify(postSlugs),
+			},
+		});
+
+		return result.json as Record<string, string | null>;
+	};
+
 	let importerPlugin: ArrayBuffer | undefined = undefined;
 	beforeAll(async () => {
 		const pluginResource = new CorePluginResource({
@@ -674,21 +719,7 @@ describe('Blueprint step importWxr', () => {
 	it(
 		'Should map imported authors to configured local users',
 		async () => {
-			await php.run({
-				code: `<?php
-			require getenv('DOCROOT') . '/wp-load.php';
-			$user_id = wp_create_user(
-				'wxr_mapped_author',
-				'password',
-				'wxr_mapped_author@example.com'
-			);
-			$user = new WP_User($user_id);
-			$user->set_role('author');
-			`,
-				env: {
-					DOCROOT: handler.documentRoot,
-				},
-			});
+			await createAuthorUsers(['wxr_mapped_author']);
 
 			await importWxr(php, {
 				file: new File(
@@ -721,6 +752,145 @@ describe('Blueprint step importWxr', () => {
 			});
 
 			expect(result.json).toBe('wxr_mapped_author');
+		},
+		{ timeout: 30_000 }
+	);
+
+	it(
+		'Should map multiple imported authors without reindexing them',
+		async () => {
+			await createAuthorUsers(['wxr_mapped_alice', 'wxr_mapped_bob']);
+
+			await importWxr(php, {
+				file: new File(
+					[
+						createAuthorsWxr([
+							{
+								authorLogin: 'remote_alice',
+								postTitle: 'Mapped Alice Post',
+								postSlug: 'mapped-alice-post',
+								importId: 601,
+							},
+							{
+								authorLogin: 'remote_bob',
+								postTitle: 'Mapped Bob Post',
+								postSlug: 'mapped-bob-post',
+								importId: 602,
+							},
+						]),
+					],
+					'import.wxr'
+				),
+				authorsMode: 'map',
+				authorsMap: {
+					remote_alice: 'wxr_mapped_alice',
+					remote_bob: 'wxr_mapped_bob',
+				},
+			});
+
+			await expect(
+				getPostAuthorLogins(['mapped-alice-post', 'mapped-bob-post'])
+			).resolves.toEqual({
+				'mapped-alice-post': 'wxr_mapped_alice',
+				'mapped-bob-post': 'wxr_mapped_bob',
+			});
+		},
+		{ timeout: 30_000 }
+	);
+
+	it(
+		'Should reject missing or invalid imported author maps',
+		async () => {
+			const createFile = (importId: number) =>
+				new File(
+					[
+						createAuthorWxr(
+							'remote_author',
+							'Invalid Author Map Post',
+							'invalid-author-map-post',
+							importId
+						),
+					],
+					'import.wxr'
+				);
+
+			await expect(
+				importWxr(php, {
+					file: createFile(701),
+					authorsMode: 'map',
+					authorsMap: {},
+				})
+			).rejects.toThrow(
+				/Missing local user mapping for WXR author.*remote_author/
+			);
+
+			await expect(
+				importWxr(php, {
+					file: createFile(702),
+					authorsMode: 'map',
+					authorsMap: {
+						remote_author: 'missing_local_author',
+					},
+				})
+			).rejects.toThrow(
+				/Could not find local user.*missing_local_author.*remote_author/
+			);
+
+			await expect(
+				importWxr(php, {
+					file: createFile(703),
+					authorsMode: 'map',
+					authorsMap: {
+						remote_author: '',
+					},
+				})
+			).rejects.toThrow(
+				/Invalid local user mapping for WXR author.*remote_author/
+			);
+		},
+		{ timeout: 30_000 }
+	);
+
+	it(
+		'Should use explicit author maps before default-author fallback',
+		async () => {
+			await createAuthorUsers(['wxr_partially_mapped_author']);
+
+			await importWxr(php, {
+				file: new File(
+					[
+						createAuthorsWxr([
+							{
+								authorLogin: 'remote_mapped',
+								postTitle: 'Partially Mapped Post',
+								postSlug: 'partially-mapped-post',
+								importId: 801,
+							},
+							{
+								authorLogin: 'remote_unmapped',
+								postTitle: 'Defaulted Author Post',
+								postSlug: 'defaulted-author-post',
+								importId: 802,
+							},
+						]),
+					],
+					'import.wxr'
+				),
+				authorsMode: 'default-author',
+				authorsMap: {
+					remote_mapped: 'wxr_partially_mapped_author',
+				},
+			});
+
+			await expect(
+				getPostAuthorLogins([
+					'partially-mapped-post',
+					'defaulted-author-post',
+				])
+			).resolves.toEqual({
+				'partially-mapped-post': 'wxr_partially_mapped_author',
+				'defaulted-author-post': 'admin',
+			});
 		},
 		{ timeout: 30_000 }
 	);
@@ -768,6 +938,79 @@ describe('Blueprint step importWxr', () => {
 	);
 
 	it(
+		'Should use the default author when user importing is disabled',
+		async () => {
+			await importWxr(php, {
+				file: new File(
+					[
+						createAuthorWxr(
+							'remote_author',
+							'Create Disabled Post',
+							'create-disabled-post',
+							901
+						),
+					],
+					'import.wxr'
+				),
+				authorsMode: 'create',
+				importUsers: false,
+			});
+
+			const authorLogins = await getPostAuthorLogins([
+				'create-disabled-post',
+			]);
+			const result = await php.run({
+				code: `<?php
+			require getenv('DOCROOT') . '/wp-load.php';
+			echo json_encode((bool) get_user_by('login', 'remote_author'));
+			`,
+				env: {
+					DOCROOT: handler.documentRoot,
+				},
+			});
+
+			expect(authorLogins).toEqual({
+				'create-disabled-post': 'admin',
+			});
+			expect(result.json).toBe(false);
+		},
+		{ timeout: 30_000 }
+	);
+
+	it(
+		'Should derive missing WXR authors from post creators',
+		async () => {
+			await importWxr(php, {
+				file: new File(
+					[
+						createAuthorsWxr(
+							[
+								{
+									authorLogin: 'derived_remote_author',
+									postTitle: 'Derived Author Post',
+									postSlug: 'derived-author-post',
+									importId: 1001,
+								},
+							],
+							false
+						),
+					],
+					'import.wxr'
+				),
+				authorsMode: 'create',
+				importUsers: true,
+			});
+
+			await expect(
+				getPostAuthorLogins(['derived-author-post'])
+			).resolves.toEqual({
+				'derived-author-post': 'derived_remote_author',
+			});
+		},
+		{ timeout: 30_000 }
+	);
+
+	it(
 		'Should fail when the configured default author does not exist',
 		async () => {
 			const fileData = await readFile(
@@ -798,6 +1041,37 @@ function createAuthorWxr(
 	postSlug: string,
 	importId: number
 ) {
+	return createAuthorsWxr([
+		{
+			authorLogin,
+			postTitle,
+			postSlug,
+			importId,
+		},
+	]);
+}
+
+type WxrAuthorPost = {
+	authorLogin: string;
+	postTitle: string;
+	postSlug: string;
+	importId: number;
+};
+
+/**
+ * Creates a minimal WXR file with author and post entries.
+ */
+function createAuthorsWxr(
+	posts: WxrAuthorPost[],
+	includeAuthorElements = true
+) {
+	const authorsByLogin = new Map<string, WxrAuthorPost>();
+	for (const post of posts) {
+		if (!authorsByLogin.has(post.authorLogin)) {
+			authorsByLogin.set(post.authorLogin, post);
+		}
+	}
+
 	return `<?xml version="1.0" encoding="UTF-8" ?>
 <rss version="2.0"
 	xmlns:excerpt="http://wordpress.org/export/1.2/excerpt/"
@@ -811,38 +1085,58 @@ function createAuthorWxr(
 	<wp:wxr_version>1.2</wp:wxr_version>
 	<wp:base_site_url>https://example.com</wp:base_site_url>
 	<wp:base_blog_url>https://example.com</wp:base_blog_url>
-	<wp:author>
-		<wp:author_id>${importId}</wp:author_id>
-		<wp:author_login><![CDATA[${authorLogin}]]></wp:author_login>
-		<wp:author_email><![CDATA[${authorLogin}@example.com]]></wp:author_email>
-		<wp:author_display_name><![CDATA[${authorLogin}]]></wp:author_display_name>
+	${
+		includeAuthorElements
+			? Array.from(authorsByLogin.values())
+					.map(createWxrAuthor)
+					.join('\n')
+			: ''
+	}
+	${posts.map(createWxrPost).join('\n')}
+</channel>
+</rss>`;
+}
+
+/**
+ * Creates one WXR author entry.
+ */
+function createWxrAuthor(post: WxrAuthorPost) {
+	return `<wp:author>
+		<wp:author_id>${post.importId}</wp:author_id>
+		<wp:author_login><![CDATA[${post.authorLogin}]]></wp:author_login>
+		<wp:author_email><![CDATA[${post.authorLogin}@example.com]]></wp:author_email>
+		<wp:author_display_name><![CDATA[${post.authorLogin}]]></wp:author_display_name>
 		<wp:author_first_name><![CDATA[]]></wp:author_first_name>
 		<wp:author_last_name><![CDATA[]]></wp:author_last_name>
-	</wp:author>
-	<item>
-		<title><![CDATA[${postTitle}]]></title>
-		<link>https://example.com/${postSlug}/</link>
+	</wp:author>`;
+}
+
+/**
+ * Creates one WXR post entry.
+ */
+function createWxrPost(post: WxrAuthorPost) {
+	return `<item>
+		<title><![CDATA[${post.postTitle}]]></title>
+		<link>https://example.com/${post.postSlug}/</link>
 		<pubDate>Wed, 01 Jan 2025 00:00:00 +0000</pubDate>
-		<dc:creator><![CDATA[${authorLogin}]]></dc:creator>
-		<guid isPermaLink="false">https://example.com/?p=${importId}</guid>
+		<dc:creator><![CDATA[${post.authorLogin}]]></dc:creator>
+		<guid isPermaLink="false">https://example.com/?p=${post.importId}</guid>
 		<description></description>
 		<content:encoded><![CDATA[<p>Imported author post</p>]]></content:encoded>
 		<excerpt:encoded><![CDATA[]]></excerpt:encoded>
-		<wp:post_id>${importId}</wp:post_id>
+		<wp:post_id>${post.importId}</wp:post_id>
 		<wp:post_date><![CDATA[2025-01-01 00:00:00]]></wp:post_date>
 		<wp:post_date_gmt><![CDATA[2025-01-01 00:00:00]]></wp:post_date_gmt>
 		<wp:post_modified><![CDATA[2025-01-01 00:00:00]]></wp:post_modified>
 		<wp:post_modified_gmt><![CDATA[2025-01-01 00:00:00]]></wp:post_modified_gmt>
 		<wp:comment_status><![CDATA[open]]></wp:comment_status>
 		<wp:ping_status><![CDATA[closed]]></wp:ping_status>
-		<wp:post_name><![CDATA[${postSlug}]]></wp:post_name>
+		<wp:post_name><![CDATA[${post.postSlug}]]></wp:post_name>
 		<wp:status><![CDATA[publish]]></wp:status>
 		<wp:post_parent>0</wp:post_parent>
 		<wp:menu_order>0</wp:menu_order>
 		<wp:post_type><![CDATA[post]]></wp:post_type>
 		<wp:post_password><![CDATA[]]></wp:post_password>
 		<wp:is_sticky>0</wp:is_sticky>
-	</item>
-</channel>
-</rss>`;
+	</item>`;
 }


### PR DESCRIPTION
## What it does

Adds Blueprint v2 support for WXR author handling options.

The v2 compiler now lowers WXR `authorsMode`, `authorsMap`, `defaultAuthorUsername`, and `importUsers` into `importWxr` steps. The WXR importer can map remote authors to existing local users, create imported users when requested, or assign unmapped authors to the configured default author.

## Rationale

WXR author behavior is part of the Blueprint v2 schema, but the TypeScript runner previously left those declarations unsupported except for the narrow default-author path. Supporting these options reduces WXR parity gaps before adding broader content-import features.

## Implementation

Extends `importWxr` with author assignment options and builds the same author-mapping form payload that the WordPress importer expects. Explicit author maps are resolved to existing local users; create mode asks the importer to create local users only when `importUsers` is enabled.

The v2 compiler passes supported author options through and still leaves WXR URL maps unsupported in this branch.

## Testing instructions

```bash
npm exec nx -- lint playground-blueprints
npm exec nx -- typecheck playground-blueprints
npx vitest run packages/playground/blueprints/src/tests/compile.spec.ts packages/playground/blueprints/src/tests/steps/import-wxr.spec.ts --config packages/playground/blueprints/vite.config.ts
npm exec nx -- test playground-blueprints
```
