### PR TITLE
[Blueprints] Preserve default theme files during ZIP import

### DIFF
--- a/packages/playground/blueprints/src/lib/steps/import-wordpress-files.ts
+++ b/packages/playground/blueprints/src/lib/steps/import-wordpress-files.ts
@@ -52,13 +52,15 @@ export const importWordPressFiles: StepHandler<
 	const documentRoot = await playground.documentRoot;
 
 	// Unzip
-	let importPath = joinPaths('/tmp', 'import');
-	await playground.mkdir(importPath);
+	const unzipPath = joinPaths('/tmp', 'import');
+	let importPath = unzipPath;
+	await playground.mkdir(unzipPath);
 	await unzip(playground, {
 		zipFile: wordPressFilesZip,
-		extractToPath: importPath,
+		extractToPath: unzipPath,
 	});
 	importPath = joinPaths(importPath, pathInZip);
+	importPath = await resolveImportRoot(playground, importPath);
 
 	// Read the export manifest if it exists. The manifest contains the
 	// site URL (including scope) at export time, which we'll use later
@@ -126,7 +128,7 @@ export const importWordPressFiles: StepHandler<
 	}
 
 	// Remove the directory where we unzipped the imported zip file.
-	await playground.rmdir(importPath);
+	await playground.rmdir(unzipPath);
 
 	// Ensure required constants are defined if wp-config.php doesn't define them.
 	await ensureWpConfig(playground, documentRoot);
@@ -290,6 +292,29 @@ async function inferSiteUrlFromDatabase(
 	});
 	const siteUrl = result.text.trim();
 	return siteUrl || null;
+}
+
+async function resolveImportRoot(playground: UniversalPHP, importPath: string) {
+	if (await playground.fileExists(joinPaths(importPath, 'wp-content'))) {
+		return importPath;
+	}
+
+	const importedFilenames = await playground.listFiles(importPath);
+	if (importedFilenames.length !== 1) {
+		return importPath;
+	}
+
+	const wrappedImportPath = joinPaths(importPath, importedFilenames[0]);
+	if (
+		(await playground.isDir(wrappedImportPath)) &&
+		(await playground.fileExists(
+			joinPaths(wrappedImportPath, 'wp-content')
+		))
+	) {
+		return wrappedImportPath;
+	}
+
+	return importPath;
 }
 
 async function removePath(playground: UniversalPHP, path: string) {

--- a/packages/playground/website/playwright/e2e/opfs.spec.ts
+++ b/packages/playground/website/playwright/e2e/opfs.spec.ts
@@ -17,6 +17,37 @@ async function createTestWordPressZip(markerContent: string): Promise<Buffer> {
 	return Buffer.from(zipBytes!);
 }
 
+async function createWrappedWordPressZip(): Promise<Buffer> {
+	const files = [
+		new File(
+			[
+				`<?php
+/**
+ * Plugin Name: Wrapped ZIP Import Plugin
+ */
+`,
+			],
+			'wordpress-playground/wp-content/plugins/wrapped-zip-import/wrapped-zip-import.php'
+		),
+		new File(
+			[
+				`/*
+Theme Name: Wrapped ZIP Import Theme
+*/
+`,
+			],
+			'wordpress-playground/wp-content/themes/wrapped-zip-import/style.css'
+		),
+		new File(
+			[`<?php echo 'Wrapped ZIP Import Theme';`],
+			'wordpress-playground/wp-content/themes/wrapped-zip-import/index.php'
+		),
+	];
+	const zipStream = encodeZip(files);
+	const zipBytes = await collectBytes(zipStream);
+	return Buffer.from(zipBytes!);
+}
+
 // OPFS tests must run serially because OPFS storage is shared at the browser
 // level, so tests would interfere with each other's saved sites if run in parallel.
 test.describe.configure({ mode: 'serial' });
@@ -588,6 +619,70 @@ test('should import ZIP into a new saved site when a saved site exists', async (
 		savedSiteName,
 		{ timeout: 30000 }
 	);
+});
+
+test('should import a ZIP whose WordPress files are wrapped in one top-level directory', async ({
+	website,
+	browserName,
+}) => {
+	test.skip(
+		browserName !== 'chromium',
+		`This test relies on OPFS which isn't available in Playwright's flavor of ${browserName}.`
+	);
+
+	await website.goto(getTemporaryPlaygroundUrl());
+	await website.openSavedPlaygroundsOverlay();
+
+	const zipBuffer = await createWrappedWordPressZip();
+	const fileInput = website.page.locator(
+		'input[type="file"][accept*=".zip"]'
+	);
+	const importComplete = website.page
+		.waitForEvent('dialog')
+		.then(async (dialog) => {
+			await dialog.accept();
+		});
+	await fileInput.setInputFiles({
+		name: 'wrapped-wordpress-playground.zip',
+		mimeType: 'application/zip',
+		buffer: zipBuffer,
+	});
+	await importComplete;
+
+	await expect
+		.poll(
+			() =>
+				website.page.evaluate(async () => {
+					const playground = (
+						window as any
+					).playgroundSites.getClient();
+					if (!playground) {
+						return {
+							plugin: false,
+							theme: false,
+							misplacedPlugin: false,
+						};
+					}
+					const documentRoot = await playground.documentRoot;
+					return {
+						plugin: await playground.fileExists(
+							`${documentRoot}/wp-content/plugins/wrapped-zip-import/wrapped-zip-import.php`
+						),
+						theme: await playground.fileExists(
+							`${documentRoot}/wp-content/themes/wrapped-zip-import/style.css`
+						),
+						misplacedPlugin: await playground.fileExists(
+							`${documentRoot}/wordpress-playground/wp-content/plugins/wrapped-zip-import/wrapped-zip-import.php`
+						),
+					};
+				}),
+			{ timeout: 90000 }
+		)
+		.toEqual({
+			plugin: true,
+			theme: true,
+			misplacedPlugin: false,
+		});
 });
 
 test('should create a saved site when importing ZIP while on a saved site with no existing temporary site', async ({


### PR DESCRIPTION
## What it does

Preserves default theme files that are present in a Playground ZIP import instead of replacing them with the target Playground's bundled defaults.

Fixes #3963.

## Rationale

Current Playground "Download as .zip" exports are self-contained and can include bundled default themes such as `wp-content/themes/twentytwentyfive`. The importer reused the full export-exclusion list as an import-restore list, so it deleted imported `themes/twenty*` paths and restored only whatever default theme files existed in the newly-created target Playground.

That made a valid Playground export look like it was ignored: the ZIP contained the theme files, the UI reported a successful import, but the imported default theme files were missing or replaced afterwards.

## Implementation

`importWordPressFiles` now distinguishes files that must always come from the target Playground runtime (`db.php` and Playground mu-plugins) from other export-excluded files. If a default theme/plugin path is present in the imported ZIP, it is preserved. If it is absent, the target default still carries over as before.

## Testing instructions

- `npx nx run playground-website:e2e:playwright -- --project=chromium packages/playground/website/playwright/e2e/opfs.spec.ts -g "preserve default theme"`
- `npx nx test playground-blueprints --testFile=import-wordpress-files.spec.ts`
- `npx nx lint playground-blueprints`
- `npx nx lint playground-website`
