### PR TITLE
[Website] Add a file editor e2e test harness

### DIFF
--- a/packages/playground/components/e2e/tests/playground-file-editor.spec.ts
+++ b/packages/playground/components/e2e/tests/playground-file-editor.spec.ts
@@ -1,0 +1,57 @@
+import { expect, type Page, test } from '@playwright/test';
+import type { AsyncWritableFilesystem } from '@wp-playground/storage';
+
+declare global {
+	interface Window {
+		__fileEditorHarness?: {
+			filesystem: AsyncWritableFilesystem;
+			readFileAsText: (path: string) => Promise<string>;
+		};
+	}
+}
+
+const initialPath = '/wordpress/workspace/index.php';
+
+async function gotoHarness(page: Page) {
+	await page.goto('/playwright-file-editor.html');
+	await page.waitForFunction(() => Boolean(window.__fileEditorHarness));
+	await expect(page.locator('.cm-content')).toBeVisible();
+}
+
+async function readHarnessFile(page: Page, path: string) {
+	return page.evaluate((filePath) => {
+		const harness = window.__fileEditorHarness;
+		if (!harness) {
+			throw new Error('File editor harness is not mounted');
+		}
+		return harness.readFileAsText(filePath);
+	}, path);
+}
+
+test.beforeEach(async ({ page }) => {
+	await gotoHarness(page);
+});
+
+test('opens the initial file', async ({ page }) => {
+	await expect(page.getByText(initialPath)).toBeVisible();
+	await expect(page.locator('.cm-content')).toContainText(
+		"<?php echo 'Hello';"
+	);
+});
+
+test('autosaves editor changes into the harness filesystem', async ({
+	page,
+}) => {
+	const nextContent = "<?php echo 'Changed in harness';";
+	const editor = page.locator('.cm-content');
+
+	await editor.click();
+	await page.keyboard.press('ControlOrMeta+A');
+	await page.keyboard.insertText(nextContent);
+
+	await expect
+		.poll(() => readHarnessFile(page, initialPath), {
+			timeout: 10_000,
+		})
+		.toBe(nextContent);
+});

--- a/packages/playground/components/playwright-file-editor.html
+++ b/packages/playground/components/playwright-file-editor.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<title>File Editor Harness</title>
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+	</head>
+	<body>
+		<div id="root"></div>
+		<script
+			type="module"
+			src="./src/e2e-harnesses/file-editor-entry.tsx"
+		></script>
+	</body>
+</html>

--- a/packages/playground/components/src/e2e-harnesses/file-editor-entry.tsx
+++ b/packages/playground/components/src/e2e-harnesses/file-editor-entry.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { FileEditorHarness } from './file-editor-harness';
+
+const container = document.getElementById('root');
+if (!container) {
+	throw new Error('Harness root element missing');
+}
+
+createRoot(container).render(<FileEditorHarness />);

--- a/packages/playground/components/src/e2e-harnesses/file-editor-harness.tsx
+++ b/packages/playground/components/src/e2e-harnesses/file-editor-harness.tsx
@@ -1,0 +1,55 @@
+import React, { useEffect, useMemo } from 'react';
+import type { AsyncWritableFilesystem } from '@wp-playground/storage';
+import { PlaygroundFileEditor } from '../PlaygroundFileEditor';
+import { createFilesystem } from './file-picker-tree-harness';
+
+declare global {
+	interface Window {
+		__fileEditorHarness?: {
+			filesystem: AsyncWritableFilesystem;
+			readFileAsText: (path: string) => Promise<string>;
+		};
+	}
+}
+
+export function FileEditorHarness() {
+	const filesystem = useMemo(() => createFilesystem(), []);
+
+	useEffect(() => {
+		window.__fileEditorHarness = {
+			filesystem,
+			readFileAsText: (path: string) => filesystem.readFileAsText(path),
+		};
+		return () => {
+			delete window.__fileEditorHarness;
+		};
+	}, [filesystem]);
+
+	return (
+		<div
+			style={{
+				minHeight: '100vh',
+				display: 'flex',
+				flexDirection: 'column',
+				background: '#f5f5f5',
+			}}
+		>
+			<header
+				style={{
+					padding: '0.75rem 1rem',
+					background: '#fff',
+					borderBottom: '1px solid #ddd',
+				}}
+			>
+				<strong>PlaygroundFileEditor harness</strong>
+			</header>
+			<div style={{ flex: 1, minHeight: 0 }}>
+				<PlaygroundFileEditor
+					filesystem={filesystem}
+					documentRoot="/wordpress"
+					initialPath="/wordpress/workspace/index.php"
+				/>
+			</div>
+		</div>
+	);
+}

--- a/packages/playground/components/src/e2e-harnesses/file-picker-tree-harness.tsx
+++ b/packages/playground/components/src/e2e-harnesses/file-picker-tree-harness.tsx
@@ -263,7 +263,7 @@ class InMemoryFilesystem
 	}
 }
 
-const createFilesystem = () =>
+export const createFilesystem = () =>
 	new InMemoryFilesystem(cloneStructure(baseFilesystem));
 
 export function FilePickerTreeHarness() {


### PR DESCRIPTION
## What it does

Adds a lightweight Playwright/Vite harness for `PlaygroundFileEditor` and two focused e2e checks that cover opening the initial file and autosaving an edit back into the in-memory harness filesystem.

## Rationale

This gives the file editor work a small, reviewable first step: reviewers can open the existing component locally and future PRs can add behavior against a stable harness without mixing those changes into the dock wiring.

## Implementation

- Adds `playwright-file-editor.html` as a local harness entrypoint.
- Adds a small React harness that renders the existing `PlaygroundFileEditor` against the file picker harness filesystem.
- Exports the existing in-memory filesystem factory from the file picker harness for reuse.
- Adds a Playwright spec for initial open and autosave behavior.

## Testing instructions

```bash
npm exec nx lint playground-components
npm exec nx e2e playground-components
npm exec nx build playground-components
```

To interact with it locally:

```bash
npm exec nx dev playground-components -- --host 127.0.0.1 --port 5174
```

Then open `http://127.0.0.1:5174/playwright-file-editor.html`.
