### PR TITLE
[Website] Keep ZIP imports running during overlay close attempts

### DIFF
--- a/packages/playground/website/playwright/e2e/opfs.spec.ts
+++ b/packages/playground/website/playwright/e2e/opfs.spec.ts
@@ -18,6 +18,37 @@ async function createTestWordPressZip(markerContent: string): Promise<Buffer> {
 	return Buffer.from(zipBytes!);
 }
 
+async function createPluginThemeExportZip(): Promise<Buffer> {
+	const files = [
+		new File(
+			[
+				`<?php
+/**
+ * Plugin Name: Close Race Plugin
+ */
+`,
+			],
+			'wp-content/plugins/close-race-plugin/close-race-plugin.php'
+		),
+		new File(
+			[
+				`/*
+Theme Name: Close Race Theme
+*/
+`,
+			],
+			'wp-content/themes/close-race-theme/style.css'
+		),
+		new File(
+			[`<?php echo 'Close Race Theme';`],
+			'wp-content/themes/close-race-theme/index.php'
+		),
+	];
+	const zipStream = encodeZip(files);
+	const zipBytes = await collectBytes(zipStream);
+	return Buffer.from(zipBytes!);
+}
+
 // OPFS tests must run serially because OPFS storage is shared at the browser
 // level, so tests would interfere with each other's saved sites if run in parallel.
 test.describe.configure({ mode: 'serial' });
@@ -752,6 +783,66 @@ test('should display OPFS storage option as selected by default', async ({
 
 	// Close the modal
 	await dialog.getByRole('button', { name: 'Cancel' }).click();
+});
+
+test('should flash import progress and finish after a close attempt during ZIP import', async ({
+	website,
+	browserName,
+}) => {
+	test.skip(
+		browserName !== 'chromium',
+		`This test relies on OPFS which isn't available in Playwright's flavor of ${browserName}.`
+	);
+
+	await website.goto(getTemporaryPlaygroundUrl());
+	await website.openSavedPlaygroundsOverlay();
+
+	const zipBuffer = await createPluginThemeExportZip();
+	const fileInput = website.page.locator(
+		'input[type="file"][accept*=".zip"]'
+	);
+	const importComplete = website.page
+		.waitForEvent('dialog')
+		.then(async (dialog) => {
+			await dialog.accept();
+		});
+	await fileInput.setInputFiles({
+		name: 'playground-export-with-plugin-and-theme.zip',
+		mimeType: 'application/zip',
+		buffer: zipBuffer,
+	});
+	const zipStatus = website.page.getByTestId('zip-import-status');
+	await expect(zipStatus).toBeVisible();
+	const closeButton = website.page.getByRole('button', { name: 'Close' });
+	await expect(closeButton).toBeEnabled();
+	await closeButton.click();
+	await expect(zipStatus).toBeVisible();
+	await expect(zipStatus).toHaveClass(/zipImportStatusAttention/);
+	await importComplete;
+
+	await expect
+		.poll(
+			() =>
+				website.page.evaluate(async () => {
+					const playground = (
+						window as any
+					).playgroundSites.getClient();
+					if (!playground) {
+						return { plugin: false, theme: false };
+					}
+					const documentRoot = await playground.documentRoot;
+					return {
+						plugin: await playground.fileExists(
+							`${documentRoot}/wp-content/plugins/close-race-plugin/close-race-plugin.php`
+						),
+						theme: await playground.fileExists(
+							`${documentRoot}/wp-content/themes/close-race-theme/style.css`
+						),
+					};
+				}),
+			{ timeout: 90000 }
+		)
+		.toEqual({ plugin: true, theme: true });
 });
 
 test('should import ZIP into a new saved site when a saved site exists', async ({

--- a/packages/playground/website/src/components/saved-playgrounds-overlay/index.tsx
+++ b/packages/playground/website/src/components/saved-playgrounds-overlay/index.tsx
@@ -119,6 +119,9 @@ export function SavedPlaygroundsOverlay({
 	const activeClientInfo = usePlaygroundClientInfo();
 	const zipFileInputRef = useRef<HTMLInputElement>(null);
 	const zipImportInProgressRef = useRef(false);
+	const zipImportPendingRef = useRef(false);
+	const zipImportAttentionFrameRef = useRef<number | null>(null);
+	const zipImportAttentionTimeoutRef = useRef<number | null>(null);
 
 	const [viewMode, setViewMode] = useState<OverlayViewMode>(initialViewMode);
 	const [searchQuery, setSearchQuery] = useState('');
@@ -128,8 +131,54 @@ export function SavedPlaygroundsOverlay({
 	const [pendingZipTargetSlug, setPendingZipTargetSlug] = useState<
 		string | null
 	>(null);
+	const [isZipImportPending, setIsZipImportPending] = useState(false);
+	const [isZipImportAttentionVisible, setIsZipImportAttentionVisible] =
+		useState(false);
 	const isCompactLayout = useIsCompactLayout();
 	const activeOpfsSyncStatus = activeClientInfo?.opfsSync?.status;
+
+	function setZipImportPending(isPending: boolean) {
+		zipImportPendingRef.current = isPending;
+		setIsZipImportPending(isPending);
+		if (!isPending) {
+			clearZipImportAttention();
+		}
+	}
+
+	function closeOverlay() {
+		if (zipImportPendingRef.current) {
+			clearZipImportAttention();
+			zipImportAttentionFrameRef.current = window.requestAnimationFrame(
+				() => {
+					setIsZipImportAttentionVisible(true);
+					zipImportAttentionTimeoutRef.current = window.setTimeout(
+						() => setIsZipImportAttentionVisible(false),
+						900
+					);
+				}
+			);
+			return;
+		}
+		onClose();
+	}
+
+	useEffect(() => {
+		return () => clearZipImportAttention(false);
+	}, []);
+
+	function clearZipImportAttention(hideStatus = true) {
+		if (hideStatus) {
+			setIsZipImportAttentionVisible(false);
+		}
+		if (zipImportAttentionFrameRef.current !== null) {
+			window.cancelAnimationFrame(zipImportAttentionFrameRef.current);
+			zipImportAttentionFrameRef.current = null;
+		}
+		if (zipImportAttentionTimeoutRef.current !== null) {
+			window.clearTimeout(zipImportAttentionTimeoutRef.current);
+			zipImportAttentionTimeoutRef.current = null;
+		}
+	}
 
 	useEffect(() => {
 		if (
@@ -171,9 +220,11 @@ export function SavedPlaygroundsOverlay({
 				alert(
 					'File imported! This Playground instance has been updated and will refresh shortly.'
 				);
+				setZipImportPending(false);
 				onClose();
 			} catch (error) {
 				logger.error(error);
+				setZipImportPending(false);
 				alert(
 					'Unable to import file. Is it a valid WordPress Playground export?'
 				);
@@ -213,17 +264,23 @@ export function SavedPlaygroundsOverlay({
 	const handleImportZip = async (e: React.ChangeEvent<HTMLInputElement>) => {
 		const file = e.target.files?.[0];
 		if (!file) return;
-		if (zipImportInProgressRef.current || pendingZipFile) {
+		if (
+			zipImportPendingRef.current ||
+			zipImportInProgressRef.current ||
+			pendingZipFile
+		) {
 			e.target.value = '';
 			return;
 		}
 
+		setZipImportPending(true);
 		try {
 			const targetSlug = await createSiteForImport();
 			setPendingZipTargetSlug(targetSlug);
 			setPendingZipFile(file);
 		} catch (error) {
 			logger.error(error);
+			setZipImportPending(false);
 			alert(
 				'No active Playground to import into. Please create one first.'
 			);
@@ -282,6 +339,9 @@ export function SavedPlaygroundsOverlay({
 	});
 
 	const onSiteClick = (slug: string) => {
+		if (isZipImportPending) {
+			return;
+		}
 		dispatch(setSiteManagerSection('site-details'));
 		onClose();
 		void sitesAPI.setActiveSite(slug).catch((error) => {
@@ -294,18 +354,27 @@ export function SavedPlaygroundsOverlay({
 	};
 
 	const handleDeleteSite = (site: SiteInfo, closeMenu: () => void) => {
+		if (isZipImportPending) {
+			return;
+		}
 		dispatch(setSiteSlugToDelete(site.slug));
 		dispatch(setActiveModal(modalSlugs.DELETE_SITE));
 		closeMenu();
 	};
 
 	const handleRenameSite = (site: SiteInfo, closeMenu: () => void) => {
+		if (isZipImportPending) {
+			return;
+		}
 		dispatch(setSiteSlugToRename(site.slug));
 		dispatch(setActiveModal(modalSlugs.RENAME_SITE));
 		closeMenu();
 	};
 
 	const openSaveModalForSite = (site: SiteInfo, closeMenu?: () => void) => {
+		if (isZipImportPending) {
+			return;
+		}
 		dispatch(setSiteSlugToSave(site.slug));
 		dispatch(setActiveModal(modalSlugs.SAVE_SITE));
 		closeMenu?.();
@@ -335,6 +404,9 @@ export function SavedPlaygroundsOverlay({
 	 * in-app Blueprint previews follow the default browser autosave policy.
 	 */
 	function previewBlueprint(blueprintPath: BlueprintsIndexEntry['path']) {
+		if (isZipImportPending) {
+			return;
+		}
 		dispatch(setSiteManagerOpen(false));
 		redirectTo(
 			PlaygroundRoute.newSite({
@@ -351,6 +423,9 @@ export function SavedPlaygroundsOverlay({
 	}
 
 	function createVanillaSite() {
+		if (isZipImportPending) {
+			return;
+		}
 		dispatch(setSiteManagerOpen(false));
 		// "New Playground" means start fresh. The URL change makes the
 		// selected-site guard handle this as an in-app new-site navigation.
@@ -409,13 +484,15 @@ export function SavedPlaygroundsOverlay({
 		},
 		{
 			id: 'zip',
-			title: 'Import .zip',
-			ariaLabel: 'Import .zip - Import a .zip',
+			title: isZipImportPending ? 'Importing .zip…' : 'Import .zip',
+			ariaLabel: isZipImportPending
+				? 'Importing .zip'
+				: 'Import .zip - Import a .zip',
 			icon: upload,
 			onClick: () => {
 				zipFileInputRef.current?.click();
 			},
-			disabled: false,
+			disabled: isZipImportPending,
 		},
 	];
 
@@ -447,6 +524,7 @@ export function SavedPlaygroundsOverlay({
 				<button
 					className={css.siteRowContent}
 					onClick={() => onSiteClick(site.slug)}
+					disabled={isZipImportPending}
 				>
 					<div className={css.siteRowLogo}>
 						{site.metadata.logo ? (
@@ -474,6 +552,7 @@ export function SavedPlaygroundsOverlay({
 								type="button"
 								className={css.keepButton}
 								onClick={() => openSaveModalForSite(site)}
+								disabled={isZipImportPending}
 								aria-label="Store this Playground permanently"
 								title="Store this Playground permanently so it is not pruned from recent autosaves."
 							>
@@ -489,6 +568,7 @@ export function SavedPlaygroundsOverlay({
 							icon={moreVertical}
 							label="Site actions"
 							className={css.siteRowMenu}
+							toggleProps={{ disabled: isZipImportPending }}
 							popoverProps={{
 								placement: 'bottom-end',
 							}}
@@ -580,6 +660,7 @@ export function SavedPlaygroundsOverlay({
 						type="button"
 						className={css.viewAllPlaygroundsButton}
 						onClick={() => setShowAllStoredSites(true)}
+						disabled={isZipImportPending}
 					>
 						View all
 					</button>
@@ -591,6 +672,7 @@ export function SavedPlaygroundsOverlay({
 							type="button"
 							className={css.viewAllPlaygroundsButton}
 							onClick={() => setShowAllStoredSites(false)}
+							disabled={isZipImportPending}
 						>
 							Show fewer
 						</button>
@@ -602,12 +684,12 @@ export function SavedPlaygroundsOverlay({
 	if (viewMode === 'blueprints') {
 		return (
 			<Overlay
-				onClose={onClose}
+				onClose={closeOverlay}
 				className={css.playgroundsOverlay}
 				contentClassName={css.playgroundsContent}
 			>
 				<OverlayHeader
-					onClose={onClose}
+					onClose={closeOverlay}
 					onBack={() => {
 						setViewMode('main');
 						setSearchQuery('');
@@ -777,7 +859,7 @@ export function SavedPlaygroundsOverlay({
 
 	return (
 		<Overlay
-			onClose={onClose}
+			onClose={closeOverlay}
 			className={css.playgroundsOverlay}
 			contentClassName={css.playgroundsContent}
 		>
@@ -792,7 +874,7 @@ export function SavedPlaygroundsOverlay({
 				type="button"
 				className={css.playgroundsCloseButton}
 				aria-label="Close"
-				onClick={onClose}
+				onClick={closeOverlay}
 			>
 				<Icon icon={close} size={28} />
 			</button>
@@ -813,7 +895,10 @@ export function SavedPlaygroundsOverlay({
 										className={css.creationButton}
 										aria-label={option.ariaLabel}
 										onClick={option.onClick}
-										disabled={option.disabled}
+										disabled={
+											option.disabled ||
+											isZipImportPending
+										}
 									>
 										{hasIcon && (
 											<span
@@ -841,6 +926,22 @@ export function SavedPlaygroundsOverlay({
 								);
 							})}
 						</div>
+						{isZipImportPending && (
+							<p
+								className={classNames(css.zipImportStatus, {
+									[css.zipImportStatusAttention]:
+										isZipImportAttentionVisible,
+								})}
+								role="status"
+								aria-live="polite"
+								data-testid="zip-import-status"
+							>
+								<Spinner />
+								<span>
+									Importing .zip… This may take a moment.
+								</span>
+							</p>
+						)}
 					</OverlaySection>
 					{renderYourPlaygroundsSection()}
 

--- a/packages/playground/website/src/components/saved-playgrounds-overlay/style.module.css
+++ b/packages/playground/website/src/components/saved-playgrounds-overlay/style.module.css
@@ -909,3 +909,42 @@
 		--playgrounds-close-button-offset: 16px;
 	}
 }
+
+.zipImportStatus {
+	align-items: center;
+	background: rgba(56, 88, 233, 0.12);
+	border: 1px solid rgba(108, 132, 255, 0.35);
+	border-radius: 6px;
+	color: #dcdcde;
+	display: flex;
+	font-size: 14px;
+	gap: 10px;
+	justify-content: center;
+	line-height: 1.4;
+	margin: 16px auto 0;
+	max-width: 360px;
+	padding: 10px 14px;
+}
+
+.zipImportStatusAttention {
+	animation: zipImportStatusFlash 0.9s ease-out;
+}
+
+@keyframes zipImportStatusFlash {
+	0%,
+	100% {
+		background: rgba(56, 88, 233, 0.12);
+		box-shadow: none;
+	}
+
+	35% {
+		background: rgba(56, 88, 233, 0.34);
+		box-shadow: 0 0 0 4px rgba(108, 132, 255, 0.22);
+	}
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.zipImportStatusAttention {
+		animation: none;
+	}
+}


### PR DESCRIPTION
## What it does

Prevents the user from closing the **Your Playgrounds** overlay while Playground import is ongoing. The import is managed by the component and closing the overlay breaks the process, resulting in a partial import state. This is a quick workaround. A better solution would involve moving the import to the Redux store and will be implemented as a part of the Dock UI work.

Fixes #3963.

## Reproduction:

1. Start a Playground.
2. Add a plugin directory, for example `wp-content/plugins/close-race-plugin/close-race-plugin.php`.
3. Add a theme directory, for example `wp-content/themes/close-race-theme/style.css` and `index.php`.
4. Use **Download as .zip** from the Playground UI.
5. Confirm the ZIP contains both directories from steps 2 and 3.
6. Open **Your Playgrounds**.
7. Choose **Import .zip** and select the ZIP from step 4.
8. Immediately close the **Your Playgrounds** overlay.
9. Inspect the active Playground's `wp-content/plugins` and `wp-content/themes` directories.

Before this PR, the active Playground was a new default saved site and the imported plugin/theme directories were absent. After this PR, the overlay communicates that the ZIP import is in progress, close attempts do not interrupt it, the success alert appears, and the imported plugin/theme directories are present.

## Testing instructions


```bash
PLAYWRIGHT_TEST_BASE_URL=http://127.0.0.1:5400/website-server/ npx playwright test --config=packages/playground/website/playwright/playwright.config.ts --project=chromium packages/playground/website/playwright/e2e/opfs.spec.ts -g "flash import progress"
npx nx lint playground-website
```

![ZIP import progress demo](https://raw.githubusercontent.com/WordPress/wordpress-playground/001cd1e6c1d72ef60ed970d61d8df4bd88eb20e9/.github/pr-recordings/3979/zip-import-progress-demo.gif)



