### PR TITLE
[Website] Bound file editor inline reads

### DIFF
--- a/packages/playground/components/src/PlaygroundFileEditor/file-explorer-sidebar.tsx
+++ b/packages/playground/components/src/PlaygroundFileEditor/file-explorer-sidebar.tsx
@@ -17,11 +17,11 @@ import { logger } from '@php-wasm/logger';
 import { dirname, normalizePath } from '@php-wasm/util';
 import { BinaryFilePreview } from '@wp-playground/components';
 import {
-	MAX_INLINE_FILE_BYTES,
 	seemsLikeBinary,
 	createDownloadUrl,
 	getMimeType,
 	isPreviewableBinary,
+	readFileForInlinePreview,
 } from './file-utils';
 
 export type FileExplorerSidebarProps = {
@@ -71,28 +71,17 @@ export function FileExplorerSidebar({
 	const handleOpenFile = async (path: string, shouldFocus: boolean) => {
 		try {
 			const file = await filesystem.read(path);
-			const data = new Uint8Array(await file.arrayBuffer());
-			const size = data.byteLength;
 			const filename = path.split('/').pop() || 'download';
+			const previewRead = await readFileForInlinePreview(file);
 
-			if (size > MAX_INLINE_FILE_BYTES) {
-				const { url, filename: fname } = createDownloadUrl(
-					data,
-					filename
-				);
+			if (previewRead.type === 'too-large') {
 				await onShowMessage(
 					path,
-					<>
-						<p>File too large to open (&gt;1MB).</p>
-						<p>
-							<a href={url} download={fname}>
-								Download {fname}
-							</a>
-						</p>
-					</>
+					renderTooLargeMessage(filename, previewRead.downloadUrl)
 				);
 				return;
 			}
+			const data = previewRead.data;
 
 			if (seemsLikeBinary(data)) {
 				const mimeType = getMimeType(filename);
@@ -211,5 +200,22 @@ export function FileExplorerSidebar({
 				/>
 			</div>
 		</div>
+	);
+}
+
+function renderTooLargeMessage(filename: string, downloadUrl?: string) {
+	return (
+		<>
+			<p>File too large to open (&gt;1MB).</p>
+			<p>
+				{downloadUrl ? (
+					<a href={downloadUrl} download={filename}>
+						Download {filename}
+					</a>
+				) : (
+					'Open or download it outside the in-browser editor.'
+				)}
+			</p>
+		</>
 	);
 }

--- a/packages/playground/components/src/PlaygroundFileEditor/file-explorer-sidebar.tsx
+++ b/packages/playground/components/src/PlaygroundFileEditor/file-explorer-sidebar.tsx
@@ -21,6 +21,7 @@ import {
 	createDownloadUrl,
 	getMimeType,
 	isPreviewableBinary,
+	MAX_INLINE_FILE_BYTES,
 	readFileForInlinePreview,
 } from './file-utils';
 
@@ -204,9 +205,10 @@ export function FileExplorerSidebar({
 }
 
 function renderTooLargeMessage(filename: string, downloadUrl?: string) {
+	const maxInlineMegabytes = MAX_INLINE_FILE_BYTES / 1024 / 1024;
 	return (
 		<>
-			<p>File too large to open (&gt;1MB).</p>
+			<p>{`File too large to open (>${maxInlineMegabytes}MB).`}</p>
 			<p>
 				{downloadUrl ? (
 					<a href={downloadUrl} download={filename}>

--- a/packages/playground/components/src/PlaygroundFileEditor/file-explorer-sidebar.tsx
+++ b/packages/playground/components/src/PlaygroundFileEditor/file-explorer-sidebar.tsx
@@ -78,17 +78,23 @@ export function FileExplorerSidebar({
 	const handleOpenFile = async (path: string, shouldFocus: boolean) => {
 		try {
 			const file = await filesystem.read(path);
-			const filename = path.split('/').pop() || 'download';
 			const previewRead = await readFileForInlinePreview(file);
 
 			if (previewRead.type === 'too-large') {
+				const maxInlineMegabytes = MAX_INLINE_FILE_BYTES / 1024 / 1024;
 				await onShowMessage(
 					path,
-					renderTooLargeMessage(filename, previewRead.downloadUrl)
+					<>
+						<p>{`File too large to open (>${maxInlineMegabytes}MB).`}</p>
+						<p>
+							Open or download it outside the in-browser editor.
+						</p>
+					</>
 				);
 				return;
 			}
 			const data = previewRead.data;
+			const filename = path.split('/').pop() || 'download';
 
 			if (seemsLikeBinary(data)) {
 				const mimeType = getMimeType(filename);
@@ -207,26 +213,5 @@ export function FileExplorerSidebar({
 				/>
 			</div>
 		</div>
-	);
-}
-
-/**
- * Renders the editor message shown when a file exceeds the inline read limit.
- */
-function renderTooLargeMessage(filename: string, downloadUrl?: string) {
-	const maxInlineMegabytes = MAX_INLINE_FILE_BYTES / 1024 / 1024;
-	return (
-		<>
-			<p>{`File too large to open (>${maxInlineMegabytes}MB).`}</p>
-			<p>
-				{downloadUrl ? (
-					<a href={downloadUrl} download={filename}>
-						Download {filename}
-					</a>
-				) : (
-					'Open or download it outside the in-browser editor.'
-				)}
-			</p>
-		</>
 	);
 }

--- a/packages/playground/components/src/PlaygroundFileEditor/file-explorer-sidebar.tsx
+++ b/packages/playground/components/src/PlaygroundFileEditor/file-explorer-sidebar.tsx
@@ -43,6 +43,9 @@ export type FileExplorerSidebarProps = {
 	documentRoot: string;
 };
 
+/**
+ * Renders the file explorer and opens selected files in the editor preview area.
+ */
 export function FileExplorerSidebar({
 	filesystem,
 	currentPath,
@@ -69,6 +72,9 @@ export function FileExplorerSidebar({
 		null
 	);
 
+	/**
+	 * Opens a selected file as editable text, binary preview, or too-large notice.
+	 */
 	const handleOpenFile = async (path: string, shouldFocus: boolean) => {
 		try {
 			const file = await filesystem.read(path);
@@ -204,6 +210,9 @@ export function FileExplorerSidebar({
 	);
 }
 
+/**
+ * Renders the editor message shown when a file exceeds the inline read limit.
+ */
 function renderTooLargeMessage(filename: string, downloadUrl?: string) {
 	const maxInlineMegabytes = MAX_INLINE_FILE_BYTES / 1024 / 1024;
 	return (

--- a/packages/playground/components/src/PlaygroundFileEditor/file-utils.spec.ts
+++ b/packages/playground/components/src/PlaygroundFileEditor/file-utils.spec.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from 'vitest';
+import { readFileForInlinePreview } from './file-utils';
+
+describe('readFileForInlinePreview', () => {
+	it('returns small files for inline preview', async () => {
+		const file = {
+			arrayBuffer: vi.fn(
+				async () => new TextEncoder().encode('hello').buffer
+			),
+		};
+
+		const result = await readFileForInlinePreview(file, 10);
+
+		expect(result.type).toBe('inline');
+		expect(result.type === 'inline' ? decode(result.data) : '').toBe(
+			'hello'
+		);
+	});
+
+	it('uses a known streamed filesize instead of buffering large files', async () => {
+		const file = {
+			filesize: 11,
+			arrayBuffer: vi.fn(async () => {
+				throw new Error('should not buffer');
+			}),
+		};
+
+		const result = await readFileForInlinePreview(file, 10);
+
+		expect(result).toEqual({ type: 'too-large', downloadUrl: undefined });
+		expect(file.arrayBuffer).not.toHaveBeenCalled();
+	});
+
+	it('stops reading a stream once it exceeds the inline preview limit', async () => {
+		const file = {
+			arrayBuffer: vi.fn(async () => {
+				throw new Error('should not buffer');
+			}),
+			stream: () =>
+				new ReadableStream<Uint8Array>({
+					start(controller) {
+						controller.enqueue(new TextEncoder().encode('hello'));
+					},
+				}),
+		};
+
+		const result = await readFileForInlinePreview(file, 4);
+
+		expect(result).toEqual({ type: 'too-large', downloadUrl: undefined });
+		expect(file.arrayBuffer).not.toHaveBeenCalled();
+	});
+});
+
+function decode(data: Uint8Array) {
+	return new TextDecoder().decode(data);
+}

--- a/packages/playground/components/src/PlaygroundFileEditor/file-utils.spec.ts
+++ b/packages/playground/components/src/PlaygroundFileEditor/file-utils.spec.ts
@@ -77,6 +77,9 @@ describe('readFileForInlinePreview', () => {
 	});
 });
 
+/**
+ * Converts bytes back to text for inline preview assertions.
+ */
 function decode(data: Uint8Array) {
 	return new TextDecoder().decode(data);
 }

--- a/packages/playground/components/src/PlaygroundFileEditor/file-utils.spec.ts
+++ b/packages/playground/components/src/PlaygroundFileEditor/file-utils.spec.ts
@@ -1,7 +1,12 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { readFileForInlinePreview } from './file-utils';
 
 describe('readFileForInlinePreview', () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+		vi.useRealTimers();
+	});
+
 	it('returns small files for inline preview', async () => {
 		const file = {
 			arrayBuffer: vi.fn(
@@ -48,6 +53,27 @@ describe('readFileForInlinePreview', () => {
 
 		expect(result).toEqual({ type: 'too-large', downloadUrl: undefined });
 		expect(file.arrayBuffer).not.toHaveBeenCalled();
+	});
+
+	it('creates a download URL for native blobs without buffering', async () => {
+		vi.useFakeTimers();
+		const file = new Blob(['hello']);
+		const arrayBuffer = vi.spyOn(file, 'arrayBuffer');
+		const createObjectURL = vi
+			.spyOn(URL, 'createObjectURL')
+			.mockReturnValue('blob:test');
+		const revokeObjectURL = vi
+			.spyOn(URL, 'revokeObjectURL')
+			.mockImplementation(() => undefined);
+
+		const result = await readFileForInlinePreview(file, 4);
+
+		expect(result).toEqual({ type: 'too-large', downloadUrl: 'blob:test' });
+		expect(arrayBuffer).not.toHaveBeenCalled();
+		expect(createObjectURL).toHaveBeenCalledWith(file);
+
+		await vi.advanceTimersByTimeAsync(60_000);
+		expect(revokeObjectURL).toHaveBeenCalledWith('blob:test');
 	});
 });
 

--- a/packages/playground/components/src/PlaygroundFileEditor/file-utils.spec.ts
+++ b/packages/playground/components/src/PlaygroundFileEditor/file-utils.spec.ts
@@ -1,12 +1,7 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { readFileForInlinePreview } from './file-utils';
 
 describe('readFileForInlinePreview', () => {
-	afterEach(() => {
-		vi.restoreAllMocks();
-		vi.useRealTimers();
-	});
-
 	it('returns small files for inline preview', async () => {
 		const file = {
 			arrayBuffer: vi.fn(
@@ -32,7 +27,7 @@ describe('readFileForInlinePreview', () => {
 
 		const result = await readFileForInlinePreview(file, 10);
 
-		expect(result).toEqual({ type: 'too-large', downloadUrl: undefined });
+		expect(result).toEqual({ type: 'too-large' });
 		expect(file.arrayBuffer).not.toHaveBeenCalled();
 	});
 
@@ -51,29 +46,8 @@ describe('readFileForInlinePreview', () => {
 
 		const result = await readFileForInlinePreview(file, 4);
 
-		expect(result).toEqual({ type: 'too-large', downloadUrl: undefined });
+		expect(result).toEqual({ type: 'too-large' });
 		expect(file.arrayBuffer).not.toHaveBeenCalled();
-	});
-
-	it('creates a download URL for native blobs without buffering', async () => {
-		vi.useFakeTimers();
-		const file = new Blob(['hello']);
-		const arrayBuffer = vi.spyOn(file, 'arrayBuffer');
-		const createObjectURL = vi
-			.spyOn(URL, 'createObjectURL')
-			.mockReturnValue('blob:test');
-		const revokeObjectURL = vi
-			.spyOn(URL, 'revokeObjectURL')
-			.mockImplementation(() => undefined);
-
-		const result = await readFileForInlinePreview(file, 4);
-
-		expect(result).toEqual({ type: 'too-large', downloadUrl: 'blob:test' });
-		expect(arrayBuffer).not.toHaveBeenCalled();
-		expect(createObjectURL).toHaveBeenCalledWith(file);
-
-		await vi.advanceTimersByTimeAsync(60_000);
-		expect(revokeObjectURL).toHaveBeenCalledWith('blob:test');
 	});
 });
 

--- a/packages/playground/components/src/PlaygroundFileEditor/file-utils.ts
+++ b/packages/playground/components/src/PlaygroundFileEditor/file-utils.ts
@@ -39,6 +39,113 @@ export const createDownloadUrl = (
 	return { url, filename };
 };
 
+export type InlineFilePreviewReadResult =
+	| { type: 'inline'; data: Uint8Array }
+	| { type: 'too-large'; downloadUrl?: string };
+
+type BrowserReadableFile = {
+	arrayBuffer(): Promise<ArrayBuffer>;
+	stream?: () => ReadableStream<Uint8Array>;
+	size?: number;
+	filesize?: number;
+};
+
+/**
+ * Reads a file for inline editing without buffering streams that already report
+ * they are larger than the editor limit.
+ */
+export async function readFileForInlinePreview(
+	file: BrowserReadableFile,
+	maxInlineBytes = MAX_INLINE_FILE_BYTES
+): Promise<InlineFilePreviewReadResult> {
+	const knownSize = getKnownFileSize(file);
+	if (knownSize !== undefined && knownSize > maxInlineBytes) {
+		return {
+			type: 'too-large',
+			downloadUrl: createObjectUrlForNativeBlob(file, knownSize),
+		};
+	}
+
+	if (typeof file.stream === 'function') {
+		return readStreamForInlinePreview(file, maxInlineBytes);
+	}
+
+	const data = new Uint8Array(await file.arrayBuffer());
+	if (data.byteLength > maxInlineBytes) {
+		return {
+			type: 'too-large',
+			downloadUrl: createObjectUrlForNativeBlob(file, data.byteLength),
+		};
+	}
+	return { type: 'inline', data };
+}
+
+function getKnownFileSize(file: BrowserReadableFile): number | undefined {
+	if (typeof file.filesize === 'number') {
+		return file.filesize;
+	}
+	if (typeof file.size === 'number') {
+		return file.size;
+	}
+	return undefined;
+}
+
+async function readStreamForInlinePreview(
+	file: BrowserReadableFile,
+	maxInlineBytes: number
+): Promise<InlineFilePreviewReadResult> {
+	const reader = file.stream!().getReader();
+	const chunks: Uint8Array[] = [];
+	let totalBytes = 0;
+	try {
+		while (true) {
+			const { done, value } = await reader.read();
+			if (done) {
+				return {
+					type: 'inline',
+					data: concatChunks(chunks, totalBytes),
+				};
+			}
+			if (!value) {
+				continue;
+			}
+			totalBytes += value.byteLength;
+			if (totalBytes > maxInlineBytes) {
+				await reader.cancel().catch(() => undefined);
+				return {
+					type: 'too-large',
+					downloadUrl: createObjectUrlForNativeBlob(file, totalBytes),
+				};
+			}
+			chunks.push(value);
+		}
+	} finally {
+		reader.releaseLock();
+	}
+}
+
+function concatChunks(chunks: Uint8Array[], totalBytes: number) {
+	const data = new Uint8Array(totalBytes);
+	let offset = 0;
+	for (const chunk of chunks) {
+		data.set(chunk, offset);
+		offset += chunk.byteLength;
+	}
+	return data;
+}
+
+function createObjectUrlForNativeBlob(
+	file: BrowserReadableFile,
+	expectedSize: number
+): string | undefined {
+	if (file instanceof Blob && file.size === expectedSize) {
+		const url = URL.createObjectURL(file);
+		setTimeout(() => URL.revokeObjectURL(url), 60_000);
+		return url;
+	}
+	return undefined;
+}
+
 /**
  * Gets the MIME type for a filename based on its extension.
  */

--- a/packages/playground/components/src/PlaygroundFileEditor/file-utils.ts
+++ b/packages/playground/components/src/PlaygroundFileEditor/file-utils.ts
@@ -114,7 +114,10 @@ async function readStreamForInlinePreview(
 				await reader.cancel().catch(() => undefined);
 				return {
 					type: 'too-large',
-					downloadUrl: createObjectUrlForNativeBlob(file, totalBytes),
+					downloadUrl: createObjectUrlForNativeBlob(
+						file,
+						getKnownFileSize(file)
+					),
 				};
 			}
 			chunks.push(value);
@@ -136,12 +139,16 @@ function concatChunks(chunks: Uint8Array[], totalBytes: number) {
 
 function createObjectUrlForNativeBlob(
 	file: BrowserReadableFile,
-	expectedSize: number
+	expectedSize: number | undefined
 ): string | undefined {
 	// Native Blob/File objects can be downloaded without copying their bytes into
 	// JavaScript. Stream-backed files need a streaming download path instead; do
 	// not call arrayBuffer() here just to preserve the old download link.
-	if (file instanceof Blob && file.size === expectedSize) {
+	if (
+		typeof Blob !== 'undefined' &&
+		file instanceof Blob &&
+		file.size === expectedSize
+	) {
 		const url = URL.createObjectURL(file);
 		setTimeout(() => URL.revokeObjectURL(url), 60_000);
 		return url;

--- a/packages/playground/components/src/PlaygroundFileEditor/file-utils.ts
+++ b/packages/playground/components/src/PlaygroundFileEditor/file-utils.ts
@@ -41,7 +41,7 @@ export const createDownloadUrl = (
 
 export type InlineFilePreviewReadResult =
 	| { type: 'inline'; data: Uint8Array }
-	| { type: 'too-large'; downloadUrl?: string };
+	| { type: 'too-large' };
 
 type BrowserReadableFile = {
 	arrayBuffer(): Promise<ArrayBuffer>;
@@ -62,10 +62,7 @@ export async function readFileForInlinePreview(
 ): Promise<InlineFilePreviewReadResult> {
 	const knownSize = getKnownFileSize(file);
 	if (knownSize !== undefined && knownSize > maxInlineBytes) {
-		return {
-			type: 'too-large',
-			downloadUrl: createObjectUrlForNativeBlob(file, knownSize),
-		};
+		return { type: 'too-large' };
 	}
 
 	if (typeof file.stream === 'function') {
@@ -74,10 +71,7 @@ export async function readFileForInlinePreview(
 
 	const data = new Uint8Array(await file.arrayBuffer());
 	if (data.byteLength > maxInlineBytes) {
-		return {
-			type: 'too-large',
-			downloadUrl: createObjectUrlForNativeBlob(file, data.byteLength),
-		};
+		return { type: 'too-large' };
 	}
 	return { type: 'inline', data };
 }
@@ -123,13 +117,7 @@ async function readStreamForInlinePreview(
 			totalBytes += value.byteLength;
 			if (totalBytes > maxInlineBytes) {
 				await reader.cancel().catch(() => undefined);
-				return {
-					type: 'too-large',
-					downloadUrl: createObjectUrlForNativeBlob(
-						file,
-						getKnownFileSize(file)
-					),
-				};
+				return { type: 'too-large' };
 			}
 			chunks.push(value);
 		}
@@ -149,31 +137,6 @@ function concatChunks(chunks: Uint8Array[], totalBytes: number) {
 		offset += chunk.byteLength;
 	}
 	return data;
-}
-
-/**
- * Creates a download URL only when the original file is a native Blob/File.
- *
- * This avoids copying large stream-backed files into memory just to preserve the
- * large-file download link.
- */
-function createObjectUrlForNativeBlob(
-	file: BrowserReadableFile,
-	expectedSize: number | undefined
-): string | undefined {
-	// Native Blob/File objects can be downloaded without copying their bytes into
-	// JavaScript. Stream-backed files need a streaming download path instead; do
-	// not call arrayBuffer() here just to preserve the old download link.
-	if (
-		typeof Blob !== 'undefined' &&
-		file instanceof Blob &&
-		file.size === expectedSize
-	) {
-		const url = URL.createObjectURL(file);
-		setTimeout(() => URL.revokeObjectURL(url), 60_000);
-		return url;
-	}
-	return undefined;
 }
 
 /**

--- a/packages/playground/components/src/PlaygroundFileEditor/file-utils.ts
+++ b/packages/playground/components/src/PlaygroundFileEditor/file-utils.ts
@@ -138,6 +138,9 @@ function createObjectUrlForNativeBlob(
 	file: BrowserReadableFile,
 	expectedSize: number
 ): string | undefined {
+	// Native Blob/File objects can be downloaded without copying their bytes into
+	// JavaScript. Stream-backed files need a streaming download path instead; do
+	// not call arrayBuffer() here just to preserve the old download link.
 	if (file instanceof Blob && file.size === expectedSize) {
 		const url = URL.createObjectURL(file);
 		setTimeout(() => URL.revokeObjectURL(url), 60_000);

--- a/packages/playground/components/src/PlaygroundFileEditor/file-utils.ts
+++ b/packages/playground/components/src/PlaygroundFileEditor/file-utils.ts
@@ -51,8 +51,10 @@ type BrowserReadableFile = {
 };
 
 /**
- * Reads a file for inline editing without buffering streams that already report
- * they are larger than the editor limit.
+ * Classifies a file as inline-editable or too large for the editor.
+ *
+ * Uses known size metadata before reading when it is available. Stream-backed
+ * files without a known size are read only until they cross the inline limit.
  */
 export async function readFileForInlinePreview(
 	file: BrowserReadableFile,
@@ -80,6 +82,9 @@ export async function readFileForInlinePreview(
 	return { type: 'inline', data };
 }
 
+/**
+ * Returns the file size reported by browser and storage-backed file objects.
+ */
 function getKnownFileSize(file: BrowserReadableFile): number | undefined {
 	if (typeof file.filesize === 'number') {
 		return file.filesize;
@@ -90,6 +95,12 @@ function getKnownFileSize(file: BrowserReadableFile): number | undefined {
 	return undefined;
 }
 
+/**
+ * Reads a file stream only while it remains small enough for inline editing.
+ *
+ * The stream is canceled as soon as the accumulated bytes exceed the limit so
+ * large files do not have to finish loading before the editor rejects them.
+ */
 async function readStreamForInlinePreview(
 	file: BrowserReadableFile,
 	maxInlineBytes: number
@@ -127,6 +138,9 @@ async function readStreamForInlinePreview(
 	}
 }
 
+/**
+ * Combines stream chunks that were already accepted for inline preview.
+ */
 function concatChunks(chunks: Uint8Array[], totalBytes: number) {
 	const data = new Uint8Array(totalBytes);
 	let offset = 0;
@@ -137,6 +151,12 @@ function concatChunks(chunks: Uint8Array[], totalBytes: number) {
 	return data;
 }
 
+/**
+ * Creates a download URL only when the original file is a native Blob/File.
+ *
+ * This avoids copying large stream-backed files into memory just to preserve the
+ * large-file download link.
+ */
 function createObjectUrlForNativeBlob(
 	file: BrowserReadableFile,
 	expectedSize: number | undefined

--- a/packages/playground/components/src/PlaygroundFileEditor/file-utils.ts
+++ b/packages/playground/components/src/PlaygroundFileEditor/file-utils.ts
@@ -1,3 +1,4 @@
+import { concatUint8Arrays } from '@php-wasm/util';
 import mimeTypes from '@php-wasm/universal/mime-types';
 
 export const MAX_INLINE_FILE_BYTES = 1024 * 1024; // 1MB
@@ -108,7 +109,7 @@ async function readStreamForInlinePreview(
 			if (done) {
 				return {
 					type: 'inline',
-					data: concatChunks(chunks, totalBytes),
+					data: concatUint8Arrays(chunks),
 				};
 			}
 			if (!value) {
@@ -124,19 +125,6 @@ async function readStreamForInlinePreview(
 	} finally {
 		reader.releaseLock();
 	}
-}
-
-/**
- * Combines stream chunks that were already accepted for inline preview.
- */
-function concatChunks(chunks: Uint8Array[], totalBytes: number) {
-	const data = new Uint8Array(totalBytes);
-	let offset = 0;
-	for (const chunk of chunks) {
-		data.set(chunk, offset);
-		offset += chunk.byteLength;
-	}
-	return data;
 }
 
 /**


### PR DESCRIPTION
## What it does

The file editor used to enforce its 1MB inline limit only after reading the
whole file into memory.

That is backwards.

Reject files with known large sizes before reading them. For stream-backed files
without a known size, read incrementally and stop once the inline limit is
exceeded.

## Rationale

A size limit that requires buffering the entire file first is not a useful size
limit. It still pays the memory cost before refusing to open the file.

This PR keeps the editor behavior the same for normal small files, but prevents
large files from being fully buffered just to show the “too large” message.

It deliberately does not preserve the old download link for files we refuse to
buffer. If large-file downloads need a streaming path, that should be a separate
download implementation, not hidden inside the editor preview read path.

## Testing

```bash
npm exec nx lint playground-components
npm exec nx test playground-components