### PR TITLE
[Blueprints] Default v2 network access to disabled

### DIFF
--- a/packages/playground/blueprints/src/lib/resolve-runtime-configuration.ts
+++ b/packages/playground/blueprints/src/lib/resolve-runtime-configuration.ts
@@ -60,7 +60,7 @@ export async function resolveRuntimeConfiguration(
 			phpVersion: resolveV2PHPVersion(declaration),
 			wpVersion: resolveV2WordPressVersion(declaration),
 			intl: false,
-			networking: playgroundOptions?.networkAccess ?? true,
+			networking: playgroundOptions?.networkAccess ?? false,
 			constants: declaration.constants ?? {},
 			extraLibraries: [],
 		};

--- a/packages/playground/blueprints/src/tests/v2/resolve-runtime-configuration.spec.ts
+++ b/packages/playground/blueprints/src/tests/v2/resolve-runtime-configuration.spec.ts
@@ -10,7 +10,7 @@ describe('Blueprint v2 runtime configuration', () => {
 		phpVersion: RecommendedPHPVersion,
 		wpVersion: 'latest',
 		intl: false,
-		networking: true,
+		networking: false,
 		constants: {},
 		extraLibraries: [],
 	};
@@ -63,7 +63,7 @@ describe('Blueprint v2 runtime configuration', () => {
 		});
 	});
 
-	it('uses the default networking value when network access is omitted', async () => {
+	it('disables networking by default when network access is omitted', async () => {
 		await expect(
 			resolveRuntimeConfiguration({
 				version: 2,
@@ -72,7 +72,7 @@ describe('Blueprint v2 runtime configuration', () => {
 				},
 			})
 		).resolves.toMatchObject({
-			networking: true,
+			networking: false,
 		});
 	});
 


### PR DESCRIPTION
## What it does

Makes omitted Blueprint v2 `networkAccess` mean `false`.

That is what the schema already says. The runtime used `true`. Now it does not.

## Rationale

There should not be two defaults for the same field. If the schema says network access is off by default, the runtime needs to behave that way too.

This is not a new feature. It removes a bad default.

## Implementation

Changes the `networkAccess` fallback in `resolveRuntimeConfiguration()` from `true` to `false` and updates the direct resolver tests.

## Testing instructions

```bash
npx vitest run packages/playground/blueprints/src/tests/v2/resolve-runtime-configuration.spec.ts --config packages/playground/blueprints/vite.config.ts
npm exec nx -- test playground-blueprints
npm exec nx -- lint playground-blueprints
npm exec nx -- typecheck playground-blueprints
```
