### PR TITLE
[Website] Stop default WordPress tests from checking version classes

### DIFF
--- a/packages/playground/website/cypress/e2e/query-api.cy.ts
+++ b/packages/playground/website/cypress/e2e/query-api.cy.ts
@@ -28,10 +28,14 @@ describe('Query API', () => {
 	describe('option `wp`', () => {
 		it('should load WordPress latest by default', () => {
 			cy.visit('/?url=/wp-admin/');
-			const expectedBodyClass =
-				'version-' + LatestSupportedWordPressVersion.replace('.', '-');
+			// WordPress derives the admin body branch class from (float) $wp_version.
+			const expectedBranchClass =
+				'branch-' +
+				parseFloat(LatestSupportedWordPressVersion)
+					.toString()
+					.replace('.', '-');
 			cy.wordPressDocument()
-				.find(`body.${expectedBodyClass}`)
+				.find(`body.${expectedBranchClass}`)
 				.should('exist');
 		});
 

--- a/packages/playground/website/playwright/e2e/query-api.spec.ts
+++ b/packages/playground/website/playwright/e2e/query-api.spec.ts
@@ -159,9 +159,13 @@ test('should load WordPress latest by default', async ({
 }) => {
 	await website.goto('./?storage=temp&url=/wp-admin/');
 
-	const expectedBodyClass =
-		'version-' + LatestSupportedWordPressVersion.replace('.', '-');
-	await expect(wordpress.locator(`body.${expectedBodyClass}`)).toContainText(
+	// WordPress derives the admin body branch class from (float) $wp_version.
+	const expectedBranchClass =
+		'branch-' +
+		parseFloat(LatestSupportedWordPressVersion)
+			.toString()
+			.replace('.', '-');
+	await expect(wordpress.locator(`body.${expectedBranchClass}`)).toContainText(
 		'Dashboard'
 	);
 });


### PR DESCRIPTION
## What it does

Stops the query API e2e tests from treating the WordPress version body class as the contract for the default WordPress selection.

They now check the WordPress admin branch class, e.g. `body.branch-7` for the `7.0.x` line.

## Rationale

The old test was checking the wrong thing.

`wp-versions.json` says the latest supported branch is `7.0`. A WordPress build refresh can still ship `7.0.1` for that branch. WordPress then quite reasonably emits `body.version-7-0-1`, not `body.version-7-0`.

So CI went red even though Playground loaded the right branch. That is test noise, not a product failure.

## Implementation

Use the same branch-shaping rule WordPress uses for the admin body class: derive the branch from `(float) $wp_version`, then replace the decimal point for the CSS class.

## Testing instructions

```bash
git diff --check origin/trunk...HEAD
```

I did not run the e2e suite locally because this workspace does not have `node_modules` installed.
