### PR TITLE
[Blueprints] Test v2 runtime entry points

### DIFF
--- a/packages/playground/blueprints/src/tests/compile.spec.ts
+++ b/packages/playground/blueprints/src/tests/compile.spec.ts
@@ -565,6 +565,94 @@ describe('compileBlueprintForExecution', () => {
 		).toEqual([]);
 	});
 
+	it('lowers Blueprint v2 install options to v1 install step options', async () => {
+		const compiled = await compileBlueprintForExecution({
+			version: 2,
+			plugins: [
+				{
+					source: './plugins/sample-plugin.zip',
+					active: false,
+					ifAlreadyInstalled: 'skip',
+					onError: 'skip-plugin',
+					targetDirectoryName: 'sample-plugin-target',
+					humanReadableName: 'Sample Plugin',
+					activationOptions: {
+						source: 'blueprint-v2',
+					},
+				},
+			],
+			themes: [
+				{
+					source: './themes/sample-theme.zip',
+					ifAlreadyInstalled: 'error',
+					onError: 'skip-theme',
+					targetDirectoryName: 'sample-theme-target',
+					humanReadableName: 'Sample Theme',
+				},
+			],
+			activeTheme: {
+				source: './themes/active-theme.zip',
+				ifAlreadyInstalled: 'overwrite',
+				targetDirectoryName: 'active-theme-target',
+				humanReadableName: 'Active Theme',
+			},
+		});
+
+		expect(compiled.version).toBe(2);
+		if (compiled.version !== 2) {
+			throw new Error('Expected a compiled Blueprint v2 result.');
+		}
+		expect(withoutProgressFromSteps(compiled.compiled.steps)).toEqual([
+			{
+				step: 'installTheme',
+				themeData: {
+					resource: 'bundled',
+					path: 'themes/sample-theme.zip',
+				},
+				ifAlreadyInstalled: 'error',
+				options: {
+					activate: false,
+					importStarterContent: false,
+					onError: 'skip-theme',
+					targetFolderName: 'sample-theme-target',
+					humanReadableName: 'Sample Theme',
+				},
+			},
+			{
+				step: 'installTheme',
+				themeData: {
+					resource: 'bundled',
+					path: 'themes/active-theme.zip',
+				},
+				ifAlreadyInstalled: 'overwrite',
+				options: {
+					activate: true,
+					importStarterContent: false,
+					targetFolderName: 'active-theme-target',
+					humanReadableName: 'Active Theme',
+				},
+			},
+			{
+				step: 'installPlugin',
+				pluginData: {
+					resource: 'bundled',
+					path: 'plugins/sample-plugin.zip',
+				},
+				ifAlreadyInstalled: 'skip',
+				options: {
+					activate: false,
+					activationOptions: {
+						source: 'blueprint-v2',
+					},
+					onError: 'skip-plugin',
+					targetFolderName: 'sample-plugin-target',
+					humanReadableName: 'Sample Plugin',
+				},
+			},
+		]);
+		expect(compiled.compiled.unsupportedPlan).toEqual([]);
+	});
+
 	it('adds useful progress metadata to Blueprint v2 generated steps', async () => {
 		const compiled = await compileBlueprintForExecution({
 			version: 2,

--- a/packages/playground/blueprints/src/tests/v2/runtime-smoke.spec.ts
+++ b/packages/playground/blueprints/src/tests/v2/runtime-smoke.spec.ts
@@ -124,6 +124,38 @@ describe('Blueprint v2 runtime smoke tests', () => {
 		});
 	});
 
+	it('applies site configuration declarations', async () => {
+		await applyBlueprint({
+			version: 2,
+			constants: {
+				WP_DEBUG: true,
+				WP_ENVIRONMENT_TYPE: 'local',
+			},
+			siteOptions: {
+				blogname: 'V2 Runtime Site',
+				timezone_string: 'Europe/Warsaw',
+			},
+		});
+
+		const result = await runWordPressJson({
+			code: `
+				echo json_encode([
+					'wpDebug' => defined('WP_DEBUG') ? WP_DEBUG : null,
+					'environment' => defined('WP_ENVIRONMENT_TYPE') ? WP_ENVIRONMENT_TYPE : null,
+					'blogname' => get_option('blogname'),
+					'timezone' => get_option('timezone_string'),
+				]);
+			`,
+		});
+
+		expect(result).toEqual({
+			wpDebug: true,
+			environment: 'local',
+			blogname: 'V2 Runtime Site',
+			timezone: 'Europe/Warsaw',
+		});
+	});
+
 	it(
 		'applies post import options at runtime',
 		async () => {
@@ -290,6 +322,115 @@ describe('Blueprint v2 runtime smoke tests', () => {
 			exists: true,
 			mime_type: 'image/png',
 			alt: 'Imported by a v2 Blueprint runtime test',
+		});
+	});
+
+	it('installs v2 plugins and themes with runtime-visible options', async () => {
+		await applyBlueprint({
+			version: 2,
+			plugins: [
+				{
+					source: {
+						directoryName: 'inactive-runtime-plugin',
+						files: {
+							'inactive-runtime-plugin.php': `<?php
+/**
+ * Plugin Name: V2 Inactive Runtime Plugin
+ */
+add_action('init', function () {
+	update_option('v2_inactive_runtime_plugin_loaded', 'yes');
+});
+`,
+						},
+					},
+					active: false,
+				},
+				{
+					source: {
+						directoryName: 'active-runtime-plugin',
+						files: {
+							'active-runtime-plugin.php': `<?php
+/**
+ * Plugin Name: V2 Active Runtime Plugin
+ */
+register_activation_hook(__FILE__, function () {
+	update_option(
+		'v2_active_runtime_plugin_activation',
+		get_option('blueprint_activation_' . plugin_basename(__FILE__))
+	);
+});
+add_action('init', function () {
+	update_option('v2_active_runtime_plugin_loaded', 'yes');
+});
+`,
+						},
+					},
+					active: true,
+					targetDirectoryName: 'active-runtime-plugin-target',
+					activationOptions: {
+						source: 'blueprint-v2-runtime-test',
+						enabled: true,
+					},
+				},
+			],
+			themes: [
+				{
+					source: {
+						directoryName: 'inactive-runtime-theme',
+						files: {
+							'style.css':
+								'/*\nTheme Name: V2 Inactive Runtime Theme\n*/',
+							'index.php': '<?php echo "inactive";',
+						},
+					},
+				},
+			],
+			activeTheme: {
+				source: {
+					directoryName: 'active-runtime-theme',
+					files: {
+						'style.css':
+							'/*\nTheme Name: V2 Active Runtime Theme\n*/',
+						'index.php': '<?php echo "active";',
+					},
+				},
+				targetDirectoryName: 'active-runtime-theme-target',
+			},
+		});
+
+		const result = await runWordPressJson({
+			code: `
+				require_once ABSPATH . 'wp-admin/includes/plugin.php';
+				$theme = wp_get_theme();
+				echo json_encode([
+					'activePluginInstalled' => file_exists(WP_PLUGIN_DIR . '/active-runtime-plugin-target/active-runtime-plugin.php'),
+					'activePluginActive' => is_plugin_active('active-runtime-plugin-target/active-runtime-plugin.php'),
+					'activePluginLoaded' => get_option('v2_active_runtime_plugin_loaded'),
+					'activationOptions' => get_option('v2_active_runtime_plugin_activation'),
+					'inactivePluginInstalled' => file_exists(WP_PLUGIN_DIR . '/inactive-runtime-plugin/inactive-runtime-plugin.php'),
+					'inactivePluginActive' => is_plugin_active('inactive-runtime-plugin/inactive-runtime-plugin.php'),
+					'inactivePluginLoaded' => get_option('v2_inactive_runtime_plugin_loaded', false),
+					'activeThemeName' => $theme->get('Name'),
+					'activeThemeStylesheet' => get_stylesheet(),
+					'inactiveThemeInstalled' => wp_get_theme('inactive-runtime-theme')->exists(),
+				]);
+			`,
+		});
+
+		expect(result).toEqual({
+			activePluginInstalled: true,
+			activePluginActive: true,
+			activePluginLoaded: 'yes',
+			activationOptions: {
+				source: 'blueprint-v2-runtime-test',
+				enabled: true,
+			},
+			inactivePluginInstalled: true,
+			inactivePluginActive: false,
+			inactivePluginLoaded: false,
+			activeThemeName: 'V2 Active Runtime Theme',
+			activeThemeStylesheet: 'active-runtime-theme-target',
+			inactiveThemeInstalled: true,
 		});
 	});
 

--- a/packages/playground/cli/tests/run-cli.spec.ts
+++ b/packages/playground/cli/tests/run-cli.spec.ts
@@ -1049,6 +1049,37 @@ describe.each(blueprintVersions)(
 	60_000 * 5
 );
 
+test('should execute v2 blueprints through the CLI server', async () => {
+	await using cliServer = await runCLI({
+		command: 'server',
+		workers: 1,
+		blueprint: {
+			version: 2,
+			siteOptions: {
+				blogname: 'V2 CLI Smoke',
+			},
+			additionalStepsAfterExecution: [
+				{
+					step: 'writeFiles',
+					files: {
+						'site:v2-cli-smoke.php': {
+							filename: 'v2-cli-smoke.php',
+							content:
+								'<?php require __DIR__ . "/wp-load.php"; echo get_option("blogname");',
+						},
+					},
+				},
+			],
+		},
+	});
+	const response = await fetch(
+		new URL('/v2-cli-smoke.php', cliServer.serverUrl)
+	);
+
+	expect(response.status).toBe(200);
+	expect(await response.text()).toBe('V2 CLI Smoke');
+}, 120000);
+
 describe('native Blueprint v2 modes', () => {
 	fullNativeBlueprintV2ModeTest(
 		'should support --mode=create-new-site',

--- a/packages/playground/website/playwright/e2e/blueprints.spec.ts
+++ b/packages/playground/website/playwright/e2e/blueprints.spec.ts
@@ -22,6 +22,41 @@ test('Base64-encoded Blueprints should work', async ({
 	await expect(wordpress.locator('body')).toContainText('Dashboard');
 });
 
+test('Blueprint v2 declarations should run through the website flow', async ({
+	website,
+	wordpress,
+}) => {
+	const blueprint: Blueprint = {
+		version: 2,
+		applicationOptions: {
+			'wordpress-playground': {
+				landingPage: '/v2-website-smoke.php',
+			},
+		},
+		siteOptions: {
+			blogname: 'V2 Website Smoke',
+		},
+		additionalStepsAfterExecution: [
+			{
+				step: 'writeFiles',
+				files: {
+					'site:v2-website-smoke.php': {
+						filename: 'v2-website-smoke.php',
+						content:
+							'<?php require __DIR__ . "/wp-load.php"; echo get_option("blogname");',
+					},
+				},
+			},
+		],
+	};
+
+	const encodedBlueprint = encodeStringAsBase64(JSON.stringify(blueprint));
+	await website.goto(
+		`./?experimental-blueprints-v2-runner=yes#${encodedBlueprint}`
+	);
+	await expect(wordpress.locator('body')).toContainText('V2 Website Smoke');
+});
+
 test('spawning less should work', async ({ website, wordpress }) => {
 	const blueprint: Blueprint = {
 		landingPage: '/less.php',
@@ -550,7 +585,9 @@ test('CURLFile uploads via curl_exec() should work', async ({
 	await website.goto(`/#${JSON.stringify(blueprint)}`);
 	await expect(wordpress.locator('body')).toContainText('HTTP_CODE:200');
 	await expect(wordpress.locator('body')).toContainText('POST_RECEIVED:YES');
-	await expect(wordpress.locator('body')).toContainText('MULTIPART_UPLOAD:YES');
+	await expect(wordpress.locator('body')).toContainText(
+		'MULTIPART_UPLOAD:YES'
+	);
 });
 
 /**


### PR DESCRIPTION
## What it does

Adds tests for Blueprint v2 behavior that was already supposed to work.

This covers:

- runtime execution for `constants` and `siteOptions`
- runtime execution for plugin and theme installs
- compiler lowering for install options
- CLI server execution of a v2 Blueprint
- website execution of a v2 Blueprint through Playwright

No Blueprint v2 feature is added here.

## Rationale

Compiler tests are not runtime tests. A lowered step can look fine and still fail in the CLI, the website, or WordPress itself.

So test the actual entry points. That is the whole point of this PR.

## Implementation

Adds focused smoke tests around existing v2 lowering and execution paths. The only non-test adjustment is the longer timeout for the CLI smoke test, because Windows is slow and pretending otherwise just gives us a useless red CI job.

## Testing instructions

```bash
npx vitest run packages/playground/blueprints/src/tests/compile.spec.ts packages/playground/blueprints/src/tests/v2/runtime-smoke.spec.ts --config packages/playground/blueprints/vite.config.ts
npm exec nx -- test playground-blueprints
npm exec nx -- lint playground-blueprints
npm exec nx -- typecheck playground-blueprints
npm exec nx -- lint playground-cli
npm exec nx -- typecheck playground-cli
npm exec nx -- run playground-cli:test-playground-cli -- --run packages/playground/cli/tests/run-cli.spec.ts -t "should execute v2 blueprints through the CLI server"
npm exec nx -- lint playground-website
npm exec nx -- typecheck playground-website
```
