### PR TITLE
[Blueprints] Import nested WordPress file ZIPs

### DIFF
--- a/packages/playground/blueprints/src/lib/steps/import-wordpress-files.ts
+++ b/packages/playground/blueprints/src/lib/steps/import-wordpress-files.ts
@@ -52,13 +52,13 @@ export const importWordPressFiles: StepHandler<
 	const documentRoot = await playground.documentRoot;
 
 	// Unzip
-	let importPath = joinPaths('/tmp', 'import');
-	await playground.mkdir(importPath);
+	const unzipRoot = joinPaths('/tmp', 'import');
+	await playground.mkdir(unzipRoot);
 	await unzip(playground, {
 		zipFile: wordPressFilesZip,
-		extractToPath: importPath,
+		extractToPath: unzipRoot,
 	});
-	importPath = joinPaths(importPath, pathInZip);
+	let importPath = joinPaths(unzipRoot, pathInZip);
 	importPath =
 		(await findWordPressFilesRoot(playground, importPath)) || importPath;
 
@@ -128,7 +128,9 @@ export const importWordPressFiles: StepHandler<
 	}
 
 	// Remove the directory where we unzipped the imported zip file.
-	await playground.rmdir(importPath);
+	await playground.rmdir(unzipRoot, {
+		recursive: true,
+	});
 
 	// Ensure required constants are defined if wp-config.php doesn't define them.
 	await ensureWpConfig(playground, documentRoot);
@@ -294,6 +296,8 @@ async function inferSiteUrlFromDatabase(
 	return siteUrl || null;
 }
 
+const MAX_WORDPRESS_ROOT_SEARCH_DEPTH = 32;
+
 const WORDPRESS_ROOT_MARKERS = [
 	'wp-content',
 	'wp-admin',
@@ -317,23 +321,33 @@ async function findWordPressFilesRoot(
 	playground: UniversalPHP,
 	importPath: string
 ): Promise<string | null> {
-	if (await hasWordPressRootMarker(playground, importPath)) {
-		return importPath;
+	let currentPath = importPath;
+
+	for (let depth = 0; depth <= MAX_WORDPRESS_ROOT_SEARCH_DEPTH; depth++) {
+		if (await hasWordPressRootMarker(playground, currentPath)) {
+			return currentPath;
+		}
+
+		if (depth === MAX_WORDPRESS_ROOT_SEARCH_DEPTH) {
+			return null;
+		}
+
+		const fileNames = (await playground.listFiles(currentPath)).filter(
+			(fileName) => fileName !== '__MACOSX' && fileName !== '.DS_Store'
+		);
+		if (fileNames.length !== 1) {
+			return null;
+		}
+
+		const nestedPath = joinPaths(currentPath, fileNames[0]);
+		if (!(await playground.isDir(nestedPath))) {
+			return null;
+		}
+
+		currentPath = nestedPath;
 	}
 
-	const fileNames = (await playground.listFiles(importPath)).filter(
-		(fileName) => fileName !== '__MACOSX' && fileName !== '.DS_Store'
-	);
-	if (fileNames.length !== 1) {
-		return null;
-	}
-
-	const nestedPath = joinPaths(importPath, fileNames[0]);
-	if (!(await playground.isDir(nestedPath))) {
-		return null;
-	}
-
-	return await findWordPressFilesRoot(playground, nestedPath);
+	return null;
 }
 
 async function hasWordPressRootMarker(

--- a/packages/playground/blueprints/src/lib/steps/import-wordpress-files.ts
+++ b/packages/playground/blueprints/src/lib/steps/import-wordpress-files.ts
@@ -296,8 +296,6 @@ async function inferSiteUrlFromDatabase(
 	return siteUrl || null;
 }
 
-const MAX_WORDPRESS_ROOT_SEARCH_DEPTH = 32;
-
 const WORDPRESS_ROOT_MARKERS = [
 	'wp-content',
 	'wp-admin',
@@ -313,6 +311,10 @@ const WORDPRESS_ROOT_MARKERS = [
  * unwrapping that directory, importWordPressFiles() reports success but moves
  * the wrapper into WordPress, leaving the live wp-content unchanged.
  *
+ * Only one wrapper directory is supported, and only when it is the only entry
+ * at the requested import path. Deeper layouts are ambiguous, so they are left
+ * unchanged instead of guessing.
+ *
  * wp-content is not required here. importWordPressFiles() can also replace
  * other top-level WordPress files such as wp-admin, wp-includes, or
  * wp-config.php.
@@ -321,30 +323,22 @@ async function findWordPressFilesRoot(
 	playground: UniversalPHP,
 	importPath: string
 ): Promise<string | null> {
-	let currentPath = importPath;
+	if (await hasWordPressRootMarker(playground, importPath)) {
+		return importPath;
+	}
 
-	for (let depth = 0; depth <= MAX_WORDPRESS_ROOT_SEARCH_DEPTH; depth++) {
-		if (await hasWordPressRootMarker(playground, currentPath)) {
-			return currentPath;
-		}
+	const fileNames = await playground.listFiles(importPath);
+	if (fileNames.length !== 1) {
+		return null;
+	}
 
-		if (depth === MAX_WORDPRESS_ROOT_SEARCH_DEPTH) {
-			return null;
-		}
+	const nestedPath = joinPaths(importPath, fileNames[0]);
+	if (!(await playground.isDir(nestedPath))) {
+		return null;
+	}
 
-		const fileNames = (await playground.listFiles(currentPath)).filter(
-			(fileName) => fileName !== '__MACOSX' && fileName !== '.DS_Store'
-		);
-		if (fileNames.length !== 1) {
-			return null;
-		}
-
-		const nestedPath = joinPaths(currentPath, fileNames[0]);
-		if (!(await playground.isDir(nestedPath))) {
-			return null;
-		}
-
-		currentPath = nestedPath;
+	if (await hasWordPressRootMarker(playground, nestedPath)) {
+		return nestedPath;
 	}
 
 	return null;

--- a/packages/playground/blueprints/src/lib/steps/import-wordpress-files.ts
+++ b/packages/playground/blueprints/src/lib/steps/import-wordpress-files.ts
@@ -59,6 +59,8 @@ export const importWordPressFiles: StepHandler<
 		extractToPath: importPath,
 	});
 	importPath = joinPaths(importPath, pathInZip);
+	importPath =
+		(await findWordPressFilesRoot(playground, importPath)) || importPath;
 
 	// Read the export manifest if it exists. The manifest contains the
 	// site URL (including scope) at export time, which we'll use later
@@ -290,6 +292,60 @@ async function inferSiteUrlFromDatabase(
 	});
 	const siteUrl = result.text.trim();
 	return siteUrl || null;
+}
+
+const WORDPRESS_ROOT_MARKERS = [
+	'wp-content',
+	'wp-admin',
+	'wp-includes',
+	'wp-config.php',
+	'wp-config-sample.php',
+];
+
+/**
+ * Finds the directory containing the WordPress files in an extracted archive.
+ *
+ * Some ZIP tools wrap the selected files in a single parent directory. Without
+ * unwrapping that directory, importWordPressFiles() reports success but moves
+ * the wrapper into WordPress, leaving the live wp-content unchanged.
+ *
+ * wp-content is not required here. importWordPressFiles() can also replace
+ * other top-level WordPress files such as wp-admin, wp-includes, or
+ * wp-config.php.
+ */
+async function findWordPressFilesRoot(
+	playground: UniversalPHP,
+	importPath: string
+): Promise<string | null> {
+	if (await hasWordPressRootMarker(playground, importPath)) {
+		return importPath;
+	}
+
+	const fileNames = (await playground.listFiles(importPath)).filter(
+		(fileName) => fileName !== '__MACOSX' && fileName !== '.DS_Store'
+	);
+	if (fileNames.length !== 1) {
+		return null;
+	}
+
+	const nestedPath = joinPaths(importPath, fileNames[0]);
+	if (!(await playground.isDir(nestedPath))) {
+		return null;
+	}
+
+	return await findWordPressFilesRoot(playground, nestedPath);
+}
+
+async function hasWordPressRootMarker(
+	playground: UniversalPHP,
+	path: string
+): Promise<boolean> {
+	for (const marker of WORDPRESS_ROOT_MARKERS) {
+		if (await playground.fileExists(joinPaths(path, marker))) {
+			return true;
+		}
+	}
+	return false;
 }
 
 async function removePath(playground: UniversalPHP, path: string) {

--- a/packages/playground/blueprints/src/tests/steps/import-wordpress-files.spec.ts
+++ b/packages/playground/blueprints/src/tests/steps/import-wordpress-files.spec.ts
@@ -197,7 +197,6 @@ describe('Blueprint step importWordPressFiles', () => {
 			$zip->open(${phpVar(zipPath)}, ZipArchive::CREATE | ZipArchive::OVERWRITE);
 			$zip->addFromString(${phpVar(pluginPath)}, ${phpVar('<?php /* Plugin Name: Nested Plugin */')});
 			$zip->addFromString(${phpVar(themePath)}, ${phpVar('/* Theme Name: Nested Theme */')});
-			$zip->addFromString('__MACOSX/._ignored', '');
 			$zip->close();
 			`,
 		});

--- a/packages/playground/blueprints/src/tests/steps/import-wordpress-files.spec.ts
+++ b/packages/playground/blueprints/src/tests/steps/import-wordpress-files.spec.ts
@@ -184,6 +184,83 @@ describe('Blueprint step importWordPressFiles', () => {
 		expect(result.text).not.toContain(`scope:${sourceScope}`);
 	});
 
+	it('should import WordPress files from a single wrapping directory', async () => {
+		const zipPath = '/tmp/nested-wordpress-files.zip';
+		const pluginPath =
+			'playground-export/wp-content/plugins/nested-plugin/nested-plugin.php';
+		const themePath =
+			'playground-export/wp-content/themes/nested-theme/style.css';
+
+		await targetPHP.run({
+			code: `<?php
+			$zip = new ZipArchive();
+			$zip->open(${phpVar(zipPath)}, ZipArchive::CREATE);
+			$zip->addFromString(${phpVar(pluginPath)}, ${phpVar('<?php /* Plugin Name: Nested Plugin */')});
+			$zip->addFromString(${phpVar(themePath)}, ${phpVar('/* Theme Name: Nested Theme */')});
+			$zip->addFromString('__MACOSX/._ignored', '');
+			$zip->close();
+			`,
+		});
+
+		const zipBuffer = await targetPHP.readFileAsBuffer(zipPath);
+		const zipFile = new File([zipBuffer], 'nested-wordpress-files.zip');
+
+		await importWordPressFiles(targetPHP, {
+			wordPressFilesZip: zipFile,
+		});
+
+		const documentRoot = await targetPHP.documentRoot;
+		expect(
+			await targetPHP.fileExists(
+				`${documentRoot}/wp-content/plugins/nested-plugin/nested-plugin.php`
+			)
+		).toBe(true);
+		expect(
+			await targetPHP.fileExists(
+				`${documentRoot}/wp-content/themes/nested-theme/style.css`
+			)
+		).toBe(true);
+		expect(
+			await targetPHP.fileExists(
+				`${documentRoot}/playground-export/wp-content/plugins/nested-plugin/nested-plugin.php`
+			)
+		).toBe(false);
+	});
+
+	it('should unwrap WordPress file archives without wp-content', async () => {
+		const zipPath = '/tmp/nested-wordpress-config.zip';
+		const configSamplePath = 'playground-export/wp-config-sample.php';
+		const configSampleContents = '<?php /* Nested config sample */';
+
+		await targetPHP.run({
+			code: `<?php
+			$zip = new ZipArchive();
+			$zip->open(${phpVar(zipPath)}, ZipArchive::CREATE);
+			$zip->addFromString(${phpVar(configSamplePath)}, ${phpVar(configSampleContents)});
+			$zip->close();
+			`,
+		});
+
+		const zipBuffer = await targetPHP.readFileAsBuffer(zipPath);
+		const zipFile = new File([zipBuffer], 'nested-wordpress-config.zip');
+
+		await importWordPressFiles(targetPHP, {
+			wordPressFilesZip: zipFile,
+		});
+
+		const documentRoot = await targetPHP.documentRoot;
+		expect(
+			await targetPHP.readFileAsText(
+				`${documentRoot}/wp-config-sample.php`
+			)
+		).toBe(configSampleContents);
+		expect(
+			await targetPHP.fileExists(
+				`${documentRoot}/playground-export/wp-config-sample.php`
+			)
+		).toBe(false);
+	});
+
 	it('should infer scope from database when manifest is missing and still replace URLs', async () => {
 		// Create a post with an image URL containing the source scope
 		const sourceUrl = sourcePHP.absoluteUrl;

--- a/packages/playground/blueprints/src/tests/steps/import-wordpress-files.spec.ts
+++ b/packages/playground/blueprints/src/tests/steps/import-wordpress-files.spec.ts
@@ -8,7 +8,7 @@ import {
 } from '@wp-playground/wordpress-builds';
 import { bootWordPressAndRequestHandler } from '@wp-playground/wordpress';
 import { loadNodeRuntime } from '@php-wasm/node';
-import { phpVar } from '@php-wasm/util';
+import { joinPaths, phpVar, randomFilename } from '@php-wasm/util';
 import { setURLScope } from '@php-wasm/scopes';
 
 describe('Blueprint step importWordPressFiles', () => {
@@ -185,7 +185,7 @@ describe('Blueprint step importWordPressFiles', () => {
 	});
 
 	it('should import WordPress files from a single wrapping directory', async () => {
-		const zipPath = '/tmp/nested-wordpress-files.zip';
+		const zipPath = joinPaths('/tmp', `${randomFilename()}.zip`);
 		const pluginPath =
 			'playground-export/wp-content/plugins/nested-plugin/nested-plugin.php';
 		const themePath =
@@ -194,7 +194,7 @@ describe('Blueprint step importWordPressFiles', () => {
 		await targetPHP.run({
 			code: `<?php
 			$zip = new ZipArchive();
-			$zip->open(${phpVar(zipPath)}, ZipArchive::CREATE);
+			$zip->open(${phpVar(zipPath)}, ZipArchive::CREATE | ZipArchive::OVERWRITE);
 			$zip->addFromString(${phpVar(pluginPath)}, ${phpVar('<?php /* Plugin Name: Nested Plugin */')});
 			$zip->addFromString(${phpVar(themePath)}, ${phpVar('/* Theme Name: Nested Theme */')});
 			$zip->addFromString('__MACOSX/._ignored', '');
@@ -203,6 +203,7 @@ describe('Blueprint step importWordPressFiles', () => {
 		});
 
 		const zipBuffer = await targetPHP.readFileAsBuffer(zipPath);
+		await targetPHP.unlink(zipPath);
 		const zipFile = new File([zipBuffer], 'nested-wordpress-files.zip');
 
 		await importWordPressFiles(targetPHP, {
@@ -228,20 +229,21 @@ describe('Blueprint step importWordPressFiles', () => {
 	});
 
 	it('should unwrap WordPress file archives without wp-content', async () => {
-		const zipPath = '/tmp/nested-wordpress-config.zip';
+		const zipPath = joinPaths('/tmp', `${randomFilename()}.zip`);
 		const configSamplePath = 'playground-export/wp-config-sample.php';
 		const configSampleContents = '<?php /* Nested config sample */';
 
 		await targetPHP.run({
 			code: `<?php
 			$zip = new ZipArchive();
-			$zip->open(${phpVar(zipPath)}, ZipArchive::CREATE);
+			$zip->open(${phpVar(zipPath)}, ZipArchive::CREATE | ZipArchive::OVERWRITE);
 			$zip->addFromString(${phpVar(configSamplePath)}, ${phpVar(configSampleContents)});
 			$zip->close();
 			`,
 		});
 
 		const zipBuffer = await targetPHP.readFileAsBuffer(zipPath);
+		await targetPHP.unlink(zipPath);
 		const zipFile = new File([zipBuffer], 'nested-wordpress-config.zip');
 
 		await importWordPressFiles(targetPHP, {


### PR DESCRIPTION
## What it does

Allows `importWordPressFiles` to import archives where the WordPress files sit inside a single wrapping directory, for example:

```text
playground-export/
  wp-content/
    plugins/example-plugin/example-plugin.php
    themes/example-theme/style.css
```

The imported plugin and theme files now land in the live `/wordpress/wp-content` tree instead of being misplaced under `/wordpress/playground-export/wp-content`.

## Rationale

Some ZIPs that look valid when inspected locally contain one parent directory around the WordPress files. Today the importer reports success, but keeps the default `wp-content` in place and moves the exported files into a nested directory. That matches the confusing failure mode from #3963: the ZIP contains plugins/themes, the import appears to work, but the file browser under `wp-content` shows only defaults.

`wp-content` is not required for `importWordPressFiles` in general. The step imports top-level WordPress files/directories; `wp-content` is only one valid marker. Archives that only replace other top-level WordPress files, such as `wp-config-sample.php`, should still unwrap correctly.

## Implementation

After unzip and `pathInZip` resolution, the importer looks for the real WordPress files root before reading the manifest or moving files into the document root. It only unwraps an unambiguous single-directory chain that leads to a known WordPress root marker (`wp-content`, `wp-admin`, `wp-includes`, `wp-config.php`, or `wp-config-sample.php`), ignoring common macOS ZIP noise (`__MACOSX`, `.DS_Store`). Ambiguous archive roots are left unchanged.

## Testing instructions

Reproduction covered by the new unit tests:

1. Build a ZIP with `playground-export/wp-content/plugins/nested-plugin/...` and `playground-export/wp-content/themes/nested-theme/...`.
2. Import it with `importWordPressFiles`.
3. Confirm those files exist under `/wordpress/wp-content/...` and not under `/wordpress/playground-export/wp-content/...`.
4. Build a ZIP with `playground-export/wp-config-sample.php` and no `wp-content`.
5. Import it and confirm the wrapper is still removed.

Validated locally:

```bash
npx nx test playground-blueprints --testFile=import-wordpress-files.spec.ts
npx nx lint playground-blueprints
```
