### PR TITLE
[Website][Dock UI] Add dock tabs and pane state primitives

### DIFF
--- a/packages/playground/website/src/components/dock/dock-tabs.spec.tsx
+++ b/packages/playground/website/src/components/dock/dock-tabs.spec.tsx
@@ -1,0 +1,75 @@
+// @vitest-environment jsdom
+
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import type { Root } from 'react-dom/client';
+import { DockTabs } from './dock-tabs';
+
+describe('DockTabs', () => {
+	let container: HTMLDivElement;
+	let root: Root;
+
+	beforeAll(() => {
+		vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+	});
+
+	afterAll(() => {
+		vi.unstubAllGlobals();
+	});
+
+	beforeEach(() => {
+		container = document.createElement('div');
+		document.body.append(container);
+		root = createRoot(container);
+	});
+
+	afterEach(() => {
+		act(() => root.unmount());
+		container.remove();
+	});
+
+	it('labels the tab region and switches the selected content', async () => {
+		await act(async () => {
+			root.render(
+				<DockTabs
+					ariaLabel="Playground tools"
+					initialTabName="files"
+					tabs={[
+						{ name: 'files', title: 'Files' },
+						{ name: 'logs', title: 'Logs' },
+					]}
+				>
+					{(tab) => <p>{tab.title} content</p>}
+				</DockTabs>
+			);
+		});
+
+		expect(container.querySelector('nav')?.getAttribute('aria-label')).toBe(
+			'Playground tools'
+		);
+		expect(container.querySelector('[role="tablist"]')).not.toBeNull();
+		expect(
+			container.querySelector('[role="tab"][aria-selected="true"]')
+				?.textContent
+		).toBe('Files');
+		expect(container.textContent).toContain('Files content');
+		expect(container.textContent).not.toContain('Logs content');
+
+		const logsTab = Array.from(
+			container.querySelectorAll<HTMLButtonElement>('[role="tab"]')
+		).find((tab) => tab.textContent === 'Logs');
+		if (!logsTab) {
+			throw new Error('The Logs tab did not render.');
+		}
+
+		await act(async () => {
+			logsTab.click();
+		});
+
+		expect(
+			container.querySelector('[role="tab"][aria-selected="true"]')
+				?.textContent
+		).toBe('Logs');
+		expect(container.textContent).toContain('Logs content');
+	});
+});

--- a/packages/playground/website/src/components/dock/dock-tabs.spec.tsx
+++ b/packages/playground/website/src/components/dock/dock-tabs.spec.tsx
@@ -44,16 +44,18 @@ describe('DockTabs', () => {
 			);
 		});
 
-		expect(container.querySelector('nav')?.getAttribute('aria-label')).toBe(
-			'Playground tools'
-		);
+		expect(
+			container
+				.querySelector('[role="region"]')
+				?.getAttribute('aria-label')
+		).toBe('Playground tools');
 		expect(container.querySelector('[role="tablist"]')).not.toBeNull();
 		expect(
 			container.querySelector('[role="tab"][aria-selected="true"]')
 				?.textContent
 		).toBe('Files');
-		expect(container.textContent).toContain('Files content');
-		expect(container.textContent).not.toContain('Logs content');
+		expect(getSelectedTabPanel().textContent).toContain('Files content');
+		expect(getSelectedTabPanel().textContent).not.toContain('Logs content');
 
 		const logsTab = Array.from(
 			container.querySelectorAll<HTMLButtonElement>('[role="tab"]')
@@ -70,6 +72,20 @@ describe('DockTabs', () => {
 			container.querySelector('[role="tab"][aria-selected="true"]')
 				?.textContent
 		).toBe('Logs');
-		expect(container.textContent).toContain('Logs content');
+		expect(getSelectedTabPanel().textContent).toContain('Logs content');
 	});
+
+	function getSelectedTabPanel(): HTMLElement {
+		const selectedTab = container.querySelector(
+			'[role="tab"][aria-selected="true"]'
+		);
+		const panelId = selectedTab?.getAttribute('aria-controls');
+		const panel = panelId ? document.getElementById(panelId) : null;
+
+		if (!panel || !container.contains(panel)) {
+			throw new Error('The selected tab panel did not render.');
+		}
+
+		return panel;
+	}
 });

--- a/packages/playground/website/src/components/dock/dock-tabs.tsx
+++ b/packages/playground/website/src/components/dock/dock-tabs.tsx
@@ -1,0 +1,48 @@
+import { TabPanel } from '@wordpress/components';
+import classNames from 'classnames';
+import type { ReactNode } from 'react';
+import css from './style.module.css';
+
+export type DockTab = {
+	name: string;
+	title: string;
+	disabled?: boolean;
+};
+
+export type DockTabsProps = {
+	ariaLabel: string;
+	tabs: DockTab[];
+	children: (tab: DockTab) => ReactNode;
+	className?: string;
+	initialTabName?: string;
+	onSelect?: (tabName: string) => void;
+};
+
+/**
+ * Renders a dock-sized tab view while delegating ARIA and keyboard behavior to
+ * WordPress's public TabPanel component.
+ */
+export function DockTabs({
+	ariaLabel,
+	tabs,
+	children,
+	className,
+	initialTabName,
+	onSelect,
+}: DockTabsProps) {
+	return (
+		<nav
+			className={classNames(css.dockTabs, className)}
+			aria-label={ariaLabel}
+		>
+			<TabPanel
+				className={css.dockTabsPanel}
+				tabs={tabs}
+				initialTabName={initialTabName}
+				onSelect={onSelect}
+			>
+				{children}
+			</TabPanel>
+		</nav>
+	);
+}

--- a/packages/playground/website/src/components/dock/dock-tabs.tsx
+++ b/packages/playground/website/src/components/dock/dock-tabs.tsx
@@ -19,8 +19,8 @@ export type DockTabsProps = {
 };
 
 /**
- * Renders a dock-sized tab view while delegating ARIA and keyboard behavior to
- * WordPress's public TabPanel component.
+ * Renders a named dock tab region while delegating tab ARIA and keyboard
+ * behavior to WordPress's public TabPanel component.
  */
 export function DockTabs({
 	ariaLabel,
@@ -31,8 +31,9 @@ export function DockTabs({
 	onSelect,
 }: DockTabsProps) {
 	return (
-		<nav
+		<div
 			className={classNames(css.dockTabs, className)}
+			role="region"
 			aria-label={ariaLabel}
 		>
 			<TabPanel
@@ -43,6 +44,6 @@ export function DockTabs({
 			>
 				{children}
 			</TabPanel>
-		</nav>
+		</div>
 	);
 }

--- a/packages/playground/website/src/components/dock/index.ts
+++ b/packages/playground/website/src/components/dock/index.ts
@@ -1,5 +1,7 @@
 export * from './dock-corner-launcher';
 export * from './dock-item-button';
 export * from './dock-pane';
+export * from './dock-tabs';
 export * from './dock-toggle-pill';
 export * from './icons';
+export * from './use-dock-pane-state';

--- a/packages/playground/website/src/components/dock/style.module.css
+++ b/packages/playground/website/src/components/dock/style.module.css
@@ -176,6 +176,29 @@
 	line-height: 0;
 }
 
+.dock-tabs {
+	display: flex;
+	flex: 1;
+	flex-direction: column;
+	min-height: 0;
+}
+
+.dock-tabs-panel {
+	display: flex;
+	flex: 1;
+	flex-direction: column;
+	min-height: 0;
+}
+
+.dock-tabs-panel :global(.components-tab-panel__tabs) {
+	flex: 0 0 auto;
+}
+
+.dock-tabs-panel :global(.components-tab-panel__tab-content) {
+	flex: 1;
+	min-height: 0;
+}
+
 .pane {
 	--space-3: 12px;
 	--space-4: 16px;

--- a/packages/playground/website/src/components/dock/use-dock-pane-state.spec.tsx
+++ b/packages/playground/website/src/components/dock/use-dock-pane-state.spec.tsx
@@ -1,0 +1,61 @@
+// @vitest-environment jsdom
+
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import type { Root } from 'react-dom/client';
+import { useDockPaneState } from './use-dock-pane-state';
+import type { DockPaneState } from './use-dock-pane-state';
+
+describe('useDockPaneState', () => {
+	let container: HTMLDivElement;
+	let root: Root;
+	let state: DockPaneState | undefined;
+
+	beforeAll(() => {
+		vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+	});
+
+	afterAll(() => {
+		vi.unstubAllGlobals();
+	});
+
+	beforeEach(() => {
+		container = document.createElement('div');
+		document.body.append(container);
+		root = createRoot(container);
+	});
+
+	afterEach(() => {
+		act(() => root.unmount());
+		container.remove();
+	});
+
+	it('keeps the selected width while the pane closes and reopens', () => {
+		act(() => {
+			root.render(<DockPaneStateProbe />);
+		});
+
+		expect(getState().isOpen).toBe(false);
+		expect(getState().width).toBe(480);
+
+		act(() => getState().open());
+		act(() => getState().setWidth(640));
+		act(() => getState().close());
+		act(() => getState().open());
+
+		expect(getState()).toMatchObject({ isOpen: true, width: 640 });
+	});
+
+	function DockPaneStateProbe() {
+		state = useDockPaneState(480);
+		return null;
+	}
+
+	function getState(): DockPaneState {
+		if (!state) {
+			throw new Error('The pane state probe has not rendered.');
+		}
+
+		return state;
+	}
+});

--- a/packages/playground/website/src/components/dock/use-dock-pane-state.spec.tsx
+++ b/packages/playground/website/src/components/dock/use-dock-pane-state.spec.tsx
@@ -37,6 +37,7 @@ describe('useDockPaneState', () => {
 
 		expect(getState().isOpen).toBe(false);
 		expect(getState().width).toBe(480);
+		const { open, close, setWidth } = getState();
 
 		act(() => getState().open());
 		act(() => getState().setWidth(640));
@@ -44,6 +45,9 @@ describe('useDockPaneState', () => {
 		act(() => getState().open());
 
 		expect(getState()).toMatchObject({ isOpen: true, width: 640 });
+		expect(getState().open).toBe(open);
+		expect(getState().close).toBe(close);
+		expect(getState().setWidth).toBe(setWidth);
 	});
 
 	function DockPaneStateProbe() {

--- a/packages/playground/website/src/components/dock/use-dock-pane-state.ts
+++ b/packages/playground/website/src/components/dock/use-dock-pane-state.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 
 export type DockPaneState = {
 	isOpen: boolean;
@@ -18,12 +18,18 @@ export type DockPaneState = {
 export function useDockPaneState(initialWidth: number): DockPaneState {
 	const [isOpen, setIsOpen] = useState(false);
 	const [width, setPaneWidth] = useState(initialWidth);
+	const open = useCallback(() => setIsOpen(true), []);
+	const close = useCallback(() => setIsOpen(false), []);
+	const setWidth = useCallback(
+		(nextWidth: number) => setPaneWidth(nextWidth),
+		[]
+	);
 
 	return {
 		isOpen,
 		width,
-		open: () => setIsOpen(true),
-		close: () => setIsOpen(false),
-		setWidth: (nextWidth) => setPaneWidth(nextWidth),
+		open,
+		close,
+		setWidth,
 	};
 }

--- a/packages/playground/website/src/components/dock/use-dock-pane-state.ts
+++ b/packages/playground/website/src/components/dock/use-dock-pane-state.ts
@@ -1,0 +1,29 @@
+import { useState } from 'react';
+
+export type DockPaneState = {
+	isOpen: boolean;
+	width: number;
+	/** Makes the pane visible without changing its current width. */
+	open: () => void;
+	/** Hides the pane without discarding its current width. */
+	close: () => void;
+	/** Updates the width chosen by the caller's resizable layout. */
+	setWidth: (width: number) => void;
+};
+
+/**
+ * Keeps the two pane values that survive a close/reopen cycle together. Layout
+ * constraints and persistence stay with the product that owns them.
+ */
+export function useDockPaneState(initialWidth: number): DockPaneState {
+	const [isOpen, setIsOpen] = useState(false);
+	const [width, setPaneWidth] = useState(initialWidth);
+
+	return {
+		isOpen,
+		width,
+		open: () => setIsOpen(true),
+		close: () => setIsOpen(false),
+		setWidth: (nextWidth) => setPaneWidth(nextWidth),
+	};
+}


### PR DESCRIPTION
## What changes

- Adds `DockTabs` around the public WordPress `TabPanel`.
- Adds in-memory `useDockPaneState` for open/close state and a caller-owned width.
- Reuses the existing `DockPane` shell.

No product UI imports these primitives. Persistence, resizer wiring, drag math, and product state stay out of this PR.

## Testing

- `npm exec -- nx run playground-website:test`
- `npm exec -- nx run playground-website:lint`
- `npm exec -- nx run playground-website:typecheck`
- `git diff --check`

## Manual check

Use a small dev-only Vite/HTML page that mounts `DockPane`, `DockTabs`, and `useDockPaneState` in isolation. Verify an outside control opens and closes the shell, clicking and Arrow/Home/End switch tabs and move focus correctly, and an existing `ResizableBox` can update the pane width. This hook is intentionally in-memory, so reload persistence is not expected; recheck remount/reload only if persistence is added later.