### PR TITLE
[Website] Extract saved Playground state helpers

### DIFF
--- a/packages/playground/website/src/components/saved-playgrounds-overlay/index.tsx
+++ b/packages/playground/website/src/components/saved-playgrounds-overlay/index.tsx
@@ -21,12 +21,14 @@ import {
 	useActiveSite,
 	useAppSelector,
 	useAppDispatch,
+	useTemporarySite,
 } from '../../lib/state/redux/store';
 import type { SiteLogo, SiteInfo } from '../../lib/state/redux/slice-sites';
 import {
 	isAutosavedSite,
-	selectSortedSites,
-	selectTemporarySite,
+	isStoredSite,
+	isTemporarySite,
+	selectSortedStoredSites,
 } from '../../lib/state/redux/slice-sites';
 import {
 	modalSlugs,
@@ -108,10 +110,8 @@ export function SavedPlaygroundsOverlay({
 	initialViewMode = 'main',
 }: SavedPlaygroundsOverlayProps) {
 	const offline = useAppSelector((state) => state.ui.offline);
-	const storedSites = useAppSelector(selectSortedSites).filter(
-		(site) => site.metadata.storage !== 'none'
-	);
-	const temporarySite = useAppSelector(selectTemporarySite);
+	const storedSites = useAppSelector(selectSortedStoredSites);
+	const temporarySite = useTemporarySite();
 	const activeSite = useActiveSite();
 	const dispatch = useAppDispatch();
 	const sitesAPI = useSitesAPI();
@@ -382,7 +382,7 @@ export function SavedPlaygroundsOverlay({
 	};
 
 	const getStoredSiteDetails = (site: SiteInfo) => {
-		if (site.metadata.storage === 'none') {
+		if (isTemporarySite(site)) {
 			return 'Not saved to browser storage';
 		}
 		const createdDate = formatSiteCreatedDate(site);
@@ -512,7 +512,7 @@ export function SavedPlaygroundsOverlay({
 	function renderSiteRow(site: SiteInfo) {
 		const isSelected = site.slug === activeSite?.slug;
 		const isAutosave = isAutosavedSite(site);
-		const isStoredSite = site.metadata.storage !== 'none';
+		const isStored = isStoredSite(site);
 
 		return (
 			<div
@@ -545,7 +545,7 @@ export function SavedPlaygroundsOverlay({
 						</span>
 					</div>
 				</button>
-				{isStoredSite && (
+				{isStored && (
 					<div className={css.siteRowActions}>
 						{isAutosave && (
 							<button

--- a/packages/playground/website/src/lib/state/redux/site-lifecycle.spec.ts
+++ b/packages/playground/website/src/lib/state/redux/site-lifecycle.spec.ts
@@ -4,6 +4,10 @@ import {
 	getSitePublicPersistence,
 	getSitesSortedByRecency,
 	isAutosavedSite,
+	isExplicitlySavedSite,
+	isOpfsBackedSite,
+	isStoredSite,
+	isTemporarySite,
 	wasSiteRecentlyInteractedWith,
 } from './site-lifecycle';
 import type { SiteInfo } from './slice-sites';
@@ -132,6 +136,35 @@ describe('autosaved site helpers', () => {
 				now
 			)
 		).toBe(false);
+	});
+});
+
+describe('site storage helpers', () => {
+	it('keeps temporary, stored, and OPFS-backed classifications distinct', () => {
+		const temporarySite = createSite('temporary', { storage: 'none' });
+		const opfsSite = createSite('opfs', { storage: 'opfs' });
+		const autosavedSite = createSite('autosaved', {
+			storage: 'opfs',
+			persistence: 'autosave',
+		});
+		const localSite = createSite('local', { storage: 'local-fs' });
+
+		expect(isTemporarySite(temporarySite)).toBe(true);
+		expect(isStoredSite(temporarySite)).toBe(false);
+		expect(isOpfsBackedSite(temporarySite)).toBe(false);
+
+		expect(isTemporarySite(opfsSite)).toBe(false);
+		expect(isStoredSite(opfsSite)).toBe(true);
+		expect(isOpfsBackedSite(opfsSite)).toBe(true);
+		expect(isExplicitlySavedSite(opfsSite)).toBe(true);
+
+		expect(isAutosavedSite(autosavedSite)).toBe(true);
+		expect(isStoredSite(autosavedSite)).toBe(true);
+		expect(isExplicitlySavedSite(autosavedSite)).toBe(false);
+
+		expect(isTemporarySite(localSite)).toBe(false);
+		expect(isStoredSite(localSite)).toBe(true);
+		expect(isOpfsBackedSite(localSite)).toBe(false);
 	});
 });
 

--- a/packages/playground/website/src/lib/state/redux/site-lifecycle.ts
+++ b/packages/playground/website/src/lib/state/redux/site-lifecycle.ts
@@ -75,8 +75,8 @@ export function isExplicitlySavedSite(site: SiteInfo) {
 }
 
 /**
- * Indicates whether a site only exists in Redux for the current browser
- * session and will be lost when the session ends.
+ * Indicates whether a site is not yet a stored Playground. The classification
+ * follows metadata.storage, which can remain 'none' while storage work runs.
  */
 export function isTemporarySite(site: SiteInfo) {
 	return !isStoredSite(site);

--- a/packages/playground/website/src/lib/state/redux/site-lifecycle.ts
+++ b/packages/playground/website/src/lib/state/redux/site-lifecycle.ts
@@ -64,17 +64,39 @@ export function wasSiteRecentlyInteractedWith(
  * Indicates whether a site is an automatic browser-storage recovery copy.
  */
 export function isAutosavedSite(site: SiteInfo) {
-	return (
-		site.metadata.storage === 'opfs' &&
-		site.metadata.persistence === 'autosave'
-	);
+	return isOpfsBackedSite(site) && site.metadata.persistence === 'autosave';
 }
 
 /**
  * Indicates whether a site should be treated as explicitly saved.
  */
 export function isExplicitlySavedSite(site: SiteInfo) {
-	return site.metadata.storage !== 'none' && !isAutosavedSite(site);
+	return isStoredSite(site) && !isAutosavedSite(site);
+}
+
+/**
+ * Indicates whether a site only exists in Redux for the current browser
+ * session and will be lost when the session ends.
+ */
+export function isTemporarySite(site: SiteInfo) {
+	return !isStoredSite(site);
+}
+
+/**
+ * Indicates whether a site has durable storage. Autosaved sites are stored but
+ * not explicitly saved, so callers that need user-pinned sites use
+ * isExplicitlySavedSite instead.
+ */
+export function isStoredSite(site: SiteInfo) {
+	return site.metadata.storage !== 'none';
+}
+
+/**
+ * Indicates whether a site's durable backend is browser OPFS, rather than a
+ * local directory or temporary memory-only storage.
+ */
+export function isOpfsBackedSite(site: SiteInfo) {
+	return site.metadata.storage === 'opfs';
 }
 
 /**
@@ -84,7 +106,7 @@ export function isExplicitlySavedSite(site: SiteInfo) {
  * report a value here.
  */
 export function getSitePublicPersistence(site: SiteInfo) {
-	if (site.metadata.storage === 'none') {
+	if (isTemporarySite(site)) {
 		return undefined;
 	}
 	return isAutosavedSite(site) ? 'autosave' : 'explicit';

--- a/packages/playground/website/src/lib/state/redux/slice-sites.ts
+++ b/packages/playground/website/src/lib/state/redux/slice-sites.ts
@@ -35,6 +35,8 @@ import {
 	getAutosavedSitesToPrune,
 	getSitesSortedByRecency,
 	isAutosavedSite,
+	isStoredSite,
+	isTemporarySite,
 	type AutosavedSitesPruneOptions,
 	type SitePersistence,
 } from './site-lifecycle';
@@ -52,6 +54,9 @@ export {
 	getSitePublicPersistence,
 	isAutosavedSite,
 	isExplicitlySavedSite,
+	isOpfsBackedSite,
+	isStoredSite,
+	isTemporarySite,
 	wasSiteRecentlyInteractedWith,
 } from './site-lifecycle';
 export type {
@@ -886,17 +891,26 @@ export const selectSortedSites = createSelector(
 	(sites: SiteInfo[]) => getSitesSortedByRecency(sites)
 );
 
+/**
+ * Returns durable Playgrounds in recency order. Temporary Playgrounds remain
+ * outside this list because they are only available for the current session.
+ */
+export const selectSortedStoredSites = createSelector(
+	[selectSortedSites],
+	(sites: SiteInfo[]) => sites.filter(isStoredSite)
+);
+
 export const selectTemporarySite = createSelector(
 	[selectAllSites],
 	(sites: SiteInfo[]) => {
-		return sites.find((site) => site.metadata.storage === 'none');
+		return sites.find(isTemporarySite);
 	}
 );
 
 export const selectTemporarySites = createSelector(
 	[selectAllSites],
 	(sites: SiteInfo[]) => {
-		return sites.filter((site) => site.metadata.storage === 'none');
+		return sites.filter(isTemporarySite);
 	}
 );
 
@@ -910,8 +924,7 @@ export const selectSitesLoaded = createSelector(
 	],
 	(opfsSitesLoadingState, firstTemporarySiteCreated, activeSite) =>
 		['loaded', 'error'].includes(opfsSitesLoadingState) &&
-		((activeSite && activeSite.metadata.storage !== 'none') ||
-			firstTemporarySiteCreated)
+		((activeSite && isStoredSite(activeSite)) || firstTemporarySiteCreated)
 );
 
 export default sitesSlice.reducer;

--- a/packages/playground/website/src/lib/state/redux/slice-sites.ts
+++ b/packages/playground/website/src/lib/state/redux/slice-sites.ts
@@ -892,8 +892,9 @@ export const selectSortedSites = createSelector(
 );
 
 /**
- * Returns durable Playgrounds in recency order. Temporary Playgrounds remain
- * outside this list because they are only available for the current session.
+ * Returns storage-backed Playgrounds, including autosaves, in recency order.
+ * Temporary Playgrounds remain outside this list because they are only
+ * available for the current session.
  */
 export const selectSortedStoredSites = createSelector(
 	[selectSortedSites],

--- a/packages/playground/website/src/lib/state/redux/store.spec.ts
+++ b/packages/playground/website/src/lib/state/redux/store.spec.ts
@@ -1,0 +1,104 @@
+// @vitest-environment jsdom
+
+import { selectActiveStoredSite } from './store';
+import type { PlaygroundReduxState } from './store';
+import { selectSortedStoredSites } from './slice-sites';
+import type { SiteInfo } from './slice-sites';
+
+describe('saved Playground state selectors', () => {
+	it('returns the active stored site with a stable reference', () => {
+		const temporarySite = createSite('temporary', 'none', 1);
+		const storedSite = createSite('stored', 'opfs', 2);
+		const localStoredSite = createSite('local', 'local-fs', 3);
+		const state = createState(storedSite.slug, [temporarySite, storedSite]);
+
+		const activeStoredSite = selectActiveStoredSite(state);
+
+		expect(activeStoredSite).toBe(storedSite);
+		expect(selectActiveStoredSite(state)).toBe(activeStoredSite);
+		expect(
+			selectActiveStoredSite(
+				createState(localStoredSite.slug, [localStoredSite])
+			)
+		).toBe(localStoredSite);
+	});
+
+	it('does not classify temporary or missing active sites as stored', () => {
+		const temporarySite = createSite('temporary', 'none', 1);
+
+		expect(
+			selectActiveStoredSite(
+				createState(temporarySite.slug, [temporarySite])
+			)
+		).toBeUndefined();
+		expect(
+			selectActiveStoredSite(createState(undefined, [temporarySite]))
+		).toBeUndefined();
+		expect(
+			selectActiveStoredSite(createState('missing', []))
+		).toBeUndefined();
+	});
+
+	it('returns a stable recency-sorted list without temporary sites', () => {
+		const temporarySite = createSite('temporary', 'none', 3);
+		const olderStoredSite = createSite('older', 'opfs', 1);
+		const newerStoredSite = createSite('newer', 'local-fs', 2);
+		const state = createState(undefined, [
+			temporarySite,
+			olderStoredSite,
+			newerStoredSite,
+		]);
+
+		const storedSites = selectSortedStoredSites(state);
+
+		expect(storedSites).toEqual([newerStoredSite, olderStoredSite]);
+		expect(selectSortedStoredSites(state)).toBe(storedSites);
+	});
+});
+
+function createState(
+	activeSiteSlug: string | undefined,
+	sites: SiteInfo[]
+): PlaygroundReduxState {
+	return {
+		ui: {
+			activeSite: activeSiteSlug
+				? {
+						slug: activeSiteSlug,
+					}
+				: undefined,
+		},
+		sites: {
+			ids: sites.map((site) => site.slug),
+			entities: Object.fromEntries(
+				sites.map((site) => [site.slug, site])
+			),
+		},
+	} as PlaygroundReduxState;
+}
+
+function createSite(
+	slug: string,
+	storage: SiteInfo['metadata']['storage'],
+	whenCreated: number
+): SiteInfo {
+	return {
+		slug,
+		metadata: {
+			id: slug,
+			name: slug,
+			storage,
+			whenCreated,
+			runtimeConfiguration: {
+				phpVersion: '8.3',
+				wpVersion: 'latest',
+				intl: false,
+				networking: true,
+				extraLibraries: [],
+				constants: {},
+			},
+			originalBlueprint: {},
+			originalBlueprintSource: { type: 'none' },
+		},
+	};
+}

--- a/packages/playground/website/src/lib/state/redux/store.ts
+++ b/packages/playground/website/src/lib/state/redux/store.ts
@@ -8,7 +8,9 @@ import { siteManagementMiddleware } from './site-management-api-middleware';
 import { mcpBridgeMiddleware } from './init-mcp-bridge';
 import type { SiteInfo } from './slice-sites';
 import sitesReducer, {
+	isStoredSite,
 	selectSiteBySlug,
+	selectTemporarySite,
 	selectTemporarySites,
 } from './slice-sites';
 import { PlaygroundRoute, redirectTo } from '../url/router';
@@ -87,6 +89,16 @@ export const selectActiveSite = (
 		? state.sites.entities[state.ui.activeSite.slug]
 		: undefined;
 
+/**
+ * Returns the active site only when it has durable storage. Autosaves count as
+ * stored; callers that need an explicit save should use isExplicitlySavedSite.
+ */
+export const selectActiveStoredSite = createSelector(
+	[selectActiveSite],
+	(activeSite) =>
+		activeSite && isStoredSite(activeSite) ? activeSite : undefined
+);
+
 export const selectActiveSiteError = (
 	state: PlaygroundReduxState
 ): SiteError | undefined =>
@@ -98,6 +110,16 @@ export const selectActiveSiteErrorDetails = (
 	state.ui.activeSite?.slug ? state.ui.activeSite.errorDetails : undefined;
 
 export const useActiveSite = () => useAppSelector(selectActiveSite);
+
+/**
+ * Returns the active site only when it has a durable storage backend.
+ */
+export const useActiveStoredSite = () => useAppSelector(selectActiveStoredSite);
+
+/**
+ * Returns the temporary site for the current browser session, when one exists.
+ */
+export const useTemporarySite = () => useAppSelector(selectTemporarySite);
 
 export const setActiveSite = (
 	slug: string | undefined,


### PR DESCRIPTION
Extract shared selectors and hooks for temporary, stored, active-stored, and OPFS-backed Playground state.

`metadata.storage` remains the source of truth: autosaves are stored but are not explicit saves. `useSitesAPI()` remains the action boundary.

This is state plumbing for later [Dock UI](https://github.com/WordPress/wordpress-playground/issues/3965) work. It does not change product behavior.

Tests:
- `npm exec -- nx run playground-website:test`
- `npm exec -- nx run playground-website:lint`
- `npm exec -- nx run playground-website:typecheck`
- `git diff --check`