### PR TITLE
[Blueprints] Define Playground v2 support contract

### DIFF
--- a/packages/playground/blueprints/src/index.ts
+++ b/packages/playground/blueprints/src/index.ts
@@ -71,6 +71,11 @@ export type {
 	CompiledBlueprintV2,
 	CompileBlueprintV2Options,
 } from './lib/v2/compile';
+export { blueprintV2PlaygroundSupport } from './lib/v2/playground-support';
+export type {
+	BlueprintV2PlaygroundSupportEntry,
+	BlueprintV2PlaygroundSupportStatus,
+} from './lib/v2/playground-support';
 
 export {
 	resolveRemoteBlueprint,

--- a/packages/playground/blueprints/src/lib/v2/playground-support.ts
+++ b/packages/playground/blueprints/src/lib/v2/playground-support.ts
@@ -1,0 +1,123 @@
+import type { BlueprintV2Declaration } from './blueprint-v2-declaration';
+
+/**
+ * Describes how WordPress Playground handles a Blueprint v2 schema field.
+ */
+export type BlueprintV2PlaygroundSupportStatus =
+	| 'supported'
+	| 'partially-supported'
+	| 'metadata-only'
+	| 'not-applicable';
+
+/**
+ * Documents the runtime status and relevant limitations of one schema field.
+ */
+export type BlueprintV2PlaygroundSupportEntry = {
+	status: BlueprintV2PlaygroundSupportStatus;
+	description: string;
+};
+
+type BlueprintV2PlaygroundSupportContract = {
+	[Field in keyof BlueprintV2Declaration]-?: BlueprintV2PlaygroundSupportEntry;
+};
+
+/**
+ * Defines Playground's support contract for every top-level Blueprint v2 field.
+ *
+ * Keep this object exhaustive. The mapped type makes typechecking fail when the
+ * Blueprint v2 schema adds or removes a field without updating this contract.
+ */
+export const blueprintV2PlaygroundSupport = {
+	version: {
+		status: 'supported',
+		description: 'Selects the Blueprint v2 compiler and runner.',
+	},
+	$schema: {
+		status: 'not-applicable',
+		description:
+			'Used by authoring tools; Blueprint execution does not resolve or fetch it.',
+	},
+	blueprintMeta: {
+		status: 'metadata-only',
+		description:
+			'Used by Playground surfaces such as site naming and has no runner effect.',
+	},
+	applicationOptions: {
+		status: 'supported',
+		description:
+			'Applies Playground landing page, login, and network access options.',
+	},
+	siteLanguage: {
+		status: 'supported',
+		description: 'Sets the site locale and installs its translations.',
+	},
+	siteOptions: {
+		status: 'supported',
+		description: 'Updates declared WordPress site options.',
+	},
+	constants: {
+		status: 'supported',
+		description: 'Defines declared WordPress configuration constants.',
+	},
+	wordpressVersion: {
+		status: 'partially-supported',
+		description:
+			'Supports named versions, constraints, and HTTP(S) ZIP URLs. ' +
+			'Execution-context and structured data references are rejected.',
+	},
+	phpVersion: {
+		status: 'supported',
+		description:
+			'Resolves exact versions, latest, and constraints. The next build is web-only.',
+	},
+	activeTheme: {
+		status: 'supported',
+		description: 'Installs and activates the declared theme.',
+	},
+	themes: {
+		status: 'supported',
+		description: 'Installs declared inactive themes.',
+	},
+	plugins: {
+		status: 'supported',
+		description:
+			'Installs declared plugins and applies activation options.',
+	},
+	muPlugins: {
+		status: 'supported',
+		description: 'Writes declared must-use plugins into WordPress.',
+	},
+	postTypes: {
+		status: 'partially-supported',
+		description:
+			'Registers inline and file-backed post types with generated mu-plugins ' +
+			"without enforcing the schema's Secure Custom Fields requirement.",
+	},
+	fonts: {
+		status: 'partially-supported',
+		description:
+			'Supports file references and font collections. Inline-directory and ' +
+			'Git data references are not supported.',
+	},
+	media: {
+		status: 'supported',
+		description: 'Imports declared files into the Media Library.',
+	},
+	content: {
+		status: 'supported',
+		description: 'Imports MySQL dumps, posts, and WXR content.',
+	},
+	users: {
+		status: 'supported',
+		description: 'Creates or updates declared WordPress users.',
+	},
+	roles: {
+		status: 'supported',
+		description: 'Creates or updates declared WordPress roles.',
+	},
+	additionalStepsAfterExecution: {
+		status: 'supported',
+		description:
+			'Runs every imperative step currently declared by the v2 schema.',
+	},
+} as const satisfies BlueprintV2PlaygroundSupportContract;

--- a/packages/playground/blueprints/src/tests/v2/playground-support.spec.ts
+++ b/packages/playground/blueprints/src/tests/v2/playground-support.spec.ts
@@ -1,0 +1,40 @@
+import { blueprintV2PlaygroundSupport } from '../../lib/v2/playground-support';
+
+describe('Blueprint v2 Playground support contract', () => {
+	it('classifies every top-level schema field', () => {
+		expect(
+			Object.fromEntries(
+				Object.entries(blueprintV2PlaygroundSupport).map(
+					([field, support]) => [field, support.status]
+				)
+			)
+		).toEqual({
+			version: 'supported',
+			$schema: 'not-applicable',
+			blueprintMeta: 'metadata-only',
+			applicationOptions: 'supported',
+			siteLanguage: 'supported',
+			siteOptions: 'supported',
+			constants: 'supported',
+			wordpressVersion: 'partially-supported',
+			phpVersion: 'supported',
+			activeTheme: 'supported',
+			themes: 'supported',
+			plugins: 'supported',
+			muPlugins: 'supported',
+			postTypes: 'partially-supported',
+			fonts: 'partially-supported',
+			media: 'supported',
+			content: 'supported',
+			users: 'supported',
+			roles: 'supported',
+			additionalStepsAfterExecution: 'supported',
+		});
+	});
+
+	it('explains every support classification', () => {
+		for (const support of Object.values(blueprintV2PlaygroundSupport)) {
+			expect(support.description.trim()).not.toBe('');
+		}
+	});
+});


### PR DESCRIPTION
## What changed

Adds a public support contract for every top-level Blueprint v2 schema field.

Each field is classified as supported, partially supported, metadata-only, or not applicable to execution. The contract records the current WordPress version, font, and post-type limitations instead of implying full support.

The matrix is typed against `keyof BlueprintV2Declaration`, so adding or removing a top-level schema field now fails typechecking until its Playground behavior is classified. A focused test locks the classifications and requires an explanation for every entry.

## Why

The v2 compiler previously had no single definition of what Playground supports. A new top-level field could be added to the schema without any corresponding runner decision.

## Testing

- `npm exec -- nx run playground-blueprints:lint`
- `npm exec -- nx run playground-blueprints:typecheck`
- `npm exec -- nx test playground-blueprints`
- `npm exec -- nx build playground-blueprints`

Breaking changes: None.
