### PR TITLE
[Blueprints] Stop using v2 WordPress max bounds as archive names

### DIFF
--- a/packages/playground/blueprints/src/index.ts
+++ b/packages/playground/blueprints/src/index.ts
@@ -79,6 +79,9 @@ export {
 export type { ResolveRemoteBlueprintOptions } from './lib/resolve-remote-blueprint';
 export { wpContentFilesExcludedFromExport } from './lib/utils/wp-content-files-excluded-from-exports';
 export { resolveRuntimeConfiguration } from './lib/resolve-runtime-configuration';
+export type { ResolveRuntimeConfigurationOptions } from './lib/resolve-runtime-configuration';
+export { assertBlueprintV2WordPressVersionCompatibility } from './lib/v2/resolve-runtime-configuration';
+export type { BlueprintV2SiteMode } from './lib/v2/resolve-runtime-configuration';
 export { compileBlueprintForExecution } from './lib/compile';
 export type {
 	BlueprintExecutionPath,

--- a/packages/playground/blueprints/src/lib/compile.ts
+++ b/packages/playground/blueprints/src/lib/compile.ts
@@ -10,6 +10,7 @@ import {
 import type { BlueprintV1Declaration } from './v1/types';
 import type { BlueprintV2Declaration } from './v2/blueprint-v2-declaration';
 import { compileBlueprintV2, type CompiledBlueprintV2 } from './v2/compile';
+import type { ResolveRuntimeConfigurationOptions } from './resolve-runtime-configuration';
 
 export type BlueprintExecutionPath = 'v1' | 'v2';
 
@@ -27,10 +28,13 @@ export type CompiledBlueprintForExecution =
 			run: (playground: UniversalPHP) => Promise<void>;
 	  };
 
-export interface CompileBlueprintForExecutionOptions extends Omit<
-	CompileBlueprintV1Options,
-	'onBlueprintValidated' | 'streamBundledFile'
-> {
+export interface CompileBlueprintForExecutionOptions
+	extends
+		Omit<
+			CompileBlueprintV1Options,
+			'onBlueprintValidated' | 'streamBundledFile'
+		>,
+		ResolveRuntimeConfigurationOptions {
 	onBlueprintValidated?: (blueprint: BlueprintDeclaration) => void;
 }
 
@@ -75,8 +79,9 @@ async function compileBlueprintV2ForExecution(
 			? {
 					progress: options.progress,
 					streamBundledFile: (...args: [any]) => input.read(...args),
+					siteMode: options.siteMode,
 				}
-			: { progress: options.progress }
+			: { progress: options.progress, siteMode: options.siteMode }
 	);
 	return {
 		version: 2,

--- a/packages/playground/blueprints/src/lib/resolve-runtime-configuration.ts
+++ b/packages/playground/blueprints/src/lib/resolve-runtime-configuration.ts
@@ -2,16 +2,26 @@ import { BlueprintReflection } from './reflection';
 import type { Blueprint, RuntimeConfiguration } from './types';
 import { compileBlueprintV1 } from './v1/compile';
 import type { BlueprintV1 } from './v1/types';
-import { resolveBlueprintV2RuntimeConfiguration } from './v2/resolve-runtime-configuration';
+import {
+	resolveBlueprintV2RuntimeConfiguration,
+	type BlueprintV2SiteMode,
+} from './v2/resolve-runtime-configuration';
+
+export type ResolveRuntimeConfigurationOptions = {
+	/** Determines whether WordPress is selected for download or checked in place. */
+	siteMode?: BlueprintV2SiteMode;
+};
 
 /**
  * Resolves the runtime settings required before executing a Blueprint.
  *
  * Blueprint v1 settings come from its compiled form. Blueprint v2 settings are
- * delegated to the v2 runtime configuration resolver.
+ * delegated to the v2 runtime configuration resolver. Existing-site mode
+ * validates WordPress constraints without selecting a release to download.
  */
 export async function resolveRuntimeConfiguration(
-	blueprint: Blueprint
+	blueprint: Blueprint,
+	options: ResolveRuntimeConfigurationOptions = {}
 ): Promise<RuntimeConfiguration> {
 	const reflection = await BlueprintReflection.create(blueprint);
 	if (reflection.getVersion() === 1) {
@@ -38,5 +48,8 @@ export async function resolveRuntimeConfiguration(
 		};
 	}
 
-	return resolveBlueprintV2RuntimeConfiguration(reflection.getDeclaration());
+	return resolveBlueprintV2RuntimeConfiguration(
+		reflection.getDeclaration(),
+		options.siteMode
+	);
 }

--- a/packages/playground/blueprints/src/lib/v2/compile.ts
+++ b/packages/playground/blueprints/src/lib/v2/compile.ts
@@ -1,7 +1,10 @@
 import type { FileTree, UniversalPHP } from '@php-wasm/universal';
 import { basename, joinPaths } from '@php-wasm/util';
 import type { RuntimeConfiguration } from '../types';
-import { resolveRuntimeConfiguration } from '../resolve-runtime-configuration';
+import {
+	resolveRuntimeConfiguration,
+	type ResolveRuntimeConfigurationOptions,
+} from '../resolve-runtime-configuration';
 import { seemsLikeGitRepoUrl } from '../is-git-repo-url';
 import {
 	compileBlueprintV1,
@@ -198,7 +201,8 @@ export type CompiledBlueprintV2 = {
 export type CompileBlueprintV2Options = Pick<
 	CompileBlueprintV1Options,
 	'progress' | 'streamBundledFile'
->;
+> &
+	ResolveRuntimeConfigurationOptions;
 
 /**
  * Compiles a Blueprint v2 declaration into the pieces the TypeScript runner can
@@ -213,7 +217,9 @@ export async function compileBlueprintV2(
 	declaration: BlueprintV2Declaration,
 	options: CompileBlueprintV2Options = {}
 ): Promise<CompiledBlueprintV2> {
-	const runtime = await resolveRuntimeConfiguration(declaration);
+	const runtime = await resolveRuntimeConfiguration(declaration, {
+		siteMode: options.siteMode,
+	});
 	const plan = createBlueprintV2ExecutionPlan(declaration);
 	const { steps, unsupportedPlan } = lowerBlueprintV2ExecutionPlan(plan);
 	const v1Blueprint = createV1BlueprintForLoweredV2Steps(

--- a/packages/playground/blueprints/src/lib/v2/resolve-runtime-configuration.ts
+++ b/packages/playground/blueprints/src/lib/v2/resolve-runtime-configuration.ts
@@ -4,6 +4,10 @@ import {
 	type AllPHPVersion,
 } from '@php-wasm/universal';
 import { RecommendedPHPVersion } from '@wp-playground/common';
+import {
+	getWordPressStableVersions,
+	resolveWordPressRelease,
+} from '@wp-playground/wordpress';
 import type { BlueprintDeclaration, RuntimeConfiguration } from '../types';
 import type { BlueprintV2Declaration } from './blueprint-v2-declaration';
 
@@ -24,6 +28,11 @@ type V2WordPressVersionConstraint = {
 	max?: string;
 	preferred?: string;
 };
+type ComparableWordPressVersion = {
+	parts: [number, number, number, number, number];
+	patchSpecified: boolean;
+	suffix?: 'beta' | 'rc';
+};
 
 /**
  * Resolves the runtime settings required by a Blueprint v2 declaration.
@@ -31,23 +40,62 @@ type V2WordPressVersionConstraint = {
  * This module owns the v2 support boundary: unsupported declarations and
  * runtime sources are rejected here instead of falling back to v1 behavior.
  */
-export function resolveBlueprintV2RuntimeConfiguration(
-	declaration: BlueprintDeclaration
-): RuntimeConfiguration {
+export async function resolveBlueprintV2RuntimeConfiguration(
+	declaration: BlueprintDeclaration,
+	siteMode: BlueprintV2SiteMode = 'create-new-site'
+): Promise<RuntimeConfiguration> {
 	if (!isBlueprintV2Declaration(declaration)) {
 		throw new Error('Expected a Blueprint v2 declaration.');
 	}
 	const playgroundOptions =
 		declaration.applicationOptions?.['wordpress-playground'];
+	const wpVersion = await resolveV2WordPressVersion(
+		declaration,
+		siteMode === 'create-new-site'
+	);
 
 	return {
 		phpVersion: resolveV2PHPVersion(declaration),
-		wpVersion: resolveV2WordPressVersion(declaration),
+		wpVersion,
 		intl: false,
 		networking: playgroundOptions?.networkAccess ?? false,
 		constants: declaration.constants ?? {},
 		extraLibraries: [],
 	};
+}
+
+/** Describes whether Playground creates a site or applies to mounted files. */
+export type BlueprintV2SiteMode = 'create-new-site' | 'apply-to-existing-site';
+
+/**
+ * Verifies that an existing site satisfies its Blueprint v2 WordPress version.
+ *
+ * Only constraint objects restrict an existing site. Shorthand versions,
+ * including `latest` and concrete releases, are new-site selection hints.
+ * `preferred` is also a selection hint and does not narrow compatibility.
+ */
+export async function assertBlueprintV2WordPressVersionCompatibility(
+	declaration: BlueprintV2Declaration,
+	installedVersion: string
+): Promise<void> {
+	const wordpressVersion = declaration.wordpressVersion;
+	if (!isV2WordPressVersionConstraint(wordpressVersion)) {
+		return;
+	}
+
+	assertV2WordPressVersionConstraintSemantics(wordpressVersion);
+	if (
+		isV2WordPressVersionWithinConstraints(
+			installedVersion,
+			wordpressVersion
+		)
+	) {
+		return;
+	}
+	throwV2WordPressVersionCompatibilityError(
+		installedVersion,
+		wordpressVersion
+	);
 }
 
 /**
@@ -75,7 +123,23 @@ function resolveV2PHPVersion(
 
 	const recommendedVersion = getV2PHPConstraintRecommendedVersion(phpVersion);
 	if (recommendedVersion) {
-		return resolveV2PHPVersionString(recommendedVersion);
+		const resolvedRecommendedVersion =
+			resolveV2PHPVersionString(recommendedVersion);
+		if (
+			phpVersion &&
+			typeof phpVersion === 'object' &&
+			isV2PHPVersionWithinConstraints(
+				resolvedRecommendedVersion,
+				phpVersion
+			)
+		) {
+			return resolvedRecommendedVersion;
+		}
+		throw new Error(
+			`Blueprint v2 recommended PHP version ` +
+				`"${recommendedVersion}" does not satisfy constraints ` +
+				`${JSON.stringify(phpVersion)}.`
+		);
 	}
 
 	const constrainedVersion = resolveV2PHPConstraintVersion(phpVersion);
@@ -216,17 +280,24 @@ function parsePHPVersion(phpVersion: string): [number, number, number] {
  * Missing versions default to `latest`. Unsupported data references are
  * rejected instead of silently booting a different WordPress version.
  */
-function resolveV2WordPressVersion(
-	declaration: BlueprintV2Declaration
-): string {
+async function resolveV2WordPressVersion(
+	declaration: BlueprintV2Declaration,
+	selectAvailableRelease: boolean
+): Promise<string> {
 	const wordpressVersion = declaration.wordpressVersion;
 	if (typeof wordpressVersion === 'string') {
 		return resolveV2WordPressVersionString(wordpressVersion);
 	}
 
 	if (isV2WordPressVersionConstraint(wordpressVersion)) {
+		if (!selectAvailableRelease) {
+			assertV2WordPressVersionConstraintSemantics(wordpressVersion);
+			// Existing sites are checked against the bounds before WordPress boot.
+			// No concrete download is needed in apply-to-existing-site mode.
+			return 'latest';
+		}
 		const constrainedVersion =
-			resolveV2WordPressConstraintVersion(wordpressVersion);
+			await resolveV2WordPressConstraintVersion(wordpressVersion);
 		if (constrainedVersion) {
 			return constrainedVersion;
 		}
@@ -234,7 +305,7 @@ function resolveV2WordPressVersion(
 		throw new Error(
 			`Unsatisfiable Blueprint v2 WordPress version constraints ` +
 				`${JSON.stringify(wordpressVersion)}. ` +
-				'Use a max version greater than or equal to min.'
+				'No available WordPress release satisfies the declared bounds.'
 		);
 	}
 
@@ -294,16 +365,56 @@ function isV2WordPressVersionConstraint(
 }
 
 /**
- * Selects a requestable WordPress version from a Blueprint v2 constraint.
+ * Selects an available WordPress release from a Blueprint v2 constraint.
  *
- * An explicit concrete preferred version wins when it satisfies the bounds.
- * Otherwise, an unbounded constraint maps to `latest`, while a bounded
- * constraint maps to its maximum because the runtime cannot request a latest
- * release capped at a maximum version.
+ * Stable releases come from the official WordPress release catalog. A concrete
+ * preferred branch or release wins when available and compatible; otherwise the
+ * newest release satisfying the bounds is selected.
  */
-function resolveV2WordPressConstraintVersion(
+async function resolveV2WordPressConstraintVersion(
 	wordpressVersion: UnvalidatedV2WordPressVersionConstraint
-): string | undefined {
+): Promise<string | undefined> {
+	assertV2WordPressVersionConstraintSemantics(wordpressVersion);
+	const preferredVersion = wordpressVersion.preferred;
+	const availableVersions =
+		await getAvailableV2WordPressVersions(wordpressVersion);
+	if (preferredVersion && preferredVersion !== 'latest') {
+		const preferredVersions = availableVersions.filter((candidate) =>
+			doesV2WordPressVersionMatchExpression(candidate, preferredVersion)
+		);
+		if (preferredVersions.length === 0) {
+			throw new Error(
+				`Blueprint v2 preferred WordPress version ` +
+					`"${preferredVersion}" is not available.`
+			);
+		}
+		const compatiblePreferredVersion = preferredVersions.find((candidate) =>
+			isV2WordPressVersionWithinConstraints(candidate, wordpressVersion)
+		);
+		if (compatiblePreferredVersion) {
+			return compatiblePreferredVersion;
+		}
+		throw new Error(
+			`Blueprint v2 preferred WordPress version ` +
+				`"${preferredVersion}" does not satisfy constraints ` +
+				`${JSON.stringify(wordpressVersion)}.`
+		);
+	}
+
+	return availableVersions.find((candidate) =>
+		isV2WordPressVersionWithinConstraints(candidate, wordpressVersion)
+	);
+}
+
+/**
+ * Validates the shape and internal consistency of WordPress version bounds.
+ *
+ * This check does not consult the release catalog, so existing sites can be
+ * checked without requiring a downloadable release for the installed version.
+ */
+function assertV2WordPressVersionConstraintSemantics(
+	wordpressVersion: UnvalidatedV2WordPressVersionConstraint
+): asserts wordpressVersion is V2WordPressVersionConstraint {
 	assertV2WordPressVersionConstraint(wordpressVersion);
 	assertV2ComparableWordPressConstraintVersion(
 		'wordpressVersion.min',
@@ -318,32 +429,175 @@ function resolveV2WordPressConstraintVersion(
 
 	const preferredVersion = wordpressVersion.preferred;
 	if (preferredVersion && preferredVersion !== 'latest') {
-		const resolvedPreferredVersion =
-			resolveV2WordPressVersionString(preferredVersion);
+		assertV2ComparableWordPressConstraintVersion(
+			'wordpressVersion.preferred',
+			preferredVersion
+		);
 		if (
-			isV2WordPressVersionWithinConstraints(
-				resolvedPreferredVersion,
+			!doesV2WordPressVersionExpressionSatisfyConstraints(
+				preferredVersion,
 				wordpressVersion
 			)
 		) {
-			return resolvedPreferredVersion;
+			throw new Error(
+				`Blueprint v2 preferred WordPress version ` +
+					`"${preferredVersion}" does not satisfy constraints ` +
+					`${JSON.stringify(wordpressVersion)}.`
+			);
 		}
-
+	}
+	if (
+		!isV2WordPressVersionWithinConstraints(
+			wordpressVersion.min,
+			wordpressVersion
+		)
+	) {
 		throw new Error(
-			`Blueprint v2 preferred WordPress version ` +
-				`"${preferredVersion}" does not satisfy constraints ` +
-				`${JSON.stringify(wordpressVersion)}.`
+			`Unsatisfiable Blueprint v2 WordPress version constraints ` +
+				`${JSON.stringify(wordpressVersion)}. ` +
+				'The minimum version exceeds the maximum version.'
 		);
 	}
+}
 
-	if (!wordpressVersion.max) {
-		return 'latest';
+/**
+ * Returns comparable WordPress releases ordered from newest to oldest.
+ *
+ * The stable catalog is exhaustive. The current beta-channel offer is added
+ * only for constraints that mention a prerelease because historical
+ * prereleases are not part of the stable release catalog.
+ */
+async function getAvailableV2WordPressVersions(
+	constraints?: V2WordPressVersionConstraint
+): Promise<string[]> {
+	const versions = (await getWordPressStableVersions()).map(
+		normalizeV2AvailableWordPressVersion
+	);
+	if (
+		constraints &&
+		[constraints.min, constraints.max, constraints.preferred].some(
+			(version) =>
+				version &&
+				parseComparableWordPressVersion(version)?.suffix !== undefined
+		)
+	) {
+		const betaRelease = await resolveWordPressRelease('beta');
+		versions.push(betaRelease.version);
 	}
 
-	const maxVersion = resolveV2WordPressVersionString(wordpressVersion.max);
-	return isV2WordPressVersionWithinConstraints(maxVersion, wordpressVersion)
-		? maxVersion
-		: undefined;
+	return Array.from(new Set(versions))
+		.filter(isComparableWordPressVersion)
+		.sort((left, right) => compareWordPressVersions(right, left));
+}
+
+/**
+ * Preserves an initial stable release as an exact runtime request.
+ *
+ * WordPress catalogs call the first release in a branch `6.8`, while runtime
+ * consumers interpret `6.8` as the newest patch in that branch. The explicit
+ * `6.8.0` form keeps constraint selection from booting a newer patch instead.
+ */
+function normalizeV2AvailableWordPressVersion(
+	wordpressVersion: string
+): string {
+	return /^\d+\.\d+$/.test(wordpressVersion)
+		? `${wordpressVersion}.0`
+		: wordpressVersion;
+}
+
+/**
+ * Indicates whether a release matches an exact or branch-style expression.
+ *
+ * A stable expression without a patch, such as `6.8`, selects the newest stable
+ * release in that branch. Patch and prerelease expressions compare exactly.
+ */
+function doesV2WordPressVersionMatchExpression(
+	wordpressVersion: string,
+	expression: string
+): boolean {
+	const parsedVersion = parseComparableWordPressVersion(wordpressVersion);
+	const parsedExpression = parseComparableWordPressVersion(expression);
+	if (!parsedVersion || !parsedExpression) {
+		return false;
+	}
+	if (!parsedExpression.patchSpecified && !parsedExpression.suffix) {
+		return (
+			!parsedVersion.suffix &&
+			parsedVersion.parts[0] === parsedExpression.parts[0] &&
+			parsedVersion.parts[1] === parsedExpression.parts[1]
+		);
+	}
+	return compareWordPressVersions(wordpressVersion, expression) === 0;
+}
+
+/**
+ * Indicates whether a preferred exact release or branch intersects the bounds.
+ *
+ * A patchless stable expression such as `6.8` represents the entire stable
+ * branch, so it is valid when at least one theoretical `6.8.x` release could
+ * satisfy the constraint. Release availability is checked separately.
+ */
+function doesV2WordPressVersionExpressionSatisfyConstraints(
+	expression: string,
+	constraints: V2WordPressVersionConstraint
+): boolean {
+	const parsedExpression = parseComparableWordPressVersion(expression);
+	if (!parsedExpression) {
+		return false;
+	}
+	if (parsedExpression.patchSpecified || parsedExpression.suffix) {
+		return isV2WordPressVersionWithinConstraints(expression, constraints);
+	}
+
+	const parsedMin = parseComparableWordPressVersion(constraints.min)!;
+	const branch = parsedExpression.parts.slice(0, 2);
+	const minBranch = parsedMin.parts.slice(0, 2);
+	if (compareV2WordPressVersionBranches(branch, minBranch) < 0) {
+		return false;
+	}
+	if (!constraints.max) {
+		return true;
+	}
+
+	const parsedMax = parseComparableWordPressVersion(constraints.max)!;
+	const maxBranch = parsedMax.parts.slice(0, 2);
+	const maxBranchComparison = compareV2WordPressVersionBranches(
+		branch,
+		maxBranch
+	);
+	return (
+		maxBranchComparison < 0 ||
+		(maxBranchComparison === 0 && !parsedMax.suffix)
+	);
+}
+
+/**
+ * Compares WordPress major/minor branch identifiers.
+ */
+function compareV2WordPressVersionBranches(
+	left: number[],
+	right: number[]
+): number {
+	for (let i = 0; i < 2; i++) {
+		const difference = left[i] - right[i];
+		if (difference !== 0) {
+			return difference;
+		}
+	}
+	return 0;
+}
+
+/**
+ * Throws the common existing-site compatibility diagnostic.
+ */
+function throwV2WordPressVersionCompatibilityError(
+	installedVersion: string,
+	requirement: V2WordPressVersionConstraint
+): never {
+	throw new Error(
+		`Installed WordPress version "${installedVersion}" does not satisfy ` +
+			`Blueprint v2 wordpressVersion ${JSON.stringify(requirement)}.`
+	);
 }
 
 /**
@@ -419,10 +673,9 @@ function isV2WordPressVersionWithinConstraints(
 	wordpressVersion: string,
 	constraints: V2WordPressVersionConstraint
 ): boolean {
-	if (
-		!isComparableWordPressVersion(wordpressVersion) ||
-		!isComparableWordPressVersion(constraints.min)
-	) {
+	const parsedVersion = parseComparableWordPressVersion(wordpressVersion);
+	const parsedMin = parseComparableWordPressVersion(constraints.min);
+	if (!parsedVersion || !parsedMin) {
 		return false;
 	}
 	if (compareWordPressVersions(wordpressVersion, constraints.min) < 0) {
@@ -431,10 +684,19 @@ function isV2WordPressVersionWithinConstraints(
 	if (!constraints.max) {
 		return true;
 	}
-	return (
-		isComparableWordPressVersion(constraints.max) &&
-		compareWordPressVersions(wordpressVersion, constraints.max) <= 0
-	);
+	const parsedMax = parseComparableWordPressVersion(constraints.max);
+	if (!parsedMax) {
+		return false;
+	}
+	if (
+		!parsedMax.patchSpecified &&
+		!parsedMax.suffix &&
+		parsedVersion.parts[0] === parsedMax.parts[0] &&
+		parsedVersion.parts[1] === parsedMax.parts[1]
+	) {
+		return true;
+	}
+	return compareWordPressVersions(wordpressVersion, constraints.max) <= 0;
 }
 
 /**
@@ -444,15 +706,15 @@ function isV2WordPressVersionWithinConstraints(
  * newer, and zero when both releases have equal precedence.
  */
 function compareWordPressVersions(left: string, right: string): number {
-	const leftParts = parseComparableWordPressVersion(left);
-	const rightParts = parseComparableWordPressVersion(right);
-	if (!leftParts || !rightParts) {
+	const leftVersion = parseComparableWordPressVersion(left);
+	const rightVersion = parseComparableWordPressVersion(right);
+	if (!leftVersion || !rightVersion) {
 		throw new Error(
 			`Cannot compare WordPress versions "${left}" and "${right}".`
 		);
 	}
-	for (let i = 0; i < leftParts.length; i++) {
-		const difference = leftParts[i] - rightParts[i];
+	for (let i = 0; i < leftVersion.parts.length; i++) {
+		const difference = leftVersion.parts[i] - rightVersion.parts[i];
 		if (difference !== 0) {
 			return difference;
 		}
@@ -472,26 +734,36 @@ function isComparableWordPressVersion(wordpressVersion: string): boolean {
  *
  * Missing patch numbers become zero, and suffix ranks preserve the WordPress
  * release order: beta before RC before the stable release. Runtime labels and
- * custom URLs are not comparable and return `null`.
+ * custom URLs are not comparable and return `null`. `patchSpecified` remains
+ * separate so a max bound such as `6.8` can include every `6.8.x` patch.
  */
 function parseComparableWordPressVersion(
 	wordpressVersion: string
-): [number, number, number, number, number] | null {
+): ComparableWordPressVersion | null {
 	const match = wordpressVersion.match(
 		/^(\d+)\.(\d+)(?:\.(\d+))?(?:-(beta|rc)(\d+))?$/i
 	);
 	if (!match) {
 		return null;
 	}
-	const [, major, minor, patch = '0', suffix, suffixVersion = '0'] = match;
-	const suffixRank = suffix ? (suffix.toLowerCase() === 'beta' ? 0 : 1) : 2;
-	return [
-		Number(major),
-		Number(minor),
-		Number(patch),
-		suffixRank,
-		Number(suffixVersion),
-	];
+	const [, major, minor, patch, suffix, suffixVersion = '0'] = match;
+	const normalizedSuffix = suffix?.toLowerCase() as 'beta' | 'rc' | undefined;
+	const suffixRank = normalizedSuffix
+		? normalizedSuffix === 'beta'
+			? 0
+			: 1
+		: 2;
+	return {
+		parts: [
+			Number(major),
+			Number(minor),
+			Number(patch ?? '0'),
+			suffixRank,
+			Number(suffixVersion),
+		],
+		patchSpecified: patch !== undefined,
+		suffix: normalizedSuffix,
+	};
 }
 
 /**

--- a/packages/playground/blueprints/src/tests/compile.spec.ts
+++ b/packages/playground/blueprints/src/tests/compile.spec.ts
@@ -104,6 +104,25 @@ describe('compileBlueprintForExecution', () => {
 		expect(compiled.compiled.plan).toEqual([]);
 	});
 
+	it('compiles existing-site v2 constraints without selecting a download', async () => {
+		const compiled = await compileBlueprintForExecution(
+			{
+				version: 2,
+				wordpressVersion: {
+					min: '6.8.2',
+					max: '6.8.4',
+				},
+			},
+			{ siteMode: 'apply-to-existing-site' }
+		);
+
+		expect(compiled.version).toBe(2);
+		if (compiled.version !== 2) {
+			throw new Error('Expected a compiled Blueprint v2 result.');
+		}
+		expect(compiled.compiled.runtime.wpVersion).toBe('latest');
+	});
+
 	it('compiles Blueprint v2 declarations from raw JSON', async () => {
 		const compiled = await compileBlueprintForExecution(
 			JSON.stringify({

--- a/packages/playground/blueprints/src/tests/v2/resolve-runtime-configuration.spec.ts
+++ b/packages/playground/blueprints/src/tests/v2/resolve-runtime-configuration.spec.ts
@@ -1,11 +1,41 @@
 import { StreamedFile } from '@php-wasm/stream-compression';
 import { LatestSupportedPHPVersion } from '@php-wasm/universal';
 import { RecommendedPHPVersion } from '@wp-playground/common';
+import { beforeEach, vi } from 'vitest';
 import { resolveRuntimeConfiguration } from '../../lib/resolve-runtime-configuration';
 import type { BlueprintBundle } from '../../lib/types';
 import type { BlueprintV2Declaration } from '../../lib/v2/blueprint-v2-declaration';
+import { assertBlueprintV2WordPressVersionCompatibility } from '../../lib/v2/resolve-runtime-configuration';
+
+const wordpressMocks = vi.hoisted(() => ({
+	getWordPressStableVersions: vi.fn(),
+	resolveWordPressRelease: vi.fn(),
+}));
+
+vi.mock('@wp-playground/wordpress', () => ({
+	getWordPressStableVersions: wordpressMocks.getWordPressStableVersions,
+	resolveWordPressRelease: wordpressMocks.resolveWordPressRelease,
+	versionStringToLoadedWordPressVersion: (version: string) =>
+		version.includes('-alpha-') ? 'trunk' : version,
+}));
 
 describe('Blueprint v2 runtime configuration', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		wordpressMocks.getWordPressStableVersions.mockResolvedValue([
+			'6.7.5',
+			'6.8',
+			'6.8.1',
+			'6.8.5',
+			'6.9',
+		]);
+		wordpressMocks.resolveWordPressRelease.mockResolvedValue({
+			version: '7.0-beta1',
+			releaseUrl: 'https://wordpress.org/wordpress-7.0-beta1.zip',
+			source: 'api',
+		});
+	});
+
 	const expectedDefaults = {
 		phpVersion: RecommendedPHPVersion,
 		wpVersion: 'latest',
@@ -139,6 +169,22 @@ describe('Blueprint v2 runtime configuration', () => {
 		});
 	});
 
+	it('rejects recommended PHP versions outside constraint bounds', async () => {
+		for (const phpVersion of [
+			{ min: '8.2', recommended: '8.1' },
+			{ recommended: '8.5', max: '8.4' },
+		] as const) {
+			await expect(
+				resolveRuntimeConfiguration({
+					version: 2,
+					phpVersion,
+				})
+			).rejects.toThrow(
+				`Blueprint v2 recommended PHP version "${phpVersion.recommended}" does not satisfy constraints`
+			);
+		}
+	});
+
 	it('uses the default PHP version for constraints without a recommended version', async () => {
 		await expect(
 			resolveRuntimeConfiguration({
@@ -230,12 +276,27 @@ describe('Blueprint v2 runtime configuration', () => {
 			resolveRuntimeConfiguration({
 				version: 2,
 				wordpressVersion: {
-					min: '6.8',
+					min: '6.8.4',
+					max: '6.8',
 					preferred: '6.8',
 				},
 			})
 		).resolves.toMatchObject({
-			wpVersion: '6.8',
+			wpVersion: '6.8.5',
+		});
+	});
+
+	it('resolves an available exact preferred WordPress release', async () => {
+		await expect(
+			resolveRuntimeConfiguration({
+				version: 2,
+				wordpressVersion: {
+					min: '6.8',
+					preferred: '6.8.1',
+				},
+			})
+		).resolves.toMatchObject({
+			wpVersion: '6.8.1',
 		});
 	});
 
@@ -249,11 +310,11 @@ describe('Blueprint v2 runtime configuration', () => {
 				},
 			})
 		).resolves.toMatchObject({
-			wpVersion: '6.8',
+			wpVersion: '6.8.5',
 		});
 	});
 
-	it('uses the default WordPress version for constraints without a preferred version', async () => {
+	it('selects the newest available WordPress version for an open constraint', async () => {
 		await expect(
 			resolveRuntimeConfiguration({
 				version: 2,
@@ -262,23 +323,156 @@ describe('Blueprint v2 runtime configuration', () => {
 				},
 			})
 		).resolves.toMatchObject({
-			wpVersion: 'latest',
+			wpVersion: '6.9.0',
 		});
 	});
 
-	it('rejects preferred WordPress versions outside constraints', async () => {
+	it('preserves an initial release as an exact runtime request', async () => {
+		wordpressMocks.getWordPressStableVersions.mockResolvedValue(['6.8']);
+
+		await expect(
+			resolveRuntimeConfiguration({
+				version: 2,
+				wordpressVersion: {
+					min: '6.8.0',
+					max: '6.8.0',
+				},
+			})
+		).resolves.toMatchObject({
+			wpVersion: '6.8.0',
+		});
+	});
+
+	it('selects an available release below a nonexistent maximum', async () => {
+		await expect(
+			resolveRuntimeConfiguration({
+				version: 2,
+				wordpressVersion: {
+					min: '6.8',
+					max: '6.8.4',
+				},
+			})
+		).resolves.toMatchObject({
+			wpVersion: '6.8.1',
+		});
+	});
+
+	it('does not require a downloadable release when applying to an existing site', async () => {
+		wordpressMocks.getWordPressStableVersions.mockRejectedValue(
+			new Error('Release catalog unavailable')
+		);
+		const blueprint = {
+			version: 2,
+			wordpressVersion: {
+				min: '6.8.2',
+				max: '6.8.4',
+			},
+		} as const;
+
+		await expect(
+			resolveRuntimeConfiguration(blueprint, {
+				siteMode: 'apply-to-existing-site',
+			})
+		).resolves.toMatchObject({ wpVersion: 'latest' });
+		await expect(
+			assertBlueprintV2WordPressVersionCompatibility(blueprint, '6.8.3')
+		).resolves.toBeUndefined();
+
+		const prereleaseBlueprint = {
+			version: 2,
+			wordpressVersion: {
+				min: '6.8-beta1',
+				max: '6.8-rc1',
+			},
+		} as const;
+		await expect(
+			resolveRuntimeConfiguration(prereleaseBlueprint, {
+				siteMode: 'apply-to-existing-site',
+			})
+		).resolves.toMatchObject({ wpVersion: 'latest' });
+		await expect(
+			assertBlueprintV2WordPressVersionCompatibility(
+				prereleaseBlueprint,
+				'6.8-beta2'
+			)
+		).resolves.toBeUndefined();
+		expect(
+			wordpressMocks.getWordPressStableVersions
+		).not.toHaveBeenCalled();
+	});
+
+	it('selects the newest release regardless of catalog order', async () => {
+		wordpressMocks.getWordPressStableVersions.mockResolvedValue([
+			'6.8.1',
+			'6.8.5',
+			'6.8',
+		]);
+
 		await expect(
 			resolveRuntimeConfiguration({
 				version: 2,
 				wordpressVersion: {
 					min: '6.8',
 					max: '6.8',
-					preferred: '6.9',
+				},
+			})
+		).resolves.toMatchObject({
+			wpVersion: '6.8.5',
+		});
+	});
+
+	it('selects the current prerelease when it satisfies constraints', async () => {
+		await expect(
+			resolveRuntimeConfiguration({
+				version: 2,
+				wordpressVersion: {
+					min: '7.0-beta1',
+					max: '7.0-rc1',
+				},
+			})
+		).resolves.toMatchObject({
+			wpVersion: '7.0-beta1',
+		});
+	});
+
+	it('rejects preferred WordPress versions absent from the catalog', async () => {
+		await expect(
+			resolveRuntimeConfiguration({
+				version: 2,
+				wordpressVersion: {
+					min: '6.8',
+					preferred: '6.8.4',
 				},
 			})
 		).rejects.toThrow(
-			'Blueprint v2 preferred WordPress version "6.9" does not satisfy constraints'
+			'Blueprint v2 preferred WordPress version "6.8.4" is not available.'
 		);
+	});
+
+	it('rejects preferred WordPress versions outside constraints', async () => {
+		for (const siteMode of [
+			'create-new-site',
+			'apply-to-existing-site',
+		] as const) {
+			await expect(
+				resolveRuntimeConfiguration(
+					{
+						version: 2,
+						wordpressVersion: {
+							min: '6.8',
+							max: '6.8',
+							preferred: '6.9',
+						},
+					},
+					{ siteMode }
+				)
+			).rejects.toThrow(
+				'Blueprint v2 preferred WordPress version "6.9" does not satisfy constraints'
+			);
+		}
+		expect(
+			wordpressMocks.getWordPressStableVersions
+		).not.toHaveBeenCalled();
 	});
 
 	it('rejects unsatisfied WordPress version constraints', async () => {
@@ -292,6 +486,18 @@ describe('Blueprint v2 runtime configuration', () => {
 			})
 		).rejects.toThrow(
 			'Unsatisfiable Blueprint v2 WordPress version constraints {"min":"6.9","max":"6.8"}.'
+		);
+
+		await expect(
+			resolveRuntimeConfiguration({
+				version: 2,
+				wordpressVersion: {
+					min: '6.8.2',
+					max: '6.8.4',
+				},
+			})
+		).rejects.toThrow(
+			'No available WordPress release satisfies the declared bounds.'
 		);
 	});
 
@@ -361,6 +567,68 @@ describe('Blueprint v2 runtime configuration', () => {
 		).rejects.toThrow(
 			'Unsupported Blueprint v2 WordPress version "not-a-version".'
 		);
+	});
+
+	it('accepts installed WordPress patches within a branch constraint', async () => {
+		await expect(
+			assertBlueprintV2WordPressVersionCompatibility(
+				{
+					version: 2,
+					wordpressVersion: {
+						min: '6.8',
+						max: '6.8',
+						preferred: '6.8.1',
+					},
+				},
+				'6.8.5'
+			)
+		).resolves.toBeUndefined();
+	});
+
+	it('rejects installed WordPress patches above an exact maximum', async () => {
+		await expect(
+			assertBlueprintV2WordPressVersionCompatibility(
+				{
+					version: 2,
+					wordpressVersion: {
+						min: '6.8',
+						max: '6.8.1',
+					},
+				},
+				'6.8.5'
+			)
+		).rejects.toThrow(
+			'Installed WordPress version "6.8.5" does not satisfy Blueprint v2 wordpressVersion'
+		);
+	});
+
+	it('rejects installed WordPress versions below the minimum', async () => {
+		await expect(
+			assertBlueprintV2WordPressVersionCompatibility(
+				{
+					version: 2,
+					wordpressVersion: { min: '6.8' },
+				},
+				'6.7.5'
+			)
+		).rejects.toThrow(
+			'Installed WordPress version "6.7.5" does not satisfy Blueprint v2 wordpressVersion'
+		);
+	});
+
+	it('treats shorthand WordPress versions as new-site selection hints', async () => {
+		for (const wordpressVersion of [
+			undefined,
+			'latest',
+			'6.8.1',
+		] as const) {
+			await expect(
+				assertBlueprintV2WordPressVersionCompatibility(
+					{ version: 2, wordpressVersion },
+					'6.7.5'
+				)
+			).resolves.toBeUndefined();
+		}
 	});
 });
 

--- a/packages/playground/cli/src/blueprints-v2/blueprints-v2-handler.ts
+++ b/packages/playground/cli/src/blueprints-v2/blueprints-v2-handler.ts
@@ -45,6 +45,7 @@ export class BlueprintsV2Handler {
 	private siteUrl: string;
 	private args: RunCLIArgs;
 	private cliOutput: CLIOutput;
+	private wordpressInstallModePromise?: Promise<WordPressInstallMode>;
 
 	constructor(
 		args: RunCLIArgs,
@@ -257,11 +258,13 @@ export class BlueprintsV2Handler {
 	/**
 	 * Resolves the worker install mode, including migrated v1 PHP-only sites.
 	 */
-	private async getWordPressInstallMode(): Promise<WordPressInstallMode> {
-		return resolveV2WordPressInstallMode(
-			this.args,
-			await v1BlueprintRequestsPhpOnlyMode(this.args.blueprint)
+	private getWordPressInstallMode(): Promise<WordPressInstallMode> {
+		this.wordpressInstallModePromise ??= v1BlueprintRequestsPhpOnlyMode(
+			this.args.blueprint
+		).then((v1PhpOnlyMode) =>
+			resolveV2WordPressInstallMode(this.args, v1PhpOnlyMode)
 		);
+		return this.wordpressInstallModePromise;
 	}
 
 	/**
@@ -357,6 +360,9 @@ function resolveV2WordPressInstallMode(
 
 /**
  * Indicates whether boot will reuse WordPress files supplied by the caller.
+ *
+ * The `if-needed` variant may initialize the database, but it never downloads
+ * WordPress core as a fallback when the mounted files are absent.
  */
 function isV2ExistingSiteInstallMode(
 	wordpressInstallMode: WordPressInstallMode

--- a/packages/playground/cli/src/blueprints-v2/blueprints-v2-handler.ts
+++ b/packages/playground/cli/src/blueprints-v2/blueprints-v2-handler.ts
@@ -10,6 +10,7 @@ import type {
 	BlueprintV2Declaration,
 } from '@wp-playground/blueprints';
 import {
+	assertBlueprintV2WordPressVersionCompatibility,
 	BlueprintReflection,
 	compileBlueprintV2,
 	isBlueprintBundle,
@@ -66,16 +67,15 @@ export class BlueprintsV2Handler {
 		workerPostInstallMountsPort: NodeMessagePort
 	) {
 		let wordPressZip: any = undefined;
-		const v1PhpOnlyMode = await v1BlueprintRequestsPhpOnlyMode(
-			this.args.blueprint
-		);
-		const wordpressInstallMode = resolveV2WordPressInstallMode(
-			this.args,
-			v1PhpOnlyMode
-		);
+		const wordpressInstallMode = await this.getWordPressInstallMode();
 		const effectiveBlueprint = await this.getEffectiveBlueprint();
 		const runtimeConfiguration = await resolveRuntimeConfiguration(
-			effectiveBlueprint.declaration
+			effectiveBlueprint.declaration,
+			{
+				siteMode: isV2ExistingSiteInstallMode(wordpressInstallMode)
+					? 'apply-to-existing-site'
+					: 'create-new-site',
+			}
 		);
 		assertCliSupportedPHPVersion(runtimeConfiguration.phpVersion);
 		if (wordpressInstallMode === 'download-and-install') {
@@ -109,6 +109,24 @@ export class BlueprintsV2Handler {
 			logger.debug(
 				`Resolved WordPress release URL: ${wpDetails?.releaseUrl}`
 			);
+		}
+
+		if (isV2ExistingSiteInstallMode(wordpressInstallMode)) {
+			const installedVersion = await playground.run({
+				code: `<?php
+					if (file_exists('/wordpress/wp-includes/version.php')) {
+						require '/wordpress/wp-includes/version.php';
+						echo $wp_version;
+					}
+				`,
+			});
+			const installedVersionString = installedVersion.text.trim();
+			if (installedVersionString) {
+				await assertBlueprintV2WordPressVersionCompatibility(
+					effectiveBlueprint.declaration,
+					installedVersionString
+				);
+			}
 		}
 
 		let sqliteIntegrationPluginZip;
@@ -167,8 +185,14 @@ export class BlueprintsV2Handler {
 		);
 
 		await playground.isConnected();
+		const wordpressInstallMode = await this.getWordPressInstallMode();
 		const runtimeConfiguration = await resolveRuntimeConfiguration(
-			(await this.getEffectiveBlueprint()).declaration
+			(await this.getEffectiveBlueprint()).declaration,
+			{
+				siteMode: isV2ExistingSiteInstallMode(wordpressInstallMode)
+					? 'apply-to-existing-site'
+					: 'create-new-site',
+			}
 		);
 		assertCliSupportedPHPVersion(runtimeConfiguration.phpVersion);
 		await playground.useFileLockManager(fileLockManagerPort);
@@ -201,6 +225,7 @@ export class BlueprintsV2Handler {
 		const blueprint = await this.getEffectiveBlueprint(
 			additionalBlueprintSteps
 		);
+		const wordpressInstallMode = await this.getWordPressInstallMode();
 
 		const tracker = new ProgressTracker();
 		let lastCaption = '';
@@ -219,11 +244,24 @@ export class BlueprintsV2Handler {
 		const compiled = await compileBlueprintV2(blueprint.declaration, {
 			progress: tracker,
 			streamBundledFile: blueprint.streamBundledFile,
+			siteMode: isV2ExistingSiteInstallMode(wordpressInstallMode)
+				? 'apply-to-existing-site'
+				: 'create-new-site',
 		});
 		return {
 			...compiled,
 			declaration: blueprint.declaration,
 		};
+	}
+
+	/**
+	 * Resolves the worker install mode, including migrated v1 PHP-only sites.
+	 */
+	private async getWordPressInstallMode(): Promise<WordPressInstallMode> {
+		return resolveV2WordPressInstallMode(
+			this.args,
+			await v1BlueprintRequestsPhpOnlyMode(this.args.blueprint)
+		);
 	}
 
 	/**
@@ -315,6 +353,18 @@ function resolveV2WordPressInstallMode(
 			return 'download-and-install';
 	}
 	return args.wordpressInstallMode || 'download-and-install';
+}
+
+/**
+ * Indicates whether boot will reuse WordPress files supplied by the caller.
+ */
+function isV2ExistingSiteInstallMode(
+	wordpressInstallMode: WordPressInstallMode
+): boolean {
+	return (
+		wordpressInstallMode === 'install-from-existing-files' ||
+		wordpressInstallMode === 'install-from-existing-files-if-needed'
+	);
 }
 
 function assertCliSupportedPHPVersion(phpVersion: string) {

--- a/packages/playground/cli/tests/blueprints-v2-handler.spec.ts
+++ b/packages/playground/cli/tests/blueprints-v2-handler.spec.ts
@@ -7,6 +7,7 @@ import type {
 	BlueprintV1Declaration,
 	BlueprintV2Declaration,
 } from '@wp-playground/blueprints';
+import { assertBlueprintV2WordPressVersionCompatibility } from '@wp-playground/blueprints';
 import { consumeAPI } from '@php-wasm/universal';
 import { fetchSqliteIntegration } from '../src/blueprints-v1/download';
 
@@ -28,6 +29,14 @@ vi.mock('../src/blueprints-v1/download', async (importOriginal) => {
 	};
 });
 
+vi.mock('@wp-playground/blueprints', async (importOriginal) => {
+	const actual = (await importOriginal()) as Record<string, unknown>;
+	return {
+		...actual,
+		assertBlueprintV2WordPressVersionCompatibility: vi.fn(),
+	};
+});
+
 describe('BlueprintsV2Handler', () => {
 	const cliOutput = {
 		updateProgress: vi.fn(),
@@ -35,6 +44,9 @@ describe('BlueprintsV2Handler', () => {
 
 	beforeEach(() => {
 		vi.clearAllMocks();
+		vi.mocked(
+			assertBlueprintV2WordPressVersionCompatibility
+		).mockResolvedValue(undefined);
 	});
 
 	test('applies CLI defaults and normalizes additional steps before compiling', async () => {
@@ -365,6 +377,7 @@ describe('BlueprintsV2Handler', () => {
 		);
 		const playground = {
 			bootWordPress: vi.fn().mockResolvedValue(undefined),
+			run: vi.fn().mockResolvedValue({ text: ' 6.8.5\n' }),
 		};
 
 		await handler.bootWordPress(playground as any, {} as any);
@@ -375,6 +388,81 @@ describe('BlueprintsV2Handler', () => {
 			}),
 			expect.anything()
 		);
+		expect(playground.run).toHaveBeenCalledWith({
+			code: expect.stringMatching(
+				/file_exists\([^)]+version\.php[^]*echo \$wp_version/
+			),
+		});
+		expect(
+			assertBlueprintV2WordPressVersionCompatibility
+		).toHaveBeenCalledWith(
+			expect.objectContaining({
+				version: 2,
+				wordpressVersion: 'latest',
+			}),
+			'6.8.5'
+		);
+		expect(
+			vi.mocked(assertBlueprintV2WordPressVersionCompatibility).mock
+				.invocationCallOrder[0]
+		).toBeLessThan(playground.bootWordPress.mock.invocationCallOrder[0]);
+	});
+
+	test('rejects incompatible WordPress before applying a v2 Blueprint', async () => {
+		vi.mocked(
+			assertBlueprintV2WordPressVersionCompatibility
+		).mockRejectedValueOnce(new Error('Incompatible WordPress version'));
+		const handler = new BlueprintsV2Handler(
+			{
+				command: 'server',
+				mode: 'apply-to-existing-site',
+				skipSqliteSetup: true,
+				blueprint: {
+					version: 2,
+					wordpressVersion: {
+						min: '6.8',
+					},
+				},
+			} as RunCLIArgs,
+			{
+				siteUrl: 'http://127.0.0.1:9400',
+				cliOutput,
+			}
+		);
+		const playground = {
+			bootWordPress: vi.fn().mockResolvedValue(undefined),
+			run: vi.fn().mockResolvedValue({ text: '6.7.5' }),
+		};
+
+		await expect(
+			handler.bootWordPress(playground as any, {} as any)
+		).rejects.toThrow('Incompatible WordPress version');
+		expect(playground.bootWordPress).not.toHaveBeenCalled();
+	});
+
+	test('does not validate WordPress when creating a new site', async () => {
+		const handler = new BlueprintsV2Handler(
+			{
+				command: 'server',
+				mode: 'create-new-site',
+				skipSqliteSetup: true,
+			} as RunCLIArgs,
+			{
+				siteUrl: 'http://127.0.0.1:9400',
+				cliOutput,
+			}
+		);
+		const playground = {
+			bootWordPress: vi.fn().mockResolvedValue(undefined),
+			run: vi.fn(),
+		};
+
+		await handler.bootWordPress(playground as any, {} as any);
+
+		expect(playground.run).not.toHaveBeenCalled();
+		expect(
+			assertBlueprintV2WordPressVersionCompatibility
+		).not.toHaveBeenCalled();
 	});
 
 	test('preserves v2 mount-only mode from legacy install mode', async () => {
@@ -452,6 +540,7 @@ describe('BlueprintsV2Handler', () => {
 		);
 		const playground = {
 			bootWordPress: vi.fn().mockResolvedValue(undefined),
+			run: vi.fn().mockResolvedValue({ text: '6.8.5' }),
 		};
 
 		await handler.bootWordPress(playground as any, {} as any);
@@ -482,6 +571,7 @@ describe('BlueprintsV2Handler', () => {
 		);
 		const playground = {
 			bootWordPress: vi.fn().mockResolvedValue(undefined),
+			run: vi.fn().mockResolvedValue({ text: '6.8.5' }),
 		};
 
 		await handler.bootWordPress(playground as any, {} as any);

--- a/packages/playground/client/src/blueprints-v2-handler.spec.ts
+++ b/packages/playground/client/src/blueprints-v2-handler.spec.ts
@@ -147,6 +147,62 @@ describe('BlueprintsV2Handler', () => {
 
 		expect(progressTracker.pipe).not.toHaveBeenCalled();
 	});
+
+	it('passes mounted-site constraints to the worker preflight', async () => {
+		const iframe = createIframe();
+		const blueprint = {
+			version: 2,
+			wordpressVersion: {
+				min: '6.8',
+			},
+			siteOptions: {
+				blogname: 'Existing site',
+			},
+		} as const;
+		const handler = new BlueprintsV2Handler({
+			iframe,
+			remoteUrl: 'http://example.com/remote.html',
+			blueprint,
+			wordpressInstallMode: 'install-from-existing-files-if-needed',
+		});
+
+		await handler.bootPlayground(iframe, createProgressTracker());
+
+		expect(mocks.playground.boot).toHaveBeenCalledWith(
+			expect.objectContaining({
+				blueprint: {
+					version: 2,
+					wordpressVersion: blueprint.wordpressVersion,
+				},
+			})
+		);
+		expect(mocks.compileBlueprintForExecution).toHaveBeenCalledWith(
+			blueprint,
+			expect.objectContaining({
+				siteMode: 'apply-to-existing-site',
+			})
+		);
+	});
+
+	it('does not validate WordPress downloaded for a new site', async () => {
+		const iframe = createIframe();
+		const handler = new BlueprintsV2Handler({
+			iframe,
+			remoteUrl: 'http://example.com/remote.html',
+			blueprint: { version: 2 },
+			wordpressInstallMode: 'download-and-install',
+		});
+
+		await handler.bootPlayground(iframe, createProgressTracker());
+
+		expect(mocks.playground.boot).toHaveBeenCalledWith(
+			expect.objectContaining({ blueprint: undefined })
+		);
+		expect(mocks.compileBlueprintForExecution).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.objectContaining({ siteMode: 'create-new-site' })
+		);
+	});
 });
 
 function createIframe() {

--- a/packages/playground/client/src/blueprints-v2-handler.ts
+++ b/packages/playground/client/src/blueprints-v2-handler.ts
@@ -60,22 +60,28 @@ export class BlueprintsV2Handler {
 		// Connect the Comlink API client to the remote worker download monitor
 		await playground.onDownloadProgress(downloadProgress.loadingListener);
 
+		const resolvedWordPressInstallMode = resolveWordPressInstallMode({
+			shouldInstallWordPress,
+			wordpressInstallMode,
+		});
+		const appliesToExistingWordPress =
+			resolvedWordPressInstallMode === 'install-from-existing-files' ||
+			resolvedWordPressInstallMode ===
+				'install-from-existing-files-if-needed';
 		const compiled = await compileBlueprintForExecution(blueprint, {
 			progress: executionProgress,
 			onStepCompleted: onBlueprintStepCompleted,
 			onBlueprintValidated,
 			corsProxy,
 			gitAdditionalHeadersCallback,
+			siteMode: appliesToExistingWordPress
+				? 'apply-to-existing-site'
+				: 'create-new-site',
 		});
 		const runtimeConfiguration =
 			compiled.version === 2
 				? compiled.compiled.runtime
 				: await resolveRuntimeConfiguration(compiled.declaration);
-		const resolvedWordPressInstallMode = resolveWordPressInstallMode({
-			shouldInstallWordPress,
-			wordpressInstallMode,
-		});
-
 		const extensions: PHPWebExtension[] = runtimeConfiguration.intl
 			? ['intl']
 			: [];
@@ -86,6 +92,18 @@ export class BlueprintsV2Handler {
 			sapiName,
 			scope: scope ?? Math.random().toFixed(16),
 			wordpressInstallMode: resolvedWordPressInstallMode,
+			blueprint:
+				compiled.version === 2 &&
+				appliesToExistingWordPress &&
+				typeof compiled.declaration.wordpressVersion === 'object' &&
+				compiled.declaration.wordpressVersion !== null &&
+				'min' in compiled.declaration.wordpressVersion
+					? {
+							version: 2,
+							wordpressVersion:
+								compiled.declaration.wordpressVersion,
+						}
+					: undefined,
 			phpVersion: runtimeConfiguration.phpVersion,
 			wpVersion: runtimeConfiguration.wpVersion,
 			extensions,

--- a/packages/playground/client/src/blueprints-v2-handler.ts
+++ b/packages/playground/client/src/blueprints-v2-handler.ts
@@ -64,7 +64,9 @@ export class BlueprintsV2Handler {
 			shouldInstallWordPress,
 			wordpressInstallMode,
 		});
-		const appliesToExistingWordPress =
+		// The `if-needed` mode may initialize the database, but WordPress core
+		// still comes from the mounted files rather than a fallback download.
+		const usesExistingWordPressFiles =
 			resolvedWordPressInstallMode === 'install-from-existing-files' ||
 			resolvedWordPressInstallMode ===
 				'install-from-existing-files-if-needed';
@@ -74,7 +76,7 @@ export class BlueprintsV2Handler {
 			onBlueprintValidated,
 			corsProxy,
 			gitAdditionalHeadersCallback,
-			siteMode: appliesToExistingWordPress
+			siteMode: usesExistingWordPressFiles
 				? 'apply-to-existing-site'
 				: 'create-new-site',
 		});
@@ -94,7 +96,7 @@ export class BlueprintsV2Handler {
 			wordpressInstallMode: resolvedWordPressInstallMode,
 			blueprint:
 				compiled.version === 2 &&
-				appliesToExistingWordPress &&
+				usesExistingWordPressFiles &&
 				typeof compiled.declaration.wordpressVersion === 'object' &&
 				compiled.declaration.wordpressVersion !== null &&
 				'min' in compiled.declaration.wordpressVersion

--- a/packages/playground/remote/src/lib/playground-worker-endpoint-blueprints-v1.spec.ts
+++ b/packages/playground/remote/src/lib/playground-worker-endpoint-blueprints-v1.spec.ts
@@ -18,6 +18,7 @@ describe('PlaygroundWorkerEndpointBlueprintsV1', () => {
 
 	afterEach(() => {
 		vi.doUnmock('@php-wasm/web');
+		vi.doUnmock('@wp-playground/blueprints');
 		vi.doUnmock('@wp-playground/wordpress');
 		vi.unstubAllGlobals();
 	});
@@ -139,6 +140,122 @@ describe('PlaygroundWorkerEndpointBlueprintsV1', () => {
 		expect(mountOpfsIntoPhp).toHaveBeenCalledWith(php, mount);
 		expect(fetch).not.toHaveBeenCalled();
 	}, 10000);
+
+	it('rejects incompatible mounted WordPress before boot setup continues', async () => {
+		const php = {
+			fileExists: vi.fn(() => true),
+			run: vi.fn(async () => ({ text: ' 6.7.5\n' })),
+		} as unknown as PHP;
+		const bootContinued = vi.fn();
+		const assertCompatibility = vi.fn(async () => {
+			throw new Error('Incompatible WordPress version');
+		});
+		const bootWordPress = vi.fn(async (_requestHandler, options) => {
+			await options.hooks.beforeWordPressFiles(php);
+			bootContinued();
+		});
+		let endpoint:
+			| {
+					boot(options: Record<string, unknown>): Promise<void>;
+			  }
+			| undefined;
+		vi.doMock('@wp-playground/blueprints', () => ({
+			assertBlueprintV2WordPressVersionCompatibility: assertCompatibility,
+		}));
+		vi.doMock('@wp-playground/wordpress', () => ({
+			bootWordPress,
+		}));
+		vi.doMock('@php-wasm/web', () => ({
+			certificateToPEM: vi.fn(),
+			createDirectoryHandleMountHandler: vi.fn(),
+			exposeAPI: vi.fn((api) => {
+				endpoint = api;
+				return [vi.fn(), vi.fn()];
+			}),
+			loadWebRuntime: vi.fn(),
+		}));
+		await import('./playground-worker-endpoint-blueprints-v1');
+		if (!endpoint) {
+			throw new Error('Expected exposeAPI to receive an endpoint');
+		}
+		vi.spyOn(endpoint as any, 'computeSiteUrl').mockReturnValue(
+			'http://playground.test'
+		);
+		vi.spyOn(endpoint as any, 'createRequestHandler').mockResolvedValue({});
+
+		await expect(
+			endpoint.boot({
+				scope: 'test',
+				phpVersion: '8.3',
+				wordpressInstallMode: 'install-from-existing-files',
+				blueprint: {
+					version: 2,
+					wordpressVersion: { min: '6.8' },
+				},
+				withNetworking: false,
+			})
+		).rejects.toThrow('Incompatible WordPress version');
+
+		expect(assertCompatibility).toHaveBeenCalledWith(
+			expect.objectContaining({ version: 2 }),
+			'6.7.5'
+		);
+		expect(bootContinued).not.toHaveBeenCalled();
+	}, 10000);
+
+	it.each([
+		['6.8.0', 'https://wordpress.org/wordpress-6.8.zip'],
+		['7.0-rc1', 'https://wordpress.org/wordpress-7.0-RC1.zip'],
+	])(
+		'downloads concrete WordPress release %s without changing its identity',
+		async (wpVersion, releaseUrl) => {
+			const bootWordPress = vi.fn();
+			let endpoint:
+				| {
+						boot(options: Record<string, unknown>): Promise<void>;
+				  }
+				| undefined;
+			vi.doMock('@wp-playground/wordpress', () => ({
+				bootWordPress,
+			}));
+			vi.doMock('@php-wasm/web', () => ({
+				certificateToPEM: vi.fn(),
+				createDirectoryHandleMountHandler: vi.fn(),
+				exposeAPI: vi.fn((api) => {
+					endpoint = api;
+					return [vi.fn(), vi.fn()];
+				}),
+				loadWebRuntime: vi.fn(),
+			}));
+			await import('./playground-worker-endpoint-blueprints-v1');
+			if (!endpoint) {
+				throw new Error('Expected exposeAPI to receive an endpoint');
+			}
+			vi.spyOn(endpoint as any, 'computeSiteUrl').mockReturnValue(
+				'http://playground.test'
+			);
+			vi.spyOn(endpoint as any, 'createRequestHandler').mockResolvedValue(
+				{}
+			);
+			vi.spyOn(endpoint as any, 'finalizeAfterBoot').mockResolvedValue(
+				undefined
+			);
+
+			await endpoint.boot({
+				scope: 'test',
+				phpVersion: '8.3',
+				wpVersion,
+				wordpressInstallMode: 'download-and-install',
+				corsProxyUrl: 'https://proxy.test/?url=',
+				withNetworking: false,
+			});
+
+			expect(fetch).toHaveBeenCalledWith(
+				`https://proxy.test/?url=${releaseUrl}`
+			);
+		},
+		10000
+	);
 
 	it('throws a diagnostic error if the worker entrypoint is evaluated twice in the same worker global', async () => {
 		vi.doMock('@php-wasm/web', () => ({

--- a/packages/playground/remote/src/lib/playground-worker-endpoint-blueprints-v1.ts
+++ b/packages/playground/remote/src/lib/playground-worker-endpoint-blueprints-v1.ts
@@ -15,6 +15,10 @@ import {
 import { isLegacyPHPVersion } from '@php-wasm/universal';
 import { bootWordPress } from '@wp-playground/wordpress';
 import type { PHP } from '@php-wasm/universal';
+import {
+	assertBlueprintV2WordPressVersionCompatibility,
+	type BlueprintV2Declaration,
+} from '@wp-playground/blueprints';
 /* @ts-ignore */
 import { corsProxyUrl as defaultCorsProxyUrl } from 'virtual:cors-proxy-url';
 
@@ -42,6 +46,7 @@ class PlaygroundWorkerEndpointBlueprintsV1 extends PlaygroundWorkerEndpoint {
 		withNetworking = true,
 		shouldInstallWordPress,
 		wordpressInstallMode,
+		blueprint,
 		corsProxyUrl,
 		pathAliases,
 	}: WorkerBootOptions) {
@@ -123,12 +128,14 @@ class PlaygroundWorkerEndpointBlueprintsV1 extends PlaygroundWorkerEndpoint {
 						});
 				} else if (
 					!isMinifiedVersion &&
-					/^\d+\.\d+(\.\d+)?$/.test(this.requestedWordPressVersion!)
+					/^\d+\.\d+(?:\.\d+)?(?:-(?:beta|rc)\d+)?$/i.test(
+						this.requestedWordPressVersion!
+					)
 				) {
-					// Non-minified dotted version like "4.9" or "1.5":
-					// download directly from wordpress.org. Sentinel
-					// values like "latest" fall through to the minified-
-					// bundle branch below and resolve to
+					// Non-minified release like "4.9", "6.8.0", or
+					// "7.0-RC1": download directly from wordpress.org.
+					// Sentinel values like "latest" fall through to the
+					// minified-bundle branch below and resolve to
 					// LatestMinifiedWordPressVersion.
 					const normalizedVersion = normalizeWordPressVersion(
 						this.requestedWordPressVersion!
@@ -239,6 +246,26 @@ class PlaygroundWorkerEndpointBlueprintsV1 extends PlaygroundWorkerEndpoint {
 						for (const mount of mounts) {
 							await endpoint.mountOpfsIntoPhp(php, mount);
 						}
+						if (
+							(blueprint as { version?: unknown } | undefined)
+								?.version === 2 &&
+							(resolvedWordPressInstallMode ===
+								'install-from-existing-files' ||
+								resolvedWordPressInstallMode ===
+									'install-from-existing-files-if-needed') &&
+							php.fileExists('/wordpress/wp-includes/version.php')
+						) {
+							const installedVersion = await php.run({
+								code: `<?php
+									require '/wordpress/wp-includes/version.php';
+									echo $wp_version;
+								`,
+							});
+							await assertBlueprintV2WordPressVersionCompatibility(
+								blueprint as BlueprintV2Declaration,
+								installedVersion.text.trim()
+							);
+						}
 					},
 				},
 			});
@@ -285,9 +312,10 @@ const [setApiReady, setAPIError] = exposeAPI(
 
 /**
  * Normalizes WordPress version strings for wordpress.org downloads.
- * Versions >= 2.0 work as `<major>.<minor>` (wordpress.org redirects
- * to the latest patch). Versions < 2.0 need explicit patch versions
- * because wordpress.org doesn't host `wordpress-1.x.zip` files.
+ *
+ * Exact initial releases use `<major>.<minor>.0` internally but wordpress.org
+ * names their archives `<major>.<minor>`. RC archive names also use uppercase
+ * `RC`. Versions before 2.0 retain their historical archive aliases.
  */
 function normalizeWordPressVersion(version: string): string {
 	const legacyVersionMap: Record<string, string> = {
@@ -297,7 +325,10 @@ function normalizeWordPressVersion(version: string): string {
 		'1.2': '1.2.2',
 		'1.5': '1.5.2',
 	};
-	return legacyVersionMap[version] ?? version;
+	const normalizedVersion = version
+		.replace(/^(\d+\.\d+)\.0$/, '$1')
+		.replace(/-rc(\d+)$/i, '-RC$1');
+	return legacyVersionMap[normalizedVersion] ?? normalizedVersion;
 }
 
 function maybeProxyUrl(url: string, corsProxyUrl?: string) {

--- a/packages/playground/remote/src/lib/playground-worker-endpoint.ts
+++ b/packages/playground/remote/src/lib/playground-worker-endpoint.ts
@@ -83,7 +83,7 @@ export type WorkerBootOptions = {
 	corsProxyUrl?: string;
 	/** When true, skip default WP install and run Blueprints v2 in the worker */
 	experimentalBlueprintsV2Runner?: boolean;
-	/** Blueprint v2 declaration to run in the worker when experimental mode is on */
+	/** Blueprint v2 declaration used for worker-side execution or preflight checks. */
 	blueprint?: BlueprintDeclaration;
 	/**
 	 * How to handle WordPress installation.

--- a/packages/playground/wordpress/src/index.ts
+++ b/packages/playground/wordpress/src/index.ts
@@ -27,6 +27,7 @@ export type {
 } from './boot';
 export { defineWpConfigConstants, ensureWpConfig } from './wp-config';
 export { getLoadedWordPressVersion } from './version-detect';
+export { getWordPressStableVersions } from './wordpress-releases';
 
 export * from './version-detect';
 export * from './rewrite-rules';

--- a/packages/playground/wordpress/src/test/wordpress-releases.spec.ts
+++ b/packages/playground/wordpress/src/test/wordpress-releases.spec.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+	fetch: vi.fn(),
+}));
+
+vi.mock('@wp-playground/common', async (importOriginal) => ({
+	...(await importOriginal()),
+	createMemoizedFetch: () => mocks.fetch,
+}));
+
+const { getWordPressStableVersions } = await import('../wordpress-releases');
+
+describe('getWordPressStableVersions', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('returns every version key from the official catalog', async () => {
+		mocks.fetch.mockResolvedValue({
+			ok: true,
+			json: async () => ({
+				'6.7.5': 'outdated',
+				'6.8.5': 'outdated',
+				'6.9': 'latest',
+			}),
+		});
+
+		await expect(getWordPressStableVersions()).resolves.toEqual([
+			'6.7.5',
+			'6.8.5',
+			'6.9',
+		]);
+		expect(mocks.fetch).toHaveBeenCalledWith(
+			'https://api.wordpress.org/core/stable-check/1.0/'
+		);
+	});
+
+	it('rejects failed catalog requests', async () => {
+		mocks.fetch.mockResolvedValue({
+			ok: false,
+			status: 503,
+			statusText: 'Service Unavailable',
+		});
+
+		await expect(getWordPressStableVersions()).rejects.toThrow(
+			'Could not load the WordPress release catalog: 503 Service Unavailable'
+		);
+	});
+
+	it('rejects malformed catalog responses', async () => {
+		mocks.fetch.mockResolvedValue({
+			ok: true,
+			json: async () => [],
+		});
+
+		await expect(getWordPressStableVersions()).rejects.toThrow(
+			'The WordPress release catalog returned invalid data.'
+		);
+	});
+});

--- a/packages/playground/wordpress/src/wordpress-releases.ts
+++ b/packages/playground/wordpress/src/wordpress-releases.ts
@@ -1,0 +1,30 @@
+import { createMemoizedFetch } from '@wp-playground/common';
+
+const WORDPRESS_STABLE_CHECK_URL =
+	'https://api.wordpress.org/core/stable-check/1.0/';
+const fetchStableWordPressVersions = createMemoizedFetch(fetch);
+
+/**
+ * Returns every stable WordPress release listed by the official release API.
+ *
+ * The API response is memoized because Blueprint constraint resolution and
+ * runtime boot may inspect the catalog more than once during one page load.
+ */
+export async function getWordPressStableVersions(): Promise<string[]> {
+	const response = await fetchStableWordPressVersions(
+		WORDPRESS_STABLE_CHECK_URL
+	);
+	if (!response.ok) {
+		throw new Error(
+			`Could not load the WordPress release catalog: ` +
+				`${response.status} ${response.statusText}`.trim()
+		);
+	}
+
+	const releases = await response.json();
+	if (!releases || typeof releases !== 'object' || Array.isArray(releases)) {
+		throw new Error('The WordPress release catalog returned invalid data.');
+	}
+
+	return Object.keys(releases);
+}

--- a/packages/playground/wordpress/src/wordpress-releases.ts
+++ b/packages/playground/wordpress/src/wordpress-releases.ts
@@ -2,15 +2,18 @@ import { createMemoizedFetch } from '@wp-playground/common';
 
 const WORDPRESS_STABLE_CHECK_URL =
 	'https://api.wordpress.org/core/stable-check/1.0/';
-const fetchStableWordPressVersions = createMemoizedFetch(fetch);
+let fetchStableWordPressVersions:
+	| ReturnType<typeof createMemoizedFetch>
+	| undefined;
 
 /**
  * Returns every stable WordPress release listed by the official release API.
  *
- * The API response is memoized because Blueprint constraint resolution and
- * runtime boot may inspect the catalog more than once during one page load.
+ * The request is created lazily and memoized because Blueprint constraint
+ * resolution may inspect the catalog more than once during one page load.
  */
 export async function getWordPressStableVersions(): Promise<string[]> {
+	fetchStableWordPressVersions ??= createMemoizedFetch(globalThis.fetch);
 	const response = await fetchStableWordPressVersions(
 		WORDPRESS_STABLE_CHECK_URL
 	);


### PR DESCRIPTION
## What it does

Stops using `wordpressVersion.max` as if it named a WordPress archive.

For a Blueprint v2 constraint, Playground now selects the newest published WordPress release inside the declared bounds. A concrete `preferred` release must exist and satisfy those bounds. PHP `recommended` versions are checked against their own `min` and `max` instead of bypassing them.

Mounted sites are checked before boot setup changes files or database state. An installed WordPress version outside `min`/`max` fails immediately in both the browser and CLI.

## Rationale

A bound is not a release. Given `min: "6.8.2"` and `max: "6.8.4"`, version `6.8.4` may not exist. The old resolver requested it anyway and left the download path to fail on a missing archive.

Apply-to-existing-site mode had the opposite problem: it ignored the constraint and booted whatever was mounted.

## Implementation

New-site resolution reads the official stable-release catalog and sorts it by WordPress version precedence. Initial `x.y` catalog entries become explicit `x.y.0` requests because the runtime otherwise interprets `x.y` as the latest patch in that branch. Constraints mentioning beta or RC releases also consider the current prerelease offer.

The catalog request is lazy, runs only for new-site object constraints, and is memoized for the lifetime of the page or CLI process. Existing-file modes do not download WordPress core, so they skip the catalog and validate the mounted `$wp_version` instead.

Only `min` and `max` restrict an existing site. Shorthand versions and `preferred` remain new-site selection hints.

## Testing instructions

```bash
npm exec -- nx run-many -t typecheck -p playground-blueprints playground-client playground-cli playground-remote
npm exec -- nx run-many -t lint -p playground-wordpress playground-blueprints playground-client playground-cli playground-remote
npm exec -- nx test playground-wordpress
npm exec -- nx test playground-blueprints
npm exec -- nx test playground-client
npm exec -- nx test playground-remote --testFile=playground-worker-endpoint-blueprints-v1.spec.ts
npm exec -- nx run playground-cli:test-playground-cli --testFile=blueprints-v2-handler.spec.ts
npm exec -- nx run-many -t build -p playground-wordpress playground-blueprints playground-client playground-remote playground-cli
```
