### PR TITLE
[CLI] Accept Blueprint v2 modes without an experimental flag

### DIFF
--- a/packages/playground/cli/README.md
+++ b/packages/playground/cli/README.md
@@ -164,6 +164,7 @@ The `server` command supports these common optional arguments. Run `npx @wp-play
 - `--blueprint=<path>`: The path to a JSON Blueprint file to execute.
 - `--blueprint-may-read-adjacent-files`: Consent flag: Allow "bundled" resources in a local blueprint to read files in the same directory as the blueprint file.
 - `--login`: Automatically log the user in as an administrator.
+- `--mode=<mode>`: Choose how Blueprint v2 prepares the site: `create-new-site`, `apply-to-existing-site`, or `mount-only`. Cannot be combined with `--auto-mount`, `--wordpress-install-mode`, or `--skip-sqlite-setup`.
 - `--wordpress-install-mode <mode>`: Control how Playground prepares WordPress before booting. Defaults to `download-and-install`. Other options: `install-from-existing-files` (install using files you've mounted), `install-from-existing-files-if-needed` (same, but skip setup when an existing site is detected), and `do-not-attempt-installing` (never download or install WordPress).
 - `--skip-sqlite-setup`: Do not set up the SQLite database integration.
 - `--verbosity`: Output logs and progress messages (choices: "quiet", "normal", "debug"). Defaults to "normal".

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -328,23 +328,22 @@ export async function parseOptionsAndRunCLI(argsToParse: string[]) {
 					value === '' ? ['vscode', 'phpstorm'] : [value],
 			},
 			'experimental-blueprints-v2-runner': {
-				describe: 'Use the experimental Blueprint V2 runner.',
+				describe:
+					'Compatibility alias for selecting the Blueprint v2 handler.',
 				type: 'boolean',
 				default: false,
-				// Remove the "hidden" flag once Blueprint V2 is fully supported
+				// Keep the old opt-in available without advertising it to new callers.
 				hidden: true,
 			},
 			mode: {
 				describe:
-					'Blueprints v2 runner mode to use. This option is required when using the --experimental-blueprints-v2-runner flag with a blueprint.',
+					'Choose whether Blueprint v2 creates a site, applies to an existing site, or only mounts files.',
 				type: 'string',
 				choices: [
 					'create-new-site',
 					'apply-to-existing-site',
 					'mount-only',
 				],
-				// Remove the "hidden" flag once Blueprint V2 is fully supported
-				hidden: true,
 			},
 			phpmyadmin: {
 				describe:
@@ -636,49 +635,11 @@ export async function parseOptionsAndRunCLI(argsToParse: string[]) {
 				);
 
 				if (args['experimental-blueprints-v2-runner'] === true) {
-					if (args['mode'] !== undefined) {
-						if (args['wordpress-install-mode'] !== undefined) {
-							throw new Error(
-								'The --wordpress-install-mode option cannot be used with the --mode option. Use one or the other.'
-							);
-						}
-						if (
-							argsToParse.some(
-								(arg) =>
-									arg === '--skip-sqlite-setup' ||
-									arg.startsWith('--skip-sqlite-setup=')
-							)
-						) {
-							throw new Error(
-								'The --skipSqliteSetup option is not supported in Blueprint V2 mode.'
-							);
-						}
-						// `--mode` is an explicit v2 execution-mode choice,
-						// while `--auto-mount` infers the mode from the
-						// detected project type. Check the raw argv here
-						// because parsed `auto-mount` values include parser
-						// defaults and do not reliably tell us whether the
-						// user passed the option explicitly.
-						if (
-							argsToParse.some(
-								(arg) =>
-									arg === '--auto-mount' ||
-									arg.startsWith('--auto-mount=') ||
-									arg === '--no-auto-mount' ||
-									arg.startsWith('--no-auto-mount=')
-							)
-						) {
-							throw new Error(
-								'The --mode option cannot be used with --auto-mount because --auto-mount automatically sets the mode.'
-							);
-						}
-					} else {
-						// Support the legacy v1 runner option while the native
-						// v2 CLI path remains experimental. The old v2 runner
-						// only had two modes and used `apply-to-existing-site`
-						// for this case; the native v2 path has `mount-only`,
-						// which maps directly to the same "do not install
-						// WordPress" worker behavior.
+					if (args['mode'] === undefined) {
+						// Translate the v1-style install option for callers still
+						// using the legacy v2 handler flag. The old option family
+						// had two modes; `mount-only` maps directly to its "do not
+						// install WordPress" worker behavior.
 						if (
 							args['wordpress-install-mode'] ===
 							'do-not-attempt-installing'
@@ -689,8 +650,8 @@ export async function parseOptionsAndRunCLI(argsToParse: string[]) {
 						}
 					}
 
-					// Support the legacy v1 runner options while the native
-					// v2 CLI path remains experimental.
+					// Translate v1-style capability flags for the compatibility
+					// alias.
 					const allow = (args['allow'] as string[]) || [];
 
 					if (args['followSymlinks'] === true) {
@@ -702,10 +663,6 @@ export async function parseOptionsAndRunCLI(argsToParse: string[]) {
 					}
 
 					args['allow'] = allow;
-				} else if (hasExplicitBlueprintsV2Mode) {
-					throw new Error(
-						'The --mode option requires the --experimentalBlueprintsV2Runner flag.'
-					);
 				}
 
 				args['hasExplicitBlueprintsV2Mode'] =
@@ -1469,11 +1426,10 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer | void> {
 			}
 
 			let handler: BlueprintsV1Handler | BlueprintsV2Handler;
-			const useBlueprintsV2Handler =
-				await shouldUseBlueprintsV2Handler(
-					args,
-					hasExplicitBlueprintsV2Mode
-				);
+			const useBlueprintsV2Handler = await shouldUseBlueprintsV2Handler(
+				args,
+				hasExplicitBlueprintsV2Mode
+			);
 			if (useBlueprintsV2Handler) {
 				validateAndNormalizeBlueprintsV2Args(
 					args,
@@ -1832,10 +1788,8 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer | void> {
  * Selects the native Blueprint v2 CLI path.
  *
  * The default CLI path remains the v1 handler. We switch to v2 only when the
- * caller opts in with `--experimental-blueprints-v2-runner`, passes a resolved
- * Blueprint v2 declaration, or calls `runCLI()` directly with a v2 `mode`.
- * The yargs parser still rejects public `--mode` usage without the experimental
- * flag while the option remains hidden.
+ * caller passes `--mode`, uses the legacy compatibility flag, or provides a
+ * resolved Blueprint v2 declaration.
  *
  * `hasExplicitBlueprintsV2Mode` must be captured before `start` or auto-mount
  * expansion because full WordPress auto-mounts still set

--- a/packages/playground/cli/tests/run-cli.spec.ts
+++ b/packages/playground/cli/tests/run-cli.spec.ts
@@ -256,7 +256,7 @@ describe.each(blueprintVersions)(
 			).resolves.toBe(true);
 		});
 
-		test('should accept --mode with the experimental v2 flag when legacy options are omitted', async () => {
+		test('should accept --mode with auto-mount disabled and no experimental flag', async () => {
 			const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((
 				code?: number | string | null
 			) => {
@@ -268,8 +268,8 @@ describe.each(blueprintVersions)(
 			try {
 				await using cliResult = await parseOptionsAndRunCLI([
 					'server',
-					'--experimental-blueprints-v2-runner',
 					'--mode=mount-only',
+					'--no-auto-mount',
 					'--verbosity=quiet',
 					'--port=0',
 					'--workers=1',
@@ -286,7 +286,37 @@ describe.each(blueprintVersions)(
 			}
 		});
 
-		test('should accept URL WordPress sources with the experimental v2 flag', async () => {
+		test('should keep the experimental v2 flag as a compatibility alias', async () => {
+			const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((
+				code?: number | string | null
+			) => {
+				throw new Error(
+					`process.exit unexpectedly called with "${code}"`
+				);
+			}) as any);
+
+			try {
+				await using cliResult = await parseOptionsAndRunCLI([
+					'server',
+					'--experimental-blueprints-v2-runner',
+					'--wordpress-install-mode=do-not-attempt-installing',
+					'--verbosity=quiet',
+					'--port=0',
+					'--workers=1',
+				]);
+				const cliServer = cliResult[internalsKeyForTesting].cliServer;
+
+				expect(
+					await cliServer.playground.fileExists(
+						'/wordpress/wp-load.php'
+					)
+				).toBe(false);
+			} finally {
+				exitSpy.mockRestore();
+			}
+		});
+
+		test('should accept URL WordPress sources with --mode', async () => {
 			const fetchMock = vi.fn(async () => {
 				throw new Error('Unexpected WordPress ZIP fetch');
 			});
@@ -302,7 +332,6 @@ describe.each(blueprintVersions)(
 			try {
 				await using cliResult = await parseOptionsAndRunCLI([
 					'server',
-					'--experimental-blueprints-v2-runner',
 					'--mode=mount-only',
 					'--wp=https://example.com/wordpress.zip',
 					'--verbosity=quiet',
@@ -324,10 +353,13 @@ describe.each(blueprintVersions)(
 			}
 		});
 
-		test('should reject --mode without the experimental v2 flag', async () => {
+		test('should reject --mode with --wordpress-install-mode', async () => {
 			const consoleErrorSpy = vi
 				.spyOn(console, 'error')
 				.mockImplementation(() => {});
+			const stdoutSpy = vi
+				.spyOn(process.stdout, 'write')
+				.mockImplementation(() => true);
 			const exitSpy = vi
 				.spyOn(process, 'exit')
 				.mockImplementation((code?: number | string | null) => {
@@ -344,22 +376,26 @@ describe.each(blueprintVersions)(
 						'--port=0',
 					])
 				).rejects.toThrow('process.exit(1)');
-				expect(consoleErrorSpy).toHaveBeenCalledWith(
+				expect(stdoutSpy).toHaveBeenCalledWith(
 					expect.stringContaining(
-						'The --mode option requires the --experimentalBlueprintsV2Runner flag.'
+						'The --wordpress-install-mode option cannot be used with the --mode option.'
 					)
 				);
 				expect(exitSpy).toHaveBeenCalledWith(1);
 			} finally {
 				consoleErrorSpy.mockRestore();
+				stdoutSpy.mockRestore();
 				exitSpy.mockRestore();
 			}
 		});
 
-		test('should reject --mode with SQLite setup disabled in experimental v2 mode', async () => {
+		test('should reject --mode with SQLite setup disabled', async () => {
 			const consoleErrorSpy = vi
 				.spyOn(console, 'error')
 				.mockImplementation(() => {});
+			const stdoutSpy = vi
+				.spyOn(process.stdout, 'write')
+				.mockImplementation(() => true);
 			const exitSpy = vi
 				.spyOn(process, 'exit')
 				.mockImplementation((code?: number | string | null) => {
@@ -370,14 +406,13 @@ describe.each(blueprintVersions)(
 				await expect(
 					parseOptionsAndRunCLI([
 						'server',
-						'--experimental-blueprints-v2-runner',
 						'--mode=mount-only',
 						'--skip-sqlite-setup',
 						'--verbosity=quiet',
 						'--port=0',
 					])
 				).rejects.toThrow('process.exit(1)');
-				expect(consoleErrorSpy).toHaveBeenCalledWith(
+				expect(stdoutSpy).toHaveBeenCalledWith(
 					expect.stringContaining(
 						'The --skipSqliteSetup option is not supported in Blueprint V2 mode.'
 					)
@@ -385,14 +420,18 @@ describe.each(blueprintVersions)(
 				expect(exitSpy).toHaveBeenCalledWith(1);
 			} finally {
 				consoleErrorSpy.mockRestore();
+				stdoutSpy.mockRestore();
 				exitSpy.mockRestore();
 			}
 		});
 
-		test('should reject --mode with auto-mount in experimental v2 mode', async () => {
+		test('should reject --mode with auto-mount', async () => {
 			const consoleErrorSpy = vi
 				.spyOn(console, 'error')
 				.mockImplementation(() => {});
+			const stdoutSpy = vi
+				.spyOn(process.stdout, 'write')
+				.mockImplementation(() => true);
 			const exitSpy = vi
 				.spyOn(process, 'exit')
 				.mockImplementation((code?: number | string | null) => {
@@ -403,14 +442,13 @@ describe.each(blueprintVersions)(
 				await expect(
 					parseOptionsAndRunCLI([
 						'server',
-						'--experimental-blueprints-v2-runner',
 						'--mode=mount-only',
 						'--auto-mount=.',
 						'--verbosity=quiet',
 						'--port=0',
 					])
 				).rejects.toThrow('process.exit(1)');
-				expect(consoleErrorSpy).toHaveBeenCalledWith(
+				expect(stdoutSpy).toHaveBeenCalledWith(
 					expect.stringContaining(
 						'The --mode option cannot be used with --auto-mount because --auto-mount automatically sets the mode.'
 					)
@@ -418,6 +456,7 @@ describe.each(blueprintVersions)(
 				expect(exitSpy).toHaveBeenCalledWith(1);
 			} finally {
 				consoleErrorSpy.mockRestore();
+				stdoutSpy.mockRestore();
 				exitSpy.mockRestore();
 			}
 		});
@@ -1083,7 +1122,6 @@ describe('native Blueprint v2 modes', () => {
 				await using cliServer = await runCLI({
 					command: 'server',
 					workers: 1,
-					'experimental-blueprints-v2-runner': true,
 					mode: 'create-new-site',
 					'mount-before-install': [
 						{
@@ -1116,7 +1154,6 @@ describe('native Blueprint v2 modes', () => {
 				await using cliServer = await runCLI({
 					command: 'server',
 					workers: 1,
-					'experimental-blueprints-v2-runner': true,
 					mode: 'create-new-site',
 					'mount-before-install': [
 						{
@@ -1138,7 +1175,6 @@ describe('native Blueprint v2 modes', () => {
 				await using existingSiteServer = await runCLI({
 					command: 'server',
 					workers: 1,
-					'experimental-blueprints-v2-runner': true,
 					mode: 'apply-to-existing-site',
 					'mount-before-install': [
 						{


### PR DESCRIPTION
## What it does

Makes `--mode=create-new-site`, `--mode=apply-to-existing-site`, and `--mode=mount-only` normal CLI options. An explicit mode now selects the Blueprint v2 handler without `--experimental-blueprints-v2-runner`.

The old hidden flag remains as a compatibility alias. `start` is unchanged: it continues to infer site setup from the project and does not accept `--mode`.

## Rationale

The CLI already routes declarations with `version: 2` through the v2 handler. Explicit mode selection was the remaining experimental gate: `--mode` was hidden, and the parser rejected it unless the experimental flag was also present.

That made the apply-to-existing and mount-only paths unavailable through the supported CLI interface.

## Implementation

Explicit `--mode` still conflicts with `--auto-mount`, `--wordpress-install-mode`, and `--skip-sqlite-setup`. `--no-auto-mount` is allowed because it disables inference instead of competing with the selected mode.

The hidden compatibility flag still translates its old install and capability options for existing callers.

## Testing instructions

```bash
npm exec -- nx run playground-cli:typecheck
npm exec -- nx run playground-cli:lint
npm exec -- nx run playground-cli:test-playground-cli --testFile=run-cli.spec.ts
npm exec -- nx run playground-cli:unbuilt-asyncify -- server --help
```
