### PR TITLE
[PHP-WASM] Expose sendmail stdin as a live event stream

### DIFF
--- a/packages/php-wasm/node/project.json
+++ b/packages/php-wasm/node/project.json
@@ -170,6 +170,7 @@
 					"php-imagick.spec.ts",
 					"php-soap.spec.ts",
 					"php-image-extensions.spec.ts",
+					"php-email-capture.spec.ts",
 					"php-fsockopen.spec.ts",
 					"php-socket-timeouts.spec.ts"
 				]
@@ -185,6 +186,7 @@
 					"php-imagick.spec.ts",
 					"php-soap.spec.ts",
 					"php-image-extensions.spec.ts",
+					"php-email-capture.spec.ts",
 					"php-fsockopen.spec.ts",
 					"php-socket-timeouts.spec.ts"
 				]

--- a/packages/php-wasm/node/src/test/php-email-capture.spec.ts
+++ b/packages/php-wasm/node/src/test/php-email-capture.spec.ts
@@ -1,0 +1,194 @@
+import {
+	PHP,
+	setPhpIniEntries,
+	SupportedPHPVersions,
+} from '@php-wasm/universal';
+import {
+	SENDMAIL_CAPTURE_MAX_SIZE,
+	sendmailSpawnHandler,
+} from '@php-wasm/util';
+import type { PHPSendmailSpawnedEvent } from '@php-wasm/util';
+import { loadNodeRuntime } from '../lib';
+
+const phpVersions =
+	'PHP' in process.env ? [process.env['PHP']!] : SupportedPHPVersions;
+
+describe.each(phpVersions)('PHP %s - sendmail capture', (phpVersion) => {
+	let php: PHP;
+	let events: PHPSendmailSpawnedEvent[];
+
+	beforeEach(async () => {
+		events = [];
+		php = new PHP(await loadNodeRuntime(phpVersion as any));
+		php.setCommandSpawnHandler('sendmail', sendmailSpawnHandler(php));
+		php.addEventListener('sendmail.spawned', (event) => {
+			events.push(event as PHPSendmailSpawnedEvent);
+		});
+		await setPhpIniEntries(php, {
+			disable_functions: '',
+		});
+	}, 30_000);
+
+	afterEach(() => {
+		php?.exit();
+	});
+
+	it('captures message sent to sendmail stdin via proc_open()', async () => {
+		const result = await php.run({
+			code: `<?php
+				error_reporting(E_ALL);
+				$email = "From: sender@test.com\\r\\n"
+					. "To: recipient@test.com\\r\\n"
+					. "Subject: Raw proc_open\\r\\n"
+					. "\\r\\n"
+					. "Raw proc_open body.";
+				$proc = proc_open(
+					'/usr/sbin/sendmail -t -i -fsender@test.com',
+					[['pipe', 'r'], ['pipe', 'w'], ['pipe', 'w']],
+					$pipes
+				);
+				if (!is_resource($proc)) {
+					echo 'PROC_OPEN_FAILED';
+					exit;
+				}
+				fwrite($pipes[0], $email);
+				fclose($pipes[0]);
+				$exit = proc_close($proc);
+				echo $exit === 0 ? 'SENT' : 'EXIT_' . $exit;
+		`,
+		});
+
+		expect(result.text).toBe('SENT');
+		expect(events).toHaveLength(1);
+		const message = await decodeStream(events[0].stdin);
+		expect(message).toContain('Subject: Raw proc_open');
+		expect(message).toContain('Raw proc_open body.');
+	});
+
+	it('waits for delayed sendmail stdin bytes', async () => {
+		const result = await php.run({
+			code: `<?php
+				error_reporting(E_ALL);
+				$proc = proc_open(
+					'/usr/sbin/sendmail -t',
+					[['pipe', 'r'], ['pipe', 'w'], ['pipe', 'w']],
+					$pipes
+				);
+				if (!is_resource($proc)) {
+					echo 'PROC_OPEN_FAILED';
+					exit;
+				}
+				usleep(500000);
+				fwrite($pipes[0], "Subject: Delayed proc_open\r\n\r\nDelayed body.");
+				fclose($pipes[0]);
+				$exit = proc_close($proc);
+				echo $exit === 0 ? 'SENT' : 'EXIT_' . $exit;
+		`,
+		});
+
+		expect(result.text).toBe('SENT');
+		expect(events).toHaveLength(1);
+		const message = await decodeStream(events[0].stdin);
+		expect(message).toContain('Subject: Delayed proc_open');
+		expect(message).toContain('Delayed body.');
+	});
+
+	it('exits 75 when sendmail receives no stdin bytes', async () => {
+		const result = await php.run({
+			code: `<?php
+				error_reporting(E_ALL);
+				$proc = proc_open(
+					'/usr/sbin/sendmail -t',
+					[['pipe', 'r'], ['pipe', 'w'], ['pipe', 'w']],
+					$pipes
+				);
+				if (!is_resource($proc)) {
+					echo 'PROC_OPEN_FAILED';
+					exit;
+				}
+				fclose($pipes[0]);
+				$stderr = stream_get_contents($pipes[2]);
+				$exit = proc_close($proc);
+				echo json_encode(['exit' => $exit, 'stderr' => $stderr]);
+		`,
+		});
+
+		const data = result.json;
+		expect(data).toEqual({
+			exit: 75,
+			stderr: 'sendmail: fatal: No message bytes received over stdin\n',
+		});
+		expect(events).toHaveLength(0);
+	});
+
+	it('rejects messages larger than the fixed capture limit', async () => {
+		const result = await php.run({
+			code: `<?php
+				error_reporting(E_ALL);
+				$proc = proc_open(
+					'/usr/sbin/sendmail -t',
+					[['pipe', 'r'], ['pipe', 'w'], ['pipe', 'w']],
+					$pipes
+				);
+				if (!is_resource($proc)) {
+					echo 'PROC_OPEN_FAILED';
+					exit;
+				}
+				fwrite($pipes[0], str_repeat('a', ${SENDMAIL_CAPTURE_MAX_SIZE + 1}));
+				fclose($pipes[0]);
+				$stderr = stream_get_contents($pipes[2]);
+				$exit = proc_close($proc);
+				echo json_encode(['exit' => $exit, 'stderr' => $stderr]);
+		`,
+		});
+
+		const data = result.json;
+		expect(data).toEqual({
+			exit: 1,
+			stderr: `sendmail: Message size exceeds fixed maximum message size (${SENDMAIL_CAPTURE_MAX_SIZE})\n`,
+		});
+		expect(events).toHaveLength(1);
+		await expect(decodeStream(events[0].stdin)).rejects.toThrow(
+			`sendmail: Message size exceeds fixed maximum message size (${SENDMAIL_CAPTURE_MAX_SIZE})`
+		);
+	}, 30_000);
+
+	it('should capture email after runtime rotation', async () => {
+		await php.hotSwapPHPRuntime(await loadNodeRuntime(phpVersion as any));
+		await setPhpIniEntries(php, {
+			disable_functions: '',
+		});
+
+		const result = await php.run({
+			code: `<?php
+			error_reporting(E_ALL);
+			$result = mail(
+				'recipient@test.com',
+				'Raw subject',
+				'Raw body.',
+				'From: sender@test.com'
+			);
+			echo $result ? 'SENT' : 'FAILED';
+		`,
+		});
+
+		expect(result.text).toBe('SENT');
+		expect(events).toHaveLength(1);
+		const message = await decodeStream(events[0].stdin);
+		expect(message).toContain('Subject: Raw subject');
+		expect(message).toContain('Raw body.');
+	});
+});
+
+async function decodeStream(stream: ReadableStream<Uint8Array>) {
+	const reader = stream.getReader();
+	const decoder = new TextDecoder();
+	let text = '';
+	while (true) {
+		const { value, done } = await reader.read();
+		if (done) {
+			return text;
+		}
+		text += decoder.decode(value, { stream: true });
+	}
+}

--- a/packages/php-wasm/universal/src/lib/index.ts
+++ b/packages/php-wasm/universal/src/lib/index.ts
@@ -75,7 +75,10 @@ export {
 export type { MountHandler, UnmountFunction } from './php';
 export { loadPHPRuntime, popLoadedRuntime } from './load-php-runtime';
 export { phpEventStdinTransfer } from '@php-wasm/util';
-export type { PHPEventWithStdinTransfer } from '@php-wasm/util';
+export type {
+	PHPEventWithStdinTransfer,
+	PHPSendmailSpawnedEvent,
+} from '@php-wasm/util';
 export type { Emscripten } from './emscripten-types';
 export type {
 	DataModule,

--- a/packages/php-wasm/universal/src/lib/universal-php.ts
+++ b/packages/php-wasm/universal/src/lib/universal-php.ts
@@ -1,3 +1,4 @@
+import type { PHPSendmailSpawnedEvent } from '@php-wasm/util';
 import type { Remote } from './comlink-sync';
 import type { Pooled } from './object-pool-proxy';
 import type { LimitedPHPApi } from './php-worker';
@@ -50,7 +51,8 @@ export type PHPEvent =
 	| PHPRequestErrorEvent
 	| PHPRuntimeInitializedEvent
 	| PHPRuntimeBeforeExitEvent
-	| PHPFilesystemWriteEvent;
+	| PHPFilesystemWriteEvent
+	| PHPSendmailSpawnedEvent;
 
 /**
  * A callback function that handles PHP events.

--- a/packages/php-wasm/util/src/lib/index.ts
+++ b/packages/php-wasm/util/src/lib/index.ts
@@ -15,6 +15,11 @@ export {
 export { createSpawnHandler } from './create-spawn-handler';
 export { phpEventStdinTransfer } from './php-event';
 export type { PHPEventWithStdinTransfer } from './php-event';
+export {
+	sendmailSpawnHandler,
+	SENDMAIL_CAPTURE_MAX_SIZE,
+} from './spawn-handlers/sendmail';
+export type { PHPSendmailSpawnedEvent } from './spawn-handlers/sendmail';
 export { randomString } from './random-string';
 export { randomFilename } from './random-filename';
 export { splitShellCommand } from './split-shell-command';

--- a/packages/php-wasm/util/src/lib/spawn-handlers/sendmail.ts
+++ b/packages/php-wasm/util/src/lib/spawn-handlers/sendmail.ts
@@ -1,0 +1,146 @@
+import { createSpawnHandler } from '../create-spawn-handler';
+import {
+	phpEventStdinTransfer,
+	type PHPEventWithStdinTransfer,
+} from '../php-event';
+
+/**
+ * Limit captured sendmail stdin to 20 MB to match common email size limits.
+ *
+ * Gmail limits email attachments to 25 MB https://support.google.com/mail/answer/6584
+ * Outlook limits email attachments to 20 MB https://support.microsoft.com/outlook/reduce-attachment-size-to-send-large-files-with-outlook
+ */
+export const SENDMAIL_CAPTURE_MAX_SIZE = 20 * 1024 * 1024;
+
+/**
+ * Emitted when a sendmail null transport receives the first stdin bytes from
+ * `mail()`, `popen()`, `proc_open()`, or any other spawn of a `sendmail` binary.
+ */
+export interface PHPSendmailSpawnedEvent extends PHPEventWithStdinTransfer {
+	type: 'sendmail.spawned';
+}
+
+/**
+ * Creates a sendmail-compatible null transport for the given PHP instance.
+ * Every message handed to sendmail – via mail(), proc_open(), etc. – is streamed
+ * from stdin, dispatched as a `sendmail.spawned` event, and never delivered.
+ * A listener that wants real delivery must relay the message itself.
+ *
+ * The captured payload is exposed as the raw bytes written to sendmail stdin.
+ *
+ * This stream does not apply backpressure to PHP. Each listener queues unread
+ * chunks in JavaScript memory when it reads more slowly than PHP writes. The
+ * source accepts at most SENDMAIL_CAPTURE_MAX_SIZE bytes. Cancelling the stream
+ * stops delivery through that stream without terminating the sendmail process.
+ */
+export function sendmailSpawnHandler(php: {
+	dispatchEvent: (event: PHPSendmailSpawnedEvent) => void;
+}) {
+	return createSpawnHandler(async function (commandArray, processApi) {
+		let totalLength = 0;
+		let dispatched = false;
+		let exceededMaxSize = false;
+		let streamCancelled = false;
+		let controller: ReadableStreamDefaultController<Uint8Array>;
+		// Construct the stream before registering stdin. Event dispatch is synchronous,
+		// and a listener may start reading as soon as the first chunk arrives.
+		const stdinStream = new ReadableStream<Uint8Array>({
+			start(streamController) {
+				controller = streamController;
+			},
+			cancel() {
+				// Cancellation only means no reader wants more bytes from this source. Keep
+				// the null transport alive so PHP can finish writing and receive an exit code.
+				streamCancelled = true;
+			},
+		});
+
+		processApi.on('stdin', (data: Uint8Array) => {
+			if (!dispatched) {
+				// Do not publish an email until sendmail receives actual message bytes. An
+				// invocation that closes stdin immediately is a failed send, not an empty email.
+				dispatched = true;
+				php.dispatchEvent({
+					type: 'sendmail.spawned',
+					stdin: stdinStream,
+					[phpEventStdinTransfer]: true,
+				});
+			}
+
+			totalLength += data.length;
+			if (totalLength > SENDMAIL_CAPTURE_MAX_SIZE) {
+				// Fail the consumer now, but keep draining stdin. Exiting here would close
+				// PHP's write end before the spawning code has finished with the process.
+				exceededMaxSize = true;
+				try {
+					controller!.error(
+						new Error(
+							`sendmail: Message size exceeds fixed maximum message size (${SENDMAIL_CAPTURE_MAX_SIZE})`
+						)
+					);
+				} catch {
+					// The consumer may have cancelled the stream.
+				}
+				return;
+			}
+			if (!streamCancelled) {
+				// The PHP bridge reuses its input buffer for later chunks. A stream reader
+				// may retain this one indefinitely, so it must receive an owned copy.
+				controller!.enqueue(data.slice());
+			}
+		});
+
+		const stdin = processApi.childProcess
+			.stdin as typeof processApi.childProcess.stdin & {
+			writableEnded?: boolean;
+			writableFinished?: boolean;
+		};
+		// proc_open() may write long after the spawn handler starts. Keep sendmail
+		// alive until descriptor 0 closes or PHP will observe a truncated pipe.
+		if (!(stdin.ended || stdin.writableEnded || stdin.writableFinished)) {
+			await new Promise<void>((resolve) => {
+				// stdin can finish between the outer check and listener registration.
+				// Recheck here or that race leaves the sendmail process waiting forever.
+				if (
+					stdin.ended ||
+					stdin.writableEnded ||
+					stdin.writableFinished
+				) {
+					resolve();
+					return;
+				}
+
+				const finish = () => {
+					resolve();
+				};
+
+				stdin.once('finish', finish);
+			});
+		}
+
+		if (exceededMaxSize) {
+			processApi.stderr(
+				`sendmail: Message size exceeds fixed maximum message size (${SENDMAIL_CAPTURE_MAX_SIZE})\n`
+			);
+			processApi.exit(1);
+			return;
+		}
+
+		if (totalLength === 0) {
+			// EX_TEMPFAIL is the sendmail-compatible result for an invocation that never
+			// supplied a message. In particular, do not turn it into a successful no-op.
+			processApi.stderr(
+				'sendmail: fatal: No message bytes received over stdin\n'
+			);
+			processApi.exit(75);
+			return;
+		}
+
+		try {
+			controller!.close();
+		} catch {
+			// The consumer may have cancelled the stream.
+		}
+		processApi.exit(0);
+	});
+}

--- a/packages/php-wasm/web/playwright.config.ts
+++ b/packages/php-wasm/web/playwright.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
 		'php-dynamic-loading.spec.ts',
 		'php-networking.spec.ts',
 		'readable-stream-transfer.spec.ts',
+		'sendmail-stream.spec.ts',
 	],
 	fullyParallel: false,
 	forbidOnly: !!process.env['CI'],

--- a/packages/php-wasm/web/src/test/playwright/browser-globals.ts
+++ b/packages/php-wasm/web/src/test/playwright/browser-globals.ts
@@ -12,6 +12,7 @@ import {
 	spawnPHPWorkerThread,
 } from '../../lib';
 import readableStreamWorkerUrl from './readable-stream-worker.ts?worker&url';
+import sendmailWorkerUrl from './sendmail-worker.ts?worker&url';
 
 declare global {
 	interface Window {
@@ -23,6 +24,7 @@ declare global {
 		consumeAPI: typeof consumeAPI;
 		spawnPHPWorkerThread: typeof spawnPHPWorkerThread;
 		readableStreamWorkerUrl: string;
+		sendmailWorkerUrl: string;
 		generateCertificate: typeof generateCertificate;
 		certificateToPEM: typeof certificateToPEM;
 	}
@@ -36,5 +38,6 @@ window.setPhpIniEntries = setPhpIniEntries;
 window.consumeAPI = consumeAPI;
 window.spawnPHPWorkerThread = spawnPHPWorkerThread;
 window.readableStreamWorkerUrl = readableStreamWorkerUrl;
+window.sendmailWorkerUrl = sendmailWorkerUrl;
 window.generateCertificate = generateCertificate;
 window.certificateToPEM = certificateToPEM;

--- a/packages/php-wasm/web/src/test/playwright/sendmail-worker.ts
+++ b/packages/php-wasm/web/src/test/playwright/sendmail-worker.ts
@@ -1,0 +1,30 @@
+import {
+	exposeAPI,
+	PHP,
+	PHPWorker,
+	setPhpIniEntries,
+} from '@php-wasm/universal';
+import { sendmailSpawnHandler } from '@php-wasm/util';
+import { loadWebRuntime } from '../../lib';
+
+self.postMessage('worker-script-started');
+
+class SendmailWorker extends PHPWorker {
+	async initialize() {
+		const php = new PHP(await loadWebRuntime('8.4'));
+		php.setCommandSpawnHandler('sendmail', sendmailSpawnHandler(php));
+		await setPhpIniEntries(php, {
+			disable_functions: '',
+		});
+		await this.setPrimaryPHP(php);
+		this.registerWorkerListeners(php);
+	}
+
+	exit() {
+		this.__internal_getPHP()?.exit();
+	}
+}
+
+const endpoint = new SendmailWorker();
+const [setApiReady, setAPIError] = exposeAPI(endpoint);
+endpoint.initialize().then(setApiReady, setAPIError);

--- a/packages/php-wasm/web/src/test/sendmail-stream.spec.ts
+++ b/packages/php-wasm/web/src/test/sendmail-stream.spec.ts
@@ -1,0 +1,199 @@
+import test from '@playwright/test';
+
+test.describe('sendmail stdin streaming', () => {
+	test.beforeEach(async ({ page }) => {
+		page.on('console', (log) => console.log(log.text()));
+		await page.goto('/');
+		await page.addScriptTag({
+			type: 'module',
+			url: '/src/test/playwright/browser-globals.ts',
+		});
+	});
+
+	test('streams sendmail stdin in the browser before PHP run completes', async ({
+		page,
+	}) => {
+		const result = await page.evaluate(async () => {
+			const worker = await window.spawnPHPWorkerThread(
+				window.sendmailWorkerUrl
+			);
+			const php = window.consumeAPI<{
+				isReady(): Promise<void>;
+				addEventListener(
+					eventType: string,
+					listener: (event: {
+						type: string;
+						stdin: ReadableStream<Uint8Array>;
+					}) => void
+				): Promise<void>;
+				run(request: { code: string }): Promise<{ text: string }>;
+				exit(): Promise<void>;
+			}>(worker);
+			await php.isReady();
+
+			let runFinished = false;
+			let eventFiredBeforeRunFinished = false;
+			let chunkReadBeforeRunFinished = false;
+			let secondListenerStreamBytesPromise: Promise<number> | undefined;
+			let streamStatsPromise:
+				| Promise<{
+						bytes: number;
+						chunks: number;
+						startsWithHeaders: boolean;
+				  }>
+				| undefined;
+
+			await php.addEventListener('sendmail.spawned', (event) => {
+				if (event.type !== 'sendmail.spawned') {
+					return;
+				}
+				eventFiredBeforeRunFinished = !runFinished;
+				streamStatsPromise = (async () => {
+					const reader = event.stdin.getReader();
+					const decoder = new TextDecoder();
+					let bytes = 0;
+					let chunks = 0;
+					let prefix = '';
+					while (true) {
+						const { done, value } = await reader.read();
+						if (done) {
+							break;
+						}
+						chunkReadBeforeRunFinished ||= !runFinished;
+						bytes += value.byteLength;
+						chunks++;
+						if (prefix.length < 128) {
+							prefix += decoder.decode(value, { stream: true });
+						}
+					}
+					return {
+						bytes,
+						chunks,
+						startsWithHeaders: prefix.startsWith(
+							'From: sender@test.com\r\nTo: recipient@test.com'
+						),
+					};
+				})();
+			});
+			await php.addEventListener('sendmail.spawned', (event) => {
+				if (event.type !== 'sendmail.spawned') {
+					return;
+				}
+				secondListenerStreamBytesPromise = (async () => {
+					const reader = event.stdin.getReader();
+					let bytes = 0;
+					while (true) {
+						const { done, value } = await reader.read();
+						if (done) {
+							return bytes;
+						}
+						bytes += value.byteLength;
+					}
+				})();
+			});
+
+			try {
+				const response = await php.run({
+					code: `<?php
+						$proc = proc_open(
+							'/usr/sbin/sendmail -t',
+							[['pipe', 'r'], ['pipe', 'w'], ['pipe', 'w']],
+							$pipes
+						);
+						usleep(500000);
+						fwrite($pipes[0], "From: sender@test.com\r\n");
+						fwrite($pipes[0], "To: recipient@test.com\r\n");
+						fwrite($pipes[0], "Subject: Streamed browser mail\r\n\r\n");
+						for ($i = 0; $i < 512; $i++) {
+							fwrite($pipes[0], str_repeat('x', 1024));
+						}
+						fclose($pipes[0]);
+						$exit = proc_close($proc);
+						echo $exit === 0 ? 'SENT' : 'EXIT_' . $exit;
+					`,
+				});
+				runFinished = true;
+
+				return {
+					text: response.text,
+					eventFiredBeforeRunFinished,
+					chunkReadBeforeRunFinished,
+					streamStats: await streamStatsPromise,
+					secondListenerStreamBytes:
+						await secondListenerStreamBytesPromise,
+				};
+			} finally {
+				await php.exit();
+				worker.terminate();
+			}
+		});
+
+		test.expect(result.text).toBe('SENT');
+		test.expect(result.eventFiredBeforeRunFinished).toBe(true);
+		test.expect(result.chunkReadBeforeRunFinished).toBe(true);
+		test.expect(result.streamStats?.startsWithHeaders).toBe(true);
+		test.expect(result.streamStats?.bytes).toBeGreaterThan(512 * 1024);
+		test.expect(result.streamStats?.chunks).toBeGreaterThan(1);
+		test.expect(result.secondListenerStreamBytes).toBeGreaterThan(
+			512 * 1024
+		);
+	});
+
+	test('keeps sendmail running when the listener cancels stdin', async ({
+		page,
+	}) => {
+		const result = await page.evaluate(async () => {
+			const worker = await window.spawnPHPWorkerThread(
+				window.sendmailWorkerUrl
+			);
+			const php = window.consumeAPI<{
+				isReady(): Promise<void>;
+				addEventListener(
+					eventType: string,
+					listener: (event: {
+						type: string;
+						stdin: ReadableStream<Uint8Array>;
+					}) => void
+				): Promise<void>;
+				run(request: { code: string }): Promise<{ text: string }>;
+				exit(): Promise<void>;
+			}>(worker);
+			await php.isReady();
+
+			let resolveCancellation!: () => void;
+			const cancellation = new Promise<void>((resolve) => {
+				resolveCancellation = resolve;
+			});
+			await php.addEventListener('sendmail.spawned', (event) => {
+				if (event.type === 'sendmail.spawned') {
+					event.stdin.cancel().then(resolveCancellation);
+				}
+			});
+
+			try {
+				const response = await php.run({
+					code: `<?php
+						$proc = proc_open(
+							'/usr/sbin/sendmail -t',
+							[['pipe', 'r'], ['pipe', 'w'], ['pipe', 'w']],
+							$pipes
+						);
+						fwrite($pipes[0], "Subject: Cancelled stream\r\n\r\n");
+						usleep(1000000);
+						fwrite($pipes[0], "Sendmail must keep accepting stdin.");
+						fclose($pipes[0]);
+						$exit = proc_close($proc);
+						echo $exit === 0 ? 'SENT' : 'EXIT_' . $exit;
+					`,
+				});
+				await cancellation;
+				return response.text;
+			} finally {
+				await php.exit();
+				worker.terminate();
+			}
+		});
+
+		test.expect(result).toBe('SENT');
+	});
+});


### PR DESCRIPTION
PHP can write a message to `sendmail` through `mail()`, `popen()`, or `proc_open()`, but PHP-WASM has no reusable transport for observing those bytes. This adds a sendmail-compatible null transport. It never delivers mail. It emits `sendmail.spawned` with raw stdin as a live `ReadableStream<Uint8Array>`.

Registration is explicit:

```ts
import { sendmailSpawnHandler } from '@php-wasm/util';

php.setCommandSpawnHandler('sendmail', sendmailSpawnHandler(php));
php.addEventListener('sendmail.spawned', async (event) => {
	if (event.type !== 'sendmail.spawned') {
		return;
	}
	const rawMessage = await new Response(event.stdin).arrayBuffer();
	// Parse or relay rawMessage.
});
```

The event fires with the first stdin chunk, before PHP finishes writing. The transport stays alive until stdin closes. Empty input exits with `EX_TEMPFAIL` and emits no event. Input above 20 MB errors the stream and exits with status 1. Cancelling the stream stops delivery to that reader but keeps draining stdin, so PHP can finish writing and receive the transport's exit status. There is no backpressure to PHP; a slow listener may buffer the full message.

Node tests cover `mail()`, `proc_open()`, delayed input, empty and oversized input, and runtime rotation. Browser tests cover live delivery to multiple listeners and cancellation while PHP continues writing.

This PR does not install the transport by default. #4063 installs it in remote Playground instances.

#4064 provides the marked stdin event transport and per-listener streams used here.

