### PR TITLE
[Blueprints] Support v2 in the browser without ?experimental-blueprints-v2-runner=yes

### DIFF
--- a/packages/playground/client/src/index.spec.ts
+++ b/packages/playground/client/src/index.spec.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { ProgressTracker } from '@php-wasm/progress';
+import type { BlueprintBundle } from '@wp-playground/blueprints';
 
 const mocks = vi.hoisted(() => {
 	vi.stubGlobal('location', {
@@ -83,6 +84,35 @@ describe('startPlaygroundWeb', () => {
 			})
 		).resolves.toBe(playground);
 
+		expect(mocks.BlueprintsV2Handler).toHaveBeenCalledTimes(1);
+		expect(mocks.BlueprintsV1Handler).not.toHaveBeenCalled();
+		expect(iframe.src).toContain('blueprints-runner=v1');
+	});
+
+	it('routes Blueprint v2 bundles through the v2 handler', async () => {
+		const playground = { connected: true };
+		mocks.BlueprintsV2Handler.mockImplementation(() => ({
+			bootPlayground: mocks.bootPlaygroundV2,
+		}));
+		mocks.bootPlaygroundV2.mockResolvedValue(playground);
+		mocks.createBlueprintReflection.mockResolvedValueOnce({
+			getVersion: () => 2,
+		});
+		const iframe = createIframe();
+		const bundle = {
+			read: vi.fn(),
+		} satisfies BlueprintBundle;
+
+		await expect(
+			startPlaygroundWeb({
+				iframe,
+				remoteUrl: 'http://localhost/remote.html',
+				progressTracker: createProgressTracker(),
+				blueprint: bundle,
+			})
+		).resolves.toBe(playground);
+
+		expect(mocks.createBlueprintReflection).toHaveBeenCalledWith(bundle);
 		expect(mocks.BlueprintsV2Handler).toHaveBeenCalledTimes(1);
 		expect(mocks.BlueprintsV1Handler).not.toHaveBeenCalled();
 		expect(iframe.src).toContain('blueprints-runner=v1');

--- a/packages/playground/client/src/index.ts
+++ b/packages/playground/client/src/index.ts
@@ -62,11 +62,6 @@ export interface StartPlaygroundOptions {
 	 * PHP extensions to install before the runtime starts.
 	 */
 	extensions?: PHPWebExtension[];
-	/**
-	 * Run the supplied Blueprint through the native TypeScript v2 compiler.
-	 * Version 2 Blueprints use this path automatically.
-	 */
-	experimentalBlueprintsV2Runner?: boolean;
 	onBlueprintStepCompleted?: OnStepCompleted;
 	onBlueprintValidated?: (blueprint: BlueprintV1Declaration) => void;
 	/**
@@ -166,7 +161,9 @@ export async function startPlaygroundWeb(
 	let { remoteUrl } = options;
 	assertLikelyCompatibleRemoteOrigin(remoteUrl);
 	allowStorageAccessByUserActivation(iframe);
-	const useBlueprintV2Handler = await shouldUseBlueprintV2Handler(options);
+	const useBlueprintV2Handler = await shouldUseBlueprintV2Handler(
+		options.blueprint
+	);
 
 	remoteUrl = setQueryParams(remoteUrl, {
 		progressbar: !disableProgressBar,
@@ -196,11 +193,9 @@ export async function startPlaygroundWeb(
 	return playground;
 }
 
-async function shouldUseBlueprintV2Handler(options: StartPlaygroundWebOptions) {
-	if (options.experimentalBlueprintsV2Runner) {
-		return true;
-	}
-	const blueprint = options.blueprint;
+async function shouldUseBlueprintV2Handler(
+	blueprint: StartPlaygroundWebOptions['blueprint']
+) {
 	if (!blueprint) {
 		return false;
 	}

--- a/packages/playground/personal-wp/src/lib/state/redux/boot-site-client.ts
+++ b/packages/playground/personal-wp/src/lib/state/redux/boot-site-client.ts
@@ -281,11 +281,6 @@ export function bootSiteClient(
 				blueprint,
 				disableProgressBar: true,
 				progressTracker,
-				experimentalBlueprintsV2Runner:
-					!isWordPressInstalled &&
-					new URLSearchParams(window.location.search).get(
-						'experimental-blueprints-v2-runner'
-					) === 'yes',
 				// Intercept the Playground client even if the
 				// Blueprint fails.
 				onClientConnected: (playgroundClient) => {

--- a/packages/playground/personal-wp/src/lib/state/url/landing-page.spec.ts
+++ b/packages/playground/personal-wp/src/lib/state/url/landing-page.spec.ts
@@ -33,6 +33,15 @@ describe('getBrowserPathAsLandingPage', () => {
 		).toBeUndefined();
 	});
 
+	it('strips the retired Blueprint v2 opt-in from legacy URLs', () => {
+		expect(
+			getBrowserPathAsLandingPage({
+				pathname: getAppBaseUrl().pathname,
+				search: '?experimental-blueprints-v2-runner=yes',
+			})
+		).toBeUndefined();
+	});
+
 	it('preserves all search params on reflected WordPress paths', () => {
 		expect(
 			getBrowserPathAsLandingPage({

--- a/packages/playground/personal-wp/src/lib/state/url/router.ts
+++ b/packages/playground/personal-wp/src/lib/state/url/router.ts
@@ -53,6 +53,7 @@ export const PLAYGROUND_QUERY_KEYS = [
 	'import-content',
 	'page-title',
 	HEALTH_CHECK_RECOVERY_MODE_QUERY_PARAM,
+	// Retain the retired v2 opt-in so it is stripped from legacy URLs.
 	'experimental-blueprints-v2-runner',
 ];
 

--- a/packages/playground/remote/src/lib/playground-worker-endpoint.ts
+++ b/packages/playground/remote/src/lib/playground-worker-endpoint.ts
@@ -81,7 +81,7 @@ export type WorkerBootOptions = {
 	/** @deprecated Use `wordpressInstallMode` instead. */
 	shouldInstallWordPress?: boolean;
 	corsProxyUrl?: string;
-	/** When true, skip default WP install and run Blueprints v2 in the worker */
+	/** @deprecated Blueprint handlers are selected before boot. This option has no effect. */
 	experimentalBlueprintsV2Runner?: boolean;
 	/** Blueprint v2 declaration used for worker-side execution or preflight checks. */
 	blueprint?: BlueprintDeclaration;

--- a/packages/playground/website/playwright/e2e/blueprints.spec.ts
+++ b/packages/playground/website/playwright/e2e/blueprints.spec.ts
@@ -22,7 +22,7 @@ test('Base64-encoded Blueprints should work', async ({
 	await expect(wordpress.locator('body')).toContainText('Dashboard');
 });
 
-test('Blueprint v2 declarations should run through the website flow', async ({
+test('Blueprint v2 declarations should route by version through the website flow', async ({
 	website,
 	wordpress,
 }) => {
@@ -51,9 +51,7 @@ test('Blueprint v2 declarations should run through the website flow', async ({
 	};
 
 	const encodedBlueprint = encodeStringAsBase64(JSON.stringify(blueprint));
-	await website.goto(
-		`./?experimental-blueprints-v2-runner=yes#${encodedBlueprint}`
-	);
+	await website.goto(`./#${encodedBlueprint}`);
 	await expect(wordpress.locator('body')).toContainText('V2 Website Smoke');
 });
 

--- a/packages/playground/website/src/lib/state/redux/boot-site-client.ts
+++ b/packages/playground/website/src/lib/state/redux/boot-site-client.ts
@@ -235,11 +235,6 @@ export function bootSiteClient(
 				scope: site.slug,
 				blueprint,
 				extensions: phpExtensions,
-				experimentalBlueprintsV2Runner:
-					!shouldBootFromStoredFiles &&
-					new URLSearchParams(window.location.search).get(
-						'experimental-blueprints-v2-runner'
-					) === 'yes',
 				// Intercept the Playground client even if the
 				// Blueprint fails.
 				onClientConnected: (playgroundClient) => {


### PR DESCRIPTION
## What it does

Blueprints already have a version field. This makes it the only switch that selects the web runner.

`startPlaygroundWeb()` routes `version: 2` declarations and bundles to the v2 handler. Website and Personal WP no longer inspect `?experimental-blueprints-v2-runner=yes`, and the website smoke test boots the v2 declaration without it.

**Breaking TypeScript change:** `experimentalBlueprintsV2Runner` is gone from `StartPlaygroundOptions`. Callers must remove it and put `version: 2` in the Blueprint. The low-level `WorkerBootOptions` member remains as a deprecated no-op until the old remote v2 worker is deleted.

## Rationale

The experimental flag duplicated information already present in the Blueprint. Worse, it could force a v1 or empty Blueprint through the v2 handler. Two switches for one decision means they can disagree.

The existing website test also passed the flag, so it never tested normal v2 routing. It does now.

Bundles still use `BlueprintReflection` to read their declaration version. `blueprints-runner=v1` is deliberately unchanged: the client-side v2 handler compiles and executes the plan against the normal remote API. Personal WP keeps the retired query key only to strip it from old URLs.

## Testing instructions

```bash
nvm use
npm exec -- nx run-many -t typecheck -p playground-client playground-remote playground-website playground-personal-wp
npm exec -- nx run-many -t lint -p playground-client playground-remote playground-website playground-personal-wp
npm exec -- nx run playground-client:test:vite
npm exec -- nx run playground-personal-wp:test --testFile=landing-page.spec.ts
npm exec -- nx run playground-client:test:rollup-declarations
npm exec -- nx run playground-website:e2e:playwright -- --project=chromium packages/playground/website/playwright/e2e/blueprints.spec.ts --grep='Blueprint v2 declarations should route by version through the website flow'
```
