### PR TITLE
[PHP] Keep OPFS mounts attached when final journal flushes fail

### DIFF
--- a/packages/php-wasm/universal/src/lib/index.ts
+++ b/packages/php-wasm/universal/src/lib/index.ts
@@ -66,7 +66,12 @@ export {
 	LEGACY_PHP_INI_CONTENT,
 	LEGACY_PHP_INI_PATH,
 } from './legacy-php-ini';
-export { PHP, __private__dont__use, PHPExecutionFailureError } from './php';
+export {
+	MountStillActiveError,
+	PHP,
+	__private__dont__use,
+	PHPExecutionFailureError,
+} from './php';
 export type { MountHandler, UnmountFunction } from './php';
 export { loadPHPRuntime, popLoadedRuntime } from './load-php-runtime';
 export type { Emscripten } from './emscripten-types';

--- a/packages/php-wasm/universal/src/lib/php.spec.ts
+++ b/packages/php-wasm/universal/src/lib/php.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { __private__dont__use, PHP } from './php';
+import { __private__dont__use, MountStillActiveError, PHP } from './php';
 
 describe('PHP mounts', () => {
 	it('forgets mount tracking even when the unmount callback fails', async () => {
@@ -8,9 +8,9 @@ describe('PHP mounts', () => {
 		//
 		// 1. Invokes the underlying unmount callback returned by the
 		//    mount handler.
-		// 2. Deletes the entry from `#mounts` in a `finally` block so the
-		//    JS-side bookkeeping stays authoritative even if the
-		//    underlying filesystem unmount throws.
+		// 2. Deletes the entry from `#mounts` after ordinary failures so the
+		//    JS-side bookkeeping stays authoritative when the underlying
+		//    filesystem did not explicitly report that it remains mounted.
 		//
 		// `#mounts` is not observable from outside the class, so we
 		// verify the cleanup transitively through `hotSwapPHPRuntime`,
@@ -27,7 +27,7 @@ describe('PHP mounts', () => {
 		//
 		// - `unmountCallback` must have been called exactly once across
 		//   both the explicit `unmount()` call and the subsequent
-		//   `hotSwapPHPRuntime` attempt. Any stale `#mounts` entry would
+		//   `hotSwapPHPRuntime` attempt. Any stale ordinary-failure entry would
 		//   bump the count to 2.
 		const php = new PHP();
 		(php as any)[__private__dont__use] = {
@@ -54,5 +54,34 @@ describe('PHP mounts', () => {
 			'Runtime with id 0 not found'
 		);
 		expect(unmountCallback).toHaveBeenCalledTimes(1);
+	});
+
+	it('retains mount tracking when the unmount reports it is still active', async () => {
+		const php = new PHP();
+		(php as any)[__private__dont__use] = {
+			FS: {
+				chdir: vi.fn(),
+				cwd: vi.fn(() => '/'),
+				lookupPath: vi.fn(() => ({})),
+				readdir: vi.fn(() => ['.', '..']),
+			},
+			spawnProcess: undefined,
+		};
+		const flushError = new Error('flush failed');
+		const activeError = new MountStillActiveError(flushError);
+		const unmountCallback = vi
+			.fn()
+			.mockRejectedValueOnce(activeError)
+			.mockResolvedValueOnce(undefined);
+		const unmount = await php.mount('/mounted', async () => {
+			return unmountCallback;
+		});
+
+		await expect(unmount()).rejects.toBe(activeError);
+		await expect(php.hotSwapPHPRuntime(0 as any)).rejects.toThrow(
+			'Runtime with id 0 not found'
+		);
+
+		expect(unmountCallback).toHaveBeenCalledTimes(2);
 	});
 });

--- a/packages/php-wasm/universal/src/lib/php.ts
+++ b/packages/php-wasm/universal/src/lib/php.ts
@@ -48,6 +48,23 @@ export class PHPExecutionFailureError extends Error {
 }
 
 export type UnmountFunction = (() => Promise<any>) | (() => any);
+
+/**
+ * Signals that an unmount failed before the mount was detached.
+ *
+ * Only this error guarantees that the mount remains active and its teardown can
+ * be retried, so registries may retain it. `cause` is the underlying failure that
+ * prevented the unmount. Ordinary unmount errors make no such guarantee.
+ */
+export class MountStillActiveError extends Error {
+	constructor(cause: unknown) {
+		super('The filesystem could not be flushed and remains mounted.', {
+			cause,
+		});
+		this.name = 'MountStillActiveError';
+	}
+}
+
 export type MountHandler = (
 	php: PHP,
 	FS: Emscripten.RootFS,
@@ -1533,6 +1550,10 @@ export class PHP implements Disposable {
 	/**
 	 * Mounts a filesystem to a given path in the PHP filesystem.
 	 *
+	 * The returned unmount function removes the mount from runtime-rotation
+	 * tracking on success or ordinary failure. `MountStillActiveError` leaves it
+	 * tracked because the handler guarantees the mount remains live and retryable.
+	 *
 	 * @param  virtualFSPath - Where to mount it in the PHP virtual filesystem.
 	 * @param  mountHandler - The mount handler to use.
 	 * @return Unmount function to unmount the filesystem.
@@ -1551,13 +1572,17 @@ export class PHP implements Disposable {
 			unmount: async () => {
 				try {
 					await unmountCallback();
-				} finally {
-					// JS mount tracking is authoritative. Even if the
-					// underlying filesystem unmount fails, forget this entry
-					// so later runtime swaps and remounts cannot reuse a stale
-					// mount handler.
+				} catch (error) {
+					if (error instanceof MountStillActiveError) {
+						throw error;
+					}
+					// Unless the callback guarantees that the mount remains live,
+					// retaining it could retry stale teardown state during a later
+					// runtime swap.
 					delete this.#mounts[virtualFSPath];
+					throw error;
 				}
+				delete this.#mounts[virtualFSPath];
 			},
 		};
 		this.#mounts[virtualFSPath] = mountObject;

--- a/packages/php-wasm/web/src/lib/directory-handle-mount.spec.ts
+++ b/packages/php-wasm/web/src/lib/directory-handle-mount.spec.ts
@@ -152,6 +152,38 @@ describe('journalFSEventsToOpfs', () => {
 		await firstFlush;
 	});
 
+	it('waits for an in-flight flush when discarding an incomplete mount', async () => {
+		const writeStarted = deferred<void>();
+		const releaseWrite = deferred<void>();
+		const { FS, files, php, removeEventListener } = createFakePhp();
+		const opfsRoot = new MemoryDirectoryHandle('root', async () => {
+			writeStarted.resolve();
+			await releaseWrite.promise;
+		});
+		const mount = journalFSEventsToOpfs(
+			php,
+			opfsRoot as unknown as FileSystemDirectoryHandle,
+			'/wordpress'
+		);
+		files.set('/wordpress/file.txt', encode('saved'));
+		FS.write({ path: '/wordpress/file.txt' });
+		void mount.flush();
+		await writeStarted.promise;
+
+		let discardSettled = false;
+		const discard = mount.discard().then(() => {
+			discardSettled = true;
+		});
+		await Promise.resolve();
+
+		expect(removeEventListener).toHaveBeenCalled();
+		expect(discardSettled).toBe(false);
+
+		releaseWrite.resolve();
+		await discard;
+		expect(discardSettled).toBe(true);
+	});
+
 	it('processes new writes on a subsequent flush after the previous flush succeeded', async () => {
 		// Regression guard for the `flushPromise` single-flight reset on the
 		// success path. If `flushPromise` were not cleared in the `.finally()`
@@ -248,13 +280,52 @@ describe('journalFSEventsToOpfs', () => {
 		expect(FS.write).toBe(originalWrite);
 	});
 
-	it('removes listeners even when unmount flush fails', async () => {
+	it('flushes writes queued as the in-flight flush settles before unmounting', async () => {
+		const writeStarted = deferred<void>();
+		const releaseWrite = deferred<void>();
+		let writeCount = 0;
+		const { FS, files, php } = createFakePhp();
+		const opfsRoot = new MemoryDirectoryHandle('root', async () => {
+			writeCount++;
+			if (writeCount === 1) {
+				writeStarted.resolve();
+				await releaseWrite.promise;
+			}
+		});
+		const mount = journalFSEventsToOpfs(
+			php,
+			opfsRoot as unknown as FileSystemDirectoryHandle,
+			'/wordpress'
+		);
+
+		files.set('/wordpress/first.txt', encode('first'));
+		FS.write({ path: '/wordpress/first.txt' });
+		const inFlightFlush = mount.flush();
+		await writeStarted.promise;
+		const enqueueAtFlushBoundary = inFlightFlush.then(() => {
+			files.set('/wordpress/second.txt', encode('second'));
+			FS.write({ path: '/wordpress/second.txt' });
+		});
+		const unmount = mount.unmount();
+
+		releaseWrite.resolve();
+		await Promise.all([enqueueAtFlushBoundary, unmount]);
+
+		expect(decode(opfsRoot.files.get('first.txt')!.bytes)).toBe('first');
+		expect(decode(opfsRoot.files.get('second.txt')!.bytes)).toBe('second');
+	});
+
+	it('keeps listeners until a failed unmount flush can be retried', async () => {
 		const flushError = new Error('flush failed');
+		let shouldFail = true;
 		const { FS, addEventListener, files, php, removeEventListener } =
 			createFakePhp();
 		const originalWrite = FS.write;
 		const opfsRoot = new MemoryDirectoryHandle('root', () => {
-			throw flushError;
+			if (shouldFail) {
+				shouldFail = false;
+				throw flushError;
+			}
 		});
 		const mount = journalFSEventsToOpfs(
 			php,
@@ -271,7 +342,14 @@ describe('journalFSEventsToOpfs', () => {
 		files.set('/wordpress/file.txt', encode('saved'));
 		FS.write({ path: '/wordpress/file.txt' });
 
-		await expect(mount.unmount()).rejects.toBe(flushError);
+		await expect(mount.unmount()).rejects.toMatchObject({
+			name: 'MountStillActiveError',
+			cause: flushError,
+		});
+		expect(removeEventListener).not.toHaveBeenCalled();
+		expect(FS.write).not.toBe(originalWrite);
+
+		await mount.unmount();
 		expect(removeEventListener).toHaveBeenCalledWith(
 			'filesystem.write',
 			filesystemWriteListener
@@ -327,11 +405,37 @@ describe('journalFSEventsToOpfs', () => {
 		FS.write({ path: '/wordpress/file.txt' });
 		await expect(mount.flush()).rejects.toThrow('temporary flush failure');
 
-		files.set('/wordpress/file.txt', encode('second'));
-		FS.write({ path: '/wordpress/file.txt' });
 		await mount.flush();
 
-		expect(decode(opfsRoot.files.get('file.txt')!.bytes)).toBe('second');
+		expect(decode(opfsRoot.files.get('file.txt')!.bytes)).toBe('first');
+	});
+
+	it('retries only the failed suffix of a partially completed batch', async () => {
+		let writeCount = 0;
+		const { FS, files, php } = createFakePhp();
+		const opfsRoot = new MemoryDirectoryHandle('root', () => {
+			writeCount++;
+			if (writeCount === 2) {
+				throw new Error('second write failed');
+			}
+		});
+		const mount = journalFSEventsToOpfs(
+			php,
+			opfsRoot as unknown as FileSystemDirectoryHandle,
+			'/wordpress'
+		);
+
+		files.set('/wordpress/first.txt', encode('first'));
+		files.set('/wordpress/second.txt', encode('second'));
+		FS.write({ path: '/wordpress/first.txt' });
+		FS.write({ path: '/wordpress/second.txt' });
+
+		await expect(mount.flush()).rejects.toThrow('second write failed');
+		await mount.flush();
+
+		expect(writeCount).toBe(3);
+		expect(decode(opfsRoot.files.get('first.txt')!.bytes)).toBe('first');
+		expect(decode(opfsRoot.files.get('second.txt')!.bytes)).toBe('second');
 	});
 
 	it('fails explicit flushes that never settle instead of hanging', async () => {
@@ -418,6 +522,57 @@ describe('createDirectoryHandleMountHandler', () => {
 		// copy, which is exactly why the whole operation must reject.
 		expect(decode(opfsRoot.files.get('ok.txt')!.bytes)).toBe('ok');
 		expect(opfsRoot.files.has('autoload.php')).toBe(false);
+	});
+
+	it('discards the journal and preserves the copy error when initial sync fails', async () => {
+		const copyError = new Error('initial copy failed');
+		const flushError = new Error('rollback flush failed');
+		const { FS, dispatchEvent, files, php, removeEventListener } =
+			createFakePhp();
+		const originalWrite = FS.write;
+		FS.readdir.mockReturnValue(['.', '..', 'bad.txt']);
+		files.set('/wordpress/bad.txt', encode('bad'));
+		let writeCount = 0;
+		const opfsRoot = new MemoryDirectoryHandle('root', () => {
+			writeCount++;
+			if (writeCount === 1) {
+				files.set('/wordpress/live.txt', encode('live'));
+				FS.write({ path: '/wordpress/live.txt' });
+				dispatchEvent('filesystem.write');
+				throw copyError;
+			}
+			throw flushError;
+		});
+		const loggerError = vi
+			.spyOn(logger, 'error')
+			.mockImplementation(() => {});
+		const mountHandler = createDirectoryHandleMountHandler(
+			opfsRoot as unknown as FileSystemDirectoryHandle,
+			{
+				initialSync: { direction: 'memfs-to-opfs' },
+			}
+		);
+
+		try {
+			await expect(
+				mountHandler(php, FS as any, '/wordpress')
+			).rejects.toMatchObject({ cause: copyError });
+			expect(loggerError).toHaveBeenCalledWith(
+				'OPFS flush failed while discarding a mount',
+				flushError
+			);
+			expect(removeEventListener).toHaveBeenCalledWith(
+				'request.end',
+				expect.any(Function)
+			);
+			expect(removeEventListener).toHaveBeenCalledWith(
+				'filesystem.write',
+				expect.any(Function)
+			);
+			expect(FS.write).toBe(originalWrite);
+		} finally {
+			loggerError.mockRestore();
+		}
 	});
 
 	it('flushes changes made while the initial MEMFS to OPFS sync is still running', async () => {

--- a/packages/php-wasm/web/src/lib/directory-handle-mount.ts
+++ b/packages/php-wasm/web/src/lib/directory-handle-mount.ts
@@ -1,5 +1,9 @@
 import type { Emscripten, MountHandler, PHP } from '@php-wasm/universal';
-import { FSHelpers, __private__dont__use } from '@php-wasm/universal';
+import {
+	FSHelpers,
+	MountStillActiveError,
+	__private__dont__use,
+} from '@php-wasm/universal';
 import { Semaphore, basename, joinPaths } from '@php-wasm/util';
 import { logger } from '@php-wasm/logger';
 import type { FilesystemOperation } from '@php-wasm/fs-journal';
@@ -38,7 +42,19 @@ export interface MountOptions {
 	onMount?: (mount: DirectoryHandleMount) => void;
 }
 export interface DirectoryHandleMount {
+	/**
+	 * Replays captured MEMFS changes into OPFS until the journal settles.
+	 *
+	 * Event capture remains active. If applying a normalized operation fails,
+	 * that operation and its unattempted suffix remain queued for retry.
+	 */
 	flush(): Promise<void>;
+	/**
+	 * Flushes all captured changes and detaches after a successful drain.
+	 *
+	 * If draining fails, rejects with `MountStillActiveError` without
+	 * detaching, so callers can retry the same mount.
+	 */
 	unmount(): Promise<void>;
 }
 export type SyncProgress = {
@@ -59,6 +75,15 @@ interface JournalFSEventsToOpfsOptions {
 
 const DEFAULT_MAX_OPFS_FLUSH_PASSES = 1000;
 
+/**
+ * Creates a PHP mount handler backed by an OPFS directory.
+ *
+ * During MEMFS-to-OPFS setup, journaling starts before the initial copy so
+ * writes made during setup are captured. If copying or reporting its progress
+ * fails, it discards the incomplete mount without replacing the original
+ * setup error. Successful mounts use the retryable final-flush contract of
+ * `DirectoryHandleMount`.
+ */
 export function createDirectoryHandleMountHandler(
 	handle: FileSystemDirectoryHandle,
 	options: MountOptions = { initialSync: {} }
@@ -110,7 +135,8 @@ export function createDirectoryHandleMountHandler(
 					});
 				});
 			} catch (error) {
-				await mount.unmount();
+				// Setup never completed, so there is no valid mount to keep retryable.
+				await mount.discard();
 				throw error;
 			}
 			return mount.unmount;
@@ -343,12 +369,21 @@ async function overwriteOpfsFile(
 	}
 }
 
+/**
+ * Mirrors MEMFS changes below a mount point to an OPFS directory.
+ *
+ * The returned `flush()` persists changes without detaching. `unmount()` drains
+ * the journal and detaches only after a successful drain. `discard()` stops
+ * capture without starting a final flush, then waits for any flush already in
+ * flight. `unmount()` uses it after a successful drain; failed initial setup
+ * uses it to abandon an incomplete mount.
+ */
 export function journalFSEventsToOpfs(
 	php: PHP,
 	opfsRoot: FileSystemDirectoryHandle,
 	memfsRoot: string,
 	options: JournalFSEventsToOpfsOptions = {}
-): DirectoryHandleMount {
+) {
 	const journal: FilesystemOperation[] = [];
 	const unbindJournal = journalFSEvents(php, memfsRoot, (entry) => {
 		journal.push(entry);
@@ -356,6 +391,11 @@ export function journalFSEventsToOpfs(
 	const rewriter = new OpfsRewriter(php, opfsRoot, memfsRoot);
 	let flushPromise: Promise<void> | undefined;
 
+	/**
+	 * Drains the journal without detaching its listeners.
+	 *
+	 * Concurrent callers share the same in-flight promise.
+	 */
 	function flush() {
 		if (flushPromise === undefined) {
 			flushPromise = flushJournal().finally(() => {
@@ -365,13 +405,47 @@ export function journalFSEventsToOpfs(
 		return flushPromise;
 	}
 
+	/**
+	 * Drains the journal and detaches its listeners as one commit boundary.
+	 *
+	 * A failed drain leaves the journal attached and throws
+	 * `MountStillActiveError`, allowing the same mount to be retried.
+	 */
 	async function unmount() {
 		try {
-			await flush();
-		} finally {
-			unbindJournal();
-			php.removeEventListener('request.end', flushInBackground);
-			php.removeEventListener('filesystem.write', flushInBackground);
+			while (true) {
+				await flush();
+				if (journal.length === 0) {
+					// discard() removes the listeners synchronously before its first
+					// await, so nothing can be captured after this empty check.
+					await discard();
+					return;
+				}
+			}
+		} catch (error) {
+			throw new MountStillActiveError(error);
+		}
+	}
+
+	/**
+	 * Stops capturing changes without starting another flush.
+	 *
+	 * An in-flight flush may continue processing queued entries. Use this only
+	 * after `unmount()` has observed an empty journal or while rolling back failed
+	 * setup. It waits for that flush, but logs its failure so the setup error
+	 * remains the one returned to the caller.
+	 */
+	async function discard() {
+		const inFlightFlush = flushPromise;
+		unbindJournal();
+		php.removeEventListener('request.end', flushInBackground);
+		php.removeEventListener('filesystem.write', flushInBackground);
+		try {
+			await inFlightFlush;
+		} catch (error) {
+			// Setup rollback must finish outstanding writes, but its original copy
+			// error remains the useful failure for the caller.
+			logger.error('OPFS flush failed while discarding a mount', error);
 		}
 	}
 
@@ -399,6 +473,13 @@ export function journalFSEventsToOpfs(
 		}
 	}
 
+	/**
+	 * Replays one normalized journal batch while holding PHP's execution semaphore.
+	 *
+	 * If replay fails, restores the failed operation and its unattempted suffix
+	 * ahead of events captured during replay. Completed operations are not
+	 * retried because moves and deletes are not generally safe to apply twice.
+	 */
 	async function flushJournalOnce() {
 		if (journal.length === 0) {
 			return;
@@ -406,25 +487,25 @@ export function journalFSEventsToOpfs(
 
 		const release = await php.semaphore.acquire();
 
-		// Concurrency safety note
-		// As I understand it, journal is specific to a PHP instance,
-		// so it's not possible to have concurrency push of entries to journal
-		// But this can change in future so it doesn't hurt to read from journal
-		// in a concurrent safe way, which is what we are doing here.
-
-		// We first copy it to a new array
+		// Remove exactly this snapshot. Filesystem hooks may append entries while
+		// this batch awaits OPFS, and those newer entries must remain in the journal.
 		const journalEntries = [...journal];
-		// and then only delete however many entries we were able to grab
-		// since with concurrent writes there could have been more insertions
 		journal.splice(0, journalEntries.length);
 
 		const compressedJournal = normalizeFilesystemOperations(journalEntries);
+		let processedEntryCount = 0;
 		try {
 			// @TODO This is way too slow in practice, we need to batch the
 			// changes into groups of parallelizable operations.
 			for (const entry of compressedJournal) {
 				await rewriter.processEntry(entry);
+				processedEntryCount++;
 			}
+		} catch (error) {
+			// Put the failed operation and unattempted remainder back ahead of
+			// events captured while this batch was replaying.
+			journal.unshift(...compressedJournal.slice(processedEntryCount));
+			throw error;
 		} finally {
 			release();
 		}
@@ -435,6 +516,7 @@ export function journalFSEventsToOpfs(
 	return {
 		flush,
 		unmount,
+		discard,
 	};
 }
 
@@ -455,6 +537,12 @@ class OpfsRewriter {
 		return normalizeMemfsPath(path.substring(this.memfsRoot.length));
 	}
 
+	/**
+	 * Applies one normalized MEMFS journal operation to OPFS.
+	 *
+	 * Destructive steps tolerate an already-missing source because a previous
+	 * attempt may mutate OPFS before reporting failure and then be retried.
+	 */
 	public async processEntry(entry: JournalEntry) {
 		if (
 			!entry.path.startsWith(this.memfsRoot) ||
@@ -519,10 +607,18 @@ class OpfsRewriter {
 						opfsDir,
 						entry.toPath
 					);
-					// Then delete the old directory
-					await opfsParent.removeEntry(name, {
-						recursive: true,
-					});
+					// Then delete the old directory. A retry may observe that a
+					// previous attempt removed it before reporting an error.
+					try {
+						await opfsParent.removeEntry(name, {
+							recursive: true,
+						});
+					} catch (error) {
+						if ((error as DOMException).name !== 'NotFoundError') {
+							throw error;
+						}
+						// A previous attempt already completed the removal.
+					}
 				} else {
 					/**
 					 * Delete the old file and creating a new one.

--- a/packages/playground/remote/src/lib/playground-client.ts
+++ b/packages/playground/remote/src/lib/playground-client.ts
@@ -68,6 +68,14 @@ export interface WebClientMixin extends ProgressReceiver {
 
 	flushOpfs(mountpoint: string): Promise<void>;
 
+	/**
+	 * Flushes and detaches an OPFS mount.
+	 *
+	 * On success, clears its tracking. If the final flush fails, keeps the mount
+	 * registered for retry and rejects with the original persistence error.
+	 * Other unmount failures clear tracking because the mount did not guarantee
+	 * that it remained live.
+	 */
 	unmountOpfs(mountpoint: string): Promise<void>;
 
 	boot(options: WorkerBootOptions): Promise<void>;

--- a/packages/playground/remote/src/lib/playground-worker-endpoint.spec.ts
+++ b/packages/playground/remote/src/lib/playground-worker-endpoint.spec.ts
@@ -1,8 +1,10 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { __private__dont__use } from '@php-wasm/universal';
+import {
+	__private__dont__use,
+	MountStillActiveError,
+} from '@php-wasm/universal';
 import type { MountHandler } from '@php-wasm/universal';
 import { Semaphore } from '@php-wasm/util';
-import { logger } from '@php-wasm/logger';
 
 describe('PlaygroundWorkerEndpoint OPFS flushing', () => {
 	afterEach(() => {
@@ -85,15 +87,9 @@ describe('PlaygroundWorkerEndpoint OPFS flushing', () => {
 		);
 	});
 
-	it('flushes before unmounting an OPFS mount', async () => {
+	it('unmounts an OPFS mount and clears its tracking', async () => {
 		const opfsMount = createOpfsMount();
-		const order: string[] = [];
-		opfsMount.flush.mockImplementation(async () => {
-			order.push('flush');
-		});
-		const unmount = vi.fn(async () => {
-			order.push('unmount');
-		});
+		const unmount = vi.fn(async () => {});
 		const endpoint = await createEndpoint(
 			{ '/wordpress': opfsMount },
 			{ '/wordpress': unmount }
@@ -101,18 +97,15 @@ describe('PlaygroundWorkerEndpoint OPFS flushing', () => {
 
 		await endpoint.unmountOpfs('/wordpress');
 
-		expect(order).toEqual(['flush', 'unmount']);
+		expect(unmount).toHaveBeenCalledTimes(1);
 		expect(endpoint.opfsMounts['/wordpress']).toBeUndefined();
 		expect(endpoint.unmounts['/wordpress']).toBeUndefined();
 	});
 
-	it('rethrows and clears tracking when flush succeeds but unmount fails', async () => {
-		// Covers the `unmountOpfs` failure matrix quadrant where the flush
-		// before unmount resolves cleanly but the underlying PHP unmount
-		// callback throws. In this case the unmount error is the *only*
-		// signal callers get, so it must be re-thrown unchanged, and the
-		// mount registries must still be cleaned up in the `finally` block
-		// to avoid a stuck mountpoint that blocks future `mountOpfs` calls.
+	it('rethrows ordinary unmount errors and clears tracking', async () => {
+		// An ordinary unmount error does not guarantee that the mount remains
+		// active. Rethrow it unchanged, but clear both registries so a stale
+		// callback cannot block a later mountOpfs() call.
 		const unmountError = new Error('unmount failed');
 		const opfsMount = createOpfsMount();
 		const unmount = vi.fn(async () => {
@@ -127,17 +120,18 @@ describe('PlaygroundWorkerEndpoint OPFS flushing', () => {
 			unmountError
 		);
 
-		expect(opfsMount.flush).toHaveBeenCalledTimes(1);
 		expect(unmount).toHaveBeenCalledTimes(1);
 		expect(endpoint.opfsMounts['/wordpress']).toBeUndefined();
 		expect(endpoint.unmounts['/wordpress']).toBeUndefined();
 	});
 
-	it('removes mount tracking when the flush before unmount fails', async () => {
-		const flushError = new Error('flush failed');
+	it('retains endpoint tracking when the inner flush leaves the mount active', async () => {
+		const flushError = new Error('inner flush failed');
 		const opfsMount = createOpfsMount();
-		opfsMount.flush.mockRejectedValueOnce(flushError);
-		const unmount = vi.fn(async () => {});
+		const unmount = vi
+			.fn()
+			.mockRejectedValueOnce(new MountStillActiveError(flushError))
+			.mockResolvedValueOnce(undefined);
 		const endpoint = await createEndpoint(
 			{ '/wordpress': opfsMount },
 			{ '/wordpress': unmount }
@@ -146,52 +140,13 @@ describe('PlaygroundWorkerEndpoint OPFS flushing', () => {
 		await expect(endpoint.unmountOpfs('/wordpress')).rejects.toBe(
 			flushError
 		);
+		expect(endpoint.opfsMounts['/wordpress']).toBe(opfsMount);
+		expect(endpoint.unmounts['/wordpress']).toBe(unmount);
 
-		expect(unmount).toHaveBeenCalledTimes(1);
+		await endpoint.unmountOpfs('/wordpress');
+		expect(unmount).toHaveBeenCalledTimes(2);
 		expect(endpoint.opfsMounts['/wordpress']).toBeUndefined();
 		expect(endpoint.unmounts['/wordpress']).toBeUndefined();
-	});
-
-	it('prefers the flush error and logs the unmount error when both fail', async () => {
-		// Covers the most adversarial `unmountOpfs` quadrant: both the
-		// pre-unmount flush and the underlying unmount callback reject.
-		//
-		// The production code intentionally surfaces the *flush* error to
-		// the caller because it is the root cause (the unmount error is
-		// often a downstream symptom of an already-broken flush), and
-		// routes the unmount error through `logger.error` so it is not
-		// silently discarded. Registry cleanup must still happen.
-		//
-		// Without this test, a regression that flipped the priority
-		// (throwing the unmount error instead of the flush error) or
-		// dropped the unmount error without logging would go unnoticed.
-		const flushError = new Error('flush failed');
-		const unmountError = new Error('unmount failed');
-		const opfsMount = createOpfsMount();
-		opfsMount.flush.mockRejectedValueOnce(flushError);
-		const unmount = vi.fn(async () => {
-			throw unmountError;
-		});
-		const loggerError = vi
-			.spyOn(logger, 'error')
-			.mockImplementation(() => {});
-		try {
-			const endpoint = await createEndpoint(
-				{ '/wordpress': opfsMount },
-				{ '/wordpress': unmount }
-			);
-
-			await expect(endpoint.unmountOpfs('/wordpress')).rejects.toBe(
-				flushError
-			);
-
-			expect(unmount).toHaveBeenCalledTimes(1);
-			expect(loggerError).toHaveBeenCalledWith(unmountError);
-			expect(endpoint.opfsMounts['/wordpress']).toBeUndefined();
-			expect(endpoint.unmounts['/wordpress']).toBeUndefined();
-		} finally {
-			loggerError.mockRestore();
-		}
 	});
 
 	it('throws before mounting when an OPFS mount already exists', async () => {

--- a/packages/playground/remote/src/lib/playground-worker-endpoint.ts
+++ b/packages/playground/remote/src/lib/playground-worker-endpoint.ts
@@ -38,6 +38,7 @@ import type {
 } from '@php-wasm/universal';
 import {
 	isLegacyPHPVersion,
+	MountStillActiveError,
 	PHPResponse,
 	PHPWorker,
 	isPathToSharedFS,
@@ -456,31 +457,38 @@ export abstract class PlaygroundWorkerEndpoint extends PHPWorker {
 		await opfsMount.flush();
 	}
 
+	/**
+	 * Flushes and detaches an OPFS mount.
+	 *
+	 * On success, clears its tracking. If the final flush fails, keeps the mount
+	 * registered for retry and rejects with the original persistence error.
+	 * Other unmount failures clear tracking because the mount did not guarantee
+	 * that it remained live.
+	 */
 	async unmountOpfs(mountpoint: string) {
-		const opfsMount = this.opfsMounts[mountpoint];
 		const unmount = this.unmounts[mountpoint];
-		if (opfsMount === undefined || unmount === undefined) {
+		if (
+			this.opfsMounts[mountpoint] === undefined ||
+			unmount === undefined
+		) {
 			throw new Error(`No OPFS mount found at "${mountpoint}".`);
 		}
-		let flushError: unknown;
-		try {
-			await opfsMount.flush();
-		} catch (error) {
-			flushError = error;
-		}
+		let mountIsStillActive = false;
 		try {
 			await unmount();
 		} catch (error) {
-			if (flushError === undefined) {
-				throw error;
+			if (error instanceof MountStillActiveError) {
+				// PHP retained its callback and journal. Keep endpoint tracking
+				// aligned, but do not expose this internal lifecycle signal.
+				mountIsStillActive = true;
+				throw error.cause;
 			}
-			logger.error(error);
+			throw error;
 		} finally {
-			delete this.unmounts[mountpoint];
-			delete this.opfsMounts[mountpoint];
-		}
-		if (flushError !== undefined) {
-			throw flushError;
+			if (!mountIsStillActive) {
+				delete this.unmounts[mountpoint];
+				delete this.opfsMounts[mountpoint];
+			}
 		}
 	}
 


### PR DESCRIPTION
Without this PR, a failed journal write drops the entire OPFS mount. With this PR, the mount stays mounted.

While PHP is running, WordPress files live in MEMFS. Playground records each filesystem change—such as writing, renaming, or deleting a file—in a journal and copies those changes to OPFS. That's _a journal flush_. A flush takes the entries it is about to process out of the live queue, then applies them one at a time. This leaves the live queue free to record file changes that happen while the OPFS writes are running. 

Before this PR, Playground never put journal entries back in the queue when one of those writes failed. If the first entry succeeded, the second failed, and the third had not run yet, the second and third entries were simply forgotten.

After a failure, the bubbling exception would trigger unmounting the OPFS directory. Unmount stopped the change recording entirely and made our failure permanent. The OPFS directory was still on disk, but Playground had forgotten the live mount and its pending writes, so the caller had nothing left to retry.

This PR puts the failed entry and every entry after it back in the journal. Entries that already succeeded stay completed; replaying a rename or delete is not always safe. The file-change listener stays active, PHP and the worker keep the mount registered, and `unmountOpfs()` rejects with the original failure. Calling `unmountOpfs()` again retries the pending journal entries.

## Implementation

`unmount()` is the normal shutdown path: write every pending change to OPFS, then stop recording changes and unregister the mount. `discard()` is lower-level cleanup: stop recording changes without starting a final flush, and wait for any flush already running. Failed initial MEMFS-to-OPFS setup uses `discard()` because it never produced a valid mount worth retrying. A successful `unmount()` uses the same cleanup only after the journal is empty. That is why both functions exist, and why `discard()` is not public.

`MountStillActiveError` is the internal signal for “unmount failed, but the mount is still valid.” PHP and the worker keep their registry entries only for that error. The public caller still receives the original flush failure. Other unmount errors clear the registries because they do not promise that the mount remains usable.

The public `DirectoryHandleMount` API remains `flush()` and `unmount()`.

## Testing 

The tests cover failure partway through a flush, file changes arriving while a flush finishes, retrying a failed unmount, failed initial setup, and mount-registry cleanup:

```bash
npm exec nx -- run-many -t test,typecheck,lint \
  --projects=php-wasm-universal,php-wasm-web,playground-remote

npm exec nx -- run-many -t build \
  --projects=php-wasm-universal,php-wasm-web,playground-remote
```
