### PR TITLE
[Blueprints] Load v2 WordPress data-reference sources

### DIFF
--- a/packages/playground/blueprints/src/index.ts
+++ b/packages/playground/blueprints/src/index.ts
@@ -67,10 +67,14 @@ export type {
 export { getV2Runner } from './lib/v2/get-v2-runner';
 export { runBlueprintV2 } from './lib/v2/run-blueprint-v2';
 export type { BlueprintMessage } from './lib/v2/run-blueprint-v2';
-export { compileBlueprintV2 } from './lib/v2/compile';
+export {
+	compileBlueprintV2,
+	resolveBlueprintV2WordPressSource,
+} from './lib/v2/compile';
 export type {
 	CompiledBlueprintV2,
 	CompileBlueprintV2Options,
+	ResolveBlueprintV2WordPressSourceOptions,
 } from './lib/v2/compile';
 
 export {

--- a/packages/playground/blueprints/src/lib/v2/compile.ts
+++ b/packages/playground/blueprints/src/lib/v2/compile.ts
@@ -15,7 +15,11 @@ import type {
 	InstallThemeStep,
 	StepDefinition,
 } from '../steps';
-import type { DirectoryReference, FileReference } from '../v1/resources';
+import {
+	Resource,
+	type DirectoryReference,
+	type FileReference,
+} from '../v1/resources';
 import type { BlueprintV2Declaration } from './blueprint-v2-declaration';
 import { resolveBlueprintV2RuntimeConfiguration } from './resolve-runtime-configuration';
 
@@ -204,6 +208,15 @@ export type CompileBlueprintV2Options = Pick<
 		onBlueprintValidated?: (blueprint: BlueprintV2Declaration) => void;
 	};
 
+export type ResolveBlueprintV2WordPressSourceOptions = Pick<
+	CompileBlueprintV1Options,
+	| 'corsProxy'
+	| 'gitAdditionalHeadersCallback'
+	| 'progress'
+	| 'semaphore'
+	| 'streamBundledFile'
+>;
+
 /**
  * Compiles a Blueprint v2 declaration into the pieces the TypeScript runner can
  * understand today.
@@ -249,6 +262,41 @@ export async function compileBlueprintV2(
 			await v1Runner.run(playground);
 		},
 	};
+}
+
+/**
+ * Loads a custom WordPress source into the file expected by the boot API.
+ *
+ * Built-in versions and HTTP(S) ZIP URLs already use each consumer's normal
+ * WordPress download path. Execution-context, inline, and Git references need
+ * the Blueprint resource loader to turn them into a concrete archive first.
+ */
+export async function resolveBlueprintV2WordPressSource(
+	declaration: BlueprintV2Declaration,
+	options: ResolveBlueprintV2WordPressSourceOptions = {}
+): Promise<File | undefined> {
+	const { assertValidBlueprintV2Declaration } =
+		await import('./validate-blueprint-v2');
+	assertValidBlueprintV2Declaration(declaration);
+	const source = getCustomWordPressDataReference(
+		declaration.wordpressVersion
+	);
+	if (!source) {
+		return undefined;
+	}
+
+	const resourceReference = convertV2DataReferenceToV1(source, 'wordpress');
+	const resource = Resource.create(
+		isDirectoryReference(resourceReference)
+			? {
+					resource: 'zip',
+					inner: resourceReference,
+					name: 'wordpress.zip',
+				}
+			: resourceReference,
+		options
+	);
+	return (await resource.resolve()) as File;
 }
 
 /**
@@ -2258,6 +2306,29 @@ function normalizeAssetDefinition(
 }
 
 /**
+ * Returns WordPress data references that cannot use the existing version/URL
+ * download path and therefore need the Blueprint resource loader.
+ */
+function getCustomWordPressDataReference(
+	wordpressVersion: BlueprintV2Declaration['wordpressVersion']
+): BlueprintV2DataReference | undefined {
+	if (
+		typeof wordpressVersion === 'string' &&
+		isExecutionContextPath(wordpressVersion)
+	) {
+		return wordpressVersion;
+	}
+	if (
+		isInlineFile(wordpressVersion) ||
+		isInlineDirectory(wordpressVersion) ||
+		isGitPath(wordpressVersion)
+	) {
+		return wordpressVersion;
+	}
+	return undefined;
+}
+
+/**
  * Maps a Blueprint v2 data reference to the equivalent v1 resource.
  *
  * V2 groups URLs, WordPress.org slugs, execution-context paths, inline data,
@@ -2266,7 +2337,7 @@ function normalizeAssetDefinition(
  */
 function convertV2DataReferenceToV1(
 	reference: BlueprintV2DataReference,
-	context: 'plugin' | 'theme'
+	context: 'plugin' | 'theme' | 'wordpress'
 ): FileReference | DirectoryReference {
 	if (typeof reference === 'string') {
 		if (seemsLikeGitRepoUrl(reference)) {
@@ -2287,6 +2358,12 @@ function convertV2DataReferenceToV1(
 				resource: 'bundled',
 				path: normalizeExecutionContextPath(reference),
 			};
+		}
+		if (context === 'wordpress') {
+			throw new UnsupportedBlueprintV2FeatureError(
+				'wordpressVersion',
+				'Unsupported Blueprint v2 WordPress data reference.'
+			);
 		}
 		return wordpressOrgResource(
 			reference,

--- a/packages/playground/blueprints/src/lib/v2/resolve-runtime-configuration.ts
+++ b/packages/playground/blueprints/src/lib/v2/resolve-runtime-configuration.ts
@@ -12,6 +12,7 @@ import type { BlueprintDeclaration, RuntimeConfiguration } from '../types';
 import type { BlueprintV2Declaration } from './blueprint-v2-declaration';
 
 const V2_WORDPRESS_VERSION_LABELS = ['latest', 'beta', 'trunk', 'nightly'];
+const CUSTOM_WORDPRESS_VERSION = 'custom';
 const V2_WORDPRESS_VERSION_PATTERN =
 	/^\d+\.\d+(?:\.\d+)?(?:-(?:beta|rc)\d+)?$/i;
 const V2_PHP_CONSTRAINT_CANDIDATES = AllPHPVersions.filter(
@@ -283,8 +284,8 @@ function parsePHPVersion(phpVersion: string): [number, number, number] {
 /**
  * Resolves the WordPress runtime source from a Blueprint v2 declaration.
  *
- * Missing versions default to `latest`. Unsupported data references are
- * rejected instead of silently booting a different WordPress version.
+ * Missing versions default to `latest`. Custom data references use a synthetic
+ * runtime label because their concrete archive is resolved before boot.
  */
 async function resolveV2WordPressVersion(
 	declaration: BlueprintV2Declaration,
@@ -316,11 +317,9 @@ async function resolveV2WordPressVersion(
 	}
 
 	if (wordpressVersion && typeof wordpressVersion === 'object') {
-		throw new Error(
-			'Unsupported Blueprint v2 wordpressVersion data reference. ' +
-				'Use latest, beta, trunk, nightly, a version like 6.8, ' +
-				'or an http(s) WordPress ZIP URL.'
-		);
+		// Validation guarantees that non-constraint objects are data references.
+		// Their archive is resolved separately before WordPress boot.
+		return CUSTOM_WORDPRESS_VERSION;
 	}
 
 	return 'latest';
@@ -329,18 +328,15 @@ async function resolveV2WordPressVersion(
 /**
  * Resolves a Blueprint v2 WordPress version string to a runtime source.
  *
- * Runtime configuration can carry named WordPress builds and HTTP(S) ZIP URLs,
- * but it cannot carry file references from the Blueprint execution context.
+ * Runtime configuration carries named builds and HTTP(S) ZIP URLs directly.
+ * Execution-context references use a synthetic label and resolve separately.
  */
 function resolveV2WordPressVersionString(wordpressVersion: string): string {
 	if (isHttpUrl(wordpressVersion)) {
 		return wordpressVersion;
 	}
 	if (isExecutionContextPath(wordpressVersion)) {
-		throw new Error(
-			'Unsupported Blueprint v2 wordpressVersion file reference. ' +
-				'Use an http(s) WordPress ZIP URL instead.'
-		);
+		return CUSTOM_WORDPRESS_VERSION;
 	}
 	if (
 		V2_WORDPRESS_VERSION_LABELS.includes(wordpressVersion) ||

--- a/packages/playground/blueprints/src/tests/v2/resolve-runtime-configuration.spec.ts
+++ b/packages/playground/blueprints/src/tests/v2/resolve-runtime-configuration.spec.ts
@@ -539,28 +539,22 @@ describe('Blueprint v2 runtime configuration', () => {
 		}
 	});
 
-	it('rejects unsupported WordPress runtime data references', async () => {
-		await expect(
-			resolveRuntimeConfiguration({
-				version: 2,
-				wordpressVersion: './wordpress.zip',
-			} as BlueprintV2Declaration)
-		).rejects.toThrow(
-			'Unsupported Blueprint v2 wordpressVersion file reference.'
-		);
-
-		await expect(
-			resolveRuntimeConfiguration({
-				version: 2,
-				wordpressVersion: {
-					filename: 'wordpress.zip',
-					content: '',
-				},
-			} as unknown as BlueprintV2Declaration)
-		).rejects.toThrow(
-			'Unsupported Blueprint v2 wordpressVersion data reference.'
-		);
-	});
+	it.each([
+		'./wordpress.zip',
+		{ filename: 'wordpress.zip', content: '' },
+		{ directoryName: 'wordpress', files: {} },
+		{ gitRepository: 'https://example.com/wordpress.git' },
+	] as const)(
+		'uses WordPress data reference %j as a custom runtime source',
+		async (wordpressVersion) => {
+			await expect(
+				resolveRuntimeConfiguration({
+					version: 2,
+					wordpressVersion,
+				} as BlueprintV2Declaration)
+			).resolves.toMatchObject({ wpVersion: 'custom' });
+		}
+	);
 
 	it('rejects malformed WordPress version constraint values', async () => {
 		await expect(

--- a/packages/playground/blueprints/src/tests/v2/resolve-wordpress-source.spec.ts
+++ b/packages/playground/blueprints/src/tests/v2/resolve-wordpress-source.spec.ts
@@ -1,0 +1,160 @@
+import { StreamedFile } from '@php-wasm/stream-compression';
+import { ZipFilesystem } from '@wp-playground/storage';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { resolveBlueprintV2WordPressSource } from '../../lib/v2/compile';
+import type { BlueprintV2Declaration } from '../../lib/v2/blueprint-v2-declaration';
+
+const gitMocks = vi.hoisted(() => ({
+	listGitFiles: vi.fn(),
+	resolveCommitHash: vi.fn(),
+	sparseCheckout: vi.fn(),
+}));
+
+vi.mock('@wp-playground/storage', async (importOriginal) => {
+	const actual = (await importOriginal()) as Record<string, unknown>;
+	return {
+		...actual,
+		listGitFiles: gitMocks.listGitFiles,
+		resolveCommitHash: gitMocks.resolveCommitHash,
+		sparseCheckout: gitMocks.sparseCheckout,
+	};
+});
+
+describe('resolveBlueprintV2WordPressSource', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		gitMocks.resolveCommitHash.mockResolvedValue('abc123');
+		gitMocks.listGitFiles.mockResolvedValue([
+			{
+				name: 'src',
+				type: 'folder',
+				children: [
+					{ name: 'index.php', type: 'file' },
+					{ name: 'wp-config-sample.php', type: 'file' },
+				],
+			},
+		]);
+		gitMocks.sparseCheckout.mockResolvedValue({
+			files: {
+				'src/index.php': '<?php',
+				'src/wp-config-sample.php': '<?php',
+			},
+		});
+	});
+
+	it('loads WordPress archives from the Blueprint execution context', async () => {
+		const streamBundledFile = vi.fn(async (path: string) =>
+			streamFile('wordpress archive', path)
+		);
+
+		const archive = await resolveBlueprintV2WordPressSource(
+			{
+				version: 2,
+				wordpressVersion: './assets/wordpress.zip',
+			},
+			{ streamBundledFile }
+		);
+
+		expect(streamBundledFile).toHaveBeenCalledWith('assets/wordpress.zip');
+		await expect(archive?.text()).resolves.toBe('wordpress archive');
+	});
+
+	it('loads inline WordPress archives', async () => {
+		const archive = await resolveBlueprintV2WordPressSource({
+			version: 2,
+			wordpressVersion: {
+				filename: 'wordpress.zip',
+				content: 'inline archive',
+			},
+		});
+
+		expect(archive?.name).toBe('wordpress.zip');
+		await expect(archive?.text()).resolves.toBe('inline archive');
+	});
+
+	it('packages inline WordPress directories as archives', async () => {
+		const archive = await resolveBlueprintV2WordPressSource({
+			version: 2,
+			wordpressVersion: {
+				directoryName: 'wordpress',
+				files: {
+					'index.php': '<?php',
+					'wp-includes': {
+						files: {
+							'version.php': '<?php $wp_version = "7.0";',
+						},
+					},
+				},
+			},
+		});
+
+		const zip = await openZip(archive);
+		expect(await zip.getAllFilePaths()).toEqual(
+			expect.arrayContaining([
+				'wordpress/index.php',
+				'wordpress/wp-includes/version.php',
+			])
+		);
+		await expect(
+			(await zip.read('wordpress/wp-includes/version.php')).text()
+		).resolves.toContain('$wp_version = "7.0"');
+	});
+
+	it('checks out and packages Git WordPress directories', async () => {
+		const archive = await resolveBlueprintV2WordPressSource({
+			version: 2,
+			wordpressVersion: {
+				gitRepository: 'https://example.com/wordpress.git',
+				ref: 'trunk',
+				pathInRepository: 'src',
+			},
+		});
+
+		expect(gitMocks.resolveCommitHash).toHaveBeenCalledWith(
+			'https://example.com/wordpress.git',
+			{ value: 'trunk', type: 'infer' },
+			{}
+		);
+		expect(gitMocks.sparseCheckout).toHaveBeenCalledWith(
+			'https://example.com/wordpress.git',
+			'abc123',
+			['src/index.php', 'src/wp-config-sample.php'],
+			{ withObjects: undefined, additionalHeaders: {} }
+		);
+		const zip = await openZip(archive);
+		expect(
+			(await zip.getAllFilePaths()).some((path) =>
+				path.endsWith('/wp-config-sample.php')
+			)
+		).toBe(true);
+	});
+
+	it.each([
+		undefined,
+		'latest',
+		'https://example.com/wordpress.zip',
+		{ min: '6.8' },
+	] as const)(
+		'leaves existing WordPress source %j to the normal download path',
+		async (wordpressVersion) => {
+			await expect(
+				resolveBlueprintV2WordPressSource({
+					version: 2,
+					wordpressVersion,
+				} as BlueprintV2Declaration)
+			).resolves.toBeUndefined();
+		}
+	);
+});
+
+function streamFile(contents: string, name: string) {
+	const blob = new Blob([contents]);
+	return new StreamedFile(blob.stream(), name, { filesize: blob.size });
+}
+
+async function openZip(file: File | undefined) {
+	if (!file) {
+		throw new Error('Expected a WordPress archive');
+	}
+	return ZipFilesystem.fromArrayBuffer(await file.arrayBuffer());
+}

--- a/packages/playground/cli/src/blueprints-v2/blueprints-v2-handler.ts
+++ b/packages/playground/cli/src/blueprints-v2/blueprints-v2-handler.ts
@@ -14,6 +14,7 @@ import {
 	BlueprintReflection,
 	compileBlueprintV2,
 	isBlueprintBundle,
+	resolveBlueprintV2WordPressSource,
 	resolveRuntimeConfiguration,
 } from '@wp-playground/blueprints';
 import { RecommendedPHPVersion } from '@wp-playground/common';
@@ -67,7 +68,7 @@ export class BlueprintsV2Handler {
 		playground: Pooled<PlaygroundCliWorker>,
 		workerPostInstallMountsPort: NodeMessagePort
 	) {
-		let wordPressZip: any = undefined;
+		let wordPressZip: File | undefined;
 		const wordpressInstallMode = await this.getWordPressInstallMode();
 		const effectiveBlueprint = await this.getEffectiveBlueprint();
 		const runtimeConfiguration = await resolveRuntimeConfiguration(
@@ -80,36 +81,44 @@ export class BlueprintsV2Handler {
 		);
 		assertCliSupportedPHPVersion(runtimeConfiguration.phpVersion);
 		if (wordpressInstallMode === 'download-and-install') {
-			const monitor = new EmscriptenDownloadMonitor();
-			let progressReached100 = false;
-			monitor.addEventListener('progress', ((
-				e: CustomEvent<ProgressEvent & { finished: boolean }>
-			) => {
-				if (progressReached100) {
-					return;
+			wordPressZip = await resolveBlueprintV2WordPressSource(
+				effectiveBlueprint.declaration,
+				{
+					streamBundledFile: effectiveBlueprint.streamBundledFile,
 				}
-				const { loaded, total } = e.detail;
-				const percentProgress = Math.floor(
-					Math.min(100, (100 * loaded) / total)
-				);
-				progressReached100 = percentProgress === 100;
-				this.cliOutput.updateProgress(
-					'Downloading WordPress',
-					percentProgress
-				);
-			}) as any);
+			);
+			if (!wordPressZip) {
+				const monitor = new EmscriptenDownloadMonitor();
+				let progressReached100 = false;
+				monitor.addEventListener('progress', ((
+					e: CustomEvent<ProgressEvent & { finished: boolean }>
+				) => {
+					if (progressReached100) {
+						return;
+					}
+					const { loaded, total } = e.detail;
+					const percentProgress = Math.floor(
+						Math.min(100, (100 * loaded) / total)
+					);
+					progressReached100 = percentProgress === 100;
+					this.cliOutput.updateProgress(
+						'Downloading WordPress',
+						percentProgress
+					);
+				}) as any);
 
-			const wpDetails = await resolveWordPressRelease(
-				runtimeConfiguration.wpVersion
-			);
-			wordPressZip = await cachedDownload(
-				wpDetails.releaseUrl,
-				`${wpDetails.version}.zip`,
-				monitor
-			);
-			logger.debug(
-				`Resolved WordPress release URL: ${wpDetails?.releaseUrl}`
-			);
+				const wpDetails = await resolveWordPressRelease(
+					runtimeConfiguration.wpVersion
+				);
+				wordPressZip = await cachedDownload(
+					wpDetails.releaseUrl,
+					`${wpDetails.version}.zip`,
+					monitor
+				);
+				logger.debug(
+					`Resolved WordPress release URL: ${wpDetails?.releaseUrl}`
+				);
+			}
 		}
 
 		if (isV2ExistingSiteInstallMode(wordpressInstallMode)) {

--- a/packages/playground/cli/tests/blueprints-v2-handler.spec.ts
+++ b/packages/playground/cli/tests/blueprints-v2-handler.spec.ts
@@ -9,7 +9,10 @@ import type {
 } from '@wp-playground/blueprints';
 import { assertBlueprintV2WordPressVersionCompatibility } from '@wp-playground/blueprints';
 import { consumeAPI } from '@php-wasm/universal';
-import { fetchSqliteIntegration } from '../src/blueprints-v1/download';
+import {
+	cachedDownload,
+	fetchSqliteIntegration,
+} from '../src/blueprints-v1/download';
 
 vi.mock('@php-wasm/universal', async (importOriginal) => {
 	const actual = (await importOriginal()) as Record<string, unknown>;
@@ -23,6 +26,9 @@ vi.mock('../src/blueprints-v1/download', async (importOriginal) => {
 	const actual = (await importOriginal()) as Record<string, unknown>;
 	return {
 		...actual,
+		cachedDownload: vi.fn(
+			async () => new File(['WordPress'], 'wordpress.zip')
+		),
 		fetchSqliteIntegration: vi.fn(
 			async () => new File(['sqlite'], 'sqlite.zip')
 		),
@@ -463,6 +469,39 @@ describe('BlueprintsV2Handler', () => {
 		expect(
 			assertBlueprintV2WordPressVersionCompatibility
 		).not.toHaveBeenCalled();
+	});
+
+	test('loads a bundled v2 WordPress archive instead of downloading core', async () => {
+		const handler = new BlueprintsV2Handler(
+			{
+				command: 'server',
+				mode: 'create-new-site',
+				skipSqliteSetup: true,
+				blueprint: createBundle(
+					{
+						version: 2,
+						wordpressVersion: './wordpress.zip',
+					},
+					{ 'wordpress.zip': 'bundled WordPress' }
+				),
+			} as RunCLIArgs,
+			{
+				siteUrl: 'http://127.0.0.1:9400',
+				cliOutput,
+			}
+		);
+		const playground = {
+			bootWordPress: vi.fn().mockResolvedValue(undefined),
+			run: vi.fn(),
+		};
+
+		await handler.bootWordPress(playground as any, {} as any);
+
+		expect(cachedDownload).not.toHaveBeenCalled();
+		const bootOptions = playground.bootWordPress.mock.calls[0][0];
+		expect(new TextDecoder().decode(bootOptions.wordPressZip)).toBe(
+			'bundled WordPress'
+		);
 	});
 
 	test('preserves v2 mount-only mode from legacy install mode', async () => {

--- a/packages/playground/client/src/blueprints-v2-handler.spec.ts
+++ b/packages/playground/client/src/blueprints-v2-handler.spec.ts
@@ -11,6 +11,7 @@ const mocks = vi.hoisted(() => {
 			onDownloadProgress: vi.fn(),
 		},
 		compileBlueprintForExecution: vi.fn(),
+		resolveBlueprintV2WordPressSource: vi.fn(),
 		resolveRuntimeConfiguration: vi.fn(),
 		consumeAPI: vi.fn(),
 		collectPhpLogs: vi.fn(),
@@ -29,6 +30,10 @@ vi.mock('@php-wasm/universal', () => ({
 
 vi.mock('@wp-playground/blueprints', () => ({
 	compileBlueprintForExecution: mocks.compileBlueprintForExecution,
+	isBlueprintBundle: (blueprint: unknown) =>
+		!!blueprint &&
+		typeof (blueprint as { read?: unknown }).read === 'function',
+	resolveBlueprintV2WordPressSource: mocks.resolveBlueprintV2WordPressSource,
 	resolveRuntimeConfiguration: mocks.resolveRuntimeConfiguration,
 }));
 
@@ -40,6 +45,7 @@ describe('BlueprintsV2Handler', () => {
 		mocks.playground.isReady.mockResolvedValue(undefined);
 		mocks.playground.onDownloadProgress.mockResolvedValue(undefined);
 		mocks.compiledRun.mockResolvedValue(undefined);
+		mocks.resolveBlueprintV2WordPressSource.mockResolvedValue(undefined);
 		mocks.compileBlueprintForExecution.mockImplementation(
 			async (blueprint) => ({
 				version: 2,
@@ -146,6 +152,31 @@ describe('BlueprintsV2Handler', () => {
 		await handler.bootPlayground(iframe, progressTracker);
 
 		expect(progressTracker.pipe).not.toHaveBeenCalled();
+	});
+
+	it('passes resolved v2 WordPress archives to the worker', async () => {
+		const iframe = createIframe();
+		const blueprint = {
+			version: 2,
+			wordpressVersion: './wordpress.zip',
+		} as const;
+		const wordPressZip = new File(['wordpress'], 'wordpress.zip');
+		mocks.resolveBlueprintV2WordPressSource.mockResolvedValue(wordPressZip);
+		const handler = new BlueprintsV2Handler({
+			iframe,
+			remoteUrl: 'http://example.com/remote.html',
+			blueprint,
+		});
+
+		await handler.bootPlayground(iframe, createProgressTracker());
+
+		expect(mocks.resolveBlueprintV2WordPressSource).toHaveBeenCalledWith(
+			blueprint,
+			expect.objectContaining({ streamBundledFile: undefined })
+		);
+		expect(mocks.playground.boot).toHaveBeenCalledWith(
+			expect.objectContaining({ wordPressZip })
+		);
 	});
 
 	it('passes mounted-site constraints to the worker preflight', async () => {

--- a/packages/playground/client/src/blueprints-v2-handler.ts
+++ b/packages/playground/client/src/blueprints-v2-handler.ts
@@ -4,6 +4,8 @@ import { consumeAPI } from '@php-wasm/universal';
 import type { PHPWebExtension } from '@php-wasm/web';
 import {
 	compileBlueprintForExecution,
+	isBlueprintBundle,
+	resolveBlueprintV2WordPressSource,
 	resolveRuntimeConfiguration,
 } from '@wp-playground/blueprints';
 import type { PlaygroundClient, StartPlaygroundWebOptions } from '.';
@@ -84,6 +86,21 @@ export class BlueprintsV2Handler {
 			compiled.version === 2
 				? compiled.compiled.runtime
 				: await resolveRuntimeConfiguration(compiled.declaration);
+		const wordPressZip =
+			compiled.version === 2 &&
+			resolvedWordPressInstallMode === 'download-and-install'
+				? await resolveBlueprintV2WordPressSource(
+						compiled.declaration,
+						{
+							progress: downloadProgress,
+							corsProxy,
+							gitAdditionalHeadersCallback,
+							streamBundledFile: isBlueprintBundle(blueprint)
+								? (path) => blueprint.read(path)
+								: undefined,
+						}
+					)
+				: undefined;
 		const extensions: PHPWebExtension[] = runtimeConfiguration.intl
 			? ['intl']
 			: [];
@@ -108,6 +125,7 @@ export class BlueprintsV2Handler {
 					: undefined,
 			phpVersion: runtimeConfiguration.phpVersion,
 			wpVersion: runtimeConfiguration.wpVersion,
+			wordPressZip,
 			extensions,
 			withNetworking: runtimeConfiguration.networking,
 			corsProxyUrl: corsProxy,

--- a/packages/playground/remote/src/lib/playground-worker-endpoint-blueprints-v1.spec.ts
+++ b/packages/playground/remote/src/lib/playground-worker-endpoint-blueprints-v1.spec.ts
@@ -257,6 +257,55 @@ describe('PlaygroundWorkerEndpointBlueprintsV1', () => {
 		10000
 	);
 
+	it('uses a caller-provided WordPress archive without downloading core', async () => {
+		const bootWordPress = vi.fn();
+		let endpoint:
+			| {
+					boot(options: Record<string, unknown>): Promise<void>;
+			  }
+			| undefined;
+		vi.doMock('@wp-playground/wordpress', () => ({
+			bootWordPress,
+		}));
+		vi.doMock('@php-wasm/web', () => ({
+			certificateToPEM: vi.fn(),
+			createDirectoryHandleMountHandler: vi.fn(),
+			exposeAPI: vi.fn((api) => {
+				endpoint = api;
+				return [vi.fn(), vi.fn()];
+			}),
+			loadWebRuntime: vi.fn(),
+		}));
+		await import('./playground-worker-endpoint-blueprints-v1');
+		if (!endpoint) {
+			throw new Error('Expected exposeAPI to receive an endpoint');
+		}
+		vi.spyOn(endpoint as any, 'computeSiteUrl').mockReturnValue(
+			'http://playground.test'
+		);
+		vi.spyOn(endpoint as any, 'createRequestHandler').mockResolvedValue({});
+		vi.spyOn(endpoint as any, 'finalizeAfterBoot').mockResolvedValue(
+			undefined
+		);
+		const wordPressZip = new File(['custom WordPress'], 'wordpress.zip');
+
+		await endpoint.boot({
+			scope: 'test',
+			phpVersion: '8.3',
+			wpVersion: 'custom',
+			wordPressZip,
+			wordpressInstallMode: 'download-and-install',
+			withNetworking: false,
+		});
+
+		expect(bootWordPress).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.objectContaining({ wordPressZip })
+		);
+		// SQLite still downloads in parallel; WordPress core does not.
+		expect(fetch).toHaveBeenCalledTimes(1);
+	}, 10000);
+
 	it('throws a diagnostic error if the worker entrypoint is evaluated twice in the same worker global', async () => {
 		vi.doMock('@php-wasm/web', () => ({
 			certificateToPEM: vi.fn(),

--- a/packages/playground/remote/src/lib/playground-worker-endpoint-blueprints-v1.ts
+++ b/packages/playground/remote/src/lib/playground-worker-endpoint-blueprints-v1.ts
@@ -39,6 +39,7 @@ class PlaygroundWorkerEndpointBlueprintsV1 extends PlaygroundWorkerEndpoint {
 		scope,
 		mounts = [],
 		wpVersion = LatestMinifiedWordPressVersion,
+		wordPressZip,
 		sqliteDriverVersion = LatestSqliteDriverVersion,
 		phpVersion,
 		sapiName = 'cli',
@@ -95,7 +96,10 @@ class PlaygroundWorkerEndpointBlueprintsV1 extends PlaygroundWorkerEndpoint {
 			// Only tar.zst descriptors opt into the streaming extractor's file-count
 			// parity check. Custom URLs and wordpress.org ZIPs skip it.
 			let expectedBundleFileCount: number | undefined;
-			if (resolvedWordPressInstallMode === 'download-and-install') {
+			if (
+				resolvedWordPressInstallMode === 'download-and-install' &&
+				!wordPressZip
+			) {
 				if (this.requestedWordPressVersion!.startsWith('http')) {
 					wordPressRequest = this.downloadMonitor
 						.monitorFetch(
@@ -234,9 +238,11 @@ class PlaygroundWorkerEndpointBlueprintsV1 extends PlaygroundWorkerEndpoint {
 				// client is low on disk space. Blobs tend to be stored as temporary files,
 				// array buffers tend to be stored in memory.
 				// @see https://github.com/WordPress/wordpress-playground/issues/2769
-				wordPressZip: wordPressRequest
-					?.then((r) => r.arrayBuffer())
-					.then((b) => new File([b], 'wp.bundle')),
+				wordPressZip:
+					wordPressZip ??
+					wordPressRequest
+						?.then((r) => r.arrayBuffer())
+						.then((b) => new File([b], 'wp.bundle')),
 				wordPressBundleFileCount: expectedBundleFileCount,
 				sqliteIntegrationPluginZip: sqliteIntegrationRequest
 					.then((r) => r.arrayBuffer())

--- a/packages/playground/remote/src/lib/playground-worker-endpoint.ts
+++ b/packages/playground/remote/src/lib/playground-worker-endpoint.ts
@@ -71,6 +71,8 @@ export interface MountDescriptor {
 
 export type WorkerBootOptions = {
 	wpVersion?: string;
+	/** A caller-provided WordPress archive used instead of downloading one. */
+	wordPressZip?: File;
 	sqliteDriverVersion?: string;
 	phpVersion?: AllPHPVersion;
 	sapiName?: string;


### PR DESCRIPTION
## What

Load custom `wordpressVersion` data references in TypeScript Blueprints v2.

Blueprints v2 can now load WordPress from a custom ZIP, a directory embedded in the Blueprint, or a directory in Git. The ZIP can sit next to the Blueprint or be embedded in it. Directory sources are turned into ZIPs before WordPress boots. Both the browser and CLI use the supplied source instead of downloading another WordPress build.

Built-in versions and HTTP(S) archives keep their existing download paths. This takes the useful source-resolution idea from #3725 without reviving that PR's compiler, validator, or migration work.

## Why

The public v2 schema already accepts general data references for `wordpressVersion`, but the TypeScript runtime rejected every form except HTTP(S). A valid Blueprint could therefore validate and still fail before boot.

## Testing

CI
