### PR TITLE
[Website] Keep pending file edits with their filesystem owner

### DIFF
--- a/packages/playground/components/e2e/tests/playground-file-editor.spec.ts
+++ b/packages/playground/components/e2e/tests/playground-file-editor.spec.ts
@@ -1,11 +1,22 @@
 import { expect, type Page, test } from '@playwright/test';
 import type { AsyncWritableFilesystem } from '@wp-playground/storage';
 
+type FilesystemName = 'a' | 'b';
+
 declare global {
 	interface Window {
 		__fileEditorHarness?: {
-			filesystem: AsyncWritableFilesystem;
-			readFileAsText: (path: string) => Promise<string>;
+			filesystems: Record<FilesystemName, AsyncWritableFilesystem>;
+			readFileAsText: (
+				filesystem: FilesystemName,
+				path: string
+			) => Promise<string>;
+			switchFilesystem: (filesystem: FilesystemName) => void;
+			mountEditor: () => void;
+			unmountEditor: () => void;
+			delayNextWrite: () => void;
+			releaseDelayedWrite: () => void;
+			isWriteDelayed: () => boolean;
 		};
 	}
 }
@@ -18,14 +29,30 @@ async function gotoHarness(page: Page) {
 	await expect(page.locator('.cm-content')).toBeVisible();
 }
 
-async function readHarnessFile(page: Page, path: string) {
-	return page.evaluate((filePath) => {
-		const harness = window.__fileEditorHarness;
-		if (!harness) {
-			throw new Error('File editor harness is not mounted');
-		}
-		return harness.readFileAsText(filePath);
-	}, path);
+async function readHarnessFile(
+	page: Page,
+	path: string,
+	filesystem: FilesystemName = 'a'
+) {
+	return page.evaluate(
+		({ filePath, filesystemName }) => {
+			const harness = window.__fileEditorHarness;
+			if (!harness) {
+				throw new Error('File editor harness is not mounted');
+			}
+			return harness.readFileAsText(filesystemName, filePath);
+		},
+		{ filePath: path, filesystemName: filesystem }
+	);
+}
+
+/** Replaces the editor contents as one user edit. */
+async function replaceEditorContents(page: Page, content: string) {
+	const editor = page.locator('.cm-content');
+	await editor.click();
+	await page.keyboard.press('ControlOrMeta+A');
+	await page.keyboard.insertText(content);
+	await expect(page.getByText('Saving…')).toBeVisible();
 }
 
 /** Drops one nested host directory on the file explorer background. */
@@ -130,15 +157,77 @@ test('autosaves editor changes into the harness filesystem', async ({
 	page,
 }) => {
 	const nextContent = "<?php echo 'Changed in harness';";
-	const editor = page.locator('.cm-content');
-
-	await editor.click();
-	await page.keyboard.press('ControlOrMeta+A');
-	await page.keyboard.insertText(nextContent);
+	await replaceEditorContents(page, nextContent);
 
 	await expect
 		.poll(() => readHarnessFile(page, initialPath), {
 			timeout: 10_000,
 		})
 		.toBe(nextContent);
+});
+
+test('flushes a pending edit when the editor unmounts', async ({ page }) => {
+	const nextContent = "<?php echo 'Saved before unmount';";
+	await replaceEditorContents(page, nextContent);
+
+	await page.evaluate(() => {
+		window.__fileEditorHarness?.unmountEditor();
+	});
+	await expect(page.locator('.cm-content')).toHaveCount(0);
+	await expect
+		.poll(() => readHarnessFile(page, initialPath))
+		.toBe(nextContent);
+});
+
+test('keeps a pending edit with its old filesystem', async ({ page }) => {
+	const filesystemAContent = "<?php echo 'Filesystem A edit';";
+	const filesystemBContent = "<?php echo 'Filesystem B';";
+	await replaceEditorContents(page, filesystemAContent);
+
+	await page.evaluate(() => {
+		window.__fileEditorHarness?.switchFilesystem('b');
+	});
+
+	await expect(page.locator('.cm-content')).toContainText(filesystemBContent);
+	await expect
+		.poll(() => readHarnessFile(page, initialPath, 'a'))
+		.toBe(filesystemAContent);
+	await expect(readHarnessFile(page, initialPath, 'b')).resolves.toBe(
+		filesystemBContent
+	);
+});
+
+test('orders old writes without blocking the new filesystem', async ({
+	page,
+}) => {
+	const firstContent = "<?php echo 'First edit';";
+	const finalContent = "<?php echo 'Final edit';";
+	const filesystemBContent = "<?php echo 'Filesystem B';";
+	const filesystemBEdit = "<?php echo 'Filesystem B edit';";
+
+	await page.evaluate(() => {
+		window.__fileEditorHarness?.delayNextWrite();
+	});
+	await replaceEditorContents(page, firstContent);
+	await page.waitForFunction(
+		() => window.__fileEditorHarness?.isWriteDelayed() === true
+	);
+	await replaceEditorContents(page, finalContent);
+
+	await page.evaluate(() => {
+		window.__fileEditorHarness?.switchFilesystem('b');
+	});
+
+	await expect(page.locator('.cm-content')).toContainText(filesystemBContent);
+	await replaceEditorContents(page, filesystemBEdit);
+	await expect
+		.poll(() => readHarnessFile(page, initialPath, 'b'))
+		.toBe(filesystemBEdit);
+
+	await page.evaluate(() => {
+		window.__fileEditorHarness?.releaseDelayedWrite();
+	});
+	await expect
+		.poll(() => readHarnessFile(page, initialPath, 'a'))
+		.toBe(finalContent);
 });

--- a/packages/playground/components/src/PlaygroundFileEditor/playground-file-editor.tsx
+++ b/packages/playground/components/src/PlaygroundFileEditor/playground-file-editor.tsx
@@ -25,14 +25,12 @@ export type PlaygroundFileEditorProps = {
 	documentRoot: string;
 	initialPath?: string | null;
 	placeholderText?: string;
-	onSaveFile?: (path: string, content: string) => Promise<void>;
-	/**
-	 * Called before the filesystem changes, allowing the parent to flush
-	 * any pending saves to the old filesystem.
-	 */
-	onBeforeFilesystemChange?: (
-		oldFilesystem: AsyncWritableFilesystem
-	) => Promise<void>;
+};
+
+type PendingSave = {
+	filesystem: AsyncWritableFilesystem;
+	path: string;
+	content: string;
 };
 
 /**
@@ -46,8 +44,6 @@ export function PlaygroundFileEditor({
 	documentRoot,
 	initialPath = null,
 	placeholderText = 'Select a file to view or edit its contents.',
-	onSaveFile,
-	onBeforeFilesystemChange,
 }: PlaygroundFileEditorProps) {
 	const [selectedDirPath, setSelectedDirPath] = useState<string | null>(
 		documentRoot
@@ -66,51 +62,125 @@ export function PlaygroundFileEditor({
 	const editorRef = useRef<CodeEditorHandle | null>(null);
 	const saveTimeoutRef = useRef<number | null>(null);
 	const skipNextSaveRef = useRef<boolean>(false);
-	const codeRef = useRef<string>(code);
 	const currentPathRef = useRef<string | null>(currentPath);
-	const filesystemRef = useRef<AsyncWritableFilesystem | null>(filesystem);
-	const previousFilesystemRef = useRef<AsyncWritableFilesystem | null>(null);
+	const activeFilesystemRef = useRef<AsyncWritableFilesystem | null>(
+		filesystem
+	);
+	const pendingSaveRef = useRef<PendingSave | null>(null);
+	const saveQueuesRef = useRef(
+		new WeakMap<AsyncWritableFilesystem, Map<string, Promise<void>>>()
+	);
+	const isMountedRef = useRef<boolean>(true);
 	const cursorPositionsRef = useRef<Map<string, number>>(new Map());
 	const hasAutoOpenedRef = useRef<boolean>(false);
 
-	useEffect(() => {
-		codeRef.current = code;
-	}, [code]);
+	activeFilesystemRef.current = filesystem;
 
 	useEffect(() => {
 		currentPathRef.current = currentPath;
 	}, [currentPath]);
 
-	useEffect(() => {
-		filesystemRef.current = filesystem;
-	}, [filesystem]);
+	/**
+	 * Serializes writes to each owned path so an older write cannot finish last,
+	 * without making an unrelated filesystem wait for it.
+	 */
+	const saveFile = useCallback(async (pendingSave: PendingSave) => {
+		let filesystemQueue = saveQueuesRef.current.get(pendingSave.filesystem);
+		if (!filesystemQueue) {
+			filesystemQueue = new Map();
+			saveQueuesRef.current.set(pendingSave.filesystem, filesystemQueue);
+		}
+		const previousWrite = filesystemQueue.get(pendingSave.path);
+		const writePromise = (previousWrite ?? Promise.resolve())
+			.catch(() => undefined)
+			.then(() =>
+				pendingSave.filesystem.writeFile(
+					pendingSave.path,
+					pendingSave.content
+				)
+			);
+		filesystemQueue.set(pendingSave.path, writePromise);
 
-	// Call onBeforeFilesystemChange when filesystem changes
-	useEffect(() => {
-		const oldFilesystem = previousFilesystemRef.current;
-		if (oldFilesystem && oldFilesystem !== filesystem) {
-			// Filesystem is changing - notify parent to flush saves
-			if (onBeforeFilesystemChange) {
-				void onBeforeFilesystemChange(oldFilesystem);
+		try {
+			await writePromise;
+			if (
+				isMountedRef.current &&
+				filesystemQueue.get(pendingSave.path) === writePromise &&
+				activeFilesystemRef.current === pendingSave.filesystem &&
+				currentPathRef.current === pendingSave.path &&
+				pendingSaveRef.current === null
+			) {
+				setSaveState(SaveState.SAVED);
+				setSaveError(null);
+			}
+		} catch (error) {
+			logger.error('Failed to save file', error);
+			if (
+				isMountedRef.current &&
+				filesystemQueue.get(pendingSave.path) === writePromise &&
+				activeFilesystemRef.current === pendingSave.filesystem &&
+				currentPathRef.current === pendingSave.path &&
+				pendingSaveRef.current === null
+			) {
+				setSaveState(SaveState.ERROR);
+				setSaveError('Could not save changes. Try again.');
+			}
+		} finally {
+			if (filesystemQueue.get(pendingSave.path) === writePromise) {
+				filesystemQueue.delete(pendingSave.path);
+				if (filesystemQueue.size === 0) {
+					saveQueuesRef.current.delete(pendingSave.filesystem);
+				}
 			}
 		}
-		previousFilesystemRef.current = filesystem;
-	}, [filesystem, onBeforeFilesystemChange]);
+	}, []);
 
-	// Reset state when filesystem changes
-	useEffect(() => {
-		if (!filesystem) {
-			skipNextSaveRef.current = true;
-			setCode('');
-			setCurrentPath(null);
-			setReadOnly(true);
-			setSaveState(SaveState.IDLE);
-			setSaveError(null);
-			setShowExplorerOnMobile(false);
-			setMessageContent(null);
-			hasAutoOpenedRef.current = false;
+	/** Flushes the latest buffered edit to the filesystem that produced it. */
+	const flushPendingSave = useCallback(() => {
+		const pendingSave = pendingSaveRef.current;
+		if (!pendingSave) {
+			return;
 		}
-	}, [filesystem]);
+		if (saveTimeoutRef.current !== null) {
+			window.clearTimeout(saveTimeoutRef.current);
+			saveTimeoutRef.current = null;
+		}
+		pendingSaveRef.current = null;
+		void saveFile(pendingSave);
+	}, [saveFile]);
+
+	useEffect(() => {
+		isMountedRef.current = true;
+		return () => {
+			isMountedRef.current = false;
+		};
+	}, []);
+
+	// The cleanup captures the old filesystem. The pending save captures it too,
+	// so switching to a filesystem with the same path cannot redirect the write.
+	useEffect(() => {
+		return () => {
+			if (pendingSaveRef.current?.filesystem === filesystem) {
+				flushPendingSave();
+			}
+		};
+	}, [documentRoot, filesystem, flushPendingSave]);
+
+	// Editor state belongs to one filesystem root. Never carry a path or buffer
+	// into another filesystem just because that filesystem has the same path.
+	useEffect(() => {
+		skipNextSaveRef.current = true;
+		setSelectedDirPath(documentRoot);
+		setCode('');
+		setCurrentPath(null);
+		setReadOnly(true);
+		setSaveState(SaveState.IDLE);
+		setSaveError(null);
+		setShowExplorerOnMobile(false);
+		setMessageContent(null);
+		cursorPositionsRef.current.clear();
+		hasAutoOpenedRef.current = false;
+	}, [documentRoot, filesystem]);
 
 	// Auto-open initialPath when filesystem becomes available
 	useEffect(() => {
@@ -118,12 +188,16 @@ export function PlaygroundFileEditor({
 			return;
 		}
 
+		let cancelled = false;
 		const tryAutoOpen = async () => {
 			try {
 				const exists = await filesystem.fileExists(initialPath);
-				if (exists) {
+				if (exists && !cancelled) {
 					const content =
 						await filesystem.readFileAsText(initialPath);
+					if (cancelled) {
+						return;
+					}
 					skipNextSaveRef.current = true;
 					setCurrentPath(initialPath);
 					setCode(content);
@@ -139,44 +213,26 @@ export function PlaygroundFileEditor({
 				// Silently fail - file may not exist or may not be readable
 				logger.debug('Could not auto-open initial path:', error);
 			} finally {
-				hasAutoOpenedRef.current = true;
+				if (!cancelled) {
+					hasAutoOpenedRef.current = true;
+				}
 			}
 		};
 
 		void tryAutoOpen();
-	}, [filesystem, initialPath]);
-
-	// Reset when documentRoot changes
-	useEffect(() => {
-		setSelectedDirPath(documentRoot);
-		setCurrentPath(null);
-		setCode('');
-		setReadOnly(true);
-		setSaveState(SaveState.IDLE);
-		setSaveError(null);
-		skipNextSaveRef.current = true;
-		setMessageContent(null);
-		hasAutoOpenedRef.current = false;
-	}, [documentRoot]);
-
-	// Flush pending save on unmount
-	useEffect(() => {
 		return () => {
-			if (saveTimeoutRef.current !== null) {
-				window.clearTimeout(saveTimeoutRef.current);
-				saveTimeoutRef.current = null;
-			}
+			cancelled = true;
 		};
-	}, []);
+	}, [filesystem, initialPath]);
 
 	// Auto-save effect
 	useEffect(() => {
-		const activeFilesystem = filesystemRef.current;
-		if (!activeFilesystem || !currentPath) {
+		if (!filesystem || !currentPath) {
 			if (saveTimeoutRef.current !== null) {
 				window.clearTimeout(saveTimeoutRef.current);
 				saveTimeoutRef.current = null;
 			}
+			pendingSaveRef.current = null;
 			if (!currentPath) {
 				setSaveState(SaveState.IDLE);
 			}
@@ -184,6 +240,7 @@ export function PlaygroundFileEditor({
 		}
 		if (skipNextSaveRef.current) {
 			skipNextSaveRef.current = false;
+			pendingSaveRef.current = null;
 			return;
 		}
 		if (saveTimeoutRef.current !== null) {
@@ -191,24 +248,20 @@ export function PlaygroundFileEditor({
 			saveTimeoutRef.current = null;
 		}
 		setSaveState(SaveState.PENDING);
-		const timeout = window.setTimeout(async () => {
-			saveTimeoutRef.current = null;
-			setSaveState(SaveState.SAVING);
-			try {
-				const pathToSave = currentPathRef.current as string;
-				const contentToSave = codeRef.current;
-				if (onSaveFile) {
-					await onSaveFile(pathToSave, contentToSave);
-				} else {
-					await activeFilesystem.writeFile(pathToSave, contentToSave);
-				}
-				setSaveState(SaveState.SAVED);
-				setSaveError(null);
-			} catch (error) {
-				logger.error('Failed to save file', error);
-				setSaveState(SaveState.ERROR);
-				setSaveError('Could not save changes. Try again.');
+		const pendingSave = {
+			filesystem,
+			path: currentPath,
+			content: code,
+		};
+		pendingSaveRef.current = pendingSave;
+		const timeout = window.setTimeout(() => {
+			if (pendingSaveRef.current !== pendingSave) {
+				return;
 			}
+			saveTimeoutRef.current = null;
+			pendingSaveRef.current = null;
+			setSaveState(SaveState.SAVING);
+			void saveFile(pendingSave);
 		}, SAVE_DEBOUNCE_MS);
 		saveTimeoutRef.current = timeout;
 
@@ -218,7 +271,7 @@ export function PlaygroundFileEditor({
 				saveTimeoutRef.current = null;
 			}
 		};
-	}, [code, currentPath, onSaveFile]);
+	}, [code, currentPath, filesystem, saveFile]);
 
 	// Clear "Saved" state after 2 seconds
 	useEffect(() => {
@@ -362,37 +415,13 @@ export function PlaygroundFileEditor({
 		[]
 	);
 
-	const handleManualSave = useCallback(async () => {
-		if (saveTimeoutRef.current === null) {
+	const handleManualSave = useCallback(() => {
+		if (!pendingSaveRef.current) {
 			return;
 		}
-		if (!filesystemRef.current || !currentPathRef.current) {
-			window.clearTimeout(saveTimeoutRef.current);
-			saveTimeoutRef.current = null;
-			return;
-		}
-		window.clearTimeout(saveTimeoutRef.current);
-		saveTimeoutRef.current = null;
 		setSaveState(SaveState.SAVING);
-		try {
-			const pathToSave = currentPathRef.current;
-			const contentToSave = codeRef.current;
-			if (onSaveFile) {
-				await onSaveFile(pathToSave, contentToSave);
-			} else {
-				await filesystemRef.current.writeFile(
-					pathToSave,
-					contentToSave
-				);
-			}
-			setSaveState(SaveState.SAVED);
-			setSaveError(null);
-		} catch (error) {
-			logger.error('Failed to save file', error);
-			setSaveState(SaveState.ERROR);
-			setSaveError('Could not save changes. Try again.');
-		}
-	}, [onSaveFile]);
+		flushPendingSave();
+	}, [flushPendingSave]);
 
 	const saveStatusLabel = getSaveStatusLabel(saveState, saveError);
 	const saveStatusClassName = getSaveStatusClassName(saveState, styles);

--- a/packages/playground/components/src/PlaygroundFileEditor/playground-file-editor.tsx
+++ b/packages/playground/components/src/PlaygroundFileEditor/playground-file-editor.tsx
@@ -67,8 +67,8 @@ export function PlaygroundFileEditor({
 		filesystem
 	);
 	const pendingSaveRef = useRef<PendingSave | null>(null);
-	const saveQueuesRef = useRef(
-		new WeakMap<AsyncWritableFilesystem, Map<string, Promise<void>>>()
+	const lastWriteByFilesystemRef = useRef(
+		new WeakMap<AsyncWritableFilesystem, Promise<void>>()
 	);
 	const isMountedRef = useRef<boolean>(true);
 	const cursorPositionsRef = useRef<Map<string, number>>(new Map());
@@ -81,57 +81,45 @@ export function PlaygroundFileEditor({
 	}, [currentPath]);
 
 	/**
-	 * Serializes writes to each owned path so an older write cannot finish last,
-	 * without making an unrelated filesystem wait for it.
+	 * Keeps writes ordered within their owning filesystem without making an
+	 * unrelated filesystem wait.
 	 */
 	const saveFile = useCallback(async (pendingSave: PendingSave) => {
-		let filesystemQueue = saveQueuesRef.current.get(pendingSave.filesystem);
-		if (!filesystemQueue) {
-			filesystemQueue = new Map();
-			saveQueuesRef.current.set(pendingSave.filesystem, filesystemQueue);
-		}
-		const previousWrite = filesystemQueue.get(pendingSave.path);
+		const { filesystem, path, content } = pendingSave;
+		const writes = lastWriteByFilesystemRef.current;
+		const previousWrite = writes.get(filesystem);
+		// A failed write reports its own error, but must not poison later writes.
 		const writePromise = (previousWrite ?? Promise.resolve())
 			.catch(() => undefined)
-			.then(() =>
-				pendingSave.filesystem.writeFile(
-					pendingSave.path,
-					pendingSave.content
-				)
-			);
-		filesystemQueue.set(pendingSave.path, writePromise);
+			.then(() => filesystem.writeFile(path, content));
+		writes.set(filesystem, writePromise);
 
+		let writeFailed = false;
 		try {
 			await writePromise;
-			if (
-				isMountedRef.current &&
-				filesystemQueue.get(pendingSave.path) === writePromise &&
-				activeFilesystemRef.current === pendingSave.filesystem &&
-				currentPathRef.current === pendingSave.path &&
-				pendingSaveRef.current === null
-			) {
-				setSaveState(SaveState.SAVED);
-				setSaveError(null);
-			}
 		} catch (error) {
+			writeFailed = true;
 			logger.error('Failed to save file', error);
-			if (
-				isMountedRef.current &&
-				filesystemQueue.get(pendingSave.path) === writePromise &&
-				activeFilesystemRef.current === pendingSave.filesystem &&
-				currentPathRef.current === pendingSave.path &&
-				pendingSaveRef.current === null
-			) {
-				setSaveState(SaveState.ERROR);
-				setSaveError('Could not save changes. Try again.');
-			}
-		} finally {
-			if (filesystemQueue.get(pendingSave.path) === writePromise) {
-				filesystemQueue.delete(pendingSave.path);
-				if (filesystemQueue.size === 0) {
-					saveQueuesRef.current.delete(pendingSave.filesystem);
-				}
-			}
+		}
+
+		// The user may have switched filesystems, selected another file, or
+		// typed again while the write was running. Only the last write that still
+		// owns the visible buffer may update its save status.
+		const ownsVisibleBuffer =
+			isMountedRef.current &&
+			writes.get(filesystem) === writePromise &&
+			activeFilesystemRef.current === filesystem &&
+			currentPathRef.current === path &&
+			pendingSaveRef.current === null;
+
+		if (writes.get(filesystem) === writePromise) {
+			writes.delete(filesystem);
+		}
+		if (ownsVisibleBuffer) {
+			setSaveState(writeFailed ? SaveState.ERROR : SaveState.SAVED);
+			setSaveError(
+				writeFailed ? 'Could not save changes. Try again.' : null
+			);
 		}
 	}, []);
 

--- a/packages/playground/components/src/e2e-harnesses/file-editor-harness.tsx
+++ b/packages/playground/components/src/e2e-harnesses/file-editor-harness.tsx
@@ -1,29 +1,87 @@
-import React, { useEffect, useMemo } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import type { AsyncWritableFilesystem } from '@wp-playground/storage';
 import { PlaygroundFileEditor } from '../PlaygroundFileEditor';
 import { createFilesystem } from './file-picker-tree-harness';
 
+type FilesystemName = 'a' | 'b';
+
+type WriteGate = {
+	promise: Promise<void>;
+	release: () => void;
+};
+
 declare global {
 	interface Window {
 		__fileEditorHarness?: {
-			filesystem: AsyncWritableFilesystem;
-			readFileAsText: (path: string) => Promise<string>;
+			filesystems: Record<FilesystemName, AsyncWritableFilesystem>;
+			readFileAsText: (
+				filesystem: FilesystemName,
+				path: string
+			) => Promise<string>;
+			switchFilesystem: (filesystem: FilesystemName) => void;
+			mountEditor: () => void;
+			unmountEditor: () => void;
+			delayNextWrite: () => void;
+			releaseDelayedWrite: () => void;
+			isWriteDelayed: () => boolean;
 		};
 	}
 }
 
 export function FileEditorHarness() {
-	const filesystem = useMemo(() => createFilesystem(), []);
+	const nextWriteGateRef = useRef<WriteGate | null>(null);
+	const activeWriteGateRef = useRef<WriteGate | null>(null);
+	const filesystems = useMemo(() => {
+		const filesystemA = createFilesystem();
+		const filesystemB = createFilesystem();
+		void filesystemB.writeFile(
+			'/wordpress/workspace/index.php',
+			"<?php echo 'Filesystem B';"
+		);
+
+		const writeFile = filesystemA.writeFile.bind(filesystemA);
+		filesystemA.writeFile = async (path, data) => {
+			const gate = nextWriteGateRef.current;
+			if (gate) {
+				nextWriteGateRef.current = null;
+				activeWriteGateRef.current = gate;
+				await gate.promise;
+				activeWriteGateRef.current = null;
+			}
+			await writeFile(path, data);
+		};
+
+		return { a: filesystemA, b: filesystemB };
+	}, []);
+	const [activeFilesystem, setActiveFilesystem] =
+		useState<FilesystemName>('a');
+	const [isEditorMounted, setIsEditorMounted] = useState(true);
 
 	useEffect(() => {
 		window.__fileEditorHarness = {
-			filesystem,
-			readFileAsText: (path: string) => filesystem.readFileAsText(path),
+			filesystems,
+			readFileAsText: (filesystem, path) =>
+				filesystems[filesystem].readFileAsText(path),
+			switchFilesystem: setActiveFilesystem,
+			mountEditor: () => setIsEditorMounted(true),
+			unmountEditor: () => setIsEditorMounted(false),
+			delayNextWrite: () => {
+				let release: () => void = () => undefined;
+				const promise = new Promise<void>((resolve) => {
+					release = resolve;
+				});
+				nextWriteGateRef.current = { promise, release };
+			},
+			releaseDelayedWrite: () => {
+				activeWriteGateRef.current?.release();
+				nextWriteGateRef.current?.release();
+			},
+			isWriteDelayed: () => activeWriteGateRef.current !== null,
 		};
 		return () => {
 			delete window.__fileEditorHarness;
 		};
-	}, [filesystem]);
+	}, [filesystems]);
 
 	return (
 		<div
@@ -44,11 +102,13 @@ export function FileEditorHarness() {
 				<strong>PlaygroundFileEditor harness</strong>
 			</header>
 			<div style={{ flex: 1, minHeight: 0 }}>
-				<PlaygroundFileEditor
-					filesystem={filesystem}
-					documentRoot="/wordpress"
-					initialPath="/wordpress/workspace/index.php"
-				/>
+				{isEditorMounted ? (
+					<PlaygroundFileEditor
+						filesystem={filesystems[activeFilesystem]}
+						documentRoot="/wordpress"
+						initialPath="/wordpress/workspace/index.php"
+					/>
+				) : null}
 			</div>
 		</div>
 	);

--- a/packages/playground/personal-wp/src/components/site-manager/site-file-browser/index.tsx
+++ b/packages/playground/personal-wp/src/components/site-manager/site-file-browser/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import type { SiteInfo } from '../../../lib/state/redux/slice-sites';
 import { usePlaygroundClientInfo } from '../../../lib/use-playground-client';
 import {
@@ -27,44 +27,6 @@ export function SiteFileBrowser({
 	const client =
 		clientInfo && !clientInfo.isDependentMode ? clientInfo.client : null;
 	const filesystem = useFilesystem(client, site);
-	const clientRef = useRef<PlaygroundClient | null>(client);
-	const filesystemRef = useRef<AsyncWritableFilesystem | null>(filesystem);
-
-	// Keep refs in sync
-	clientRef.current = client;
-	filesystemRef.current = filesystem;
-
-	// Handle filesystem changes - flush pending saves to the old filesystem
-	const handleBeforeFilesystemChange = useCallback(
-		async (_oldFilesystem: AsyncWritableFilesystem) => {
-			// The old filesystem was a wrapper around a client
-			// We need to save any pending changes before switching
-			// This is handled by the fact that we're just writing to the filesystem
-			// which proxies to the client
-			logger.debug(
-				'Filesystem changing, any pending saves will be flushed'
-			);
-		},
-		[]
-	);
-
-	// Custom save handler that writes to either the client or OPFS directly
-	const handleSaveFile = useCallback(
-		async (path: string, content: string) => {
-			// Prefer the client if available (keeps memfs and OPFS in sync)
-			if (clientRef.current) {
-				await clientRef.current.writeFile(path, content);
-				return;
-			}
-			// Fall back to direct OPFS filesystem
-			if (filesystemRef.current) {
-				await filesystemRef.current.writeFile(path, content);
-				return;
-			}
-			throw new Error('No filesystem available');
-		},
-		[]
-	);
 
 	return (
 		<PlaygroundFileEditor
@@ -73,8 +35,6 @@ export function SiteFileBrowser({
 			isVisible={isVisible}
 			initialPath={`${documentRoot}/wp-config.php`}
 			placeholderText="Start this Playground to browse and edit its files."
-			onSaveFile={handleSaveFile}
-			onBeforeFilesystemChange={handleBeforeFilesystemChange}
 		/>
 	);
 }

--- a/packages/playground/website/src/components/site-manager/site-file-browser/index.tsx
+++ b/packages/playground/website/src/components/site-manager/site-file-browser/index.tsx
@@ -1,10 +1,9 @@
-import { useCallback, useMemo, useRef } from 'react';
+import { useMemo } from 'react';
 import type { SiteInfo } from '../../../lib/state/redux/slice-sites';
 import { usePlaygroundClient } from '../../../lib/use-playground-client';
 import type { AsyncWritableFilesystem } from '@wp-playground/storage';
 import type { PlaygroundClient } from '@wp-playground/remote';
 import { PlaygroundFileEditor } from '@wp-playground/components';
-import { logger } from '@php-wasm/logger';
 
 export function SiteFileBrowser({
 	site,
@@ -17,35 +16,6 @@ export function SiteFileBrowser({
 }) {
 	const client = usePlaygroundClient(site.slug);
 	const filesystem = useFilesystem(client);
-	const clientRef = useRef<PlaygroundClient | null>(client);
-
-	// Keep clientRef in sync
-	clientRef.current = client;
-
-	// Handle filesystem changes - flush pending saves to the old filesystem
-	const handleBeforeFilesystemChange = useCallback(
-		async (_oldFilesystem: AsyncWritableFilesystem) => {
-			// The old filesystem was a wrapper around a client
-			// We need to save any pending changes before switching
-			// This is handled by the fact that we're just writing to the filesystem
-			// which proxies to the client
-			logger.debug(
-				'Filesystem changing, any pending saves will be flushed'
-			);
-		},
-		[]
-	);
-
-	// Custom save handler that writes directly to the client
-	const handleSaveFile = useCallback(
-		async (path: string, content: string) => {
-			if (!clientRef.current) {
-				throw new Error('No client available');
-			}
-			await clientRef.current.writeFile(path, content);
-		},
-		[]
-	);
 
 	return (
 		<PlaygroundFileEditor
@@ -54,8 +24,6 @@ export function SiteFileBrowser({
 			isVisible={isVisible}
 			initialPath={`${documentRoot}/wp-config.php`}
 			placeholderText="Start this Playground to browse and edit its files."
-			onSaveFile={handleSaveFile}
-			onBeforeFilesystemChange={handleBeforeFilesystemChange}
 		/>
 	);
 }


### PR DESCRIPTION
## What it does

Keeps every buffered file edit attached to the filesystem that produced it.

`PlaygroundFileEditor` now writes through its `filesystem` prop, flushes a pending edit when that filesystem is replaced or the editor unmounts, and reloads editor state when the filesystem identity changes. Writes within one filesystem stay ordered; an unrelated filesystem does not wait behind them.

This removes the optional `onSaveFile` and `onBeforeFilesystemChange` props. A caller must provide the filesystem that owns both reads and writes.

## Rationale

The old unmount cleanup claimed to flush pending work. It only cleared the debounce timer, so closing the editor could discard the last edit.

The website callers also bypassed the filesystem prop and saved through callbacks that read mutable client references. If filesystem A was replaced by filesystem B while an edit was pending, A's buffer could be written into B when both filesystems contained the same path. Keeping the filesystem object as the sole owner makes that redirect impossible.

## Testing instructions

```bash
npm exec nx run playground-components:e2e
npm exec nx run playground-components:build:vite
npm exec nx run-many -t lint typecheck -p playground-components playground-website playground-personal-wp
```

The component E2E tests cover unmount before the debounce expires, A-to-B replacement with the same path, ordered writes to A, and an independent write to B while A is stalled.

