### PR TITLE
[CLI] Add native host readiness manifest

### DIFF
--- a/packages/playground/cli-native/src/server.rs
+++ b/packages/playground/cli-native/src/server.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap},
-    fs, io,
+    env, fs, io,
     io::{Cursor, Read, Seek, Write},
     net::{TcpListener, TcpStream},
     path::{Path, PathBuf},
@@ -14,7 +14,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use wasmtime::Module;
 use zip::{write::SimpleFileOptions, CompressionMethod, ZipArchive, ZipWriter};
 
@@ -49,6 +49,7 @@ const RECYCLE_WASM_MEMORY_MIB_ENV_VAR: &str = "WP_PLAYGROUND_NATIVE_RECYCLE_WASM
 const DEFAULT_RECYCLE_WASM_MEMORY_MIB: u64 = 90;
 const WORKER_RECYCLE_IDLE_DELAY: Duration = Duration::from_millis(50);
 const WORKER_RECYCLE_IDLE_DELAY_ENV_VAR: &str = "WP_PLAYGROUND_NATIVE_WORKER_RECYCLE_IDLE_MS";
+const READY_FILE_ENV_VAR: &str = "WP_PLAYGROUND_NATIVE_READY_FILE";
 const AUTO_LOGIN_COOKIE_NAME: &str = "playground_auto_login_already_happened";
 const CLEAR_AUTO_LOGIN_COOKIE: &str = "playground_auto_login_already_happened=1; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Path=/";
 const DEFAULT_WP_CLI_PATH: &str = "/tmp/wp-cli.phar";
@@ -117,6 +118,19 @@ struct HttpProtocolError {
 }
 
 type HttpParseResult<T> = std::result::Result<T, HttpProtocolError>;
+
+/// Machine-readable state published once a native host can accept requests.
+///
+/// The regular CLI output remains for people. Embedders must use this file so
+/// a wording or color change in the human banner never becomes an API break.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct NativeHostReadyManifest<'a> {
+    protocol_version: u8,
+    server_url: &'a str,
+    site_url: &'a str,
+    pid: u32,
+}
 
 impl HttpProtocolError {
     fn new(status: u16, message: impl Into<String>) -> Self {
@@ -956,6 +970,134 @@ fn ready_message(server_url: &str, worker_count: usize, style: TerminalStyle) ->
     )
 }
 
+/// Reads the optional host-only readiness destination before server startup.
+///
+/// The environment variable is deliberately not a CLI flag. It is a private
+/// process contract for the Node wrapper, not a user-facing server setting.
+fn native_host_ready_file_from_env() -> Result<Option<PathBuf>> {
+    let Some(path) = env::var_os(READY_FILE_ENV_VAR) else {
+        return Ok(None);
+    };
+    let path = PathBuf::from(path);
+    if !path.is_absolute() {
+        return Err(CliError::new(format!(
+            "{READY_FILE_ENV_VAR} must be an absolute path"
+        )));
+    }
+    let parent = path.parent().ok_or_else(|| {
+        CliError::new(format!(
+            "{READY_FILE_ENV_VAR} must name a file inside a directory"
+        ))
+    })?;
+    if !parent.is_dir() {
+        return Err(CliError::new(format!(
+            "{READY_FILE_ENV_VAR} parent directory does not exist: {}",
+            parent.display()
+        )));
+    }
+    if path.file_name().is_none() {
+        return Err(CliError::new(format!(
+            "{READY_FILE_ENV_VAR} must name a file"
+        )));
+    }
+    Ok(Some(path))
+}
+
+/// Atomically publishes the loopback address after the worker pool is ready.
+///
+/// A fresh wrapper-owned directory supplies an unused destination. Rejecting an
+/// existing manifest catches stale or incorrectly reused wrapper state.
+fn write_native_host_ready_manifest(
+    ready_file: &Path,
+    server_url: &str,
+    site_url: &str,
+) -> Result<()> {
+    if ready_file.exists() {
+        return Err(CliError::new(format!(
+            "{READY_FILE_ENV_VAR} already exists: {}",
+            ready_file.display()
+        )));
+    }
+    let parent = ready_file.parent().ok_or_else(|| {
+        CliError::new(format!(
+            "{READY_FILE_ENV_VAR} must name a file inside a directory"
+        ))
+    })?;
+    let file_name = ready_file
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| {
+            CliError::new(format!(
+                "{READY_FILE_ENV_VAR} file name must be valid UTF-8"
+            ))
+        })?;
+    let temporary = parent.join(format!(".{file_name}.{}.tmp", std::process::id()));
+    let manifest = NativeHostReadyManifest {
+        protocol_version: 1,
+        server_url,
+        site_url,
+        pid: std::process::id(),
+    };
+    let payload = serde_json::to_vec(&manifest).map_err(|error| {
+        CliError::new(format!(
+            "Failed to encode native readiness manifest: {error}"
+        ))
+    })?;
+
+    let mut temporary_created = false;
+    let write_result = (|| -> Result<()> {
+        let mut options = fs::OpenOptions::new();
+        options.write(true).create_new(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600);
+        }
+        let mut file = options.open(&temporary).map_err(|error| {
+            CliError::from_io_context(
+                format!(
+                    "Failed to create native readiness manifest {}",
+                    temporary.display()
+                ),
+                error,
+            )
+        })?;
+        temporary_created = true;
+        file.write_all(&payload).map_err(|error| {
+            CliError::from_io_context(
+                format!(
+                    "Failed to write native readiness manifest {}",
+                    temporary.display()
+                ),
+                error,
+            )
+        })?;
+        file.sync_all().map_err(|error| {
+            CliError::from_io_context(
+                format!(
+                    "Failed to sync native readiness manifest {}",
+                    temporary.display()
+                ),
+                error,
+            )
+        })?;
+        fs::rename(&temporary, ready_file).map_err(|error| {
+            CliError::from_io_context(
+                format!(
+                    "Failed to publish native readiness manifest {}",
+                    ready_file.display()
+                ),
+                error,
+            )
+        })?;
+        Ok(())
+    })();
+    if temporary_created && write_result.is_err() {
+        let _ = fs::remove_file(&temporary);
+    }
+    write_result
+}
+
 fn server_mounts(config: &RuntimeConfig) -> Result<Vec<Mount>> {
     let mut mounts = Vec::new();
     mounts.extend(config.options.mounts_before_install.clone());
@@ -1071,6 +1213,7 @@ fn run_listener(
     runtime: &NativeRuntime,
     mut host_options: HostOptions,
 ) -> Result<u8> {
+    let native_host_ready_file = native_host_ready_file_from_env()?;
     progress(&config.options, "Binding HTTP server");
     let listener = bind_server_listener(config.options.port)?;
     let actual_port = listener
@@ -1082,6 +1225,7 @@ fn run_listener(
         .site_url
         .clone()
         .unwrap_or_else(|| format!("http://127.0.0.1:{actual_port}"));
+    let loopback_server_url = format!("http://127.0.0.1:{actual_port}");
     if !matches!(config.options.verbosity, Verbosity::Quiet) {
         let style = TerminalStyle::stdout();
         let mut stdout = io::stdout().lock();
@@ -1157,6 +1301,10 @@ fn run_listener(
         lazy_workers,
     )?);
     release_unused_process_memory();
+
+    if let Some(ready_file) = native_host_ready_file.as_deref() {
+        write_native_host_ready_manifest(ready_file, &loopback_server_url, &server_url)?;
+    }
 
     if !matches!(config.options.verbosity, Verbosity::Quiet) {
         let style = TerminalStyle::stdout();
@@ -9376,11 +9524,12 @@ mod tests {
         inject_http_host_into_wp_config, install_asset_zip, install_downloadable_asset,
         install_plugin_asset, is_client_disconnect_error, lazy_worker_pool_enabled,
         looks_like_zip_file, mark_worker_request_finished, max_requests_per_worker_from_env,
-        maybe_boot_wordpress_site, multisite_url_settings, normalize_git_directory_path,
-        parse_http_request, parse_http_request_owned, parse_http_request_owned_with_counter,
-        parse_php_headers, php_failure_detail, php_request_from_http, php_request_from_run_options,
-        php_response_status, php_single_quoted_string, read_http_request, ready_message,
-        reason_phrase, recycle_wasm_memory_threshold_from_env, remove_wp_allow_multisite_define,
+        maybe_boot_wordpress_site, multisite_url_settings, native_host_ready_file_from_env,
+        normalize_git_directory_path, parse_http_request, parse_http_request_owned,
+        parse_http_request_owned_with_counter, parse_php_headers, php_failure_detail,
+        php_request_from_http, php_request_from_run_options, php_response_status,
+        php_single_quoted_string, read_http_request, ready_message, reason_phrase,
+        recycle_wasm_memory_threshold_from_env, remove_wp_allow_multisite_define,
         request_error_total_counter, request_path_from_target, request_prefers_reserved_worker,
         request_total_fields, requested_worker_count, reserve_lazy_worker_retirement,
         reset_data_script, resolve_git_directory_resource, resolve_route, route_target_label,
@@ -9393,17 +9542,17 @@ mod tests {
         validate_install_asset_zip, wordpress_importer_install_step,
         wordpress_translation_url_from_api_response, worker_after_request_label,
         worker_recycle_idle_delay_from_env, wp_cli_runner_script, wp_installation_wizard_request,
-        write_http_response_with_counter, write_server_http_response_with_counter,
-        write_static_file_response, write_wordpress_snapshot_zip, zip_path_to_string,
-        DefineWpConfigMethod, DownloadableAsset, FileContentSource, FileTreeEntry, FileTreeSource,
-        GitDirectoryResource, HttpRequest, HttpResponse, IfAlreadyInstalled, InstallAssetSource,
-        InstallAssetStep, PhpConstantValue, PhpRunOptions, PhpRunScript, PhpWorker,
-        RequestTotalRequest, RouteTarget, ServerHttpResponse, StartupHttpRequest, StartupStep,
-        WorkerAfterRequest, AUTO_LOGIN_COOKIE_NAME, CLEAR_AUTO_LOGIN_COOKIE,
-        DEFAULT_RECYCLE_WASM_MEMORY_MIB, DEFAULT_WP_CLI_PATH,
-        MAX_NATIVE_ASYNCIFY_REQUESTS_PER_WORKER, MAX_REQUESTS_PER_WORKER_ENV_VAR,
-        RECYCLE_WASM_MEMORY_MIB_ENV_VAR, WORKER_RECYCLE_IDLE_DELAY,
-        WORKER_RECYCLE_IDLE_DELAY_ENV_VAR,
+        write_http_response_with_counter, write_native_host_ready_manifest,
+        write_server_http_response_with_counter, write_static_file_response,
+        write_wordpress_snapshot_zip, zip_path_to_string, DefineWpConfigMethod, DownloadableAsset,
+        FileContentSource, FileTreeEntry, FileTreeSource, GitDirectoryResource, HttpRequest,
+        HttpResponse, IfAlreadyInstalled, InstallAssetSource, InstallAssetStep, PhpConstantValue,
+        PhpRunOptions, PhpRunScript, PhpWorker, RequestTotalRequest, RouteTarget,
+        ServerHttpResponse, StartupHttpRequest, StartupStep, WorkerAfterRequest,
+        AUTO_LOGIN_COOKIE_NAME, CLEAR_AUTO_LOGIN_COOKIE, DEFAULT_RECYCLE_WASM_MEMORY_MIB,
+        DEFAULT_WP_CLI_PATH, MAX_NATIVE_ASYNCIFY_REQUESTS_PER_WORKER,
+        MAX_REQUESTS_PER_WORKER_ENV_VAR, READY_FILE_ENV_VAR, RECYCLE_WASM_MEMORY_MIB_ENV_VAR,
+        WORKER_RECYCLE_IDLE_DELAY, WORKER_RECYCLE_IDLE_DELAY_ENV_VAR,
     };
     #[cfg(unix)]
     use super::{
@@ -10489,6 +10638,81 @@ mod tests {
 
         let listener = bind_server_listener_with_default(None, occupied_port).unwrap();
         assert_ne!(listener.local_addr().unwrap().port(), occupied_port);
+    }
+
+    #[test]
+    fn native_host_ready_manifest_publishes_the_live_loopback_address() {
+        let root = temp_dir("ready-manifest");
+        let ready_file = root.join("ready.json");
+
+        write_native_host_ready_manifest(
+            &ready_file,
+            "http://127.0.0.1:49152",
+            "https://playground.example.test",
+        )
+        .unwrap();
+
+        let manifest: serde_json::Value =
+            serde_json::from_slice(&fs::read(&ready_file).unwrap()).unwrap();
+        assert_eq!(manifest["protocolVersion"], 1);
+        assert_eq!(manifest["serverUrl"], "http://127.0.0.1:49152");
+        assert_eq!(manifest["siteUrl"], "https://playground.example.test");
+        assert_eq!(manifest["pid"], std::process::id());
+        assert_eq!(fs::read_dir(&root).unwrap().count(), 1);
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn native_host_ready_manifest_refuses_to_replace_existing_state() {
+        let root = temp_dir("ready-manifest-existing");
+        let ready_file = root.join("ready.json");
+        fs::write(&ready_file, b"old state").unwrap();
+
+        let error = write_native_host_ready_manifest(
+            &ready_file,
+            "http://127.0.0.1:49152",
+            "http://127.0.0.1:49152",
+        )
+        .expect_err("an existing readiness manifest must not be replaced");
+
+        assert!(error.to_string().contains("already exists"));
+        assert_eq!(fs::read(&ready_file).unwrap(), b"old state");
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn native_host_ready_file_environment_requires_an_absolute_existing_parent() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let previous = std::env::var_os(READY_FILE_ENV_VAR);
+        std::env::remove_var(READY_FILE_ENV_VAR);
+        assert_eq!(native_host_ready_file_from_env().unwrap(), None);
+
+        std::env::set_var(READY_FILE_ENV_VAR, "ready.json");
+        assert!(native_host_ready_file_from_env()
+            .expect_err("relative readiness paths must be rejected")
+            .to_string()
+            .contains("absolute path"));
+
+        let root = temp_dir("ready-file-environment");
+        let missing_parent = root.join("missing-parent").join("ready.json");
+        std::env::set_var(READY_FILE_ENV_VAR, &missing_parent);
+        assert!(native_host_ready_file_from_env()
+            .expect_err("the readiness parent must already exist")
+            .to_string()
+            .contains("parent directory does not exist"));
+
+        let expected = root.join("ready.json");
+        std::env::set_var(READY_FILE_ENV_VAR, &expected);
+        assert_eq!(native_host_ready_file_from_env().unwrap(), Some(expected));
+
+        if let Some(previous) = previous {
+            std::env::set_var(READY_FILE_ENV_VAR, previous);
+        } else {
+            std::env::remove_var(READY_FILE_ENV_VAR);
+        }
+        let _ = fs::remove_dir_all(root);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds a private, machine-readable readiness manifest for the experimental native Wasmtime host.

The future Node package wrapper sets `WP_PLAYGROUND_NATIVE_READY_FILE` to a fresh absolute path, starts the server on an ephemeral port, and waits for this manifest instead of parsing terminal output.

The manifest is written only after WordPress boot and the PHP worker pool are ready. It reports the loopback endpoint separately from a configured public `--site-url`.

## Scope

- No public CLI option
- No normal CLI output change
- No package publication, release, or merge

## Tests

`cargo test --manifest-path packages/playground/cli-native/Cargo.toml --lib native_host_ready -- --nocapture`