### PR TITLE
[CLI] Route package executable to native host

### DIFF
--- a/packages/playground/cli/src/cli.ts
+++ b/packages/playground/cli/src/cli.ts
@@ -1,65 +1,18 @@
-import { spawn } from 'child_process';
-import { shouldRespawnWithJSPI } from './ensure-jspi';
+import { runNativeCLI } from './native-binary';
 
-function runCLI() {
-	const args = process.argv.slice(2);
-	// Dynamic import avoids loading run-cli when we're about to respawn.
-	// Do not await — top-level await is not supported in all environments.
-	import('./run-cli').then(({ parseOptionsAndRunCLI }) => {
-		parseOptionsAndRunCLI(args);
+async function main() {
+	const result = await runNativeCLI(process.argv.slice(2), {
+		forwardSignals: true,
+		stdio: 'inherit',
 	});
-}
-
-if (shouldRespawnWithJSPI()) {
-	const spawnedAt = Date.now();
-	const child = spawn(
-		process.execPath,
-		[
-			'--experimental-wasm-jspi',
-			...process.execArgv,
-			...process.argv.slice(1),
-		],
-		{ stdio: 'inherit' }
-	);
-
-	// Forward SIGINT/SIGTERM so Ctrl+C and kill work as expected.
-	for (const sig of ['SIGINT', 'SIGTERM'] as const) {
-		process.on(sig, () => child.kill(sig));
+	if (result.signal) {
+		process.kill(process.pid, result.signal);
+		return;
 	}
-
-	// If spawn() itself fails (e.g. ENOENT), fall back to running
-	// without JSPI in this process. We might be inside of a non-Node
-	// JavaScript runtime that refuses to boot when the `--experimental-wasm-jspi`
-	// flag is present.
-	child.on('error', () => {
-		runCLI();
-	});
-
-	child.on('close', (code, signal) => {
-		// If the child exited almost immediately with an error, the
-		// --experimental-wasm-jspi flag was likely rejected by the
-		// runtime. Fall back to running without JSPI in this process
-		// instead of propagating the failure.
-		if (code !== 0 && !signal && Date.now() - spawnedAt < 1000) {
-			runCLI();
-			return;
-		}
-
-		/**
-		 * We should always get either a code or a signal as per
-		 * https://nodejs.org/api/child_process.html#event-close:
-		 *
-		 * > If the process exited, code is the final exit code of the
-		 * > process, otherwise null. If the process terminated due to
-		 * > receipt of a signal, signal is the string name of the signal,
-		 * > otherwise null. **One of the two will always be non-null.**
-		 */
-		if (signal) {
-			process.kill(process.pid, signal);
-		} else {
-			process.exit(code);
-		}
-	});
-} else {
-	runCLI();
+	process.exitCode = result.code ?? 1;
 }
+
+void main().catch((error) => {
+	process.stderr.write(`${error instanceof Error ? error.message : error}\n`);
+	process.exitCode = 1;
+});

--- a/packages/playground/cli/src/native-binary.ts
+++ b/packages/playground/cli/src/native-binary.ts
@@ -1,0 +1,211 @@
+import {
+	spawn,
+	type ChildProcess,
+	type StdioOptions,
+} from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { dirname, isAbsolute, join, resolve, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/** Environment variable for a locally built or otherwise custom native host. */
+export const nativeBinaryEnvironmentVariable = 'WP_PLAYGROUND_NATIVE_BINARY';
+
+export type NativeCLIExit = {
+	code: number | null;
+	signal: NodeJS.Signals | null;
+};
+
+export type NativeBinaryResolutionOptions = {
+	environment?: NodeJS.ProcessEnv;
+	moduleDirectory?: string;
+	platform?: NodeJS.Platform;
+	arch?: string;
+};
+
+export type SpawnNativeCLIOptions = {
+	cwd?: string;
+	env?: NodeJS.ProcessEnv;
+	stdio?: StdioOptions;
+	resolution?: NativeBinaryResolutionOptions;
+};
+
+export type RunNativeCLIOptions = SpawnNativeCLIOptions & {
+	forwardSignals?: boolean;
+};
+
+/**
+ * Resolves the executable name used by a native package on this platform.
+ */
+export function nativeBinaryFileName(platform = process.platform): string {
+	return platform === 'win32'
+		? 'wp-playground-native.exe'
+		: 'wp-playground-native';
+}
+
+/**
+ * Names the package directory containing the current platform's native host.
+ */
+export function nativeBinaryTarget(
+	platform: NodeJS.Platform = process.platform,
+	arch: string = process.arch
+): string {
+	const packagePlatform =
+		platform === 'darwin'
+			? 'macos'
+			: platform === 'win32'
+				? 'windows'
+				: platform;
+	return `${packagePlatform}-${arch}`;
+}
+
+/**
+ * Locates the Wasmtime host without substituting the legacy JavaScript runtime.
+ *
+ * Published packages will carry the host under `native/<platform>-<arch>/`.
+ * Developers may set `WP_PLAYGROUND_NATIVE_BINARY` to a locally built host.
+ */
+export function resolveNativeBinary(
+	options: NativeBinaryResolutionOptions = {}
+): string {
+	const environment = options.environment ?? process.env;
+	const configured = environment[nativeBinaryEnvironmentVariable];
+	if (configured) {
+		return resolveConfiguredBinary(configured);
+	}
+
+	const moduleDirectory =
+		options.moduleDirectory ?? dirname(fileURLToPath(import.meta.url));
+	const platform = options.platform ?? process.platform;
+	const arch = options.arch ?? process.arch;
+	const binaryName = nativeBinaryFileName(platform);
+	const candidates = [
+		join(
+			moduleDirectory,
+			'native',
+			nativeBinaryTarget(platform, arch),
+			binaryName
+		),
+		join(moduleDirectory, 'native', binaryName),
+		join(
+			moduleDirectory,
+			'..',
+			'..',
+			'cli-native',
+			'target',
+			'release',
+			binaryName
+		),
+		join(
+			moduleDirectory,
+			'..',
+			'..',
+			'cli-native',
+			'target',
+			'debug',
+			binaryName
+		),
+	];
+
+	const binary = candidates.find(existsSync);
+	if (binary) {
+		return binary;
+	}
+
+	throw new Error(
+		`Could not find the Wasmtime WordPress Playground host for ${nativeBinaryTarget(
+			platform,
+			arch
+		)}. Set ${nativeBinaryEnvironmentVariable} to wp-playground-native or install a package containing the native host. Checked:\n${candidates
+			.map((candidate) => `  ${candidate}`)
+			.join('\n')}`
+	);
+}
+
+/** Starts the native host with a resolved executable and no shell interpolation. */
+export function spawnNativeCLI(
+	args: string[],
+	options: SpawnNativeCLIOptions = {}
+): ChildProcess {
+	const binary = resolveNativeBinary({
+		...options.resolution,
+		environment: options.resolution?.environment ?? options.env,
+	});
+	return spawn(binary, args, {
+		cwd: options.cwd,
+		env: options.env,
+		stdio: options.stdio ?? 'inherit',
+	});
+}
+
+/**
+ * Runs one native CLI command and reports its natural process outcome.
+ *
+ * Signal forwarding is opt-in because an embedding application owns its own
+ * lifecycle; the executable entry point enables it for terminal use.
+ */
+export async function runNativeCLI(
+	args: string[],
+	options: RunNativeCLIOptions = {}
+): Promise<NativeCLIExit> {
+	const child = spawnNativeCLI(args, options);
+	const signals: NodeJS.Signals[] = ['SIGINT', 'SIGTERM'];
+	const forwardSignal = (signal: NodeJS.Signals) => {
+		if (!child.killed) {
+			child.kill(signal);
+		}
+	};
+
+	if (options.forwardSignals) {
+		for (const signal of signals) {
+			process.on(signal, forwardSignal);
+		}
+	}
+
+	return await new Promise<NativeCLIExit>((resolvePromise, reject) => {
+		let settled = false;
+		const cleanup = () => {
+			if (options.forwardSignals) {
+				for (const signal of signals) {
+					process.off(signal, forwardSignal);
+				}
+			}
+		};
+		const settle = (callback: () => void) => {
+			if (settled) {
+				return;
+			}
+			settled = true;
+			cleanup();
+			callback();
+		};
+
+		child.once('error', (error) => settle(() => reject(error)));
+		child.once('close', (code, signal) =>
+			settle(() => resolvePromise({ code, signal }))
+		);
+	});
+}
+
+function resolveConfiguredBinary(configured: string): string {
+	if (!looksLikePath(configured)) {
+		return configured;
+	}
+
+	const binary = resolve(configured);
+	if (!existsSync(binary)) {
+		throw new Error(
+			`${nativeBinaryEnvironmentVariable} points to a missing executable: ${binary}`
+		);
+	}
+	return binary;
+}
+
+function looksLikePath(value: string): boolean {
+	return (
+		isAbsolute(value) ||
+		value.startsWith('.') ||
+		value.includes(sep) ||
+		value.includes('/') ||
+		value.includes('\\')
+	);
+}

--- a/packages/playground/cli/tests/native-binary.spec.ts
+++ b/packages/playground/cli/tests/native-binary.spec.ts
@@ -1,0 +1,120 @@
+import {
+	chmod,
+	mkdir,
+	mkdtemp,
+	readFile,
+	rm,
+	writeFile,
+} from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+	nativeBinaryEnvironmentVariable,
+	nativeBinaryTarget,
+	resolveNativeBinary,
+	runNativeCLI,
+} from '../src/native-binary';
+
+describe('native binary launcher', () => {
+	test.each([
+		['linux', 'x64', 'linux-x64'],
+		['linux', 'arm64', 'linux-arm64'],
+		['darwin', 'x64', 'macos-x64'],
+		['darwin', 'arm64', 'macos-arm64'],
+		['win32', 'x64', 'windows-x64'],
+		['win32', 'arm64', 'windows-arm64'],
+	] as const)(
+		'maps %s-%s to the native package label %s',
+		(platform, arch, expected) => {
+			expect(nativeBinaryTarget(platform, arch)).toBe(expected);
+		}
+	);
+
+	test('prefers an explicitly configured native executable', async () => {
+		const root = await mkdtemp(join(tmpdir(), 'playground-native-binary-'));
+		const binary = join(root, 'wp-playground-native');
+		await writeFile(binary, '#!/bin/sh\nexit 0\n');
+		await chmod(binary, 0o755);
+
+		expect(
+			resolveNativeBinary({
+				environment: {
+					[nativeBinaryEnvironmentVariable]: binary,
+				},
+			})
+		).toBe(binary);
+
+		await rm(root, { recursive: true, force: true });
+	});
+
+	test('finds a native binary bundled beside the package', async () => {
+		const root = await mkdtemp(join(tmpdir(), 'playground-native-binary-'));
+		const nativeDirectory = join(root, 'native', 'linux-x64');
+		const binary = join(nativeDirectory, 'wp-playground-native');
+		await mkdir(nativeDirectory, { recursive: true });
+		await writeFile(binary, '#!/bin/sh\nexit 0\n');
+		await chmod(binary, 0o755);
+
+		expect(
+			resolveNativeBinary({
+				environment: {},
+				moduleDirectory: root,
+				platform: 'linux',
+				arch: 'x64',
+			})
+		).toBe(binary);
+
+		await rm(root, { recursive: true, force: true });
+	});
+
+	test('runs the configured Wasmtime host without a shell', async () => {
+		if (process.platform === 'win32') {
+			return;
+		}
+
+		const root = await mkdtemp(join(tmpdir(), 'playground-native-binary-'));
+		const binary = join(root, 'wp-playground-native');
+		const output = join(root, 'arguments.json');
+		await writeFile(
+			binary,
+			`#!/usr/bin/env node
+const { writeFileSync } = require('node:fs');
+writeFileSync(process.env.PLAYGROUND_NATIVE_TEST_OUTPUT, JSON.stringify(process.argv.slice(2)));
+process.exit(7);
+`
+		);
+		await chmod(binary, 0o755);
+
+		const env = {
+			...process.env,
+			[nativeBinaryEnvironmentVariable]: binary,
+			PLAYGROUND_NATIVE_TEST_OUTPUT: output,
+		};
+		const result = await runNativeCLI(['server', '--port=9400'], {
+			env,
+			stdio: 'ignore',
+		});
+
+		expect(result).toEqual({ code: 7, signal: null });
+		expect(JSON.parse(await readFile(output, 'utf8'))).toEqual([
+			'server',
+			'--port=9400',
+		]);
+
+		await rm(root, { recursive: true, force: true });
+	});
+
+	test('explains how to configure a missing native host', async () => {
+		expect(() =>
+			resolveNativeBinary({
+				environment: {},
+				moduleDirectory: join(
+					tmpdir(),
+					'missing-playground-cli-package'
+				),
+				platform: 'linux',
+				arch: 'x64',
+			})
+		).toThrow(nativeBinaryEnvironmentVariable);
+	});
+});


### PR DESCRIPTION
## Summary

Routes the existing `wp-playground-cli` executable through `wp-playground-native`, the Wasmtime host, rather than loading the JavaScript/Emscripten runtime.

The launcher:

- forwards raw CLI arguments without shell interpolation;
- preserves exit codes and terminal signals;
- resolves a platform host from the future package layout or `WP_PLAYGROUND_NATIVE_BINARY` for local development;
- maps Node platform names to the native build labels; and
- fails clearly when no Wasmtime host is present. It never falls back to the legacy runtime.

This deliberately does **not** publish or package a binary yet. The next stacked PR adds the exported programmatic `runCLI()` API.

## Tests

- `npx vitest run --config packages/playground/cli/vite.config.ts packages/playground/cli/tests/native-binary.spec.ts`
- `npx nx run playground-cli:lint`
- `npx nx run playground-cli:typecheck`
- Unbuilt Node CLI smoke against a locally built `wp-playground-native --help`