### PR TITLE
[CLI] Export native runCLI adapter

### DIFF
--- a/packages/playground/cli-native/src/server.rs
+++ b/packages/playground/cli-native/src/server.rs
@@ -50,6 +50,7 @@ const DEFAULT_RECYCLE_WASM_MEMORY_MIB: u64 = 90;
 const WORKER_RECYCLE_IDLE_DELAY: Duration = Duration::from_millis(50);
 const WORKER_RECYCLE_IDLE_DELAY_ENV_VAR: &str = "WP_PLAYGROUND_NATIVE_WORKER_RECYCLE_IDLE_MS";
 const READY_FILE_ENV_VAR: &str = "WP_PLAYGROUND_NATIVE_READY_FILE";
+const NATIVE_HOST_READY_PROTOCOL_VERSION: u8 = 2;
 const AUTO_LOGIN_COOKIE_NAME: &str = "playground_auto_login_already_happened";
 const CLEAR_AUTO_LOGIN_COOKIE: &str = "playground_auto_login_already_happened=1; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Path=/";
 const DEFAULT_WP_CLI_PATH: &str = "/tmp/wp-cli.phar";
@@ -130,6 +131,18 @@ struct NativeHostReadyManifest<'a> {
     server_url: &'a str,
     site_url: &'a str,
     pid: u32,
+    mounts: Vec<NativeHostReadyMount<'a>>,
+}
+
+/// A host-backed VFS mount selected by the native startup sequence.
+///
+/// The Node adapter needs this final list because `start` can replace its
+/// default site directory after auto-mount and managed-storage resolution.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct NativeHostReadyMount<'a> {
+    vfs_path: &'a str,
+    host_path: String,
 }
 
 impl HttpProtocolError {
@@ -1011,6 +1024,7 @@ fn write_native_host_ready_manifest(
     ready_file: &Path,
     server_url: &str,
     site_url: &str,
+    mounts: &[Mount],
 ) -> Result<()> {
     if ready_file.exists() {
         return Err(CliError::new(format!(
@@ -1033,10 +1047,17 @@ fn write_native_host_ready_manifest(
         })?;
     let temporary = parent.join(format!(".{file_name}.{}.tmp", std::process::id()));
     let manifest = NativeHostReadyManifest {
-        protocol_version: 1,
+        protocol_version: NATIVE_HOST_READY_PROTOCOL_VERSION,
         server_url,
         site_url,
         pid: std::process::id(),
+        mounts: mounts
+            .iter()
+            .map(|mount| NativeHostReadyMount {
+                vfs_path: &mount.vfs_path,
+                host_path: mount.host_path.to_string_lossy().into_owned(),
+            })
+            .collect(),
     };
     let payload = serde_json::to_vec(&manifest).map_err(|error| {
         CliError::new(format!(
@@ -1303,7 +1324,7 @@ fn run_listener(
     release_unused_process_memory();
 
     if let Some(ready_file) = native_host_ready_file.as_deref() {
-        write_native_host_ready_manifest(ready_file, &loopback_server_url, &server_url)?;
+        write_native_host_ready_manifest(ready_file, &loopback_server_url, &server_url, mounts)?;
     }
 
     if !matches!(config.options.verbosity, Verbosity::Quiet) {
@@ -9551,8 +9572,9 @@ mod tests {
         ServerHttpResponse, StartupHttpRequest, StartupStep, WorkerAfterRequest,
         AUTO_LOGIN_COOKIE_NAME, CLEAR_AUTO_LOGIN_COOKIE, DEFAULT_RECYCLE_WASM_MEMORY_MIB,
         DEFAULT_WP_CLI_PATH, MAX_NATIVE_ASYNCIFY_REQUESTS_PER_WORKER,
-        MAX_REQUESTS_PER_WORKER_ENV_VAR, READY_FILE_ENV_VAR, RECYCLE_WASM_MEMORY_MIB_ENV_VAR,
-        WORKER_RECYCLE_IDLE_DELAY, WORKER_RECYCLE_IDLE_DELAY_ENV_VAR,
+        MAX_REQUESTS_PER_WORKER_ENV_VAR, NATIVE_HOST_READY_PROTOCOL_VERSION, READY_FILE_ENV_VAR,
+        RECYCLE_WASM_MEMORY_MIB_ENV_VAR, WORKER_RECYCLE_IDLE_DELAY,
+        WORKER_RECYCLE_IDLE_DELAY_ENV_VAR,
     };
     #[cfg(unix)]
     use super::{
@@ -10644,21 +10666,33 @@ mod tests {
     fn native_host_ready_manifest_publishes_the_live_loopback_address() {
         let root = temp_dir("ready-manifest");
         let ready_file = root.join("ready.json");
+        let wordpress = root.join("wordpress");
+        fs::create_dir_all(&wordpress).unwrap();
+        let mounts = vec![Mount::new(&wordpress, "/wordpress").unwrap()];
 
         write_native_host_ready_manifest(
             &ready_file,
             "http://127.0.0.1:49152",
             "https://playground.example.test",
+            &mounts,
         )
         .unwrap();
 
         let manifest: serde_json::Value =
             serde_json::from_slice(&fs::read(&ready_file).unwrap()).unwrap();
-        assert_eq!(manifest["protocolVersion"], 1);
+        assert_eq!(
+            manifest["protocolVersion"],
+            NATIVE_HOST_READY_PROTOCOL_VERSION
+        );
         assert_eq!(manifest["serverUrl"], "http://127.0.0.1:49152");
         assert_eq!(manifest["siteUrl"], "https://playground.example.test");
         assert_eq!(manifest["pid"], std::process::id());
-        assert_eq!(fs::read_dir(&root).unwrap().count(), 1);
+        assert_eq!(manifest["mounts"][0]["vfsPath"], "/wordpress");
+        assert_eq!(
+            manifest["mounts"][0]["hostPath"].as_str(),
+            Some(wordpress.to_string_lossy().as_ref())
+        );
+        assert_eq!(fs::read_dir(&root).unwrap().count(), 2);
 
         let _ = fs::remove_dir_all(root);
     }
@@ -10673,6 +10707,7 @@ mod tests {
             &ready_file,
             "http://127.0.0.1:49152",
             "http://127.0.0.1:49152",
+            &[],
         )
         .expect_err("an existing readiness manifest must not be replaced");
 

--- a/packages/playground/cli/src/index.ts
+++ b/packages/playground/cli/src/index.ts
@@ -1,1 +1,14 @@
-export * from './run-cli';
+export {
+	internalsKeyForTesting,
+	LogVerbosity,
+	parseOptionsAndRunCLI,
+	resolveWorkerCount,
+	runCLI,
+} from './native-run-cli';
+export type {
+	PlaygroundCliWorker,
+	RunCLIArgs,
+	RunCLIServer,
+	WorkerType,
+} from './native-run-cli';
+export { mergeDefinedConstants } from './defines';

--- a/packages/playground/cli/src/native-playground.ts
+++ b/packages/playground/cli/src/native-playground.ts
@@ -1,0 +1,523 @@
+import { randomUUID } from 'node:crypto';
+import {
+	chmod,
+	cp,
+	lstat,
+	mkdir,
+	readFile,
+	readdir,
+	readlink,
+	realpath,
+	rename,
+	rm,
+	stat,
+	symlink,
+	unlink,
+	writeFile,
+} from 'node:fs/promises';
+import { basename, isAbsolute, posix, relative, resolve, sep } from 'node:path';
+import {
+	PHPResponse,
+	StreamedPHPResponse,
+	type PHPRequest,
+	type PHPRunOptions,
+	type Pooled,
+} from '@php-wasm/universal';
+import type { PlaygroundCliWorker } from './run-cli';
+
+export type NativeVfsMount = {
+	hostPath: string;
+	vfsPath: string;
+};
+
+export type NativePHPCLIResult = {
+	exitCode: number;
+	stdout: Uint8Array;
+	stderr: string;
+};
+
+export type NativePlaygroundOptions = {
+	serverUrl: string;
+	mounts: NativeVfsMount[];
+	assertActive: () => void;
+	executePHPCLI: (
+		argv: string[],
+		environment?: Record<string, string>
+	) => Promise<NativePHPCLIResult>;
+};
+
+/**
+ * Creates the programmatic PHP/VFS facade backed by the native host mounts.
+ *
+ * The public CLI API has always returned a pooled, asynchronous object. The
+ * native host already uses shared host directories for those paths, so this
+ * facade performs VFS operations against the same files and sends requests to
+ * the running Wasmtime server.
+ */
+export function createNativePlayground(
+	options: NativePlaygroundOptions
+): Pooled<PlaygroundCliWorker> {
+	return new NativePlayground(
+		options
+	) as unknown as Pooled<PlaygroundCliWorker>;
+}
+
+class NativePlayground {
+	readonly absoluteUrl: Promise<string>;
+	readonly documentRoot = Promise.resolve('/wordpress');
+	private readonly options: NativePlaygroundOptions;
+	#workingDirectory = '/wordpress';
+
+	constructor(options: NativePlaygroundOptions) {
+		this.options = options;
+		this.absoluteUrl = Promise.resolve(options.serverUrl);
+	}
+
+	async request(request: PHPRequest): Promise<PHPResponse> {
+		this.assertActive();
+		const response = await fetch(this.requestUrl(request.url), {
+			method: request.method,
+			headers: request.headers,
+			body: requestBody(request.body),
+			redirect: 'manual',
+		});
+		return new PHPResponse(
+			response.status,
+			responseHeaders(response.headers),
+			new Uint8Array(await response.arrayBuffer())
+		);
+	}
+
+	async requestStreamed(request: PHPRequest): Promise<StreamedPHPResponse> {
+		return StreamedPHPResponse.fromPHPResponse(await this.request(request));
+	}
+
+	async run(request: PHPRunOptions): Promise<PHPResponse> {
+		this.assertActive();
+		if (request.env || request.$_SERVER) {
+			throw unsupportedNativePHPOption('run() environment overrides');
+		}
+
+		let temporaryPath: string | undefined;
+		let requestPath: string;
+		if (request.code !== undefined) {
+			temporaryPath = `/wordpress/.wp-playground-native-run-${randomUUID()}.php`;
+			const source = request.code.trimStart().startsWith('<?')
+				? request.code
+				: `<?php\n${request.code}`;
+			await writeFile(this.hostPath(temporaryPath), source);
+			requestPath = this.requestPathForScript(temporaryPath);
+		} else if (request.scriptPath) {
+			if (!(await this.fileExists(request.scriptPath))) {
+				throw new Error(
+					`The script path "${request.scriptPath}" does not exist.`
+				);
+			}
+			requestPath = this.requestPathForScript(request.scriptPath);
+		} else {
+			throw new Error(
+				'Native playground run() requires code or scriptPath.'
+			);
+		}
+
+		try {
+			if (request.relativeUri && request.relativeUri !== requestPath) {
+				throw unsupportedNativePHPOption(
+					'run() relativeUri values different from the script path'
+				);
+			}
+			return await this.request({
+				url: requestPath,
+				method: request.method,
+				headers: request.headers,
+				body: request.body,
+			});
+		} finally {
+			if (temporaryPath) {
+				await rm(this.hostPath(temporaryPath), { force: true });
+			}
+		}
+	}
+
+	async cli(
+		argv: string[],
+		options?: { env?: Record<string, string> }
+	): Promise<StreamedPHPResponse> {
+		this.assertActive();
+		const phpArgs =
+			argv.length > 0 && basename(argv[0]).startsWith('php')
+				? argv.slice(1)
+				: argv;
+		const result = await this.options.executePHPCLI(phpArgs, options?.env);
+		return StreamedPHPResponse.fromPHPResponse(
+			new PHPResponse(
+				result.exitCode === 0 ? 200 : 500,
+				{},
+				result.stdout,
+				result.stderr,
+				result.exitCode
+			)
+		);
+	}
+
+	async mkdir(path: string): Promise<void> {
+		this.assertActive();
+		await mkdir(this.hostPath(path));
+	}
+
+	async mkdirTree(path: string): Promise<void> {
+		this.assertActive();
+		await mkdir(this.hostPath(path), { recursive: true });
+	}
+
+	async readFileAsText(path: string): Promise<string> {
+		this.assertActive();
+		return await readFile(this.hostPath(path), 'utf8');
+	}
+
+	async readFileAsBuffer(path: string): Promise<Uint8Array> {
+		this.assertActive();
+		return new Uint8Array(await readFile(this.hostPath(path)));
+	}
+
+	async writeFile(path: string, data: string | Uint8Array): Promise<void> {
+		this.assertActive();
+		await writeFile(this.hostPath(path), data);
+	}
+
+	async unlink(path: string): Promise<void> {
+		this.assertActive();
+		await unlink(this.hostPath(path));
+	}
+
+	async mv(fromPath: string, toPath: string): Promise<void> {
+		this.assertActive();
+		const from = this.hostPath(fromPath);
+		const to = this.hostPath(toPath);
+		try {
+			await rename(from, to);
+		} catch (error) {
+			if (!isErrorWithCode(error, 'EXDEV')) {
+				throw error;
+			}
+			const source = await stat(from);
+			await cp(from, to, { recursive: source.isDirectory() });
+			await rm(from, { recursive: source.isDirectory(), force: true });
+		}
+	}
+
+	async cp(fromPath: string, toPath: string): Promise<void> {
+		this.assertActive();
+		const from = this.hostPath(fromPath);
+		await cp(from, this.hostPath(toPath), {
+			recursive: (await stat(from)).isDirectory(),
+		});
+	}
+
+	async rmdir(
+		path: string,
+		options: { recursive?: boolean } = { recursive: true }
+	): Promise<void> {
+		this.assertActive();
+		await rm(this.hostPath(path), {
+			recursive: options.recursive ?? true,
+			force: false,
+		});
+	}
+
+	async listFiles(
+		path: string,
+		options: { prependPath?: boolean } = { prependPath: false }
+	): Promise<string[]> {
+		this.assertActive();
+		const normalizedPath = normalizeVfsPath(path);
+		if (normalizedPath === '/') {
+			return [
+				...new Set(
+					this.options.mounts.map(
+						(mount) => mount.vfsPath.split('/')[1]
+					)
+				),
+			]
+				.filter(Boolean)
+				.sort();
+		}
+		try {
+			const names = await readdir(this.hostPath(normalizedPath));
+			if (!options.prependPath) {
+				return names;
+			}
+			return names.map((name) => posix.join(normalizedPath, name));
+		} catch (error) {
+			if (
+				isErrorWithCode(error, 'ENOENT') ||
+				isErrorWithCode(error, 'ENOTDIR')
+			) {
+				return [];
+			}
+			throw error;
+		}
+	}
+
+	async isDir(path: string): Promise<boolean> {
+		this.assertActive();
+		if (normalizeVfsPath(path) === '/') {
+			return true;
+		}
+		try {
+			return (await stat(this.hostPath(path))).isDirectory();
+		} catch (error) {
+			if (isErrorWithCode(error, 'ENOENT')) {
+				return false;
+			}
+			throw error;
+		}
+	}
+
+	async isFile(path: string): Promise<boolean> {
+		this.assertActive();
+		try {
+			return (await stat(this.hostPath(path))).isFile();
+		} catch (error) {
+			if (isErrorWithCode(error, 'ENOENT')) {
+				return false;
+			}
+			throw error;
+		}
+	}
+
+	async fileExists(path: string): Promise<boolean> {
+		this.assertActive();
+		if (normalizeVfsPath(path) === '/') {
+			return true;
+		}
+		try {
+			await lstat(this.hostPath(path));
+			return true;
+		} catch (error) {
+			if (isErrorWithCode(error, 'ENOENT')) {
+				return false;
+			}
+			throw error;
+		}
+	}
+
+	async chmod(path: string, mode: number): Promise<void> {
+		this.assertActive();
+		await chmod(this.hostPath(path), mode);
+	}
+
+	async symlink(target: string, path: string): Promise<void> {
+		this.assertActive();
+		const hostTarget = target.startsWith('/')
+			? this.hostPath(target)
+			: target;
+		await symlink(hostTarget, this.hostPath(path));
+	}
+
+	async isSymlink(path: string): Promise<boolean> {
+		this.assertActive();
+		try {
+			return (await lstat(this.hostPath(path))).isSymbolicLink();
+		} catch (error) {
+			if (isErrorWithCode(error, 'ENOENT')) {
+				return false;
+			}
+			throw error;
+		}
+	}
+
+	async readlink(path: string): Promise<string> {
+		this.assertActive();
+		return await readlink(this.hostPath(path));
+	}
+
+	async realpath(path: string): Promise<string> {
+		this.assertActive();
+		return this.vfsPath(await realpath(this.hostPath(path)));
+	}
+
+	async chdir(path: string): Promise<void> {
+		this.assertActive();
+		if (!(await this.isDir(path))) {
+			throw new Error(
+				`Native playground directory does not exist: ${path}`
+			);
+		}
+		this.#workingDirectory = normalizeVfsPath(path);
+	}
+
+	async cwd(): Promise<string> {
+		this.assertActive();
+		return this.#workingDirectory;
+	}
+
+	async defineConstant(): Promise<never> {
+		throw unsupportedNativePHPOption('defineConstant() after startup');
+	}
+
+	async onMessage(): Promise<never> {
+		throw unsupportedNativePHPOption('onMessage()');
+	}
+
+	async addEventListener(): Promise<never> {
+		throw unsupportedNativePHPOption('addEventListener()');
+	}
+
+	async removeEventListener(): Promise<never> {
+		throw unsupportedNativePHPOption('removeEventListener()');
+	}
+
+	private assertActive() {
+		this.options.assertActive();
+	}
+
+	private requestUrl(value: string): URL {
+		const url = new URL(value, this.options.serverUrl);
+		const server = new URL(this.options.serverUrl);
+		if (url.origin !== server.origin) {
+			throw new Error(
+				`Native playground requests must target ${server.origin}, got ${url.origin}.`
+			);
+		}
+		return url;
+	}
+
+	private requestPathForScript(scriptPath: string): string {
+		const normalizedPath = normalizeVfsPath(scriptPath);
+		const documentRoot = '/wordpress/';
+		if (!normalizedPath.startsWith(documentRoot)) {
+			throw new Error(
+				`Native playground run() can only execute scripts below /wordpress, got ${normalizedPath}.`
+			);
+		}
+		return `/${normalizedPath.slice(documentRoot.length)}`;
+	}
+
+	private hostPath(path: string): string {
+		const normalizedPath = normalizeVfsPath(path);
+		const mount = this.options.mounts.reduce<NativeVfsMount | undefined>(
+			(best, candidate) => {
+				if (
+					normalizedPath !== candidate.vfsPath &&
+					!normalizedPath.startsWith(`${candidate.vfsPath}/`)
+				) {
+					return best;
+				}
+				return !best || candidate.vfsPath.length >= best.vfsPath.length
+					? candidate
+					: best;
+			},
+			undefined
+		);
+		if (!mount) {
+			throw new Error(
+				`Native playground has no host mount for ${normalizedPath}.`
+			);
+		}
+
+		const suffix = normalizedPath
+			.slice(mount.vfsPath.length)
+			.replace(/^\//, '');
+		const hostPath = resolve(
+			mount.hostPath,
+			...suffix.split('/').filter(Boolean)
+		);
+		if (
+			hostPath !== mount.hostPath &&
+			!hostPath.startsWith(`${mount.hostPath}${sep}`)
+		) {
+			throw new Error(
+				`Native playground path escapes its mount: ${normalizedPath}.`
+			);
+		}
+		return hostPath;
+	}
+
+	private vfsPath(hostPath: string): string {
+		const mount = this.options.mounts.reduce<NativeVfsMount | undefined>(
+			(best, candidate) => {
+				const suffix = relative(candidate.hostPath, hostPath);
+				if (pathEscapesMount(suffix)) {
+					return best;
+				}
+				return !best ||
+					candidate.hostPath.length >= best.hostPath.length
+					? candidate
+					: best;
+			},
+			undefined
+		);
+		if (!mount) {
+			throw new Error(
+				`Native playground real path is outside its mounts: ${hostPath}.`
+			);
+		}
+		const suffix = relative(mount.hostPath, hostPath)
+			.split(sep)
+			.filter(Boolean)
+			.join('/');
+		return suffix ? posix.join(mount.vfsPath, suffix) : mount.vfsPath;
+	}
+}
+
+function normalizeVfsPath(path: string): string {
+	if (!path.startsWith('/')) {
+		throw new Error(`Native playground paths must be absolute: ${path}.`);
+	}
+	const normalized = posix.normalize(path);
+	return normalized === '.' ? '/' : normalized;
+}
+
+function requestBody(body: PHPRequest['body']): BodyInit | undefined {
+	if (body === undefined || typeof body === 'string') {
+		return body;
+	}
+	if (body instanceof Uint8Array) {
+		return body as BodyInit;
+	}
+
+	const formData = new FormData();
+	for (const [name, value] of Object.entries(body)) {
+		if (typeof value === 'string') {
+			formData.append(name, value);
+		} else if (value instanceof Uint8Array) {
+			formData.append(name, new Blob([value]), name);
+		} else {
+			formData.append(name, value);
+		}
+	}
+	return formData;
+}
+
+function responseHeaders(headers: Headers): Record<string, string[]> {
+	const result: Record<string, string[]> = {};
+	headers.forEach((value, name) => {
+		result[name] = [value];
+	});
+	const setCookies = (
+		headers as Headers & { getSetCookie?: () => string[] }
+	).getSetCookie?.();
+	if (setCookies?.length) {
+		result['set-cookie'] = setCookies;
+	}
+	return result;
+}
+
+function unsupportedNativePHPOption(option: string): Error {
+	return new Error(
+		`The Wasmtime runCLI() adapter does not support ${option} yet. Supply startup options to runCLI() instead.`
+	);
+}
+
+function isErrorWithCode(error: unknown, code: string): boolean {
+	return (
+		error instanceof Error &&
+		'code' in error &&
+		(error as NodeJS.ErrnoException).code === code
+	);
+}
+
+function pathEscapesMount(path: string): boolean {
+	return path === '..' || path.startsWith(`..${sep}`) || isAbsolute(path);
+}

--- a/packages/playground/cli/src/native-run-cli.ts
+++ b/packages/playground/cli/src/native-run-cli.ts
@@ -1,0 +1,746 @@
+import type { ChildProcess } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { EventEmitter } from 'node:events';
+import { posix, join, resolve } from 'node:path';
+import type { Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import os from 'node:os';
+import { LogSeverity } from '@php-wasm/logger';
+import type { Pooled } from '@php-wasm/universal';
+import type { Mount } from '@php-wasm/cli-util';
+import type { PlaygroundCliWorker, RunCLIArgs } from './run-cli';
+import {
+	runNativeCLI,
+	spawnNativeCLI,
+	type NativeCLIExit,
+} from './native-binary';
+import {
+	createNativePlayground,
+	type NativePHPCLIResult,
+	type NativeVfsMount,
+} from './native-playground';
+
+const nativeReadyFileEnvironmentVariable = 'WP_PLAYGROUND_NATIVE_READY_FILE';
+const nativeReadyProtocolVersion = 2;
+const nativeStartupTimeoutMilliseconds = 120_000;
+const nativeShutdownTimeoutMilliseconds = 5_000;
+const defaultVfsDirectories = ['/wordpress', '/tmp', '/home', '/tools'];
+
+export const LogVerbosity = {
+	Quiet: { name: 'quiet', severity: LogSeverity.Fatal },
+	Normal: { name: 'normal', severity: LogSeverity.Info },
+	Debug: { name: 'debug', severity: LogSeverity.Debug },
+} as const;
+
+export type WorkerType = 'v1' | 'v2';
+
+export const internalsKeyForTesting = Symbol('playground-cli-testing');
+
+export interface RunCLIServer extends AsyncDisposable {
+	playground: Pooled<PlaygroundCliWorker>;
+	server: Server;
+	serverUrl: string;
+
+	[Symbol.asyncDispose](): Promise<void>;
+
+	[internalsKeyForTesting]: {
+		workerThreadCount: number;
+	};
+}
+
+type NativeReadyManifest = {
+	protocolVersion: number;
+	serverUrl: string;
+	siteUrl: string;
+	pid: number;
+	mounts: NativeVfsMount[];
+};
+
+type PreparedNativeInvocation = {
+	args: RunCLIArgs;
+	root: string;
+	mountsBeforeInstall: NativeVfsMount[];
+	mounts: NativeVfsMount[];
+	blueprintPath?: string;
+	cleanup: () => Promise<void>;
+};
+
+/**
+ * Resolves the native host worker count using the long-standing CLI policy.
+ */
+export function resolveWorkerCount(value: number | 'auto' | undefined): number {
+	const cpusMinusOne = Math.max(1, os.cpus().length - 1);
+	if (value === undefined) {
+		return Math.min(6, cpusMinusOne);
+	}
+	return value === 'auto' ? cpusMinusOne : value;
+}
+
+/**
+ * Runs raw command-line arguments through the Wasmtime host.
+ *
+ * This is the programmatic equivalent of invoking `wp-playground-cli` and is
+ * deliberately separate from runCLI(), which starts a server and returns its
+ * lifecycle and PHP/VFS facade.
+ */
+export async function parseOptionsAndRunCLI(
+	argsToParse: string[]
+): Promise<void> {
+	const result = await runNativeCLI(argsToParse, { stdio: 'inherit' });
+	ensureNativeCommandSucceeded(result, argsToParse[0] ?? 'wp-playground-cli');
+}
+
+export async function runCLI(
+	args: RunCLIArgs & {
+		command: 'build-snapshot' | 'run-blueprint' | 'php';
+	}
+): Promise<void>;
+export async function runCLI(
+	args: RunCLIArgs & { command: 'start' }
+): Promise<RunCLIServer>;
+export async function runCLI(
+	args: RunCLIArgs & { command: 'server' }
+): Promise<RunCLIServer>;
+export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer | void>;
+export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer | void> {
+	assertSupportedProgrammaticOptions(args);
+	const invocation = await prepareNativeInvocation(args);
+	const commandArgs = nativeArgsFor(invocation, args.command);
+
+	if (args.command !== 'server' && args.command !== 'start') {
+		try {
+			const result = await runNativeCLI(commandArgs, {
+				stdio: 'inherit',
+			});
+			ensureNativeCommandSucceeded(result, args.command);
+		} finally {
+			await invocation.cleanup();
+		}
+		return;
+	}
+
+	return await startNativeServer(invocation, commandArgs);
+}
+
+async function prepareNativeInvocation(
+	args: RunCLIArgs
+): Promise<PreparedNativeInvocation> {
+	const root = await mkdtemp(join(tmpdir(), 'wp-playground-native-api-'));
+	let cleaned = false;
+	const cleanup = async () => {
+		if (!cleaned) {
+			cleaned = true;
+			await rm(root, { recursive: true, force: true });
+		}
+	};
+
+	try {
+		const userMountsBeforeInstall = normalizeMounts(
+			args['mount-before-install'] ?? []
+		);
+		const userMounts = normalizeMounts(args.mount ?? []);
+		const suppliedMounts = [...userMountsBeforeInstall, ...userMounts];
+		const wrapperMounts: NativeVfsMount[] = [];
+
+		const wrapperDirectories =
+			args.command === 'start'
+				? defaultVfsDirectories.filter((path) => path !== '/wordpress')
+				: defaultVfsDirectories;
+		for (const vfsPath of wrapperDirectories) {
+			if (suppliedMounts.some((mount) => mount.vfsPath === vfsPath)) {
+				continue;
+			}
+			const hostPath = join(root, 'vfs', vfsPath.slice(1));
+			await mkdir(hostPath, { recursive: true });
+			wrapperMounts.push({ hostPath, vfsPath });
+		}
+
+		let blueprintPath: string | undefined;
+		if (args.blueprint && typeof args.blueprint !== 'string') {
+			blueprintPath = join(root, 'blueprint.json');
+			const blueprint = JSON.stringify(args.blueprint);
+			if (blueprint === undefined) {
+				throw new Error(
+					'Native runCLI() could not serialize the Blueprint input.'
+				);
+			}
+			await writeFile(blueprintPath, blueprint);
+		}
+
+		const mountsBeforeInstall = [
+			...wrapperMounts,
+			...userMountsBeforeInstall,
+		];
+		return {
+			args,
+			root,
+			mountsBeforeInstall,
+			mounts: userMounts,
+			blueprintPath,
+			cleanup,
+		};
+	} catch (error) {
+		await cleanup();
+		throw error;
+	}
+}
+
+async function startNativeServer(
+	invocation: PreparedNativeInvocation,
+	commandArgs: string[]
+): Promise<RunCLIServer> {
+	const readyPath = join(invocation.root, `ready-${randomUUID()}.json`);
+	const environment = {
+		...process.env,
+		[nativeReadyFileEnvironmentVariable]: readyPath,
+	};
+	const child = spawnNativeCLI(commandArgs, {
+		cwd: process.cwd(),
+		env: environment,
+		stdio: 'inherit',
+	});
+
+	let manifest: NativeReadyManifest;
+	try {
+		manifest = await waitForNativeReady(child, readyPath);
+	} catch (error) {
+		await terminateChild(child);
+		await invocation.cleanup();
+		throw error;
+	}
+
+	let disposePromise: Promise<void> | undefined;
+	const dispose = () => {
+		if (!disposePromise) {
+			disposePromise = (async () => {
+				await terminateChild(child);
+				await invocation.cleanup();
+			})();
+		}
+		return disposePromise;
+	};
+	const serverHandle = new NativeServerHandle(manifest.serverUrl, dispose);
+	child.once('close', () => {
+		serverHandle.emitClose();
+		void invocation.cleanup();
+	});
+
+	const playground = createNativePlayground({
+		serverUrl: manifest.serverUrl,
+		mounts: manifest.mounts,
+		assertActive: () => {
+			if (
+				disposePromise ||
+				child.exitCode !== null ||
+				child.signalCode !== null
+			) {
+				throw new Error(
+					'The native WordPress Playground server is no longer running.'
+				);
+			}
+		},
+		executePHPCLI: (argv, phpEnvironment) =>
+			executeNativePHPCLI(invocation, argv, phpEnvironment),
+	});
+
+	return {
+		playground,
+		server: serverHandle as unknown as Server,
+		serverUrl: manifest.serverUrl,
+		[Symbol.asyncDispose]: dispose,
+		[internalsKeyForTesting]: {
+			workerThreadCount: resolveWorkerCount(invocation.args.workers),
+		},
+	};
+}
+
+async function executeNativePHPCLI(
+	invocation: PreparedNativeInvocation,
+	argv: string[],
+	phpEnvironment?: Record<string, string>
+): Promise<NativePHPCLIResult> {
+	const phpArgs = nativeArgsFor(invocation, 'php', argv);
+	const child = spawnNativeCLI(phpArgs, {
+		cwd: process.cwd(),
+		env: { ...process.env, ...phpEnvironment },
+		stdio: ['ignore', 'pipe', 'pipe'],
+	});
+	const [stdout, stderr, result] = await Promise.all([
+		readChildStream(child.stdout),
+		readChildStream(child.stderr),
+		waitForChildResult(child),
+	]);
+	return {
+		exitCode: result.code ?? 1,
+		stdout,
+		stderr: new TextDecoder().decode(stderr),
+	};
+}
+
+function nativeArgsFor(
+	invocation: PreparedNativeInvocation,
+	command: RunCLIArgs['command'],
+	phpArgs: string[] = []
+): string[] {
+	const args = invocation.args;
+	const nativeArgs: string[] = [command];
+	appendValue(nativeArgs, 'php', args.php);
+	appendValue(nativeArgs, 'wp', args.wp);
+	appendValue(nativeArgs, 'port', args.port);
+	appendValue(nativeArgs, 'site-url', args['site-url']);
+
+	for (const mount of invocation.mountsBeforeInstall) {
+		nativeArgs.push(
+			'--mount-dir-before-install',
+			mount.hostPath,
+			mount.vfsPath
+		);
+	}
+	for (const mount of invocation.mounts) {
+		nativeArgs.push('--mount-dir', mount.hostPath, mount.vfsPath);
+	}
+
+	if (command === 'start') {
+		appendValue(nativeArgs, 'path', args.path);
+		if (args.reset) {
+			nativeArgs.push('--reset');
+		}
+		if (args.skipBrowser) {
+			nativeArgs.push('--skip-browser');
+		}
+	}
+	if (command === 'start' || command === 'server') {
+		appendValue(nativeArgs, 'workers', args.workers);
+	}
+
+	if (args.autoMount === false) {
+		nativeArgs.push('--no-auto-mount');
+	} else if (typeof args.autoMount === 'string') {
+		if (args.autoMount) {
+			nativeArgs.push('--auto-mount', args.autoMount);
+		} else {
+			nativeArgs.push('--auto-mount');
+		}
+	}
+	if (args.login === true) {
+		nativeArgs.push('--login');
+	} else if (args.login === false) {
+		nativeArgs.push('--no-login');
+	}
+	if (args.wordpressInstallMode) {
+		appendValue(
+			nativeArgs,
+			'wordpress-install-mode',
+			args.wordpressInstallMode
+		);
+	}
+	if (args.skipSqliteSetup) {
+		nativeArgs.push('--skip-sqlite-setup');
+	}
+	if (args.blueprint) {
+		appendValue(
+			nativeArgs,
+			'blueprint',
+			typeof args.blueprint === 'string'
+				? args.blueprint
+				: invocation.blueprintPath
+		);
+	}
+	if (args['blueprint-may-read-adjacent-files']) {
+		nativeArgs.push('--blueprint-may-read-adjacent-files');
+	}
+	if (command === 'build-snapshot') {
+		appendValue(nativeArgs, 'outfile', args.outfile);
+	}
+	if (args.quiet) {
+		nativeArgs.push('--quiet');
+	} else {
+		appendValue(nativeArgs, 'verbosity', args.verbosity);
+	}
+	if (args.debug) {
+		nativeArgs.push('--debug');
+	}
+	if (args.followSymlinks) {
+		nativeArgs.push('--follow-symlinks');
+	}
+	if (args.intl === false) {
+		nativeArgs.push('--no-intl');
+	}
+	if (args.redis) {
+		nativeArgs.push('--redis');
+	}
+	if (args.memcached) {
+		nativeArgs.push('--memcached');
+	}
+	if (args.xdebug === true) {
+		nativeArgs.push('--xdebug');
+	}
+
+	appendDefinedConstants(nativeArgs, 'define', args.define);
+	appendDefinedConstants(nativeArgs, 'define-bool', args['define-bool']);
+	appendDefinedConstants(nativeArgs, 'define-number', args['define-number']);
+
+	if (command === 'php') {
+		const positional = phpArgs.length
+			? phpArgs
+			: dropLeadingCommand(args._ ?? [], 'php');
+		if (positional.length) {
+			nativeArgs.push('--', ...positional);
+		}
+	} else if (command === 'run-blueprint' && !args.blueprint) {
+		const positional = dropLeadingCommand(args._ ?? [], 'run-blueprint');
+		nativeArgs.push(...positional);
+	}
+
+	return nativeArgs;
+}
+
+function dropLeadingCommand(tokens: string[], command: string): string[] {
+	return tokens[0] === command ? tokens.slice(1) : tokens;
+}
+
+function appendValue(
+	args: string[],
+	name: string,
+	value: string | number | undefined
+) {
+	if (value !== undefined) {
+		args.push(`--${name}=${value}`);
+	}
+}
+
+function appendDefinedConstants(
+	args: string[],
+	name: string,
+	values: Record<string, string | number | boolean> | undefined
+) {
+	for (const [constant, value] of Object.entries(values ?? {})) {
+		args.push(`--${name}`, constant, String(value));
+	}
+}
+
+function normalizeMounts(mounts: Mount[]): NativeVfsMount[] {
+	return mounts.map((mount) => {
+		if (
+			!mount ||
+			typeof mount.hostPath !== 'string' ||
+			typeof mount.vfsPath !== 'string'
+		) {
+			throw new Error(
+				'Native runCLI() mounts require hostPath and vfsPath strings.'
+			);
+		}
+		const vfsPath = normalizeVfsMountPath(mount.vfsPath);
+		return {
+			hostPath: resolve(mount.hostPath),
+			vfsPath,
+		};
+	});
+}
+
+function normalizeVfsMountPath(path: string): string {
+	if (!path.startsWith('/')) {
+		throw new Error(
+			`Native runCLI() mount paths must be absolute: ${path}.`
+		);
+	}
+	return posix.normalize(path);
+}
+
+function assertSupportedProgrammaticOptions(args: RunCLIArgs) {
+	const unsupported: Array<[string, unknown]> = [
+		['pathAliases', args.pathAliases?.length],
+		[
+			'additional-blueprint-steps',
+			args['additional-blueprint-steps']?.length,
+		],
+		['phpmyadmin', args.phpmyadmin],
+		['phpExtension', args.phpExtension?.length],
+		[
+			'experimentalUnsafeIdeIntegration',
+			args.experimentalUnsafeIdeIntegration?.length,
+		],
+		['experimentalDevtools', args.experimentalDevtools],
+		[
+			'experimental-blueprints-v2-runner',
+			args['experimental-blueprints-v2-runner'],
+		],
+		['experimental-multi-worker', args['experimental-multi-worker']],
+		['experimentalTrace', args.experimentalTrace],
+		['internalCookieStore', args.internalCookieStore],
+		['mode', args.mode],
+		['db-engine', args['db-engine']],
+		['db-host', args['db-host']],
+		['db-user', args['db-user']],
+		['db-pass', args['db-pass']],
+		['db-name', args['db-name']],
+		['db-path', args['db-path']],
+		['truncate-new-site-directory', args['truncate-new-site-directory']],
+		['allow', args.allow],
+	];
+	const option = unsupported.find(([, value]) => Boolean(value))?.[0];
+	if (option) {
+		throw new Error(
+			`The Wasmtime runCLI() adapter does not support ${option} yet. Use a native v1-compatible CLI option instead.`
+		);
+	}
+	if (args.xdebug && args.xdebug !== true) {
+		throw new Error(
+			'The Wasmtime runCLI() adapter supports xdebug: true, but not Node Xdebug configuration objects.'
+		);
+	}
+}
+
+async function waitForNativeReady(
+	child: ChildProcess,
+	readyPath: string
+): Promise<NativeReadyManifest> {
+	let processFailure: Error | undefined;
+	const onError = (error: Error) => {
+		processFailure = error;
+	};
+	const onClose = (code: number | null, signal: NodeJS.Signals | null) => {
+		processFailure = new Error(
+			`wp-playground-native exited before it became ready (code ${code ?? 'none'}, signal ${signal ?? 'none'}).`
+		);
+	};
+	child.once('error', onError);
+	child.once('close', onClose);
+
+	try {
+		const deadline = Date.now() + nativeStartupTimeoutMilliseconds;
+		while (Date.now() < deadline) {
+			if (processFailure) {
+				throw processFailure;
+			}
+			try {
+				const manifest = parseNativeReadyManifest(
+					JSON.parse(await readFile(readyPath, 'utf8'))
+				);
+				return manifest;
+			} catch (error) {
+				if (
+					!(error instanceof SyntaxError) &&
+					!isErrorWithCode(error, 'ENOENT')
+				) {
+					throw error;
+				}
+			}
+			await wait(20);
+		}
+		throw new Error(
+			`Timed out waiting for wp-playground-native readiness after ${nativeStartupTimeoutMilliseconds}ms.`
+		);
+	} finally {
+		child.off('error', onError);
+		child.off('close', onClose);
+	}
+}
+
+function parseNativeReadyManifest(value: unknown): NativeReadyManifest {
+	if (!value || typeof value !== 'object') {
+		throw new Error(
+			'wp-playground-native wrote an invalid readiness manifest.'
+		);
+	}
+	const manifest = value as Partial<NativeReadyManifest>;
+	if (manifest.protocolVersion !== nativeReadyProtocolVersion) {
+		throw new Error(
+			`wp-playground-native readiness protocol ${manifest.protocolVersion} is not supported.`
+		);
+	}
+	if (
+		typeof manifest.serverUrl !== 'string' ||
+		typeof manifest.siteUrl !== 'string'
+	) {
+		throw new Error(
+			'wp-playground-native readiness manifest is missing server URLs.'
+		);
+	}
+	const serverUrl = new URL(manifest.serverUrl);
+	if (serverUrl.protocol !== 'http:' || serverUrl.hostname !== '127.0.0.1') {
+		throw new Error(
+			`wp-playground-native readiness endpoint must be loopback HTTP, got ${manifest.serverUrl}.`
+		);
+	}
+	if (!Array.isArray(manifest.mounts)) {
+		throw new Error(
+			'wp-playground-native readiness manifest is missing mounts.'
+		);
+	}
+	const mounts = manifest.mounts.map((mount) => {
+		if (
+			!mount ||
+			typeof mount.hostPath !== 'string' ||
+			typeof mount.vfsPath !== 'string'
+		) {
+			throw new Error(
+				'wp-playground-native readiness manifest has an invalid mount.'
+			);
+		}
+		return {
+			hostPath: resolve(mount.hostPath),
+			vfsPath: normalizeVfsMountPath(mount.vfsPath),
+		};
+	});
+	return {
+		protocolVersion: manifest.protocolVersion,
+		serverUrl: manifest.serverUrl,
+		siteUrl: manifest.siteUrl,
+		pid: typeof manifest.pid === 'number' ? manifest.pid : 0,
+		mounts,
+	};
+}
+
+async function terminateChild(child: ChildProcess): Promise<void> {
+	if (child.exitCode !== null || child.signalCode !== null) {
+		return;
+	}
+	child.kill('SIGTERM');
+	if (await waitForChildExit(child, nativeShutdownTimeoutMilliseconds)) {
+		return;
+	}
+	child.kill('SIGKILL');
+	await waitForChildExit(child, nativeShutdownTimeoutMilliseconds);
+}
+
+async function waitForChildExit(
+	child: ChildProcess,
+	timeoutMilliseconds = nativeShutdownTimeoutMilliseconds
+): Promise<boolean> {
+	if (child.exitCode !== null || child.signalCode !== null) {
+		return true;
+	}
+	return await new Promise<boolean>((resolvePromise) => {
+		let settled = false;
+		const settle = (didExit: boolean) => {
+			if (settled) {
+				return;
+			}
+			settled = true;
+			clearTimeout(timeout);
+			child.off('close', onClose);
+			child.off('error', onError);
+			resolvePromise(didExit);
+		};
+		const timeout = setTimeout(() => settle(false), timeoutMilliseconds);
+		const onClose = () => settle(true);
+		const onError = () => settle(true);
+		child.once('close', onClose);
+		child.once('error', onError);
+	});
+}
+
+async function waitForChildResult(child: ChildProcess): Promise<NativeCLIExit> {
+	if (child.exitCode !== null || child.signalCode !== null) {
+		return { code: child.exitCode, signal: child.signalCode };
+	}
+	return await new Promise<NativeCLIExit>((resolvePromise) => {
+		const onClose = (
+			code: number | null,
+			signal: NodeJS.Signals | null
+		) => {
+			child.off('error', onError);
+			resolvePromise({ code, signal });
+		};
+		const onError = () => {
+			child.off('close', onClose);
+			resolvePromise({ code: child.exitCode, signal: child.signalCode });
+		};
+		child.once('close', onClose);
+		child.once('error', onError);
+	});
+}
+
+async function readChildStream(
+	stream: NodeJS.ReadableStream | null
+): Promise<Uint8Array> {
+	if (!stream) {
+		return new Uint8Array();
+	}
+	const chunks: Uint8Array[] = [];
+	for await (const chunk of stream) {
+		chunks.push(
+			typeof chunk === 'string' ? new TextEncoder().encode(chunk) : chunk
+		);
+	}
+	const length = chunks.reduce((total, chunk) => total + chunk.byteLength, 0);
+	const result = new Uint8Array(length);
+	let offset = 0;
+	for (const chunk of chunks) {
+		result.set(chunk, offset);
+		offset += chunk.byteLength;
+	}
+	return result;
+}
+
+function ensureNativeCommandSucceeded(result: NativeCLIExit, command: string) {
+	if (result.signal) {
+		throw new Error(
+			`wp-playground-native ${command} stopped with ${result.signal}.`
+		);
+	}
+	if (result.code !== 0) {
+		throw new Error(
+			`wp-playground-native ${command} exited with code ${result.code ?? 'none'}.`
+		);
+	}
+}
+
+function isErrorWithCode(error: unknown, code: string): boolean {
+	return (
+		error instanceof Error &&
+		'code' in error &&
+		(error as NodeJS.ErrnoException).code === code
+	);
+}
+
+function wait(milliseconds: number): Promise<void> {
+	return new Promise((resolvePromise) =>
+		setTimeout(resolvePromise, milliseconds)
+	);
+}
+
+class NativeServerHandle extends EventEmitter {
+	#closed = false;
+	private readonly serverUrl: string;
+	private readonly dispose: () => Promise<void>;
+
+	constructor(serverUrl: string, dispose: () => Promise<void>) {
+		super();
+		this.serverUrl = serverUrl;
+		this.dispose = dispose;
+	}
+
+	close(callback?: (error?: Error) => void): this {
+		void this.dispose().then(
+			() => callback?.(),
+			(error) => callback?.(error as Error)
+		);
+		return this;
+	}
+
+	closeAllConnections() {
+		void this.dispose();
+	}
+
+	address(): AddressInfo {
+		const url = new URL(this.serverUrl);
+		return {
+			address: url.hostname,
+			family: url.hostname.includes(':') ? 'IPv6' : 'IPv4',
+			port: Number(url.port),
+		};
+	}
+
+	emitClose() {
+		if (!this.#closed) {
+			this.#closed = true;
+			this.emit('close');
+		}
+	}
+}
+
+export type { PlaygroundCliWorker, RunCLIArgs } from './run-cli';

--- a/packages/playground/cli/tests/native-run-cli.spec.ts
+++ b/packages/playground/cli/tests/native-run-cli.spec.ts
@@ -1,0 +1,278 @@
+import { chmod, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { internalsKeyForTesting, runCLI } from '../src';
+import { nativeBinaryEnvironmentVariable } from '../src/native-binary';
+
+const nativeDescribe = process.platform === 'win32' ? describe.skip : describe;
+const fixtureArgumentsEnvironmentVariable = 'PLAYGROUND_NATIVE_TEST_ARGUMENTS';
+
+nativeDescribe('native runCLI()', () => {
+	let previousBinary: string | undefined;
+	let previousFixtureArguments: string | undefined;
+
+	beforeEach(() => {
+		previousBinary = process.env[nativeBinaryEnvironmentVariable];
+		previousFixtureArguments =
+			process.env[fixtureArgumentsEnvironmentVariable];
+	});
+
+	afterEach(() => {
+		if (previousBinary === undefined) {
+			delete process.env[nativeBinaryEnvironmentVariable];
+		} else {
+			process.env[nativeBinaryEnvironmentVariable] = previousBinary;
+		}
+		if (previousFixtureArguments === undefined) {
+			delete process.env[fixtureArgumentsEnvironmentVariable];
+		} else {
+			process.env[fixtureArgumentsEnvironmentVariable] =
+				previousFixtureArguments;
+		}
+	});
+
+	test('returns a native-backed PHP, VFS, and server facade', async () => {
+		const fixture = await createNativeHostFixture();
+		process.env[nativeBinaryEnvironmentVariable] = fixture.binary;
+
+		try {
+			await using server = await runCLI({
+				command: 'server',
+				port: 0,
+				verbosity: 'quiet',
+				wordpressInstallMode: 'do-not-attempt-installing',
+				skipSqliteSetup: true,
+			});
+			const playground = server.playground;
+
+			expect(server.serverUrl).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/);
+			expect(
+				server[internalsKeyForTesting].workerThreadCount
+			).toBeGreaterThan(0);
+
+			await playground.writeFile('/wordpress/hello.txt', 'hello native');
+			expect(
+				await playground.readFileAsText('/wordpress/hello.txt')
+			).toBe('hello native');
+			expect(await playground.fileExists('/wordpress/hello.txt')).toBe(
+				true
+			);
+			await playground.mkdir('/tools/example');
+			expect(await playground.isDir('/tools/example')).toBe(true);
+
+			const response = await playground.request({
+				method: 'POST',
+				url: '/echo',
+				body: 'request body',
+			});
+			expect(response.httpStatusCode).toBe(200);
+			expect(response.text).toContain('request body');
+
+			const runResponse = await playground.run({
+				code: '<?php echo "native run";',
+			});
+			expect(runResponse.text).toBe('native run');
+			await playground.writeFile(
+				'/wordpress/file-run.php',
+				'<?php echo "file run";'
+			);
+			expect(
+				(
+					await playground.run({
+						scriptPath: '/wordpress/file-run.php',
+					})
+				).text
+			).toBe('file run');
+			await expect(
+				playground.run({ scriptPath: '/wordpress/missing.php' })
+			).rejects.toThrow('does not exist');
+
+			const cliResponse = await (playground as any).cli([
+				'php',
+				'php',
+				'-v',
+			]);
+			expect(await cliResponse.stdoutText).toBe('native php');
+			const phpArgs = JSON.parse(
+				await readFile(fixture.argumentsPath, 'utf8')
+			) as string[];
+			expect(phpArgs.slice(phpArgs.indexOf('--'))).toEqual([
+				'--',
+				'php',
+				'-v',
+			]);
+		} finally {
+			await fixture.cleanup();
+		}
+	});
+
+	test('uses the native mount table for start-managed WordPress storage', async () => {
+		const fixture = await createNativeHostFixture();
+		process.env[nativeBinaryEnvironmentVariable] = fixture.binary;
+
+		try {
+			await using server = await runCLI({
+				command: 'start',
+				port: 0,
+				autoMount: false,
+				skipBrowser: true,
+				verbosity: 'quiet',
+			});
+			await server.playground.writeFile(
+				'/wordpress/managed.txt',
+				'managed'
+			);
+			expect(
+				await server.playground.readFileAsText('/wordpress/managed.txt')
+			).toBe('managed');
+
+			const args = JSON.parse(
+				await readFile(fixture.argumentsPath, 'utf8')
+			);
+			expect(hasMount(args, '/wordpress')).toBe(false);
+		} finally {
+			await fixture.cleanup();
+		}
+	});
+
+	test('serializes programmatic options and rejects Node-only options', async () => {
+		const fixture = await createNativeHostFixture();
+		process.env[nativeBinaryEnvironmentVariable] = fixture.binary;
+		const customMount = join(fixture.root, 'custom');
+		await writeFile(customMount, 'mounted file');
+
+		try {
+			await using server = await runCLI({
+				command: 'server',
+				port: 0,
+				define: { STRING_VALUE: 'hello' },
+				'define-bool': { BOOL_VALUE: true },
+				'define-number': { NUMBER_VALUE: 42 },
+				'mount-before-install': [
+					{ hostPath: customMount, vfsPath: '/custom.txt' },
+				],
+				verbosity: 'quiet',
+			});
+			const args = JSON.parse(
+				await readFile(fixture.argumentsPath, 'utf8')
+			);
+
+			expect(args).toContain('--define');
+			expect(args).toContain('STRING_VALUE');
+			expect(args).toContain('--define-bool');
+			expect(args).toContain('--define-number');
+			expect(hasMount(args, '/custom.txt')).toBe(true);
+			expect(await server.playground.readFileAsText('/custom.txt')).toBe(
+				'mounted file'
+			);
+
+			await expect(
+				runCLI({
+					command: 'server',
+					pathAliases: [
+						{ urlPrefix: '/alias', fsPath: '/tools/alias' },
+					],
+				})
+			).rejects.toThrow('pathAliases');
+		} finally {
+			await fixture.cleanup();
+		}
+	});
+});
+
+async function createNativeHostFixture() {
+	const root = await mkdtemp(join(tmpdir(), 'playground-native-run-cli-'));
+	const binary = join(root, 'wp-playground-native');
+	const argumentsPath = join(root, 'arguments.json');
+	process.env[fixtureArgumentsEnvironmentVariable] = argumentsPath;
+	await writeFile(
+		binary,
+		`#!/usr/bin/env node
+const fs = require('node:fs');
+const http = require('node:http');
+const path = require('node:path');
+
+const args = process.argv.slice(2);
+const command = args[0];
+const output = process.env.PLAYGROUND_NATIVE_TEST_ARGUMENTS;
+if (output) {
+  fs.writeFileSync(output, JSON.stringify(args));
+}
+if (command === 'php') {
+  process.stdout.write('native php');
+  process.exit(0);
+}
+
+const mounts = [];
+for (let index = 1; index < args.length; index++) {
+  if (args[index] === '--mount-dir-before-install' || args[index] === '--mount-dir') {
+    mounts.push({ hostPath: args[index + 1], vfsPath: args[index + 2] });
+    index += 2;
+  }
+}
+if (command === 'start' && !mounts.some((mount) => mount.vfsPath === '/wordpress')) {
+  const managed = path.join(path.dirname(process.env.WP_PLAYGROUND_NATIVE_READY_FILE), 'managed-wordpress');
+  fs.mkdirSync(managed, { recursive: true });
+  mounts.push({ hostPath: managed, vfsPath: '/wordpress' });
+}
+const requestedPort = Number((args.find((arg) => arg.startsWith('--port=')) || '--port=0').slice(7));
+const server = http.createServer((request, response) => {
+  const chunks = [];
+  request.on('data', (chunk) => chunks.push(chunk));
+  request.on('end', () => {
+    const url = new URL(request.url, 'http://127.0.0.1');
+    if (url.pathname === '/echo') {
+      response.end(JSON.stringify({ method: request.method, body: Buffer.concat(chunks).toString() }));
+      return;
+    }
+    const wordpress = mounts.find((mount) => mount.vfsPath === '/wordpress');
+    const file = wordpress && path.join(wordpress.hostPath, url.pathname.replace(/^\\//, ''));
+    if (file && fs.existsSync(file)) {
+      const source = fs.readFileSync(file, 'utf8');
+      const echo = source.match(/echo\\s+['"]([^'"]*)['"]/);
+      response.end(echo ? echo[1] : source);
+      return;
+    }
+    response.statusCode = 404;
+    response.end('not found');
+  });
+});
+server.listen(requestedPort, '127.0.0.1', () => {
+  const address = server.address();
+  const serverUrl = 'http://127.0.0.1:' + address.port;
+  fs.writeFileSync(process.env.WP_PLAYGROUND_NATIVE_READY_FILE, JSON.stringify({
+    protocolVersion: 2,
+    serverUrl,
+    siteUrl: (args.find((arg) => arg.startsWith('--site-url=')) || '').slice(11) || serverUrl,
+    pid: process.pid,
+    mounts,
+  }));
+});
+process.on('SIGTERM', () => server.close(() => process.exit(0)));
+process.on('SIGINT', () => server.close(() => process.exit(0)));
+`
+	);
+	await chmod(binary, 0o755);
+
+	return {
+		root,
+		binary,
+		argumentsPath,
+		cleanup: async () => {
+			await rm(root, { recursive: true, force: true });
+		},
+	};
+}
+
+function hasMount(args: string[], vfsPath: string): boolean {
+	for (let index = 0; index < args.length; index++) {
+		if (
+			(args[index] === '--mount-dir-before-install' ||
+				args[index] === '--mount-dir') &&
+			args[index + 2] === vfsPath
+		) {
+			return true;
+		}
+	}
+	return false;
+}

--- a/packages/playground/cli/vite.config.ts
+++ b/packages/playground/cli/vite.config.ts
@@ -168,6 +168,11 @@ const plugins = [
 
 const external = [
 	...getExternalModules(),
+	'node:child_process',
+	'node:events',
+	'node:os',
+	'node:path',
+	'node:url',
 	'@php-wasm/node',
 	'@php-wasm/web',
 	'@php-wasm/universal',
@@ -221,8 +226,6 @@ export default defineConfig({
 			entry: {
 				index: 'src/index.ts',
 				cli: 'src/cli.ts',
-				'worker-thread-v1': 'src/blueprints-v1/worker-thread-v1.ts',
-				'worker-thread-v2': 'src/blueprints-v2/worker-thread-v2.ts',
 			},
 			name: 'playground-cli',
 			formats: ['es', 'cjs'],


### PR DESCRIPTION
## Summary

- export the existing `runCLI()` API from `@wp-playground/cli`, backed by the Wasmtime native host
- expose a host-backed PHP/VFS facade and native server lifecycle while preserving the established `RunCLIServer` shape
- publish the final native mount table through the readiness manifest so `start` managed storage remains addressable from Node

## Scope

This is stack 3 of 3 so far: #4012 -> #4013 -> this PR. It intentionally does not publish packages, create releases, or merge anything.

The adapter supports the common programmatic server lifecycle, HTTP requests, mounted VFS operations, `run()`, and `cli()`. Node-only worker features that have no Wasmtime equivalent yet fail explicitly rather than silently falling back to the Emscripten runtime.

## Verification

- `cargo fmt --manifest-path packages/playground/cli-native/Cargo.toml -- --check`
- `cargo test --manifest-path packages/playground/cli-native/Cargo.toml --lib`
- `npx vitest run --config packages/playground/cli/vite.config.ts packages/playground/cli/tests/native-binary.spec.ts packages/playground/cli/tests/native-run-cli.spec.ts`
- `npx nx run playground-cli:lint`
- `npx nx run playground-cli:typecheck`
- `npx nx run playground-cli:build`
- source-level `runCLI()` smoke against the rebuilt native host
- built executable `--help` smoke against the rebuilt native host