### PR TITLE
[CLI] Resolve native hosts from platform packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54093,6 +54093,14 @@
 			"license": "GPL-2.0-or-later",
 			"bin": {
 				"wp-playground-cli": "wp-playground.js"
+			},
+			"optionalDependencies": {
+				"@wp-playground/cli-native-linux-arm64": "3.1.43",
+				"@wp-playground/cli-native-linux-x64": "3.1.43",
+				"@wp-playground/cli-native-macos-arm64": "3.1.43",
+				"@wp-playground/cli-native-macos-x64": "3.1.43",
+				"@wp-playground/cli-native-windows-arm64": "3.1.43",
+				"@wp-playground/cli-native-windows-x64": "3.1.43"
 			}
 		},
 		"packages/playground/client": {

--- a/packages/playground/cli-native/npm-packages/linux-arm64/package.json
+++ b/packages/playground/cli-native/npm-packages/linux-arm64/package.json
@@ -1,0 +1,21 @@
+{
+	"name": "@wp-playground/cli-native-linux-arm64",
+	"version": "3.1.43",
+	"description": "Wasmtime native host for @wp-playground/cli on Linux arm64",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/WordPress/wordpress-playground"
+	},
+	"homepage": "https://developer.wordpress.org/playground",
+	"license": "GPL-2.0-or-later",
+	"os": ["linux"],
+	"cpu": ["arm64"],
+	"files": ["bin", "share", "package-manifest.json"],
+	"exports": {
+		"./package.json": "./package.json"
+	},
+	"engines": {
+		"node": ">=20.10.0",
+		"npm": ">=10.2.3"
+	}
+}

--- a/packages/playground/cli-native/npm-packages/linux-x64/package.json
+++ b/packages/playground/cli-native/npm-packages/linux-x64/package.json
@@ -1,0 +1,21 @@
+{
+	"name": "@wp-playground/cli-native-linux-x64",
+	"version": "3.1.43",
+	"description": "Wasmtime native host for @wp-playground/cli on Linux x64",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/WordPress/wordpress-playground"
+	},
+	"homepage": "https://developer.wordpress.org/playground",
+	"license": "GPL-2.0-or-later",
+	"os": ["linux"],
+	"cpu": ["x64"],
+	"files": ["bin", "share", "package-manifest.json"],
+	"exports": {
+		"./package.json": "./package.json"
+	},
+	"engines": {
+		"node": ">=20.10.0",
+		"npm": ">=10.2.3"
+	}
+}

--- a/packages/playground/cli-native/npm-packages/macos-arm64/package.json
+++ b/packages/playground/cli-native/npm-packages/macos-arm64/package.json
@@ -1,0 +1,21 @@
+{
+	"name": "@wp-playground/cli-native-macos-arm64",
+	"version": "3.1.43",
+	"description": "Wasmtime native host for @wp-playground/cli on macOS arm64",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/WordPress/wordpress-playground"
+	},
+	"homepage": "https://developer.wordpress.org/playground",
+	"license": "GPL-2.0-or-later",
+	"os": ["darwin"],
+	"cpu": ["arm64"],
+	"files": ["bin", "share", "package-manifest.json"],
+	"exports": {
+		"./package.json": "./package.json"
+	},
+	"engines": {
+		"node": ">=20.10.0",
+		"npm": ">=10.2.3"
+	}
+}

--- a/packages/playground/cli-native/npm-packages/macos-x64/package.json
+++ b/packages/playground/cli-native/npm-packages/macos-x64/package.json
@@ -1,0 +1,21 @@
+{
+	"name": "@wp-playground/cli-native-macos-x64",
+	"version": "3.1.43",
+	"description": "Wasmtime native host for @wp-playground/cli on macOS x64",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/WordPress/wordpress-playground"
+	},
+	"homepage": "https://developer.wordpress.org/playground",
+	"license": "GPL-2.0-or-later",
+	"os": ["darwin"],
+	"cpu": ["x64"],
+	"files": ["bin", "share", "package-manifest.json"],
+	"exports": {
+		"./package.json": "./package.json"
+	},
+	"engines": {
+		"node": ">=20.10.0",
+		"npm": ">=10.2.3"
+	}
+}

--- a/packages/playground/cli-native/npm-packages/windows-arm64/package.json
+++ b/packages/playground/cli-native/npm-packages/windows-arm64/package.json
@@ -1,0 +1,21 @@
+{
+	"name": "@wp-playground/cli-native-windows-arm64",
+	"version": "3.1.43",
+	"description": "Wasmtime native host for @wp-playground/cli on Windows arm64",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/WordPress/wordpress-playground"
+	},
+	"homepage": "https://developer.wordpress.org/playground",
+	"license": "GPL-2.0-or-later",
+	"os": ["win32"],
+	"cpu": ["arm64"],
+	"files": ["bin", "share", "package-manifest.json"],
+	"exports": {
+		"./package.json": "./package.json"
+	},
+	"engines": {
+		"node": ">=20.10.0",
+		"npm": ">=10.2.3"
+	}
+}

--- a/packages/playground/cli-native/npm-packages/windows-x64/package.json
+++ b/packages/playground/cli-native/npm-packages/windows-x64/package.json
@@ -1,0 +1,21 @@
+{
+	"name": "@wp-playground/cli-native-windows-x64",
+	"version": "3.1.43",
+	"description": "Wasmtime native host for @wp-playground/cli on Windows x64",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/WordPress/wordpress-playground"
+	},
+	"homepage": "https://developer.wordpress.org/playground",
+	"license": "GPL-2.0-or-later",
+	"os": ["win32"],
+	"cpu": ["x64"],
+	"files": ["bin", "share", "package-manifest.json"],
+	"exports": {
+		"./package.json": "./package.json"
+	},
+	"engines": {
+		"node": ">=20.10.0",
+		"npm": ">=10.2.3"
+	}
+}

--- a/packages/playground/cli/package.json
+++ b/packages/playground/cli/package.json
@@ -34,5 +34,13 @@
 	"bin": {
 		"wp-playground-cli": "wp-playground.js"
 	},
-	"gitHead": "2f8d8f3cea548fbd75111e8659a92f601cddc593"
+	"gitHead": "2f8d8f3cea548fbd75111e8659a92f601cddc593",
+	"optionalDependencies": {
+		"@wp-playground/cli-native-linux-x64": "3.1.43",
+		"@wp-playground/cli-native-linux-arm64": "3.1.43",
+		"@wp-playground/cli-native-macos-x64": "3.1.43",
+		"@wp-playground/cli-native-macos-arm64": "3.1.43",
+		"@wp-playground/cli-native-windows-x64": "3.1.43",
+		"@wp-playground/cli-native-windows-arm64": "3.1.43"
+	}
 }

--- a/packages/playground/cli/project.json
+++ b/packages/playground/cli/project.json
@@ -16,6 +16,13 @@
 					"cp packages/playground/cli/README.md dist/packages/playground/cli"
 				]
 			},
+			"dependsOn": ["build:sync-native-host-packages"]
+		},
+		"build:sync-native-host-packages": {
+			"executor": "nx:run-commands",
+			"options": {
+				"command": "node packages/playground/cli/scripts/sync-native-host-package-versions.mjs"
+			},
 			"dependsOn": ["build:package-json"]
 		},
 		"build:package-json": {

--- a/packages/playground/cli/scripts/sync-native-host-package-versions.mjs
+++ b/packages/playground/cli/scripts/sync-native-host-package-versions.mjs
@@ -1,0 +1,25 @@
+import { readFile, writeFile } from 'node:fs/promises';
+
+const packageJsonPath = 'dist/packages/playground/cli/package.json';
+const nativeHostPackageNames = [
+	'@wp-playground/cli-native-linux-x64',
+	'@wp-playground/cli-native-linux-arm64',
+	'@wp-playground/cli-native-macos-x64',
+	'@wp-playground/cli-native-macos-arm64',
+	'@wp-playground/cli-native-windows-x64',
+	'@wp-playground/cli-native-windows-arm64',
+];
+
+const packageJson = JSON.parse(await readFile(packageJsonPath, 'utf8'));
+if (!packageJson.version) {
+	throw new Error(`${packageJsonPath} has no package version.`);
+}
+
+packageJson.optionalDependencies = {
+	...packageJson.optionalDependencies,
+	...Object.fromEntries(
+		nativeHostPackageNames.map((name) => [name, packageJson.version])
+	),
+};
+
+await writeFile(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`);

--- a/packages/playground/cli/src/native-binary.ts
+++ b/packages/playground/cli/src/native-binary.ts
@@ -4,6 +4,7 @@ import {
 	type StdioOptions,
 } from 'node:child_process';
 import { existsSync } from 'node:fs';
+import { createRequire } from 'node:module';
 import { dirname, isAbsolute, join, resolve, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -58,10 +59,19 @@ export function nativeBinaryTarget(
 	return `${packagePlatform}-${arch}`;
 }
 
+/** Names the optional npm package that provides this platform's native host. */
+export function nativeBinaryPackageName(
+	platform: NodeJS.Platform = process.platform,
+	arch: string = process.arch
+): string {
+	return `@wp-playground/cli-native-${nativeBinaryTarget(platform, arch)}`;
+}
+
 /**
  * Locates the Wasmtime host without substituting the legacy JavaScript runtime.
  *
- * Published packages will carry the host under `native/<platform>-<arch>/`.
+ * Published packages install the matching host as an optional platform package.
+ * A colocated `native/` directory remains supported for self-contained bundles.
  * Developers may set `WP_PLAYGROUND_NATIVE_BINARY` to a locally built host.
  */
 export function resolveNativeBinary(
@@ -78,7 +88,7 @@ export function resolveNativeBinary(
 	const platform = options.platform ?? process.platform;
 	const arch = options.arch ?? process.arch;
 	const binaryName = nativeBinaryFileName(platform);
-	const candidates = [
+	const bundledCandidates = [
 		join(
 			moduleDirectory,
 			'native',
@@ -86,6 +96,22 @@ export function resolveNativeBinary(
 			binaryName
 		),
 		join(moduleDirectory, 'native', binaryName),
+	];
+	const bundledBinary = bundledCandidates.find(existsSync);
+	if (bundledBinary) {
+		return bundledBinary;
+	}
+
+	const nativePackageBinary = resolveNativePackageBinary(
+		moduleDirectory,
+		platform,
+		arch
+	);
+	if (nativePackageBinary) {
+		return nativePackageBinary;
+	}
+
+	const sourceCandidates = [
 		join(
 			moduleDirectory,
 			'..',
@@ -105,8 +131,7 @@ export function resolveNativeBinary(
 			binaryName
 		),
 	];
-
-	const binary = candidates.find(existsSync);
+	const binary = sourceCandidates.find(existsSync);
 	if (binary) {
 		return binary;
 	}
@@ -115,10 +140,40 @@ export function resolveNativeBinary(
 		`Could not find the Wasmtime WordPress Playground host for ${nativeBinaryTarget(
 			platform,
 			arch
-		)}. Set ${nativeBinaryEnvironmentVariable} to wp-playground-native or install a package containing the native host. Checked:\n${candidates
+		)}. Set ${nativeBinaryEnvironmentVariable} to wp-playground-native or install ${nativeBinaryPackageName(
+			platform,
+			arch
+		)}. Checked:\n${[...bundledCandidates, ...sourceCandidates]
 			.map((candidate) => `  ${candidate}`)
 			.join('\n')}`
 	);
+}
+
+function resolveNativePackageBinary(
+	moduleDirectory: string,
+	platform: NodeJS.Platform,
+	arch: string
+): string | undefined {
+	const packageName = nativeBinaryPackageName(platform, arch);
+	let packageJson: string;
+	try {
+		packageJson = createRequire(join(moduleDirectory, 'package.json')).resolve(
+			`${packageName}/package.json`
+		);
+	} catch (error) {
+		if (isModuleNotFound(error)) {
+			return undefined;
+		}
+		throw error;
+	}
+
+	const binary = join(dirname(packageJson), 'bin', nativeBinaryFileName(platform));
+	if (!existsSync(binary)) {
+		throw new Error(
+			`${packageName} is installed but does not contain ${binary}. Reinstall the package or set ${nativeBinaryEnvironmentVariable}.`
+		);
+	}
+	return binary;
 }
 
 /** Starts the native host with a resolved executable and no shell interpolation. */
@@ -207,5 +262,13 @@ function looksLikePath(value: string): boolean {
 		value.includes(sep) ||
 		value.includes('/') ||
 		value.includes('\\')
+	);
+}
+
+function isModuleNotFound(error: unknown): boolean {
+	return (
+		error instanceof Error &&
+		'code' in error &&
+		(error as NodeJS.ErrnoException).code === 'MODULE_NOT_FOUND'
 	);
 }

--- a/packages/playground/cli/tests/native-binary.spec.ts
+++ b/packages/playground/cli/tests/native-binary.spec.ts
@@ -10,6 +10,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
 	nativeBinaryEnvironmentVariable,
+	nativeBinaryPackageName,
 	nativeBinaryTarget,
 	resolveNativeBinary,
 	runNativeCLI,
@@ -25,8 +26,25 @@ describe('native binary launcher', () => {
 		['win32', 'arm64', 'windows-arm64'],
 	] as const)(
 		'maps %s-%s to the native package label %s',
-		(platform, arch, expected) => {
+		async (platform, arch, expected) => {
 			expect(nativeBinaryTarget(platform, arch)).toBe(expected);
+			const template = JSON.parse(
+				await readFile(
+					join(
+						import.meta.dirname,
+						'..',
+						'..',
+						'cli-native',
+						'npm-packages',
+						expected,
+						'package.json'
+					),
+					'utf8'
+				)
+			);
+			expect(template.name).toBe(nativeBinaryPackageName(platform, arch));
+			expect(template.os).toEqual([platform]);
+			expect(template.cpu).toEqual([arch]);
 		}
 	);
 
@@ -52,6 +70,38 @@ describe('native binary launcher', () => {
 		const nativeDirectory = join(root, 'native', 'linux-x64');
 		const binary = join(nativeDirectory, 'wp-playground-native');
 		await mkdir(nativeDirectory, { recursive: true });
+		await writeFile(binary, '#!/bin/sh\nexit 0\n');
+		await chmod(binary, 0o755);
+
+		expect(
+			resolveNativeBinary({
+				environment: {},
+				moduleDirectory: root,
+				platform: 'linux',
+				arch: 'x64',
+			})
+		).toBe(binary);
+
+		await rm(root, { recursive: true, force: true });
+	});
+
+	test('finds the installed platform-native package', async () => {
+		const root = await mkdtemp(join(tmpdir(), 'playground-native-binary-'));
+		const packageDirectory = join(
+			root,
+			'node_modules',
+			'@wp-playground',
+			'cli-native-linux-x64'
+		);
+		const binary = join(packageDirectory, 'bin', 'wp-playground-native');
+		await mkdir(join(packageDirectory, 'bin'), { recursive: true });
+		await writeFile(
+			join(packageDirectory, 'package.json'),
+			JSON.stringify({
+				name: nativeBinaryPackageName('linux', 'x64'),
+				exports: { './package.json': './package.json' },
+			})
+		);
 		await writeFile(binary, '#!/bin/sh\nexit 0\n');
 		await chmod(binary, 0o755);
 

--- a/packages/playground/cli/vite.config.ts
+++ b/packages/playground/cli/vite.config.ts
@@ -170,6 +170,7 @@ const external = [
 	...getExternalModules(),
 	'node:child_process',
 	'node:events',
+	'node:module',
 	'node:os',
 	'node:path',
 	'node:url',


### PR DESCRIPTION
## Summary

- keep `@wp-playground/cli` as the public package while adding optional native-host package templates for Linux, macOS, and Windows on x64 and arm64
- resolve the matching installed native package before considering source-tree developer builds
- pin generated package optional dependencies to the CLI package version at build time

## Stack

This is stacked on #4015, which is stacked on #4013 and #4012. It does not publish packages, create releases, merge branches, or run release workflows.

The platform package templates intentionally live outside the npm workspace: npm rejects non-host OS/CPU workspaces during normal `npm ci`.

## Verification

- `npx vitest run --config packages/playground/cli/vite.config.ts packages/playground/cli/tests/native-binary.spec.ts packages/playground/cli/tests/native-run-cli.spec.ts`
- `npx nx run playground-cli:lint`
- `npx nx run playground-cli:typecheck`
- `npx nx run playground-cli:build`
- `npm pack --dry-run --json ./dist/packages/playground/cli`
- simulated installed `node_modules` layout: built `wp-playground-cli --help` resolved a sibling platform host without `WP_PLAYGROUND_NATIVE_BINARY`