### PR TITLE
[CLI] Package native hosts for npm

### DIFF
--- a/packages/playground/cli-native/npm-packages/linux-arm64/package.json
+++ b/packages/playground/cli-native/npm-packages/linux-arm64/package.json
@@ -8,11 +8,22 @@
 	},
 	"homepage": "https://developer.wordpress.org/playground",
 	"license": "GPL-2.0-or-later",
-	"os": ["linux"],
-	"cpu": ["arm64"],
-	"files": ["bin", "share", "package-manifest.json"],
+	"os": [
+		"linux"
+	],
+	"cpu": [
+		"arm64"
+	],
+	"files": [
+		"bin",
+		"share",
+		"package-manifest.json"
+	],
 	"exports": {
 		"./package.json": "./package.json"
+	},
+	"publishConfig": {
+		"access": "public"
 	},
 	"engines": {
 		"node": ">=20.10.0",

--- a/packages/playground/cli-native/npm-packages/linux-x64/package.json
+++ b/packages/playground/cli-native/npm-packages/linux-x64/package.json
@@ -8,11 +8,22 @@
 	},
 	"homepage": "https://developer.wordpress.org/playground",
 	"license": "GPL-2.0-or-later",
-	"os": ["linux"],
-	"cpu": ["x64"],
-	"files": ["bin", "share", "package-manifest.json"],
+	"os": [
+		"linux"
+	],
+	"cpu": [
+		"x64"
+	],
+	"files": [
+		"bin",
+		"share",
+		"package-manifest.json"
+	],
 	"exports": {
 		"./package.json": "./package.json"
+	},
+	"publishConfig": {
+		"access": "public"
 	},
 	"engines": {
 		"node": ">=20.10.0",

--- a/packages/playground/cli-native/npm-packages/macos-arm64/package.json
+++ b/packages/playground/cli-native/npm-packages/macos-arm64/package.json
@@ -8,11 +8,22 @@
 	},
 	"homepage": "https://developer.wordpress.org/playground",
 	"license": "GPL-2.0-or-later",
-	"os": ["darwin"],
-	"cpu": ["arm64"],
-	"files": ["bin", "share", "package-manifest.json"],
+	"os": [
+		"darwin"
+	],
+	"cpu": [
+		"arm64"
+	],
+	"files": [
+		"bin",
+		"share",
+		"package-manifest.json"
+	],
 	"exports": {
 		"./package.json": "./package.json"
+	},
+	"publishConfig": {
+		"access": "public"
 	},
 	"engines": {
 		"node": ">=20.10.0",

--- a/packages/playground/cli-native/npm-packages/macos-x64/package.json
+++ b/packages/playground/cli-native/npm-packages/macos-x64/package.json
@@ -8,11 +8,22 @@
 	},
 	"homepage": "https://developer.wordpress.org/playground",
 	"license": "GPL-2.0-or-later",
-	"os": ["darwin"],
-	"cpu": ["x64"],
-	"files": ["bin", "share", "package-manifest.json"],
+	"os": [
+		"darwin"
+	],
+	"cpu": [
+		"x64"
+	],
+	"files": [
+		"bin",
+		"share",
+		"package-manifest.json"
+	],
 	"exports": {
 		"./package.json": "./package.json"
+	},
+	"publishConfig": {
+		"access": "public"
 	},
 	"engines": {
 		"node": ">=20.10.0",

--- a/packages/playground/cli-native/npm-packages/windows-arm64/package.json
+++ b/packages/playground/cli-native/npm-packages/windows-arm64/package.json
@@ -8,11 +8,22 @@
 	},
 	"homepage": "https://developer.wordpress.org/playground",
 	"license": "GPL-2.0-or-later",
-	"os": ["win32"],
-	"cpu": ["arm64"],
-	"files": ["bin", "share", "package-manifest.json"],
+	"os": [
+		"win32"
+	],
+	"cpu": [
+		"arm64"
+	],
+	"files": [
+		"bin",
+		"share",
+		"package-manifest.json"
+	],
 	"exports": {
 		"./package.json": "./package.json"
+	},
+	"publishConfig": {
+		"access": "public"
 	},
 	"engines": {
 		"node": ">=20.10.0",

--- a/packages/playground/cli-native/npm-packages/windows-x64/package.json
+++ b/packages/playground/cli-native/npm-packages/windows-x64/package.json
@@ -8,11 +8,22 @@
 	},
 	"homepage": "https://developer.wordpress.org/playground",
 	"license": "GPL-2.0-or-later",
-	"os": ["win32"],
-	"cpu": ["x64"],
-	"files": ["bin", "share", "package-manifest.json"],
+	"os": [
+		"win32"
+	],
+	"cpu": [
+		"x64"
+	],
+	"files": [
+		"bin",
+		"share",
+		"package-manifest.json"
+	],
 	"exports": {
 		"./package.json": "./package.json"
+	},
+	"publishConfig": {
+		"access": "public"
 	},
 	"engines": {
 		"node": ">=20.10.0",

--- a/packages/playground/cli-native/project.json
+++ b/packages/playground/cli-native/project.json
@@ -17,6 +17,12 @@
 				"command": "cargo test --manifest-path packages/playground/cli-native/Cargo.toml"
 			}
 		},
+		"test:npm-platform-package": {
+			"executor": "nx:run-commands",
+			"options": {
+				"command": "node --test packages/playground/cli-native/scripts/prepare-npm-platform-package.test.mjs"
+			}
+		},
 		"lint": {
 			"executor": "nx:run-commands",
 			"options": {

--- a/packages/playground/cli-native/scripts/prepare-npm-platform-package.mjs
+++ b/packages/playground/cli-native/scripts/prepare-npm-platform-package.mjs
@@ -1,0 +1,147 @@
+import {
+	access,
+	cp,
+	mkdir,
+	readFile,
+	rename,
+	rm,
+	writeFile,
+} from 'node:fs/promises';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const cliNativeDirectory = dirname(dirname(fileURLToPath(import.meta.url)));
+const npmPackageTemplatesDirectory = join(cliNativeDirectory, 'npm-packages');
+
+/**
+ * Converts the directory emitted by `package-native-cli` into an npm package.
+ *
+ * Rust owns the binary and its asset layout. This helper only moves that
+ * verified layout into the npm staging directory and writes the target-specific
+ * package metadata.
+ */
+export async function prepareNpmPlatformPackage({
+	label,
+	sourceDirectory,
+	destinationDirectory,
+	version,
+}) {
+	if (!label || !sourceDirectory || !destinationDirectory || !version) {
+		throw new Error(
+			'prepareNpmPlatformPackage requires label, sourceDirectory, destinationDirectory, and version.'
+		);
+	}
+
+	const source = resolve(sourceDirectory);
+	const destination = resolve(destinationDirectory);
+	if (source === destination) {
+		throw new Error(
+			'The native package source and destination must differ.'
+		);
+	}
+	const templatePath = join(
+		npmPackageTemplatesDirectory,
+		label,
+		'package.json'
+	);
+	const template = JSON.parse(await readFile(templatePath, 'utf8'));
+	const binaryName = label.startsWith('windows-')
+		? 'wp-playground-native.exe'
+		: 'wp-playground-native';
+
+	await Promise.all([
+		access(join(source, 'package-manifest.json')),
+		access(join(source, 'bin', binaryName)),
+		access(
+			join(
+				source,
+				'share',
+				'wp-playground-native',
+				'packages',
+				'playground',
+				'cli-native',
+				'assets',
+				'php-assets.json'
+			)
+		),
+	]);
+
+	await rm(destination, { recursive: true, force: true });
+	await mkdir(dirname(destination), { recursive: true });
+	try {
+		await rename(source, destination);
+	} catch (error) {
+		if (!isCrossDeviceRename(error)) {
+			throw error;
+		}
+		await cp(source, destination, { recursive: true });
+		await rm(source, { recursive: true, force: true });
+	}
+
+	await writeFile(
+		join(destination, 'package.json'),
+		`${JSON.stringify({ ...template, version }, null, 2)}\n`
+	);
+	return destination;
+}
+
+async function main() {
+	if (process.argv.slice(2).includes('--help')) {
+		process.stdout.write(`${usage()}\n`);
+		return;
+	}
+	const options = parseArguments(process.argv.slice(2));
+	const destination = await prepareNpmPlatformPackage(options);
+	process.stdout.write(`${destination}\n`);
+}
+
+function parseArguments(args) {
+	const options = {};
+	for (let index = 0; index < args.length; index += 2) {
+		const name = args[index];
+		const value = args[index + 1];
+		if (
+			!value ||
+			!['--label', '--source', '--destination', '--version'].includes(
+				name
+			)
+		) {
+			throw new Error(usage());
+		}
+		switch (name) {
+			case '--label':
+				options.label = value;
+				break;
+			case '--source':
+				options.sourceDirectory = value;
+				break;
+			case '--destination':
+				options.destinationDirectory = value;
+				break;
+			case '--version':
+				options.version = value;
+				break;
+		}
+	}
+	return options;
+}
+
+function usage() {
+	return 'Usage: prepare-npm-platform-package.mjs --label <label> --source <native-package> --destination <npm-package> --version <version>';
+}
+
+function isCrossDeviceRename(error) {
+	return error instanceof Error && 'code' in error && error.code === 'EXDEV';
+}
+
+if (
+	process.argv[1] &&
+	resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
+	main().catch((error) => {
+		process.stderr.write(
+			`${error instanceof Error ? error.message : error}\n`
+		);
+		process.exitCode = 1;
+	});
+}

--- a/packages/playground/cli-native/scripts/prepare-npm-platform-package.test.mjs
+++ b/packages/playground/cli-native/scripts/prepare-npm-platform-package.test.mjs
@@ -1,0 +1,88 @@
+import assert from 'node:assert/strict';
+import {
+	access,
+	chmod,
+	mkdir,
+	mkdtemp,
+	readFile,
+	rm,
+	writeFile,
+} from 'node:fs/promises';
+import { test } from 'node:test';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { prepareNpmPlatformPackage } from './prepare-npm-platform-package.mjs';
+
+test('prepares an npm package from a native package directory', async () => {
+	const root = await mkdtemp(
+		join(tmpdir(), 'playground-native-npm-package-')
+	);
+	const source = join(root, 'native-package');
+	const destination = join(root, 'npm-package');
+	const binary = join(source, 'bin', 'wp-playground-native');
+	const manifest = join(
+		source,
+		'share',
+		'wp-playground-native',
+		'packages',
+		'playground',
+		'cli-native',
+		'assets',
+		'php-assets.json'
+	);
+
+	try {
+		await mkdir(join(source, 'bin'), { recursive: true });
+		await mkdir(dirname(manifest), { recursive: true });
+		await writeFile(binary, '#!/bin/sh\nexit 0\n');
+		await chmod(binary, 0o755);
+		await writeFile(manifest, '{}');
+		await writeFile(join(source, 'package-manifest.json'), '{}');
+
+		await prepareNpmPlatformPackage({
+			label: 'linux-x64',
+			sourceDirectory: source,
+			destinationDirectory: destination,
+			version: '9.8.7',
+		});
+
+		assert.deepEqual(
+			JSON.parse(
+				await readFile(join(destination, 'package.json'), 'utf8')
+			),
+			{
+				name: '@wp-playground/cli-native-linux-x64',
+				version: '9.8.7',
+				description:
+					'Wasmtime native host for @wp-playground/cli on Linux x64',
+				repository: {
+					type: 'git',
+					url: 'https://github.com/WordPress/wordpress-playground',
+				},
+				homepage: 'https://developer.wordpress.org/playground',
+				license: 'GPL-2.0-or-later',
+				os: ['linux'],
+				cpu: ['x64'],
+				files: ['bin', 'share', 'package-manifest.json'],
+				exports: { './package.json': './package.json' },
+				publishConfig: { access: 'public' },
+				engines: { node: '>=20.10.0', npm: '>=10.2.3' },
+			}
+		);
+		await access(join(destination, 'bin', 'wp-playground-native'));
+		await access(
+			join(
+				destination,
+				'share',
+				'wp-playground-native',
+				'packages',
+				'playground',
+				'cli-native',
+				'assets',
+				'php-assets.json'
+			)
+		);
+	} finally {
+		await rm(root, { recursive: true, force: true });
+	}
+});


### PR DESCRIPTION
## Summary

- convert the existing Rust native-host package layout into an npm platform package without duplicating packaging logic
- add Linux/macOS/Windows platform metadata, public npm access metadata, and a deterministic staging helper
- add a self-contained Node test for the staging helper

## Stack

This is stacked on #4016 -> #4015 -> #4013 -> #4012. It adds no npm publish, GitHub release, merge, or distribution action.

## Verification

- `npx nx run playground-cli-native:test:npm-platform-package`
- `node --test packages/playground/cli-native/scripts/prepare-npm-platform-package.test.mjs`
- reduced real package assembly from `package-native-cli` (PHP 8.5) followed by `npm pack --dry-run`
- Prettier check for changed files

A separate local CI-only commit adds target-matrix package verification; GitHub rejected that push because this agent token lacks the required `workflow` scope. It is intentionally not hidden or discarded.