### PR TITLE
[CLI] Prepare native npm package releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,6 +201,10 @@ jobs:
             - uses: actions/checkout@v4
               with:
                   submodules: true
+            - uses: ./.github/actions/prepare-playground
+              if: matrix.label == 'linux-x64'
+              with:
+                  node-version: 22
             - name: Install Rust components
               run: |
                   rustup toolchain install stable --profile minimal --component clippy --component rustfmt
@@ -255,7 +259,42 @@ jobs:
                     --source "$native_package_root" \
                     --destination "$npm_package_root" \
                     --version "$WP_PLAYGROUND_NATIVE_VERSION"
-                  npm pack --dry-run "$npm_package_root"
+                  mkdir -p "$RUNNER_TEMP/native-npm-packages"
+                  pack_json="$(npm pack --json --pack-destination "$RUNNER_TEMP/native-npm-packages" "$npm_package_root")"
+                  node -e '
+                    const [entry] = JSON.parse(process.argv[1]);
+                    const maximumBytes = 95 * 1024 * 1024;
+                    if (entry.size > maximumBytes) {
+                      throw new Error(`Native npm package is ${entry.size} bytes; npm registry packages must remain below ${maximumBytes} bytes.`);
+                    }
+                    console.log(`native npm package: ${entry.filename} (${entry.size} bytes)`);
+                  ' "$pack_json"
+            - name: Verify packed CLI resolves the installed native host
+              if: matrix.label == 'linux-x64'
+              shell: bash
+              run: |
+                  set -euo pipefail
+                  cli_package_dir="$RUNNER_TEMP/cli-npm-package"
+                  install_dir="$RUNNER_TEMP/cli-native-install"
+                  mkdir -p "$cli_package_dir" "$install_dir"
+                  npx nx run playground-cli:build
+                  npm pack --json --pack-destination "$cli_package_dir" dist/packages/playground/cli >/dev/null
+                  cli_archive="$(find "$cli_package_dir" -name '*.tgz' -print -quit)"
+                  native_archive="$(find "$RUNNER_TEMP/native-npm-packages" -name '*.tgz' -print -quit)"
+                  test -n "$cli_archive"
+                  test -n "$native_archive"
+                  (
+                    cd "$install_dir"
+                    npm init --yes >/dev/null
+                    npm install --ignore-scripts "$cli_archive" "$native_archive"
+                    unset WP_PLAYGROUND_NATIVE_BINARY
+                    ./node_modules/.bin/wp-playground-cli --help | grep -q 'wp-playground-native'
+                    ./node_modules/.bin/wp-playground-cli php \
+                      --php=8.5 \
+                      --skip-wordpress-install \
+                      --skip-sqlite-setup \
+                      -- -v | grep -q 'PHP 8.5'
+                  )
             - name: Upload native package archive
               uses: actions/upload-artifact@v4
               with:
@@ -560,7 +599,16 @@ jobs:
             - uses: ./.github/actions/prepare-playground
               with:
                   node-version: 22
-            - run: packages/playground/cli/tests/test-running-unbuilt-cli.sh
+            - name: Install Rust components
+              run: |
+                  rustup toolchain install stable --profile minimal
+                  rustup default stable
+            - name: Build Wasmtime host
+              run: cargo build --manifest-path packages/playground/cli-native/Cargo.toml --bin wp-playground-native
+            - name: Run unbuilt native CLI smoke
+              env:
+                  WP_PLAYGROUND_NATIVE_BINARY: ${{ github.workspace }}/packages/playground/cli-native/target/debug/wp-playground-native
+              run: packages/playground/cli/tests/test-running-unbuilt-cli.sh
 
     test-php-wasm-cli-smoke:
         if: github.repository == 'WordPress/wordpress-playground' || github.event_name == 'pull_request'

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -23,7 +23,128 @@ concurrency:
     group: npm-release
 
 jobs:
+    build-native-host-packages:
+        # The public CLI keeps its JavaScript package name. These platform
+        # packages carry the Wasmtime binary and its verified runtime assets.
+        if: >
+            github.repository == 'WordPress/wordpress-playground' &&
+            (
+              github.actor == 'adamziel' ||
+              github.actor == 'dmsnell' ||
+              github.actor == 'bgrgicak' ||
+              github.actor == 'brandonpayton' ||
+              github.actor == 'zaerl' ||
+              github.actor == 'janjakes' ||
+              github.actor == 'mho22' ||
+              github.actor == 'ashfame'
+            )
+        strategy:
+            fail-fast: false
+            matrix:
+                include:
+                    - label: linux-x64
+                      os: ubuntu-latest
+                      target: x86_64-unknown-linux-gnu
+                      exe: ''
+                    - label: linux-arm64
+                      os: ubuntu-24.04-arm
+                      target: aarch64-unknown-linux-gnu
+                      exe: ''
+                    - label: windows-x64
+                      os: windows-latest
+                      target: x86_64-pc-windows-msvc
+                      exe: '.exe'
+                    - label: windows-arm64
+                      os: windows-11-arm
+                      target: aarch64-pc-windows-msvc
+                      exe: '.exe'
+                    - label: macos-x64
+                      os: macos-15-intel
+                      target: x86_64-apple-darwin
+                      exe: ''
+                    - label: macos-arm64
+                      os: macos-latest
+                      target: aarch64-apple-darwin
+                      exe: ''
+        runs-on: ${{ matrix.os }}
+        timeout-minutes: 90
+        permissions:
+            contents: read
+        name: 'build native npm host (${{ matrix.label }})'
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                  submodules: true
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: '20'
+            - name: Install Rust components
+              run: |
+                  rustup toolchain install stable --profile minimal
+                  rustup default stable
+                  rustup target add ${{ matrix.target }}
+            - name: Calculate release version
+              shell: bash
+              env:
+                  RELEASE_BUMP: ${{ inputs.version_bump || 'patch' }}
+              run: |
+                  VERSION="$(node -e '
+                    const version = require("./lerna.json").version;
+                    const bump = process.env.RELEASE_BUMP;
+                    const parts = version.split(".").map(Number);
+                    if (parts.length !== 3 || parts.some((part) => !Number.isInteger(part))) {
+                      throw new Error(`Cannot increment non-semver release version: ${version}`);
+                    }
+                    if (bump === "major") parts[0] += 1, parts[1] = 0, parts[2] = 0;
+                    else if (bump === "minor") parts[1] += 1, parts[2] = 0;
+                    else if (bump === "patch") parts[2] += 1;
+                    else throw new Error(`Unsupported release bump: ${bump}`);
+                    console.log(parts.join("."));
+                  ')"
+                  echo "WP_PLAYGROUND_NATIVE_VERSION=$VERSION" >> "$GITHUB_ENV"
+            - name: Build native npm package
+              shell: bash
+              env:
+                  WP_PLAYGROUND_NATIVE_TARGET_TRIPLE: ${{ matrix.target }}
+                  WP_PLAYGROUND_NATIVE_SOURCE_COMMIT: ${{ github.sha }}
+              run: |
+                  set -euo pipefail
+                  package_name="wp-playground-native-npm-${{ matrix.label }}"
+                  native_package_root="$RUNNER_TEMP/native-host-package"
+                  npm_package_root="$RUNNER_TEMP/npm-host-package"
+                  cargo build --manifest-path packages/playground/cli-native/Cargo.toml --release --bins --target ${{ matrix.target }}
+                  cargo run --manifest-path packages/playground/cli-native/Cargo.toml --release --bin package-native-cli -- \
+                    --binary "packages/playground/cli-native/target/${{ matrix.target }}/release/wp-playground-native${{ matrix.exe }}" \
+                    --out-dir "$native_package_root" \
+                    --name "$package_name" \
+                    --skip-archive
+                  node packages/playground/cli-native/scripts/prepare-npm-platform-package.mjs \
+                    --label "${{ matrix.label }}" \
+                    --source "$native_package_root/$package_name" \
+                    --destination "$npm_package_root" \
+                    --version "$WP_PLAYGROUND_NATIVE_VERSION"
+                  mkdir -p "$RUNNER_TEMP/native-host-tarballs"
+                  pack_json="$(
+                    cd "$npm_package_root"
+                    npm pack --json --pack-destination "$RUNNER_TEMP/native-host-tarballs"
+                  )"
+                  node -e '
+                    const [entry] = JSON.parse(process.argv[1]);
+                    const maximumBytes = 95 * 1024 * 1024;
+                    if (entry.size > maximumBytes) {
+                      throw new Error(`Native npm package is ${entry.size} bytes; npm registry packages must remain below ${maximumBytes} bytes.`);
+                    }
+                    console.log(`native npm package: ${entry.filename} (${entry.size} bytes)`);
+                  ' "$pack_json"
+            - name: Upload native npm package
+              uses: actions/upload-artifact@v4
+              with:
+                  name: native-cli-npm-package-${{ matrix.label }}
+                  path: ${{ runner.temp }}/native-host-tarballs/*.tgz
+                  if-no-files-found: error
+
     release:
+        needs: build-native-host-packages
         # Only run on the playground repo, and only allow Playground maintainers to trigger this workflow.
         # Non-trunk branches are allowed but require a custom dist tag (not "latest").
         if: >
@@ -46,6 +167,7 @@ jobs:
         permissions:
             id-token: write # Required for OIDC-based npm trusted publishing.
             contents: write # Required to push the version bump commit and tags.
+            actions: read # Required to download native package artifacts.
         environment:
             name: npm
 
@@ -96,6 +218,73 @@ jobs:
 
             - name: Validate publish package overrides
               run: node tools/scripts/check-publish-package-overrides.mjs
+
+            - name: Calculate native package version
+              shell: bash
+              env:
+                  RELEASE_BUMP: ${{ inputs.version_bump || 'patch' }}
+              run: |
+                  VERSION="$(node -e '
+                    const version = require("./lerna.json").version;
+                    const bump = process.env.RELEASE_BUMP;
+                    const parts = version.split(".").map(Number);
+                    if (parts.length !== 3 || parts.some((part) => !Number.isInteger(part))) {
+                      throw new Error(`Cannot increment non-semver release version: ${version}`);
+                    }
+                    if (bump === "major") parts[0] += 1, parts[1] = 0, parts[2] = 0;
+                    else if (bump === "minor") parts[1] += 1, parts[2] = 0;
+                    else if (bump === "patch") parts[2] += 1;
+                    else throw new Error(`Unsupported release bump: ${bump}`);
+                    console.log(parts.join("."));
+                  ')"
+                  echo "WP_PLAYGROUND_NATIVE_NPM_VERSION=$VERSION" >> "$GITHUB_ENV"
+                  echo "NPM_DIST_TAG=${{ inputs.dist_tag || 'latest' }}" >> "$GITHUB_ENV"
+
+            - name: Download native npm packages
+              uses: actions/download-artifact@v4
+              with:
+                  pattern: native-cli-npm-package-*
+                  path: ${{ runner.temp }}/native-cli-npm-packages
+                  merge-multiple: true
+
+            - name: Build CLI package with matching native host versions
+              run: |
+                  npx nx run playground-cli:build
+                  node -e '
+                    const fs = require("node:fs");
+                    const packageJson = JSON.parse(fs.readFileSync("dist/packages/playground/cli/package.json", "utf8"));
+                    const expected = process.env.WP_PLAYGROUND_NATIVE_NPM_VERSION;
+                    const dependencies = packageJson.optionalDependencies || {};
+                    const nativeDependencies = Object.entries(dependencies).filter(([name]) => name.startsWith("@wp-playground/cli-native-"));
+                    if (nativeDependencies.length !== 6 || nativeDependencies.some(([, version]) => version !== expected)) {
+                      throw new Error(`CLI native optional dependencies must all equal ${expected}: ${JSON.stringify(nativeDependencies)}`);
+                    }
+                  '
+
+            - name: Publish native host packages
+              shell: bash
+              run: |
+                  set -euo pipefail
+                  shopt -s nullglob
+                  archives=("$RUNNER_TEMP"/native-cli-npm-packages/*.tgz)
+                  if [ "${#archives[@]}" -ne 6 ]; then
+                    echo "::error::Expected six native npm package archives, found ${#archives[@]}."
+                    exit 1
+                  fi
+                  for archive in "${archives[@]}"; do
+                    metadata="$(tar -xOf "$archive" package/package.json)"
+                    name="$(node -e 'console.log(JSON.parse(process.argv[1]).name)' "$metadata")"
+                    version="$(node -e 'console.log(JSON.parse(process.argv[1]).version)' "$metadata")"
+                    if [ "$version" != "$WP_PLAYGROUND_NATIVE_NPM_VERSION" ]; then
+                      echo "::error::Native package $name has version $version; expected $WP_PLAYGROUND_NATIVE_NPM_VERSION."
+                      exit 1
+                    fi
+                    if npm view "$name@$version" version >/dev/null 2>&1; then
+                      echo "$name@$version is already published; keeping the existing package."
+                    else
+                      npm publish "$archive" --access public --provenance --tag "$NPM_DIST_TAG"
+                    fi
+                  done
 
             - name: Publish NPM packages
               # Version bump, release, tag a new version on GitHub.

--- a/packages/playground/cli/project.json
+++ b/packages/playground/cli/project.json
@@ -120,6 +120,20 @@
 				"parallel": false
 			}
 		},
+		"unbuilt-native": {
+			"executor": "nx:run-commands",
+			"options": {
+				"commands": [
+					{
+						"command": "node -e \"if (parseInt(process.versions.node) < 22) { console.error('Node.js version 22 or greater is required'); process.exit(1); }\"",
+						"forwardAllArgs": false
+					},
+					"node --experimental-strip-types --experimental-transform-types --disable-warning=ExperimentalWarning --import ./packages/meta/src/node-es-module-loader/register.mts ./packages/playground/cli/src/cli.ts"
+				],
+				"tty": true,
+				"parallel": false
+			}
+		},
 		"publish": {
 			"executor": "nx:run-commands",
 			"options": {

--- a/packages/playground/cli/scripts/sync-native-host-package-versions.mjs
+++ b/packages/playground/cli/scripts/sync-native-host-package-versions.mjs
@@ -14,11 +14,13 @@ const packageJson = JSON.parse(await readFile(packageJsonPath, 'utf8'));
 if (!packageJson.version) {
 	throw new Error(`${packageJsonPath} has no package version.`);
 }
+const nativeHostVersion =
+	process.env.WP_PLAYGROUND_NATIVE_NPM_VERSION ?? packageJson.version;
 
 packageJson.optionalDependencies = {
 	...packageJson.optionalDependencies,
 	...Object.fromEntries(
-		nativeHostPackageNames.map((name) => [name, packageJson.version])
+		nativeHostPackageNames.map((name) => [name, nativeHostVersion])
 	),
 };
 

--- a/packages/playground/cli/tests/test-running-unbuilt-cli.sh
+++ b/packages/playground/cli/tests/test-running-unbuilt-cli.sh
@@ -2,53 +2,24 @@
 
 set -euo pipefail
 
-if node -e 'if (parseInt(process.versions.node) < 24) { process.exit(0); }'; then
-	source ~/.nvm/nvm.sh
-	nvm install 24
-	npm ci
+node -e 'if (parseInt(process.versions.node) < 22) { console.error("Node.js version 22 or greater is required"); process.exit(1); }'
+
+if [[ -z "${WP_PLAYGROUND_NATIVE_BINARY:-}" ]]; then
+	echo 'WP_PLAYGROUND_NATIVE_BINARY must point to a built Wasmtime host.' >&2
+	exit 1
 fi
 
-function test_playground_cli() {
-	TARGET="$1"
-	shift
+echo 'Running the unbuilt public CLI through the Wasmtime host.'
+timeout -s TERM 90s npx nx run playground-cli:unbuilt-native -- php \
+	--php=8.5 \
+	--skip-wordpress-install \
+	--skip-sqlite-setup \
+	-- -v > playground-cli-test-output 2>&1
 
-	# Run Playground CLI with a timeout.
-	echo "Running Playground CLI with Nx target: $TARGET $@"
-	timeout -s TERM 30s npx nx "$TARGET" playground-cli server --php=8.3 $@ 2>&1 > playground-cli-test-output &
-	PID=$!
-	CLI_STARTUP_STRING='WordPress is running on http://127.0.0.1:9400'
+if ! grep -q 'PHP 8.5' playground-cli-test-output; then
+	cat playground-cli-test-output
+	echo 'The unbuilt Wasmtime CLI did not run PHP 8.5.' >&2
+	exit 1
+fi
 
-	# Sleep until Playground CLI starts or the process times out.
-	while ps -p "$PID" > /dev/null && ! grep -q "$CLI_STARTUP_STRING" playground-cli-test-output; do
-		sleep 1
-	done
-
-	# Kill Playground CLI if it is still running.
-	trap 'kill "$PID" 2>&1 > /dev/null || true' RETURN
-
-	if grep -q "$CLI_STARTUP_STRING" playground-cli-test-output; then
-		echo "Playground CLI started successfully"
-		echo "Checking WordPress home page..."
-
-		HOME_PAGE_OUTPUT="$(curl -sL http://127.0.0.1:9400 || echo 'No output')"
-		if [[ $HOME_PAGE_OUTPUT != *"My WordPress Website"* ]]; then
-			echo "Home page output: $HOME_PAGE_OUTPUT"
-			echo "Error: Home page did not contain 'My WordPress Website'"
-			return 1
-		else
-			echo 'Looks good!'
-			return 0
-		fi
-	else
-		cat playground-cli-test-output
-		echo
-		echo Playground CLI failed to start
-		return 1
-	fi
-}
-
-echo
-test_playground_cli unbuilt-asyncify
-echo
-test_playground_cli unbuilt-jspi
-echo
+cat playground-cli-test-output


### PR DESCRIPTION
## Summary

- build six signed-off platform-native npm tarballs on their native runners before the existing npm release job
- make the release job validate, publish, and version-match those tarballs before publishing `@wp-playground/cli`
- add a Linux clean-install smoke: install the packed public CLI plus packed native host into an empty project and run it without a developer binary override
- replace the old Emscripten unbuilt CLI acceptance test with a source CLI -> Wasmtime host PHP smoke

## Stack

This is stacked on #4018 -> #4016 -> #4015 -> #4013 -> #4012. This PR defines future release behavior only. It has not run a workflow, published a package, created a release, merged a branch, or changed any production artifact.

## Verification

- `WP_PLAYGROUND_NATIVE_BINARY=<debug host> packages/playground/cli/tests/test-running-unbuilt-cli.sh`
- `npx vitest run --config packages/playground/cli/vite.config.ts packages/playground/cli/tests/native-binary.spec.ts packages/playground/cli/tests/native-run-cli.spec.ts`
- `npx nx run playground-cli:typecheck`
- `npx nx run playground-cli:lint`
- `npx nx run playground-cli-native:test:npm-platform-package`
- `cargo fmt --manifest-path packages/playground/cli-native/Cargo.toml -- --check`
- YAML parse, Prettier, and shell syntax checks
- `npm ci --dry-run --ignore-scripts --no-audit --no-fund`

The workflow guards platform tarballs at 95 MiB, validates all six optional dependencies use the calculated release version, and skips an already-published matching platform package on a rerun.