### PR TITLE
[Website] Flush Blueprint edits and suppress hidden editor focus

### DIFF
--- a/packages/playground/components/e2e/tests/playground-file-editor.spec.ts
+++ b/packages/playground/components/e2e/tests/playground-file-editor.spec.ts
@@ -14,6 +14,10 @@ declare global {
 			switchFilesystem: (filesystem: FilesystemName) => void;
 			mountEditor: () => void;
 			unmountEditor: () => void;
+			setEditorVisible: (isVisible: boolean) => void;
+			delayNextRead: () => void;
+			releaseDelayedRead: () => void;
+			isReadDelayed: () => boolean;
 			delayNextWrite: () => void;
 			releaseDelayedWrite: () => void;
 			isWriteDelayed: () => boolean;
@@ -126,6 +130,60 @@ test('opens the initial file', async ({ page }) => {
 	await expect(page.locator('.cm-content')).toContainText(
 		"<?php echo 'Hello';"
 	);
+});
+
+test('keeps focus outside a hidden editor when its initial file finishes opening', async ({
+	page,
+}) => {
+	await page.evaluate(() => {
+		window.__fileEditorHarness?.delayNextRead();
+		window.__fileEditorHarness?.switchFilesystem('b');
+	});
+	await page.waitForFunction(
+		() => window.__fileEditorHarness?.isReadDelayed() === true
+	);
+
+	await page.evaluate(() => {
+		window.__fileEditorHarness?.setEditorVisible(false);
+	});
+	const focusSentinel = page.getByTestId('file-editor-focus-sentinel');
+	await focusSentinel.focus();
+	await expect(focusSentinel).toBeFocused();
+
+	await page.evaluate(() => {
+		window.__fileEditorHarness?.releaseDelayedRead();
+	});
+	await expect(page.locator('.cm-content')).toContainText(
+		"<?php echo 'Filesystem B';"
+	);
+	await page.waitForTimeout(150);
+	await expect(focusSentinel).toBeFocused({ timeout: 1000 });
+});
+
+test('keeps focus outside a hidden editor when a double-clicked file finishes opening', async ({
+	page,
+}) => {
+	await page.evaluate(() => {
+		window.__fileEditorHarness?.delayNextRead();
+	});
+	await page.locator('button[data-path="/wordpress/readme.html"]').dblclick();
+	await page.waitForFunction(
+		() => window.__fileEditorHarness?.isReadDelayed() === true
+	);
+
+	await page.evaluate(() => {
+		window.__fileEditorHarness?.setEditorVisible(false);
+	});
+	const focusSentinel = page.getByTestId('file-editor-focus-sentinel');
+	await focusSentinel.focus();
+	await expect(focusSentinel).toBeFocused();
+
+	await page.evaluate(() => {
+		window.__fileEditorHarness?.releaseDelayedRead();
+	});
+	await expect(page.getByText('/wordpress/readme.html')).toBeVisible();
+	await page.waitForTimeout(100);
+	await expect(focusSentinel).toBeFocused({ timeout: 1000 });
 });
 
 test('imports a local directory dropped on the explorer background', async ({

--- a/packages/playground/components/src/PlaygroundFileEditor/playground-file-editor.tsx
+++ b/packages/playground/components/src/PlaygroundFileEditor/playground-file-editor.tsx
@@ -66,6 +66,7 @@ export function PlaygroundFileEditor({
 	const activeFilesystemRef = useRef<AsyncWritableFilesystem | null>(
 		filesystem
 	);
+	const isVisibleRef = useRef(isVisible);
 	const pendingSaveRef = useRef<PendingSave | null>(null);
 	const lastWriteByFilesystemRef = useRef(
 		new WeakMap<AsyncWritableFilesystem, Promise<void>>()
@@ -75,6 +76,7 @@ export function PlaygroundFileEditor({
 	const hasAutoOpenedRef = useRef<boolean>(false);
 
 	activeFilesystemRef.current = filesystem;
+	isVisibleRef.current = isVisible;
 
 	useEffect(() => {
 		currentPathRef.current = currentPath;
@@ -192,9 +194,12 @@ export function PlaygroundFileEditor({
 					setReadOnly(false);
 					setSaveState(SaveState.IDLE);
 					setSaveError(null);
-					// Focus the editor after opening
+					// A hidden but mounted editor must not steal focus from the
+					// surface that replaced it.
 					setTimeout(() => {
-						editorRef.current?.focus();
+						if (isVisibleRef.current) {
+							editorRef.current?.focus();
+						}
 					}, 100);
 				}
 			} catch (error) {
@@ -304,7 +309,7 @@ export function PlaygroundFileEditor({
 				if (savedPos !== undefined) {
 					editorRef.current?.setCursorPosition(savedPos);
 				}
-				if (shouldFocus) {
+				if (shouldFocus && isVisibleRef.current) {
 					editorRef.current?.focus();
 				} else {
 					editorRef.current?.blur();

--- a/packages/playground/components/src/e2e-harnesses/file-editor-harness.tsx
+++ b/packages/playground/components/src/e2e-harnesses/file-editor-harness.tsx
@@ -5,7 +5,7 @@ import { createFilesystem } from './file-picker-tree-harness';
 
 type FilesystemName = 'a' | 'b';
 
-type WriteGate = {
+type OperationGate = {
 	promise: Promise<void>;
 	release: () => void;
 };
@@ -21,6 +21,10 @@ declare global {
 			switchFilesystem: (filesystem: FilesystemName) => void;
 			mountEditor: () => void;
 			unmountEditor: () => void;
+			setEditorVisible: (isVisible: boolean) => void;
+			delayNextRead: () => void;
+			releaseDelayedRead: () => void;
+			isReadDelayed: () => boolean;
 			delayNextWrite: () => void;
 			releaseDelayedWrite: () => void;
 			isWriteDelayed: () => boolean;
@@ -29,8 +33,10 @@ declare global {
 }
 
 export function FileEditorHarness() {
-	const nextWriteGateRef = useRef<WriteGate | null>(null);
-	const activeWriteGateRef = useRef<WriteGate | null>(null);
+	const nextReadGateRef = useRef<OperationGate | null>(null);
+	const activeReadGateRef = useRef<OperationGate | null>(null);
+	const nextWriteGateRef = useRef<OperationGate | null>(null);
+	const activeWriteGateRef = useRef<OperationGate | null>(null);
 	const filesystems = useMemo(() => {
 		const filesystemA = createFilesystem();
 		const filesystemB = createFilesystem();
@@ -38,6 +44,36 @@ export function FileEditorHarness() {
 			'/wordpress/workspace/index.php',
 			"<?php echo 'Filesystem B';"
 		);
+
+		/** Blocks text and binary reads on the same deterministic gate. */
+		const waitForReadRelease = async () => {
+			const gate = activeReadGateRef.current ?? nextReadGateRef.current;
+			if (!gate) {
+				return;
+			}
+			if (nextReadGateRef.current === gate) {
+				nextReadGateRef.current = null;
+				activeReadGateRef.current = gate;
+			}
+			await gate.promise;
+			if (activeReadGateRef.current === gate) {
+				activeReadGateRef.current = null;
+			}
+		};
+
+		for (const filesystem of [filesystemA, filesystemB]) {
+			const readFileAsText = filesystem.readFileAsText.bind(filesystem);
+			filesystem.readFileAsText = async (path) => {
+				await waitForReadRelease();
+				return readFileAsText(path);
+			};
+
+			const read = filesystem.read.bind(filesystem);
+			filesystem.read = async (path) => {
+				await waitForReadRelease();
+				return read(path);
+			};
+		}
 
 		const writeFile = filesystemA.writeFile.bind(filesystemA);
 		filesystemA.writeFile = async (path, data) => {
@@ -56,6 +92,7 @@ export function FileEditorHarness() {
 	const [activeFilesystem, setActiveFilesystem] =
 		useState<FilesystemName>('a');
 	const [isEditorMounted, setIsEditorMounted] = useState(true);
+	const [isEditorVisible, setIsEditorVisible] = useState(true);
 
 	useEffect(() => {
 		window.__fileEditorHarness = {
@@ -65,12 +102,17 @@ export function FileEditorHarness() {
 			switchFilesystem: setActiveFilesystem,
 			mountEditor: () => setIsEditorMounted(true),
 			unmountEditor: () => setIsEditorMounted(false),
+			setEditorVisible: setIsEditorVisible,
+			delayNextRead: () => {
+				nextReadGateRef.current = createOperationGate();
+			},
+			releaseDelayedRead: () => {
+				activeReadGateRef.current?.release();
+				nextReadGateRef.current?.release();
+			},
+			isReadDelayed: () => activeReadGateRef.current !== null,
 			delayNextWrite: () => {
-				let release: () => void = () => undefined;
-				const promise = new Promise<void>((resolve) => {
-					release = resolve;
-				});
-				nextWriteGateRef.current = { promise, release };
+				nextWriteGateRef.current = createOperationGate();
 			},
 			releaseDelayedWrite: () => {
 				activeWriteGateRef.current?.release();
@@ -100,11 +142,15 @@ export function FileEditorHarness() {
 				}}
 			>
 				<strong>PlaygroundFileEditor harness</strong>
+				<button type="button" data-testid="file-editor-focus-sentinel">
+					Focus sentinel
+				</button>
 			</header>
 			<div style={{ flex: 1, minHeight: 0 }}>
 				{isEditorMounted ? (
 					<PlaygroundFileEditor
 						filesystem={filesystems[activeFilesystem]}
+						isVisible={isEditorVisible}
 						documentRoot="/wordpress"
 						initialPath="/wordpress/workspace/index.php"
 					/>
@@ -112,4 +158,13 @@ export function FileEditorHarness() {
 			</div>
 		</div>
 	);
+}
+
+/** Creates a manually released gate for deterministic harness operations. */
+function createOperationGate(): OperationGate {
+	let release: () => void = () => undefined;
+	const promise = new Promise<void>((resolve) => {
+		release = resolve;
+	});
+	return { promise, release };
 }

--- a/packages/playground/website/src/components/blueprint-editor/BlueprintBundleEditor.tsx
+++ b/packages/playground/website/src/components/blueprint-editor/BlueprintBundleEditor.tsx
@@ -347,6 +347,14 @@ export const BlueprintBundleEditor = forwardRef<
 		[filesystem]
 	);
 
+	// A parent surface may unmount immediately after a keystroke. Start the pending
+	// write before this editor releases the filesystem that owns the edit.
+	useEffect(() => {
+		return () => {
+			void saveFile.flush();
+		};
+	}, [saveFile]);
+
 	const handleCodeChange = useCallback(
 		(newCode: string) => {
 			setCode(newCode);
@@ -398,6 +406,7 @@ export const BlueprintBundleEditor = forwardRef<
 		try {
 			setIsRecreating(true);
 			setSaveError(null);
+			await saveFile.flush();
 			const isAutosaved = isAutosavedSite(site);
 			const bundle =
 				(filesystem as EventedFilesystem | null) ??

--- a/packages/playground/website/src/components/blueprint-editor/SiteBlueprintBundleEditor.tsx
+++ b/packages/playground/website/src/components/blueprint-editor/SiteBlueprintBundleEditor.tsx
@@ -3,7 +3,7 @@ import { dirname, ensureAbsolutePath } from '@php-wasm/util';
 import { type Blueprint, BlueprintReflection } from '@wp-playground/blueprints';
 import {
 	type AsyncWritableFilesystem,
-	EventedFilesystem,
+	type EventedFilesystem,
 	InMemoryFilesystemBackend,
 	type WritableFilesystemBackend,
 } from '@wp-playground/storage';
@@ -31,6 +31,10 @@ import {
 	type BlueprintBundleEditorHandle,
 	BlueprintBundleEditor,
 } from './BlueprintBundleEditor';
+import {
+	BlueprintEditorFilesystem,
+	getBlueprintEditorFilesystem,
+} from './blueprint-editor-filesystem';
 
 /**
  * Check if an object implements the writable filesystem backend interface.
@@ -95,16 +99,16 @@ async function populateFilesystemFromBlueprint(
  */
 async function createFilesystemFromOriginalBlueprint(
 	originalBlueprint: SiteInfo['metadata']['originalBlueprint']
-): Promise<EventedFilesystem> {
+): Promise<BlueprintEditorFilesystem> {
 	// If originalBlueprint is already a filesystem backend (e.g.,
 	// PersistedBlueprintBundle), use it directly instead of populating from
 	// Blueprint JSON.
 	if (isFilesystemBackend(originalBlueprint)) {
-		return new EventedFilesystem(originalBlueprint);
+		return getBlueprintEditorFilesystem(originalBlueprint);
 	}
 
 	// Otherwise, populate an in-memory filesystem with the Blueprint JSON.
-	const fs = new EventedFilesystem(new InMemoryFilesystemBackend());
+	const fs = new BlueprintEditorFilesystem(new InMemoryFilesystemBackend());
 	if (originalBlueprint) {
 		await populateFilesystemFromBlueprint(
 			fs,
@@ -165,9 +169,8 @@ export const SiteBlueprintBundleEditor = forwardRef<
 	SiteBlueprintBundleEditorProps
 >(function SiteBlueprintBundleEditor({ className, site }, ref) {
 	const dispatch = useAppDispatch();
-	const [filesystem, setFilesystem] = useState<EventedFilesystem | null>(
-		null
-	);
+	const [filesystem, setFilesystem] =
+		useState<BlueprintEditorFilesystem | null>(null);
 
 	const innerEditorRef = useRef<BlueprintBundleEditorHandle | null>(null);
 
@@ -180,7 +183,7 @@ export const SiteBlueprintBundleEditor = forwardRef<
 
 	useEffect(() => {
 		let cancelled = false;
-		const setFilesystemIfMounted = (fs: EventedFilesystem) => {
+		const setFilesystemIfMounted = (fs: BlueprintEditorFilesystem) => {
 			if (!cancelled) {
 				setFilesystem(fs);
 			}
@@ -200,7 +203,7 @@ export const SiteBlueprintBundleEditor = forwardRef<
 				// WordPress files. Declaration-only metadata is converted once into a
 				// per-site OPFS bundle so later edits cannot leak into another site.
 				await persistBlueprintBundle(site.slug, fs.backend);
-				const opfsFilesystem = new EventedFilesystem(
+				const opfsFilesystem = getBlueprintEditorFilesystem(
 					await loadPersistedBlueprintBundle(site.slug)
 				);
 				await dispatch(

--- a/packages/playground/website/src/components/blueprint-editor/blueprint-editor-filesystem.spec.ts
+++ b/packages/playground/website/src/components/blueprint-editor/blueprint-editor-filesystem.spec.ts
@@ -1,0 +1,89 @@
+import type { WritableFilesystemBackend } from '@wp-playground/storage';
+import { describe, expect, it, vi } from 'vitest';
+import { getBlueprintEditorFilesystem } from './blueprint-editor-filesystem';
+
+describe('getBlueprintEditorFilesystem', () => {
+	it('makes a remounted editor wait for a write started by its predecessor', async () => {
+		let finishWrite = () => {};
+		const pendingWrite = new Promise<void>((resolve) => {
+			finishWrite = resolve;
+		});
+		const backend = {
+			writeFile: vi.fn(() => pendingWrite),
+			read: vi.fn(async () => ({ path: '/blueprint.json' })),
+		} as unknown as WritableFilesystemBackend;
+
+		const firstEditor = getBlueprintEditorFilesystem(backend);
+		const remountedEditor = getBlueprintEditorFilesystem(backend);
+		expect(remountedEditor).toBe(firstEditor);
+
+		const write = firstEditor.writeFile('/blueprint.json', 'edited');
+		const read = remountedEditor.read('/blueprint.json');
+		await Promise.resolve();
+		expect(backend.read).not.toHaveBeenCalled();
+
+		finishWrite();
+		await write;
+		await read;
+		expect(backend.read).toHaveBeenCalledWith('/blueprint.json');
+	});
+
+	it('serializes writes requested before and after a remount', async () => {
+		let finishFirstWrite = () => {};
+		const firstWritePending = new Promise<void>((resolve) => {
+			finishFirstWrite = resolve;
+		});
+		const observedWrites: Array<{ path: string; data: Uint8Array }> = [];
+		const backend = {
+			writeFile: async (path: string, data: Uint8Array) => {
+				observedWrites.push({ path, data });
+				if (observedWrites.length === 1) {
+					await firstWritePending;
+				}
+			},
+		} as unknown as WritableFilesystemBackend;
+		const firstEditor = getBlueprintEditorFilesystem(backend);
+		const remountedEditor = getBlueprintEditorFilesystem(backend);
+
+		const firstWrite = firstEditor.writeFile('/first.json', 'first');
+		const secondWrite = remountedEditor.writeFile('/second.json', 'second');
+		await Promise.resolve();
+		expect(observedWrites).toHaveLength(1);
+
+		finishFirstWrite();
+		await Promise.all([firstWrite, secondWrite]);
+		expect(
+			observedWrites.map(({ path, data }) => [
+				path,
+				new TextDecoder().decode(data),
+			])
+		).toEqual([
+			['/first.json', 'first'],
+			['/second.json', 'second'],
+		]);
+	});
+
+	it('continues with later operations after a write fails', async () => {
+		const writeError = new Error('OPFS write failed');
+		const writeFile = vi
+			.fn<WritableFilesystemBackend['writeFile']>()
+			.mockRejectedValueOnce(writeError)
+			.mockResolvedValueOnce(undefined);
+		const backend = {
+			writeFile,
+			read: vi.fn(async () => ({ path: '/blueprint.json' })),
+		} as unknown as WritableFilesystemBackend;
+		const filesystem = getBlueprintEditorFilesystem(backend);
+
+		await expect(
+			filesystem.writeFile('/blueprint.json', 'first')
+		).rejects.toBe(writeError);
+		await expect(
+			filesystem.writeFile('/blueprint.json', 'second')
+		).resolves.toBeUndefined();
+		await filesystem.read('/blueprint.json');
+
+		expect(writeFile).toHaveBeenCalledTimes(2);
+		expect(backend.read).toHaveBeenCalledWith('/blueprint.json');
+	});
+});

--- a/packages/playground/website/src/components/blueprint-editor/blueprint-editor-filesystem.ts
+++ b/packages/playground/website/src/components/blueprint-editor/blueprint-editor-filesystem.ts
@@ -1,0 +1,48 @@
+import {
+	EventedFilesystem,
+	type WritableFilesystemBackend,
+} from '@wp-playground/storage';
+
+/**
+ * A site-scoped editor filesystem whose reads cannot overtake a queued write.
+ *
+ * An editor can unmount while its last debounced OPFS write is still running.
+ * Reusing this wrapper when that storage backend is opened again
+ * makes the next read wait instead of returning stale contents. Failed writes
+ * remain visible to their caller but do not block later reads or writes forever.
+ */
+export class BlueprintEditorFilesystem extends EventedFilesystem {
+	private writeQueue: Promise<void> = Promise.resolve();
+
+	/** Serializes editor writes in the order in which they were requested. */
+	override writeFile(path: string, data: Uint8Array | string): Promise<void> {
+		const write = this.writeQueue.then(() => super.writeFile(path, data));
+		this.writeQueue = write.catch(() => undefined);
+		return write;
+	}
+
+	/** Waits for queued editor writes before reading a file. */
+	override async read(path: string) {
+		await this.writeQueue;
+		return super.read(path);
+	}
+}
+
+// OPFS backends outlive their editor component. Keep one queued wrapper per
+// backend so a remount observes any write started by the previous component.
+const editorFilesystems = new WeakMap<
+	WritableFilesystemBackend,
+	BlueprintEditorFilesystem
+>();
+
+/** Returns the queued editor wrapper owned by a filesystem backend. */
+export function getBlueprintEditorFilesystem(
+	backend: WritableFilesystemBackend
+): BlueprintEditorFilesystem {
+	let filesystem = editorFilesystems.get(backend);
+	if (!filesystem) {
+		filesystem = new BlueprintEditorFilesystem(backend);
+		editorFilesystems.set(backend, filesystem);
+	}
+	return filesystem;
+}

--- a/packages/playground/website/src/lib/hooks/use-debounced-callback.spec.tsx
+++ b/packages/playground/website/src/lib/hooks/use-debounced-callback.spec.tsx
@@ -1,0 +1,115 @@
+// @vitest-environment jsdom
+
+import { act, useEffect } from 'react';
+import { createRoot } from 'react-dom/client';
+import type { Root } from 'react-dom/client';
+import { useDebouncedCallback } from './use-debounced-callback';
+
+type SaveCallback = {
+	(value: string): void;
+	flush: () => Promise<string> | undefined;
+};
+
+describe('useDebouncedCallback', () => {
+	let container: HTMLDivElement;
+	let root: Root;
+	let isMounted: boolean;
+	let save: SaveCallback | undefined;
+
+	beforeAll(() => {
+		vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+	});
+
+	afterAll(() => {
+		vi.unstubAllGlobals();
+	});
+
+	beforeEach(() => {
+		vi.useFakeTimers();
+		container = document.createElement('div');
+		document.body.append(container);
+		root = createRoot(container);
+		isMounted = true;
+		save = undefined;
+	});
+
+	afterEach(() => {
+		if (isMounted) {
+			act(() => root.unmount());
+		}
+		container.remove();
+		vi.clearAllTimers();
+		vi.useRealTimers();
+	});
+
+	it('flushes only the latest pending call and returns its result', async () => {
+		const result = Promise.resolve('saved');
+		const callback = vi.fn(() => result);
+		act(() => {
+			root.render(<DebouncedCallbackProbe callback={callback} />);
+		});
+
+		act(() => {
+			getSave()('first');
+			getSave()('latest');
+		});
+		const flushResult = getSave().flush();
+
+		expect(flushResult).toBe(result);
+		expect(callback).toHaveBeenCalledOnce();
+		expect(callback).toHaveBeenCalledWith('latest');
+		await expect(flushResult).resolves.toBe('saved');
+
+		act(() => vi.advanceTimersByTime(100));
+		expect(callback).toHaveBeenCalledOnce();
+	});
+
+	it('allows an owner cleanup to flush during unmount', () => {
+		const callback = vi.fn(async (value: string) => value);
+		act(() => {
+			root.render(
+				<DebouncedCallbackProbe callback={callback} flushOnUnmount />
+			);
+		});
+
+		act(() => getSave()('pending'));
+		act(() => root.unmount());
+		isMounted = false;
+
+		expect(callback).toHaveBeenCalledOnce();
+		expect(callback).toHaveBeenCalledWith('pending');
+		act(() => vi.advanceTimersByTime(100));
+		expect(callback).toHaveBeenCalledOnce();
+	});
+
+	/** Exposes the hook result and optionally mirrors an owner's cleanup flush. */
+	function DebouncedCallbackProbe({
+		callback,
+		flushOnUnmount = false,
+	}: {
+		callback: (value: string) => Promise<string>;
+		flushOnUnmount?: boolean;
+	}) {
+		const debounced = useDebouncedCallback(callback, 100);
+		save = debounced;
+
+		useEffect(() => {
+			if (!flushOnUnmount) {
+				return;
+			}
+			return () => {
+				void debounced.flush();
+			};
+		}, [debounced, flushOnUnmount]);
+
+		return null;
+	}
+
+	/** Returns the latest hook result after its probe has rendered. */
+	function getSave(): SaveCallback {
+		if (!save) {
+			throw new Error('The debounced callback probe has not rendered.');
+		}
+		return save;
+	}
+});

--- a/packages/playground/website/src/lib/hooks/use-debounced-callback.ts
+++ b/packages/playground/website/src/lib/hooks/use-debounced-callback.ts
@@ -1,19 +1,27 @@
-import { useCallback, useEffect, useRef } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 
+type DebouncedCallback<T extends (...args: any[]) => any> = {
+	(...args: Parameters<T>): void;
+	flush: () => ReturnType<T> | undefined;
+};
+
+/** Debounces a callback and exposes its latest pending call for explicit flushes. */
 export function useDebouncedCallback<T extends (...args: any[]) => any>(
 	callback: T,
 	delay = 250,
 	dependencies: React.DependencyList = []
-): (...args: Parameters<T>) => void {
+): DebouncedCallback<T> {
 	const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 	const callbackRef = useRef(callback);
+	const pendingArgsRef = useRef<Parameters<T> | null>(null);
 
 	// Keep callback ref up to date
 	useEffect(() => {
 		callbackRef.current = callback;
 	}, [callback, ...dependencies]);
 
-	// Cleanup on unmount
+	// Cancel the timer but retain the pending arguments so a consumer cleanup
+	// can still flush the last call during the same unmount.
 	useEffect(() => {
 		return () => {
 			if (timeoutRef.current) {
@@ -22,15 +30,33 @@ export function useDebouncedCallback<T extends (...args: any[]) => any>(
 		};
 	}, []);
 
-	return useCallback(
-		(...args: Parameters<T>) => {
+	return useMemo(() => {
+		/** Replaces the pending call and restarts its delay. */
+		function debounced(...args: Parameters<T>) {
 			if (timeoutRef.current) {
 				clearTimeout(timeoutRef.current);
 			}
+			pendingArgsRef.current = args;
 			timeoutRef.current = setTimeout(() => {
-				callbackRef.current(...args);
+				flush();
 			}, delay);
-		},
-		[delay, ...dependencies]
-	);
+		}
+
+		/** Runs the latest scheduled call immediately, if one exists. */
+		function flush(): ReturnType<T> | undefined {
+			if (timeoutRef.current) {
+				clearTimeout(timeoutRef.current);
+				timeoutRef.current = null;
+			}
+			const args = pendingArgsRef.current;
+			pendingArgsRef.current = null;
+			if (!args) {
+				return undefined;
+			}
+			return callbackRef.current(...args);
+		}
+
+		debounced.flush = flush;
+		return debounced;
+	}, [delay, ...dependencies]);
 }


### PR DESCRIPTION
## What it does

Stops hidden file editors from taking focus after an asynchronous file open, and carries the latest Blueprint edit across editor teardown or Playground recreation.

Blueprint writes now use one queued filesystem wrapper per storage backend. A remounted editor waits for writes started by its predecessor before reading the same backend. This PR does not mount, restyle, or otherwise change the Dock UI from #4009.

## Rationale

File-open callbacks restore CodeMirror focus after a short delay. When the editor becomes hidden before that callback finishes, the delayed focus previously moved keyboard focus away from the active surface.

Blueprint saves are debounced. If a parent unmounts immediately after a keystroke, the hook cleanup cancels the timer before the write starts. React cleanup cannot wait for that write, so a remounted editor could then read the same OPFS backend first and show stale Blueprint contents.

The editor now flushes the pending call during teardown and awaits it before recreating a Playground. Backend-scoped write serialization makes the teardown handoff safe: failed writes still reach their caller, while later reads and writes remain unblocked.

## Testing instructions

```bash
npm exec nx test playground-website
npm exec nx run playground-components:e2e
npm exec nx run playground-website:typecheck
npm exec nx run playground-website:lint
npm exec nx run playground-components:lint
```
