### PR TITLE
[Website] Save pending Blueprint edits before Run

### DIFF
--- a/packages/playground/website/src/components/blueprint-editor/BlueprintBundleEditor.spec.tsx
+++ b/packages/playground/website/src/components/blueprint-editor/BlueprintBundleEditor.spec.tsx
@@ -1,0 +1,221 @@
+// @vitest-environment jsdom
+
+import { act, createRef } from 'react';
+import { createRoot } from 'react-dom/client';
+import type { Root } from 'react-dom/client';
+import type { AsyncWritableFilesystem } from '@wp-playground/storage';
+import type { SiteInfo } from '../../lib/state/redux/slice-sites';
+import {
+	BlueprintBundleEditor,
+	type BlueprintBundleEditorHandle,
+} from './BlueprintBundleEditor';
+
+const EDITED_BLUEPRINT = '{"steps":[{"step":"login"}]}';
+const mocks = vi.hoisted(() => ({
+	changeCode: undefined as ((code: string) => void) | undefined,
+	codeEditorPath: null as string | null,
+	codeEditorReadOnly: false,
+	dispatch: vi.fn(),
+	fileExplorerReadOnly: false,
+	loggerError: vi.fn(),
+	openFile: undefined as
+		| ((path: string, content: string, shouldFocus?: boolean) => void)
+		| undefined,
+	resolveRuntimeConfiguration: vi.fn(),
+}));
+
+vi.mock('@php-wasm/logger', () => ({
+	logger: { error: mocks.loggerError },
+}));
+
+vi.mock('@wp-playground/blueprints', () => ({
+	resolveRuntimeConfiguration: mocks.resolveRuntimeConfiguration,
+}));
+
+vi.mock('@wp-playground/components', async () => {
+	const { forwardRef } = await import('react');
+	return {
+		CodeEditor: forwardRef(
+			(
+				props: {
+					currentPath: string | null;
+					onChange: (code: string) => void;
+					readOnly?: boolean;
+				},
+				_ref
+			) => {
+				mocks.changeCode = props.onChange;
+				mocks.codeEditorPath = props.currentPath;
+				mocks.codeEditorReadOnly = Boolean(props.readOnly);
+				return null;
+			}
+		),
+		FileExplorerSidebar: (props: {
+			onFileOpened: (
+				path: string,
+				content: string,
+				shouldFocus?: boolean
+			) => void;
+			readOnly?: boolean;
+		}) => {
+			mocks.fileExplorerReadOnly = Boolean(props.readOnly);
+			mocks.openFile = props.onFileOpened;
+			return null;
+		},
+	};
+});
+
+vi.mock('../../lib/hooks/use-blueprint-url-hash', () => ({
+	useBlueprintUrlHash: () => ({ isShareable: true, urlHash: '' }),
+}));
+
+vi.mock('../../lib/state/redux/store', () => ({
+	useAppDispatch: () => mocks.dispatch,
+	useAppSelector: () => undefined,
+}));
+
+describe('BlueprintBundleEditor Run barrier', () => {
+	let container: HTMLDivElement;
+	let root: Root;
+	let filesystem: AsyncWritableFilesystem;
+	let writeFile: ReturnType<typeof vi.fn>;
+	const site = {
+		metadata: {
+			initialOpfsSyncPending: false,
+			originalBlueprint: null,
+			storage: 'none',
+		},
+		slug: 'test-site',
+	} as SiteInfo;
+
+	beforeAll(() => {
+		vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+	});
+
+	afterAll(() => {
+		vi.unstubAllGlobals();
+	});
+
+	beforeEach(() => {
+		vi.useFakeTimers();
+		container = document.createElement('div');
+		document.body.append(container);
+		root = createRoot(container);
+		writeFile = vi.fn().mockResolvedValue(undefined);
+		filesystem = {
+			readFileAsText: vi.fn().mockResolvedValue('{}'),
+			writeFile,
+		} as unknown as AsyncWritableFilesystem;
+		mocks.changeCode = undefined;
+		mocks.codeEditorPath = null;
+		mocks.dispatch.mockReset();
+		mocks.loggerError.mockReset();
+		mocks.resolveRuntimeConfiguration.mockReset();
+		mocks.resolveRuntimeConfiguration.mockResolvedValue({});
+		mocks.openFile = undefined;
+	});
+
+	afterEach(() => {
+		act(() => root.unmount());
+		container.remove();
+		vi.clearAllTimers();
+		vi.useRealTimers();
+	});
+
+	it('saves the pending edit before resolving and dispatching the recreation', async () => {
+		let finishWrite!: () => void;
+		writeFile.mockReturnValue(
+			new Promise<void>((resolve) => {
+				finishWrite = resolve;
+			})
+		);
+		const editorRef = await renderEditor();
+		changeCode('{"steps":[]}');
+		changeCode(EDITED_BLUEPRINT);
+
+		let recreate!: Promise<void>;
+		act(() => {
+			recreate = editorRef.current!.triggerRecreate();
+		});
+		await act(async () => Promise.resolve());
+
+		expect(writeFile).toHaveBeenCalledWith(
+			'/blueprint.json',
+			EDITED_BLUEPRINT
+		);
+		expect(writeFile).toHaveBeenCalledOnce();
+		expect(mocks.resolveRuntimeConfiguration).not.toHaveBeenCalled();
+		expect(mocks.dispatch).not.toHaveBeenCalled();
+		expect(mocks.codeEditorReadOnly).toBe(true);
+		expect(mocks.fileExplorerReadOnly).toBe(true);
+
+		finishWrite();
+		await act(async () => recreate);
+
+		expect(mocks.resolveRuntimeConfiguration).toHaveBeenCalledWith(
+			filesystem
+		);
+		expect(mocks.dispatch).toHaveBeenCalledTimes(2);
+		act(() => vi.advanceTimersByTime(201));
+		expect(writeFile).toHaveBeenCalledOnce();
+	});
+
+	it('retries a failed save after the user navigates to another file', async () => {
+		writeFile.mockRejectedValueOnce(new Error('disk full'));
+		const editorRef = await renderEditor();
+		changeCode(EDITED_BLUEPRINT);
+
+		await act(async () => editorRef.current!.triggerRecreate());
+
+		expect(mocks.resolveRuntimeConfiguration).not.toHaveBeenCalled();
+		expect(mocks.dispatch).not.toHaveBeenCalled();
+		expect(container.textContent).toContain(
+			'Could not save changes. Try again.'
+		);
+		openFile('/notes.txt', 'notes');
+		expect(mocks.codeEditorPath).toBe('/notes.txt');
+
+		await act(async () => editorRef.current!.triggerRecreate());
+
+		expect(writeFile).toHaveBeenCalledTimes(2);
+		expect(writeFile).toHaveBeenNthCalledWith(
+			2,
+			'/blueprint.json',
+			EDITED_BLUEPRINT
+		);
+		expect(mocks.codeEditorPath).toBe('/notes.txt');
+		expect(mocks.resolveRuntimeConfiguration).toHaveBeenCalledOnce();
+		expect(mocks.dispatch).toHaveBeenCalledTimes(2);
+	});
+
+	/** Renders an editable Blueprint and waits for its initial file read. */
+	async function renderEditor(): Promise<
+		React.RefObject<BlueprintBundleEditorHandle>
+	> {
+		const editorRef = createRef<BlueprintBundleEditorHandle>();
+		await act(async () => {
+			root.render(
+				<BlueprintBundleEditor
+					ref={editorRef}
+					filesystem={filesystem}
+					site={site}
+				/>
+			);
+			await Promise.resolve();
+		});
+		expect(editorRef.current).not.toBeNull();
+		expect(mocks.changeCode).toBeTypeOf('function');
+		expect(mocks.openFile).toBeTypeOf('function');
+		return editorRef;
+	}
+
+	/** Delivers a source change through the mocked CodeEditor. */
+	function changeCode(code: string): void {
+		act(() => mocks.changeCode!(code));
+	}
+
+	/** Opens a file through the mocked FileExplorerSidebar. */
+	function openFile(path: string, content: string): void {
+		act(() => mocks.openFile!(path, content));
+	}
+});

--- a/packages/playground/website/src/components/blueprint-editor/BlueprintBundleEditor.spec.tsx
+++ b/packages/playground/website/src/components/blueprint-editor/BlueprintBundleEditor.spec.tsx
@@ -13,19 +13,12 @@ import {
 const EDITED_BLUEPRINT = '{"steps":[{"step":"login"}]}';
 const mocks = vi.hoisted(() => ({
 	changeCode: undefined as ((code: string) => void) | undefined,
-	codeEditorPath: null as string | null,
-	codeEditorReadOnly: false,
 	dispatch: vi.fn(),
-	fileExplorerReadOnly: false,
-	loggerError: vi.fn(),
-	openFile: undefined as
-		| ((path: string, content: string, shouldFocus?: boolean) => void)
-		| undefined,
 	resolveRuntimeConfiguration: vi.fn(),
 }));
 
 vi.mock('@php-wasm/logger', () => ({
-	logger: { error: mocks.loggerError },
+	logger: { error: vi.fn() },
 }));
 
 vi.mock('@wp-playground/blueprints', () => ({
@@ -36,32 +29,12 @@ vi.mock('@wp-playground/components', async () => {
 	const { forwardRef } = await import('react');
 	return {
 		CodeEditor: forwardRef(
-			(
-				props: {
-					currentPath: string | null;
-					onChange: (code: string) => void;
-					readOnly?: boolean;
-				},
-				_ref
-			) => {
+			(props: { onChange: (code: string) => void }, _ref) => {
 				mocks.changeCode = props.onChange;
-				mocks.codeEditorPath = props.currentPath;
-				mocks.codeEditorReadOnly = Boolean(props.readOnly);
 				return null;
 			}
 		),
-		FileExplorerSidebar: (props: {
-			onFileOpened: (
-				path: string,
-				content: string,
-				shouldFocus?: boolean
-			) => void;
-			readOnly?: boolean;
-		}) => {
-			mocks.fileExplorerReadOnly = Boolean(props.readOnly);
-			mocks.openFile = props.onFileOpened;
-			return null;
-		},
+		FileExplorerSidebar: () => null,
 	};
 });
 
@@ -97,41 +70,33 @@ describe('BlueprintBundleEditor Run barrier', () => {
 	});
 
 	beforeEach(() => {
-		vi.useFakeTimers();
 		container = document.createElement('div');
 		document.body.append(container);
 		root = createRoot(container);
-		writeFile = vi.fn().mockResolvedValue(undefined);
+		writeFile = vi.fn();
 		filesystem = {
 			readFileAsText: vi.fn().mockResolvedValue('{}'),
 			writeFile,
 		} as unknown as AsyncWritableFilesystem;
 		mocks.changeCode = undefined;
-		mocks.codeEditorPath = null;
 		mocks.dispatch.mockReset();
-		mocks.loggerError.mockReset();
 		mocks.resolveRuntimeConfiguration.mockReset();
-		mocks.resolveRuntimeConfiguration.mockResolvedValue({});
-		mocks.openFile = undefined;
 	});
 
 	afterEach(() => {
 		act(() => root.unmount());
 		container.remove();
-		vi.clearAllTimers();
-		vi.useRealTimers();
 	});
 
-	it('saves the pending edit before resolving and dispatching the recreation', async () => {
-		let finishWrite!: () => void;
+	it('does not recreate when the pending edit cannot be saved', async () => {
+		let failWrite!: (error: Error) => void;
 		writeFile.mockReturnValue(
-			new Promise<void>((resolve) => {
-				finishWrite = resolve;
+			new Promise<void>((_resolve, reject) => {
+				failWrite = reject;
 			})
 		);
 		const editorRef = await renderEditor();
-		changeCode('{"steps":[]}');
-		changeCode(EDITED_BLUEPRINT);
+		act(() => mocks.changeCode!(EDITED_BLUEPRINT));
 
 		let recreate!: Promise<void>;
 		act(() => {
@@ -139,56 +104,25 @@ describe('BlueprintBundleEditor Run barrier', () => {
 		});
 		await act(async () => Promise.resolve());
 
+		expect(writeFile).toHaveBeenCalledOnce();
 		expect(writeFile).toHaveBeenCalledWith(
 			'/blueprint.json',
 			EDITED_BLUEPRINT
 		);
-		expect(writeFile).toHaveBeenCalledOnce();
 		expect(mocks.resolveRuntimeConfiguration).not.toHaveBeenCalled();
-		expect(mocks.dispatch).not.toHaveBeenCalled();
-		expect(mocks.codeEditorReadOnly).toBe(true);
-		expect(mocks.fileExplorerReadOnly).toBe(true);
 
-		finishWrite();
-		await act(async () => recreate);
-
-		expect(mocks.resolveRuntimeConfiguration).toHaveBeenCalledWith(
-			filesystem
-		);
-		expect(mocks.dispatch).toHaveBeenCalledTimes(2);
-		act(() => vi.advanceTimersByTime(201));
-		expect(writeFile).toHaveBeenCalledOnce();
-	});
-
-	it('retries a failed save after the user navigates to another file', async () => {
-		writeFile.mockRejectedValueOnce(new Error('disk full'));
-		const editorRef = await renderEditor();
-		changeCode(EDITED_BLUEPRINT);
-
-		await act(async () => editorRef.current!.triggerRecreate());
+		await act(async () => {
+			failWrite(new Error('disk full'));
+			await recreate;
+		});
 
 		expect(mocks.resolveRuntimeConfiguration).not.toHaveBeenCalled();
 		expect(mocks.dispatch).not.toHaveBeenCalled();
 		expect(container.textContent).toContain(
 			'Could not save changes. Try again.'
 		);
-		openFile('/notes.txt', 'notes');
-		expect(mocks.codeEditorPath).toBe('/notes.txt');
-
-		await act(async () => editorRef.current!.triggerRecreate());
-
-		expect(writeFile).toHaveBeenCalledTimes(2);
-		expect(writeFile).toHaveBeenNthCalledWith(
-			2,
-			'/blueprint.json',
-			EDITED_BLUEPRINT
-		);
-		expect(mocks.codeEditorPath).toBe('/notes.txt');
-		expect(mocks.resolveRuntimeConfiguration).toHaveBeenCalledOnce();
-		expect(mocks.dispatch).toHaveBeenCalledTimes(2);
 	});
 
-	/** Renders an editable Blueprint and waits for its initial file read. */
 	async function renderEditor(): Promise<
 		React.RefObject<BlueprintBundleEditorHandle>
 	> {
@@ -205,17 +139,6 @@ describe('BlueprintBundleEditor Run barrier', () => {
 		});
 		expect(editorRef.current).not.toBeNull();
 		expect(mocks.changeCode).toBeTypeOf('function');
-		expect(mocks.openFile).toBeTypeOf('function');
 		return editorRef;
-	}
-
-	/** Delivers a source change through the mocked CodeEditor. */
-	function changeCode(code: string): void {
-		act(() => mocks.changeCode!(code));
-	}
-
-	/** Opens a file through the mocked FileExplorerSidebar. */
-	function openFile(path: string, content: string): void {
-		act(() => mocks.openFile!(path, content));
 	}
 });

--- a/packages/playground/website/src/components/blueprint-editor/BlueprintBundleEditor.tsx
+++ b/packages/playground/website/src/components/blueprint-editor/BlueprintBundleEditor.tsx
@@ -327,12 +327,8 @@ export const BlueprintBundleEditor = forwardRef<
 	const editorRef = useRef<CodeEditorHandle | null>(null);
 	// Store the CodeMirror EditorView for string editor operations
 	const cmViewRef = useRef<EditorView | null>(null);
-	// Writes must finish in edit order, and Run needs one local barrier that
-	// includes every save started by this mounted editor.
-	const saveQueueRef = useRef<Promise<void>>(Promise.resolve());
-	// The queue remains usable after a rejected write, so retain the latest
-	// unsaved content for each failed path separately.
-	const failedSavesRef = useRef(new Map<string, string>());
+	// Serialize saves so Run can wait for writes already started by this editor.
+	const saveBarrierRef = useRef<Promise<boolean>>(Promise.resolve(true));
 	const dispatch = useAppDispatch();
 	const playgroundClient = useAppSelector((state) =>
 		site ? selectClientInfoBySiteSlug(state, site.slug)?.client : undefined
@@ -341,22 +337,19 @@ export const BlueprintBundleEditor = forwardRef<
 	// Save file to filesystem
 	const saveFile = useDebouncedCallback(enqueueSave, 200, [filesystem]);
 
-	/** Adds a write to this editor's ordered save queue. */
-	function enqueueSave(path: string, content: string): Promise<void> {
-		saveQueueRef.current = saveQueueRef.current.then(async () => {
+	function enqueueSave(path: string, content: string): Promise<boolean> {
+		saveBarrierRef.current = saveBarrierRef.current.then(async () => {
 			try {
 				await filesystem.writeFile(path, content);
-				failedSavesRef.current.delete(path);
-				if (failedSavesRef.current.size === 0) {
-					setSaveError(null);
-				}
+				setSaveError(null);
+				return true;
 			} catch (error) {
-				failedSavesRef.current.set(path, content);
 				logger.error('Failed to save file', error);
 				setSaveError('Could not save changes. Try again.');
+				return false;
 			}
 		});
-		return saveQueueRef.current;
+		return saveBarrierRef.current;
 	}
 
 	const handleCodeChange = useCallback(
@@ -412,20 +405,11 @@ export const BlueprintBundleEditor = forwardRef<
 		}
 		try {
 			setIsRecreating(true);
-			setSaveError(null);
-			const retryCandidates = [...failedSavesRef.current];
 			saveFile.flush();
-			await saveQueueRef.current;
-			for (const [path, content] of retryCandidates) {
-				if (failedSavesRef.current.get(path) === content) {
-					enqueueSave(path, content);
-				}
-			}
-			await saveQueueRef.current;
-			if (failedSavesRef.current.size > 0) {
-				setSaveError('Could not save changes. Try again.');
+			if (!(await saveBarrierRef.current)) {
 				return;
 			}
+			setSaveError(null);
 			const isAutosaved = isAutosavedSite(site);
 			const bundle =
 				(filesystem as EventedFilesystem | null) ??

--- a/packages/playground/website/src/components/blueprint-editor/BlueprintBundleEditor.tsx
+++ b/packages/playground/website/src/components/blueprint-editor/BlueprintBundleEditor.tsx
@@ -327,7 +327,10 @@ export const BlueprintBundleEditor = forwardRef<
 	const editorRef = useRef<CodeEditorHandle | null>(null);
 	// Store the CodeMirror EditorView for string editor operations
 	const cmViewRef = useRef<EditorView | null>(null);
-	// Serialize saves so Run can wait for writes already started by this editor.
+	/**
+	 * `flush()` starts the latest delayed save. This ordered promise also includes
+	 * earlier in-flight writes, so Run can wait before reading the Blueprint bundle.
+	 */
 	const saveBarrierRef = useRef<Promise<boolean>>(Promise.resolve(true));
 	const dispatch = useAppDispatch();
 	const playgroundClient = useAppSelector((state) =>

--- a/packages/playground/website/src/components/blueprint-editor/BlueprintBundleEditor.tsx
+++ b/packages/playground/website/src/components/blueprint-editor/BlueprintBundleEditor.tsx
@@ -327,34 +327,49 @@ export const BlueprintBundleEditor = forwardRef<
 	const editorRef = useRef<CodeEditorHandle | null>(null);
 	// Store the CodeMirror EditorView for string editor operations
 	const cmViewRef = useRef<EditorView | null>(null);
+	// Writes must finish in edit order, and Run needs one local barrier that
+	// includes every save started by this mounted editor.
+	const saveQueueRef = useRef<Promise<void>>(Promise.resolve());
+	// The queue remains usable after a rejected write, so retain the latest
+	// unsaved content for each failed path separately.
+	const failedSavesRef = useRef(new Map<string, string>());
 	const dispatch = useAppDispatch();
 	const playgroundClient = useAppSelector((state) =>
 		site ? selectClientInfoBySiteSlug(state, site.slug)?.client : undefined
 	);
 
 	// Save file to filesystem
-	const saveFile = useDebouncedCallback(
-		async (path: string, content: string) => {
+	const saveFile = useDebouncedCallback(enqueueSave, 200, [filesystem]);
+
+	/** Adds a write to this editor's ordered save queue. */
+	function enqueueSave(path: string, content: string): Promise<void> {
+		saveQueueRef.current = saveQueueRef.current.then(async () => {
 			try {
 				await filesystem.writeFile(path, content);
-				setSaveError(null);
+				failedSavesRef.current.delete(path);
+				if (failedSavesRef.current.size === 0) {
+					setSaveError(null);
+				}
 			} catch (error) {
+				failedSavesRef.current.set(path, content);
 				logger.error('Failed to save file', error);
 				setSaveError('Could not save changes. Try again.');
 			}
-		},
-		200,
-		[filesystem]
-	);
+		});
+		return saveQueueRef.current;
+	}
 
 	const handleCodeChange = useCallback(
 		(newCode: string) => {
+			if (readOnly || isRecreating) {
+				return;
+			}
 			setCode(newCode);
 			if (currentPath) {
 				saveFile(currentPath, newCode);
 			}
 		},
-		[currentPath, saveFile]
+		[currentPath, isRecreating, readOnly, saveFile]
 	);
 
 	// Load initial blueprint.json and focus tree
@@ -398,6 +413,19 @@ export const BlueprintBundleEditor = forwardRef<
 		try {
 			setIsRecreating(true);
 			setSaveError(null);
+			const retryCandidates = [...failedSavesRef.current];
+			saveFile.flush();
+			await saveQueueRef.current;
+			for (const [path, content] of retryCandidates) {
+				if (failedSavesRef.current.get(path) === content) {
+					enqueueSave(path, content);
+				}
+			}
+			await saveQueueRef.current;
+			if (failedSavesRef.current.size > 0) {
+				setSaveError('Could not save changes. Try again.');
+				return;
+			}
 			const isAutosaved = isAutosavedSite(site);
 			const bundle =
 				(filesystem as EventedFilesystem | null) ??
@@ -473,7 +501,7 @@ export const BlueprintBundleEditor = forwardRef<
 		} finally {
 			setIsRecreating(false);
 		}
-	}, [dispatch, filesystem, playgroundClient, readOnly, site]);
+	}, [dispatch, filesystem, playgroundClient, readOnly, saveFile, site]);
 
 	// autorun token hook
 	useEffect(() => {
@@ -543,6 +571,9 @@ export const BlueprintBundleEditor = forwardRef<
 	// Handle saving from the string editor modal
 	const handleStringEditorSave = useCallback(
 		(newValue: string) => {
+			if (readOnly || isRecreating) {
+				return;
+			}
 			const view = cmViewRef.current;
 			if (!view) return;
 
@@ -560,7 +591,12 @@ export const BlueprintBundleEditor = forwardRef<
 			// Format the document after the change
 			setTimeout(() => formatEditor(view), 0);
 		},
-		[stringEditorState.contentStart, stringEditorState.contentEnd]
+		[
+			isRecreating,
+			readOnly,
+			stringEditorState.contentEnd,
+			stringEditorState.contentStart,
+		]
 	);
 
 	const closeStringEditor = useCallback(() => {
@@ -721,7 +757,7 @@ export const BlueprintBundleEditor = forwardRef<
 							onSelectionCleared={handleClearSelection}
 							onShowMessage={handleShowMessage}
 							documentRoot="/"
-							readOnly={readOnly}
+							readOnly={readOnly || isRecreating}
 						/>
 					</aside>
 					<section className={styles.editorWrapper}>
@@ -846,7 +882,7 @@ export const BlueprintBundleEditor = forwardRef<
 										onChange={handleCodeChange}
 										currentPath={currentPath}
 										className={styles.editor}
-										readOnly={readOnly}
+										readOnly={readOnly || isRecreating}
 										additionalExtensions={
 											currentPath === BLUEPRINT_JSON_PATH
 												? blueprintSchemaExtensions

--- a/packages/playground/website/src/lib/hooks/use-debounced-callback.ts
+++ b/packages/playground/website/src/lib/hooks/use-debounced-callback.ts
@@ -3,12 +3,6 @@ import type { DependencyList } from 'react';
 
 type DebouncedCallback<T extends (...args: any[]) => any> = {
 	(...args: Parameters<T>): void;
-	/**
-	 * Invokes the pending call immediately and returns its result, matching the
-	 * conventional debounce API exposed by Lodash.
-	 *
-	 * @see https://lodash.com/docs/#debounce
-	 */
 	flush: () => ReturnType<T> | undefined;
 };
 
@@ -48,6 +42,12 @@ export function useDebouncedCallback<T extends (...args: any[]) => any>(
 			}, delay);
 		}
 
+		/**
+		 * Invokes the pending call immediately and returns its result, matching the
+		 * conventional debounce API exposed by Lodash.
+		 *
+		 * @see https://lodash.com/docs/#debounce
+		 */
 		function flush(): ReturnType<T> | undefined {
 			if (timeoutRef.current) {
 				clearTimeout(timeoutRef.current);

--- a/packages/playground/website/src/lib/hooks/use-debounced-callback.ts
+++ b/packages/playground/website/src/lib/hooks/use-debounced-callback.ts
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef } from 'react';
+import type { DependencyList } from 'react';
 
 type DebouncedCallback<T extends (...args: any[]) => any> = {
 	(...args: Parameters<T>): void;
@@ -9,7 +10,7 @@ type DebouncedCallback<T extends (...args: any[]) => any> = {
 export function useDebouncedCallback<T extends (...args: any[]) => any>(
 	callback: T,
 	delay = 250,
-	dependencies: React.DependencyList = []
+	dependencies: DependencyList = []
 ): DebouncedCallback<T> {
 	const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 	const callbackRef = useRef(callback);

--- a/packages/playground/website/src/lib/hooks/use-debounced-callback.ts
+++ b/packages/playground/website/src/lib/hooks/use-debounced-callback.ts
@@ -1,12 +1,19 @@
-import { useCallback, useEffect, useRef } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 
+type DebouncedCallback<T extends (...args: any[]) => any> = {
+	(...args: Parameters<T>): void;
+	flush: () => ReturnType<T> | undefined;
+};
+
+/** Debounces a callback and exposes its latest pending call for explicit flushes. */
 export function useDebouncedCallback<T extends (...args: any[]) => any>(
 	callback: T,
 	delay = 250,
 	dependencies: React.DependencyList = []
-): (...args: Parameters<T>) => void {
+): DebouncedCallback<T> {
 	const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 	const callbackRef = useRef(callback);
+	const pendingArgsRef = useRef<Parameters<T> | null>(null);
 
 	// Keep callback ref up to date
 	useEffect(() => {
@@ -19,18 +26,37 @@ export function useDebouncedCallback<T extends (...args: any[]) => any>(
 			if (timeoutRef.current) {
 				clearTimeout(timeoutRef.current);
 			}
+			pendingArgsRef.current = null;
 		};
 	}, []);
 
-	return useCallback(
-		(...args: Parameters<T>) => {
+	return useMemo(() => {
+		/** Replaces the pending call and restarts its delay. */
+		function debounced(...args: Parameters<T>) {
 			if (timeoutRef.current) {
 				clearTimeout(timeoutRef.current);
 			}
+			pendingArgsRef.current = args;
 			timeoutRef.current = setTimeout(() => {
-				callbackRef.current(...args);
+				flush();
 			}, delay);
-		},
-		[delay, ...dependencies]
-	);
+		}
+
+		/** Runs the latest scheduled call immediately, if one exists. */
+		function flush(): ReturnType<T> | undefined {
+			if (timeoutRef.current) {
+				clearTimeout(timeoutRef.current);
+				timeoutRef.current = null;
+			}
+			const args = pendingArgsRef.current;
+			pendingArgsRef.current = null;
+			if (!args) {
+				return undefined;
+			}
+			return callbackRef.current(...args);
+		}
+
+		debounced.flush = flush;
+		return debounced;
+	}, [delay, ...dependencies]);
 }

--- a/packages/playground/website/src/lib/hooks/use-debounced-callback.ts
+++ b/packages/playground/website/src/lib/hooks/use-debounced-callback.ts
@@ -32,7 +32,6 @@ export function useDebouncedCallback<T extends (...args: any[]) => any>(
 	}, []);
 
 	return useMemo(() => {
-		/** Replaces the pending call and restarts its delay. */
 		function debounced(...args: Parameters<T>) {
 			if (timeoutRef.current) {
 				clearTimeout(timeoutRef.current);
@@ -43,7 +42,6 @@ export function useDebouncedCallback<T extends (...args: any[]) => any>(
 			}, delay);
 		}
 
-		/** Runs the latest scheduled call immediately, if one exists. */
 		function flush(): ReturnType<T> | undefined {
 			if (timeoutRef.current) {
 				clearTimeout(timeoutRef.current);

--- a/packages/playground/website/src/lib/hooks/use-debounced-callback.ts
+++ b/packages/playground/website/src/lib/hooks/use-debounced-callback.ts
@@ -3,6 +3,12 @@ import type { DependencyList } from 'react';
 
 type DebouncedCallback<T extends (...args: any[]) => any> = {
 	(...args: Parameters<T>): void;
+	/**
+	 * Invokes the pending call immediately and returns its result, matching the
+	 * conventional debounce API exposed by Lodash.
+	 *
+	 * @see https://lodash.com/docs/#debounce
+	 */
 	flush: () => ReturnType<T> | undefined;
 };
 


### PR DESCRIPTION
## What it does

Flushes the current debounced Blueprint save before **Run Blueprint**, waits for
that write and any earlier editor write, and leaves the current Playground
untouched when the save fails.

`useDebouncedCallback` returned value now provides a `.flush()` call for manually calling the debounced function.

## Rationale

Blueprint saves wait for a 200 ms debounce. Run previously resolved the bundle
immediately, so a quick edit followed by Run could recreate the Playground from
the previous `blueprint.json` contents.

## Testing

```bash
npm exec nx test playground-website -- --testFile=BlueprintBundleEditor.spec.tsx
npm exec nx test playground-website
npm exec nx run playground-website:typecheck
npm exec nx run playground-website:lint
```
