### PR TITLE
[Website] Create stored Playgrounds from URLs or bundles

### DIFF
--- a/packages/playground/website/src/lib/state/redux/slice-sites.spec.ts
+++ b/packages/playground/website/src/lib/state/redux/slice-sites.spec.ts
@@ -1,7 +1,8 @@
 import type { OriginalUrlParams } from '../original-url-params';
 import type { SiteInfo } from './slice-sites';
+import type { TraversableFilesystemBackend } from '@wp-playground/storage';
 
-describe('stored site specs', () => {
+describe('stored site creation', () => {
 	let createSite: ReturnType<typeof vi.fn>;
 	let updateSiteStorage: ReturnType<typeof vi.fn>;
 	let persistBlueprintBundle: ReturnType<typeof vi.fn>;
@@ -318,11 +319,13 @@ describe('stored site specs', () => {
 		expect(removeWordPressFilesKeepMetadata).not.toHaveBeenCalled();
 	});
 
-	it('does not persist a bundle for a new stored site before validating setup', async () => {
+	it('keeps setStoredSiteSpec as the setup URL compatibility alias', async () => {
 		resolveRuntimeConfiguration.mockRejectedValue(
 			new Error('Invalid setup')
 		);
-		const { setStoredSiteSpec } = await import('./slice-sites');
+		const { createStoredSite, setStoredSiteSpec } =
+			await import('./slice-sites');
+		expect(setStoredSiteSpec).toBe(createStoredSite);
 		const addSite = setStoredSiteSpec(
 			'Autosaved site',
 			new URL(
@@ -340,8 +343,7 @@ describe('stored site specs', () => {
 	});
 
 	it('creates a new stored site from an edited Blueprint bundle', async () => {
-		const { setStoredSiteSpecFromBlueprintBundle, sitesSlice } =
-			await import('./slice-sites');
+		const { createStoredSite, sitesSlice } = await import('./slice-sites');
 		const runtimeConfiguration = {
 			phpVersion: '8.3',
 			wpVersion: 'latest',
@@ -381,9 +383,9 @@ describe('stored site specs', () => {
 			writes.push('metadata');
 		});
 
-		const newSite = await setStoredSiteSpecFromBlueprintBundle(
+		const newSite = await createStoredSite(
 			'Edited Blueprint',
-			editedBundle as any,
+			editedBundle,
 			'source-site',
 			{ persistence: 'autosave' }
 		)(dispatch as any, getState as any);
@@ -419,14 +421,13 @@ describe('stored site specs', () => {
 		resolveRuntimeConfiguration.mockRejectedValue(
 			new Error('Invalid setup')
 		);
-		const { setStoredSiteSpecFromBlueprintBundle } =
-			await import('./slice-sites');
+		const { createStoredSite } = await import('./slice-sites');
 
 		await expect(
-			setStoredSiteSpecFromBlueprintBundle(
-				'Edited Blueprint',
-				createBundleBlueprint() as any
-			)(createDispatch() as any, createEmptyGetState() as any)
+			createStoredSite('Edited Blueprint', createBundleBlueprint())(
+				createDispatch() as any,
+				createEmptyGetState() as any
+			)
 		).rejects.toThrow('Invalid setup');
 
 		expect(persistBlueprintBundle).not.toHaveBeenCalled();
@@ -434,8 +435,7 @@ describe('stored site specs', () => {
 	});
 
 	it('removes an edited Blueprint bundle when site creation fails', async () => {
-		const { setStoredSiteSpecFromBlueprintBundle } =
-			await import('./slice-sites');
+		const { createStoredSite } = await import('./slice-sites');
 		resolveRuntimeConfiguration.mockResolvedValue({
 			phpVersion: '8.3',
 			wpVersion: 'latest',
@@ -447,9 +447,9 @@ describe('stored site specs', () => {
 		createSite.mockRejectedValue(new Error('Could not write metadata'));
 
 		await expect(
-			setStoredSiteSpecFromBlueprintBundle(
+			createStoredSite(
 				'Edited Blueprint',
-				createBundleBlueprint() as any,
+				createBundleBlueprint(),
 				'edited-blueprint'
 			)(createThunkDispatch() as any, createEmptyGetState() as any)
 		).rejects.toThrow('Could not write metadata');
@@ -545,7 +545,7 @@ function createThunkDispatch() {
 	return dispatch;
 }
 
-function createBundleBlueprint() {
+function createBundleBlueprint(): TraversableFilesystemBackend {
 	return {
 		read: vi.fn(),
 		listFiles: vi.fn(),

--- a/packages/playground/website/src/lib/state/redux/slice-sites.spec.ts
+++ b/packages/playground/website/src/lib/state/redux/slice-sites.spec.ts
@@ -335,6 +335,99 @@ describe('stored site specs', () => {
 
 		expect(persistBlueprintBundle).not.toHaveBeenCalled();
 	});
+
+	it('creates a new stored site from an edited Blueprint bundle', async () => {
+		const { setStoredSiteSpecFromBlueprintBundle, sitesSlice } =
+			await import('./slice-sites');
+		const runtimeConfiguration = {
+			phpVersion: '8.3',
+			wpVersion: 'latest',
+			intl: false,
+			networking: true,
+			extraLibraries: [],
+			constants: {},
+		};
+		resolveRuntimeConfiguration.mockResolvedValue(runtimeConfiguration);
+		const sourceSite = createSiteInfo({
+			slug: 'source-site',
+			name: 'Original Playground',
+		});
+		const editedBundle = createBundleBlueprint();
+		let state = {
+			sites: sitesSlice.reducer(
+				undefined,
+				sitesSlice.actions.addSite(sourceSite)
+			),
+		};
+		const getState = () => state;
+		const dispatch = vi.fn();
+		dispatch.mockImplementation((action) => {
+			if (typeof action === 'function') {
+				return action(dispatch, getState);
+			}
+			state = {
+				sites: sitesSlice.reducer(state.sites, action),
+			};
+			return action;
+		});
+		const writes: string[] = [];
+		persistBlueprintBundle.mockImplementation(async () => {
+			writes.push('bundle');
+		});
+		createSite.mockImplementation(async () => {
+			writes.push('metadata');
+		});
+
+		const newSite = await setStoredSiteSpecFromBlueprintBundle(
+			'Edited Blueprint',
+			editedBundle as any,
+			'source-site',
+			{ persistence: 'autosave' }
+		)(dispatch as any, getState as any);
+
+		expect(newSite.slug).toBe('source-site-2');
+		expect(newSite.metadata).toMatchObject({
+			name: 'Edited Blueprint',
+			storage: 'opfs',
+			persistence: 'autosave',
+			initialOpfsSyncPending: true,
+			originalBlueprint: editedBundle,
+			originalBlueprintSource: { type: 'opfs-site' },
+			runtimeConfiguration,
+		});
+		expect(persistBlueprintBundle).toHaveBeenCalledWith(
+			'source-site-2',
+			editedBundle
+		);
+		expect(createSite).toHaveBeenCalledWith(
+			'source-site-2',
+			newSite.metadata,
+			undefined
+		);
+		expect(writes).toEqual(['bundle', 'metadata']);
+		expect(state.sites.entities).toMatchObject({
+			'source-site': sourceSite,
+			'source-site-2': newSite,
+		});
+	});
+
+	it('does not persist an edited Blueprint bundle when its runtime is invalid', async () => {
+		resolveRuntimeConfiguration.mockRejectedValue(
+			new Error('Invalid setup')
+		);
+		const { setStoredSiteSpecFromBlueprintBundle } =
+			await import('./slice-sites');
+
+		await expect(
+			setStoredSiteSpecFromBlueprintBundle(
+				'Edited Blueprint',
+				createBundleBlueprint() as any
+			)(createDispatch() as any, createEmptyGetState() as any)
+		).rejects.toThrow('Invalid setup');
+
+		expect(persistBlueprintBundle).not.toHaveBeenCalled();
+		expect(createSite).not.toHaveBeenCalled();
+	});
 });
 
 function createEmptyGetState() {
@@ -381,15 +474,19 @@ function createGetState() {
 
 function createSiteInfo({
 	originalUrlParams,
+	slug = 'stored-site',
+	name = 'Stored site',
 }: {
 	originalUrlParams?: OriginalUrlParams;
+	slug?: string;
+	name?: string;
 } = {}): SiteInfo {
 	return {
-		slug: 'stored-site',
+		slug,
 		originalUrlParams,
 		metadata: {
-			id: 'stored-site',
-			name: 'Stored site',
+			id: slug,
+			name,
 			storage: 'opfs' as const,
 			originalBlueprint: {},
 			originalBlueprintSource: { type: 'none' as const },

--- a/packages/playground/website/src/lib/state/redux/slice-sites.spec.ts
+++ b/packages/playground/website/src/lib/state/redux/slice-sites.spec.ts
@@ -5,6 +5,7 @@ describe('stored site specs', () => {
 	let createSite: ReturnType<typeof vi.fn>;
 	let updateSiteStorage: ReturnType<typeof vi.fn>;
 	let persistBlueprintBundle: ReturnType<typeof vi.fn>;
+	let deleteBlueprintBundle: ReturnType<typeof vi.fn>;
 	let removeWordPressFilesKeepMetadata: ReturnType<typeof vi.fn>;
 	let resolveRuntimeConfiguration: ReturnType<typeof vi.fn>;
 
@@ -13,6 +14,7 @@ describe('stored site specs', () => {
 		createSite = vi.fn();
 		updateSiteStorage = vi.fn();
 		persistBlueprintBundle = vi.fn();
+		deleteBlueprintBundle = vi.fn();
 		removeWordPressFilesKeepMetadata = vi.fn();
 		resolveRuntimeConfiguration = vi.fn();
 
@@ -35,6 +37,7 @@ describe('stored site specs', () => {
 			resolveRuntimeConfiguration,
 		}));
 		vi.doMock('../opfs/opfs-blueprint-bundle-storage', () => ({
+			deleteBlueprintBundle,
 			isTraversableFilesystemBackend: (value: unknown) =>
 				typeof value === 'object' &&
 				value !== null &&
@@ -404,6 +407,7 @@ describe('stored site specs', () => {
 			newSite.metadata,
 			undefined
 		);
+		expect(deleteBlueprintBundle).not.toHaveBeenCalled();
 		expect(writes).toEqual(['bundle', 'metadata']);
 		expect(state.sites.entities).toMatchObject({
 			'source-site': sourceSite,
@@ -427,6 +431,30 @@ describe('stored site specs', () => {
 
 		expect(persistBlueprintBundle).not.toHaveBeenCalled();
 		expect(createSite).not.toHaveBeenCalled();
+	});
+
+	it('removes an edited Blueprint bundle when site creation fails', async () => {
+		const { setStoredSiteSpecFromBlueprintBundle } =
+			await import('./slice-sites');
+		resolveRuntimeConfiguration.mockResolvedValue({
+			phpVersion: '8.3',
+			wpVersion: 'latest',
+			intl: false,
+			networking: true,
+			extraLibraries: [],
+			constants: {},
+		});
+		createSite.mockRejectedValue(new Error('Could not write metadata'));
+
+		await expect(
+			setStoredSiteSpecFromBlueprintBundle(
+				'Edited Blueprint',
+				createBundleBlueprint() as any,
+				'edited-blueprint'
+			)(createThunkDispatch() as any, createEmptyGetState() as any)
+		).rejects.toThrow('Could not write metadata');
+
+		expect(deleteBlueprintBundle).toHaveBeenCalledWith('edited-blueprint');
 	});
 });
 
@@ -504,6 +532,17 @@ function createSiteInfo({
 
 function createDispatch() {
 	return vi.fn(async (action) => action);
+}
+
+function createThunkDispatch() {
+	const dispatch = vi.fn();
+	dispatch.mockImplementation(async (action) => {
+		if (typeof action === 'function') {
+			return action(dispatch, createEmptyGetState());
+		}
+		return action;
+	});
+	return dispatch;
 }
 
 function createBundleBlueprint() {

--- a/packages/playground/website/src/lib/state/redux/slice-sites.ts
+++ b/packages/playground/website/src/lib/state/redux/slice-sites.ts
@@ -582,6 +582,11 @@ export function createStoredSite(
 			);
 		}
 
+		/**
+		 * A setup URL needs resolving and carries its original URL params and
+		 * autosave fingerprint. An editable bundle is already the source of
+		 * truth and will be persisted below, so it has neither.
+		 */
 		let blueprint: ResolvedBlueprint['blueprint'];
 		let originalBlueprintSource: BlueprintSource;
 		let originalUrlParams: OriginalUrlParams | undefined;

--- a/packages/playground/website/src/lib/state/redux/slice-sites.ts
+++ b/packages/playground/website/src/lib/state/redux/slice-sites.ts
@@ -557,101 +557,13 @@ export function setTemporarySiteSpec(
 }
 
 /**
- * Creates the metadata record for a new OPFS-backed Playground.
- *
- * This intentionally overlaps with `setTemporarySiteSpec`: both capture the
- * setup URL, resolve the Blueprint, and derive the runtime configuration.
- * Stored sites diverge after that by writing OPFS metadata immediately, keeping
- * more than one site record, and marking the first file sync as pending. Boot
- * then uses the same setup URL to install WordPress in MEMFS before copying the
- * initialized files into OPFS.
+ * Creates a new OPFS-backed Playground from a setup URL or editable Blueprint
+ * bundle. Bundles are stored with the new Playground before their metadata is
+ * written because they may include edits that cannot be represented by a URL.
  */
-export function setStoredSiteSpec(
+export function createStoredSite(
 	siteName: string,
-	playgroundUrlWithQueryApiArgs: URL,
-	preferredSlug?: string,
-	options: {
-		/**
-		 * Whether the stored site is an autosave or an explicit user save.
-		 */
-		persistence?: SitePersistence;
-	} = {}
-) {
-	return async (
-		dispatch: PlaygroundDispatch,
-		getState: () => PlaygroundReduxState
-	) => {
-		const originalUrlParams = getOriginalUrlParams(
-			playgroundUrlWithQueryApiArgs
-		);
-
-		const resolvedBlueprint = await resolveSiteBlueprintFromUrl(
-			playgroundUrlWithQueryApiArgs
-		);
-		const now = Date.now();
-		const sites = selectAllSites(getState());
-		let displayName = siteName;
-		let slugBaseName = siteName;
-		if (!preferredSlug) {
-			slugBaseName = getDefaultSiteNameFromBlueprint(
-				resolvedBlueprint.blueprint,
-				siteName
-			);
-			displayName = getSiteNameWithCreationTimeIfDuplicate(
-				slugBaseName,
-				sites.map((site) => site.metadata.name),
-				new Date(now)
-			);
-		}
-		const siteSlug = getUniqueSiteSlug(
-			preferredSlug || deriveSlugFromSiteName(slugBaseName),
-			{ unavailableSlugs: sites.map((site) => site.slug) }
-		);
-		const runtimeConfiguration = (await resolveRuntimeConfiguration(
-			resolvedBlueprint.blueprint
-		))!;
-		let originalBlueprintSource = resolvedBlueprint.source!;
-		if (isTraversableFilesystemBackend(resolvedBlueprint.blueprint)) {
-			await persistBlueprintBundle(siteSlug, resolvedBlueprint.blueprint);
-			originalBlueprintSource = {
-				type: 'opfs-site',
-			};
-		}
-		const newSiteInfo: SiteInfo = {
-			slug: siteSlug,
-			originalUrlParams,
-			metadata: {
-				name: displayName,
-				id: crypto.randomUUID(),
-				whenCreated: now,
-				whenLastUsed: now,
-				persistence: options.persistence ?? 'explicit',
-				storage: 'opfs' as const,
-				initialOpfsSyncPending: true,
-				sourceSetupUrlFingerprint: getAutosaveFingerprintFromURL(
-					playgroundUrlWithQueryApiArgs
-				),
-				originalBlueprint: resolvedBlueprint.blueprint,
-				originalBlueprintSource,
-				runtimeConfiguration,
-			},
-		};
-
-		await dispatch(addSite(newSiteInfo));
-		return newSiteInfo;
-	};
-}
-
-/**
- * Creates a new OPFS-backed Playground from an editable Blueprint bundle.
- *
- * Unlike `setStoredSiteSpec`, this does not need a setup URL. The bundle may
- * include edited files that cannot be represented by a Blueprint URL, so it
- * is stored with the new Playground before its metadata is written.
- */
-export function setStoredSiteSpecFromBlueprintBundle(
-	siteName: string,
-	blueprintBundle: TraversableFilesystemBackend,
+	source: URL | TraversableFilesystemBackend,
 	preferredSlug?: string,
 	options: {
 		/**
@@ -670,17 +582,16 @@ export function setStoredSiteSpecFromBlueprintBundle(
 			);
 		}
 
+		const resolvedSource = await resolveStoredSiteSource(source);
+		const blueprint = resolvedSource.blueprint;
 		const runtimeConfiguration =
-			await resolveRuntimeConfiguration(blueprintBundle);
+			await resolveRuntimeConfiguration(blueprint);
 		const now = Date.now();
 		const sites = selectAllSites(getState());
 		let displayName = siteName;
 		let slugBaseName = siteName;
 		if (!preferredSlug) {
-			slugBaseName = getDefaultSiteNameFromBlueprint(
-				blueprintBundle,
-				siteName
-			);
+			slugBaseName = getDefaultSiteNameFromBlueprint(blueprint, siteName);
 			displayName = getSiteNameWithCreationTimeIfDuplicate(
 				slugBaseName,
 				sites.map((site) => site.metadata.name),
@@ -691,10 +602,17 @@ export function setStoredSiteSpecFromBlueprintBundle(
 			preferredSlug || deriveSlugFromSiteName(slugBaseName),
 			{ unavailableSlugs: sites.map((site) => site.slug) }
 		);
-
-		await persistBlueprintBundle(siteSlug, blueprintBundle);
+		let originalBlueprintSource = resolvedSource.originalBlueprintSource;
+		const isBlueprintBundle = isTraversableFilesystemBackend(blueprint);
+		if (isBlueprintBundle) {
+			await persistBlueprintBundle(siteSlug, blueprint);
+			originalBlueprintSource = {
+				type: 'opfs-site',
+			};
+		}
 		const newSiteInfo: SiteInfo = {
 			slug: siteSlug,
+			originalUrlParams: resolvedSource.originalUrlParams,
 			metadata: {
 				name: displayName,
 				id: crypto.randomUUID(),
@@ -703,8 +621,14 @@ export function setStoredSiteSpecFromBlueprintBundle(
 				persistence: options.persistence ?? 'explicit',
 				storage: 'opfs' as const,
 				initialOpfsSyncPending: true,
-				originalBlueprint: blueprintBundle,
-				originalBlueprintSource: { type: 'opfs-site' },
+				...(resolvedSource.sourceSetupUrlFingerprint
+					? {
+							sourceSetupUrlFingerprint:
+								resolvedSource.sourceSetupUrlFingerprint,
+						}
+					: {}),
+				originalBlueprint: blueprint,
+				originalBlueprintSource,
 				runtimeConfiguration,
 			},
 		};
@@ -712,10 +636,41 @@ export function setStoredSiteSpecFromBlueprintBundle(
 		try {
 			await dispatch(addSite(newSiteInfo));
 		} catch (error) {
-			await deleteBlueprintBundle(siteSlug);
+			if (isBlueprintBundle) {
+				await deleteBlueprintBundle(siteSlug);
+			}
 			throw error;
 		}
 		return newSiteInfo;
+	};
+}
+
+/**
+ * Compatibility alias for callers that create a stored Playground from a URL.
+ */
+export const setStoredSiteSpec = createStoredSite;
+
+async function resolveStoredSiteSource(
+	source: URL | TraversableFilesystemBackend
+): Promise<{
+	blueprint: ResolvedBlueprint['blueprint'];
+	originalBlueprintSource: BlueprintSource;
+	originalUrlParams?: OriginalUrlParams;
+	sourceSetupUrlFingerprint?: string;
+}> {
+	if (!(source instanceof URL)) {
+		return {
+			blueprint: source,
+			originalBlueprintSource: { type: 'opfs-site' as const },
+		};
+	}
+
+	const resolvedBlueprint = await resolveSiteBlueprintFromUrl(source);
+	return {
+		blueprint: resolvedBlueprint.blueprint,
+		originalBlueprintSource: resolvedBlueprint.source!,
+		originalUrlParams: getOriginalUrlParams(source),
+		sourceSetupUrlFingerprint: getAutosaveFingerprintFromURL(source),
 	};
 }
 

--- a/packages/playground/website/src/lib/state/redux/slice-sites.ts
+++ b/packages/playground/website/src/lib/state/redux/slice-sites.ts
@@ -23,6 +23,7 @@ import {
 	applyQueryOverrides,
 } from '../url/resolve-blueprint-from-url';
 import {
+	deleteBlueprintBundle,
 	isTraversableFilesystemBackend,
 	persistBlueprintBundle,
 } from '../opfs/opfs-blueprint-bundle-storage';
@@ -669,16 +670,15 @@ export function setStoredSiteSpecFromBlueprintBundle(
 			);
 		}
 
-		const runtimeConfiguration = (await resolveRuntimeConfiguration(
-			blueprintBundle as any
-		))!;
+		const runtimeConfiguration =
+			await resolveRuntimeConfiguration(blueprintBundle);
 		const now = Date.now();
 		const sites = selectAllSites(getState());
 		let displayName = siteName;
 		let slugBaseName = siteName;
 		if (!preferredSlug) {
 			slugBaseName = getDefaultSiteNameFromBlueprint(
-				blueprintBundle as any,
+				blueprintBundle,
 				siteName
 			);
 			displayName = getSiteNameWithCreationTimeIfDuplicate(
@@ -709,7 +709,12 @@ export function setStoredSiteSpecFromBlueprintBundle(
 			},
 		};
 
-		await dispatch(addSite(newSiteInfo));
+		try {
+			await dispatch(addSite(newSiteInfo));
+		} catch (error) {
+			await deleteBlueprintBundle(siteSlug);
+			throw error;
+		}
 		return newSiteInfo;
 	};
 }

--- a/packages/playground/website/src/lib/state/redux/slice-sites.ts
+++ b/packages/playground/website/src/lib/state/redux/slice-sites.ts
@@ -582,8 +582,20 @@ export function createStoredSite(
 			);
 		}
 
-		const resolvedSource = await resolveStoredSiteSource(source);
-		const blueprint = resolvedSource.blueprint;
+		let blueprint: ResolvedBlueprint['blueprint'];
+		let originalBlueprintSource: BlueprintSource;
+		let originalUrlParams: OriginalUrlParams | undefined;
+		let sourceSetupUrlFingerprint: string | undefined;
+		if (source instanceof URL) {
+			const resolvedBlueprint = await resolveSiteBlueprintFromUrl(source);
+			blueprint = resolvedBlueprint.blueprint;
+			originalBlueprintSource = resolvedBlueprint.source!;
+			originalUrlParams = getOriginalUrlParams(source);
+			sourceSetupUrlFingerprint = getAutosaveFingerprintFromURL(source);
+		} else {
+			blueprint = source;
+			originalBlueprintSource = { type: 'opfs-site' };
+		}
 		const runtimeConfiguration =
 			await resolveRuntimeConfiguration(blueprint);
 		const now = Date.now();
@@ -602,17 +614,18 @@ export function createStoredSite(
 			preferredSlug || deriveSlugFromSiteName(slugBaseName),
 			{ unavailableSlugs: sites.map((site) => site.slug) }
 		);
-		let originalBlueprintSource = resolvedSource.originalBlueprintSource;
-		const isBlueprintBundle = isTraversableFilesystemBackend(blueprint);
-		if (isBlueprintBundle) {
-			await persistBlueprintBundle(siteSlug, blueprint);
+		const blueprintBundle = isTraversableFilesystemBackend(blueprint)
+			? blueprint
+			: undefined;
+		if (blueprintBundle) {
+			await persistBlueprintBundle(siteSlug, blueprintBundle);
 			originalBlueprintSource = {
 				type: 'opfs-site',
 			};
 		}
 		const newSiteInfo: SiteInfo = {
 			slug: siteSlug,
-			originalUrlParams: resolvedSource.originalUrlParams,
+			originalUrlParams,
 			metadata: {
 				name: displayName,
 				id: crypto.randomUUID(),
@@ -621,10 +634,10 @@ export function createStoredSite(
 				persistence: options.persistence ?? 'explicit',
 				storage: 'opfs' as const,
 				initialOpfsSyncPending: true,
-				...(resolvedSource.sourceSetupUrlFingerprint
+				...(sourceSetupUrlFingerprint
 					? {
 							sourceSetupUrlFingerprint:
-								resolvedSource.sourceSetupUrlFingerprint,
+								sourceSetupUrlFingerprint,
 						}
 					: {}),
 				originalBlueprint: blueprint,
@@ -636,7 +649,7 @@ export function createStoredSite(
 		try {
 			await dispatch(addSite(newSiteInfo));
 		} catch (error) {
-			if (isBlueprintBundle) {
+			if (blueprintBundle) {
 				await deleteBlueprintBundle(siteSlug);
 			}
 			throw error;
@@ -649,30 +662,6 @@ export function createStoredSite(
  * Compatibility alias for callers that create a stored Playground from a URL.
  */
 export const setStoredSiteSpec = createStoredSite;
-
-async function resolveStoredSiteSource(
-	source: URL | TraversableFilesystemBackend
-): Promise<{
-	blueprint: ResolvedBlueprint['blueprint'];
-	originalBlueprintSource: BlueprintSource;
-	originalUrlParams?: OriginalUrlParams;
-	sourceSetupUrlFingerprint?: string;
-}> {
-	if (!(source instanceof URL)) {
-		return {
-			blueprint: source,
-			originalBlueprintSource: { type: 'opfs-site' as const },
-		};
-	}
-
-	const resolvedBlueprint = await resolveSiteBlueprintFromUrl(source);
-	return {
-		blueprint: resolvedBlueprint.blueprint,
-		originalBlueprintSource: resolvedBlueprint.source!,
-		originalUrlParams: getOriginalUrlParams(source),
-		sourceSetupUrlFingerprint: getAutosaveFingerprintFromURL(source),
-	};
-}
 
 /**
  * Replaces an autosaved Playground's WordPress files with files from a new setup.

--- a/packages/playground/website/src/lib/state/redux/slice-sites.ts
+++ b/packages/playground/website/src/lib/state/redux/slice-sites.ts
@@ -26,6 +26,7 @@ import {
 	isTraversableFilesystemBackend,
 	persistBlueprintBundle,
 } from '../opfs/opfs-blueprint-bundle-storage';
+import type { TraversableFilesystemBackend } from '@wp-playground/storage';
 import { logger } from '@php-wasm/logger';
 import { setActiveSiteError, type SiteError } from './slice-ui';
 import { RecommendedPHPVersion } from '@wp-playground/common';
@@ -631,6 +632,79 @@ export function setStoredSiteSpec(
 				),
 				originalBlueprint: resolvedBlueprint.blueprint,
 				originalBlueprintSource,
+				runtimeConfiguration,
+			},
+		};
+
+		await dispatch(addSite(newSiteInfo));
+		return newSiteInfo;
+	};
+}
+
+/**
+ * Creates a new OPFS-backed Playground from an editable Blueprint bundle.
+ *
+ * Unlike `setStoredSiteSpec`, this does not need a setup URL. The bundle may
+ * include edited files that cannot be represented by a Blueprint URL, so it
+ * is stored with the new Playground before its metadata is written.
+ */
+export function setStoredSiteSpecFromBlueprintBundle(
+	siteName: string,
+	blueprintBundle: TraversableFilesystemBackend,
+	preferredSlug?: string,
+	options: {
+		/**
+		 * Whether the stored site is an autosave or an explicit user save.
+		 */
+		persistence?: SitePersistence;
+	} = {}
+) {
+	return async (
+		dispatch: PlaygroundDispatch,
+		getState: () => PlaygroundReduxState
+	) => {
+		if (!opfsSiteStorage) {
+			throw new Error(
+				'Cannot create a saved Playground because browser storage is not available.'
+			);
+		}
+
+		const runtimeConfiguration = (await resolveRuntimeConfiguration(
+			blueprintBundle as any
+		))!;
+		const now = Date.now();
+		const sites = selectAllSites(getState());
+		let displayName = siteName;
+		let slugBaseName = siteName;
+		if (!preferredSlug) {
+			slugBaseName = getDefaultSiteNameFromBlueprint(
+				blueprintBundle as any,
+				siteName
+			);
+			displayName = getSiteNameWithCreationTimeIfDuplicate(
+				slugBaseName,
+				sites.map((site) => site.metadata.name),
+				new Date(now)
+			);
+		}
+		const siteSlug = getUniqueSiteSlug(
+			preferredSlug || deriveSlugFromSiteName(slugBaseName),
+			{ unavailableSlugs: sites.map((site) => site.slug) }
+		);
+
+		await persistBlueprintBundle(siteSlug, blueprintBundle);
+		const newSiteInfo: SiteInfo = {
+			slug: siteSlug,
+			metadata: {
+				name: displayName,
+				id: crypto.randomUUID(),
+				whenCreated: now,
+				whenLastUsed: now,
+				persistence: options.persistence ?? 'explicit',
+				storage: 'opfs' as const,
+				initialOpfsSyncPending: true,
+				originalBlueprint: blueprintBundle,
+				originalBlueprintSource: { type: 'opfs-site' },
 				runtimeConfiguration,
 			},
 		};


### PR DESCRIPTION
Stored-site creation only accepted setup URLs. The Blueprint editor needs to create a separate Playground from its in-memory edited bundle.

Expose `createStoredSite()` for both inputs. Keep `setStoredSiteSpec` as the URL-compatible alias. Bundle creation persists the bundle before metadata and removes it if metadata creation fails.

No UI action is wired yet.