### PR TITLE
Make Playwright e2e runs reliable and flake-sensitive

### DIFF
--- a/packages/playground/common/vite.config.ts
+++ b/packages/playground/common/vite.config.ts
@@ -1,4 +1,5 @@
 /// <reference types='vitest' />
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vite';
 import dts from 'vite-plugin-dts';
 // eslint-disable-next-line @nx/enforce-module-boundaries
@@ -7,7 +8,10 @@ import { viteTsConfigPaths } from '../../vite-extensions/vite-ts-config-paths';
 import { getExternalModules } from '../../vite-extensions/vite-external-modules';
 // eslint-disable-next-line @nx/enforce-module-boundaries
 import viteGlobalExtensions from '../../vite-extensions/vite-global-extensions';
-const path = (filename: string) => new URL(filename, import.meta.url).pathname;
+
+// URL.pathname leaves spaces percent-encoded, while Vite needs a native filesystem path.
+const path = (filename: string) =>
+	fileURLToPath(new URL(filename, import.meta.url));
 export default defineConfig({
 	root: __dirname,
 	assetsInclude: ['**/*.wasm', '**/*.dat', '*.zip', '**/*.tar.zst'],

--- a/packages/playground/personal-wp/vite.config.ts
+++ b/packages/playground/personal-wp/vite.config.ts
@@ -36,7 +36,9 @@ const proxy: CommonServerOptions['proxy'] = {
 	},
 };
 
-const path = (filename: string) => new URL(filename, import.meta.url).pathname;
+// URL.pathname leaves spaces percent-encoded, while Vite needs a native filesystem path.
+const path = (filename: string) =>
+	fileURLToPath(new URL(filename, import.meta.url));
 export default defineConfig(({ command, mode }) => {
 	const isProductionBuild = mode === 'production';
 

--- a/packages/playground/php-cors-proxy/project.json
+++ b/packages/playground/php-cors-proxy/project.json
@@ -8,7 +8,7 @@
 			"executor": "nx:run-commands",
 			"options": {
 				"commands": [
-					"PLAYGROUND_CORS_PROXY_DISABLE_RATE_LIMIT=true php -S 127.0.0.1:5263"
+					"PLAYGROUND_CORS_PROXY_DISABLE_RATE_LIMIT=true php -d max_execution_time=120 -S 127.0.0.1:5263"
 				],
 				"cwd": "packages/playground/php-cors-proxy"
 			}

--- a/packages/playground/remote/project.json
+++ b/packages/playground/remote/project.json
@@ -43,6 +43,13 @@
 					"buildTarget": "playground-remote:build:development",
 					"hmr": true
 				},
+				"development-for-playwright": {
+					"buildTarget": "playground-remote:build:development",
+					"hmr": {
+						"host": "127.0.0.1",
+						"clientPort": 4400
+					}
+				},
 				"production": {
 					"buildTarget": "playground-remote:build:production",
 					"hmr": false

--- a/packages/playground/remote/vite.config.ts
+++ b/packages/playground/remote/vite.config.ts
@@ -2,6 +2,7 @@
 import { defineConfig } from 'vite';
 import type { Plugin } from 'vite';
 import { join } from 'path';
+import { fileURLToPath } from 'node:url';
 import dts from 'vite-plugin-dts';
 // eslint-disable-next-line @nx/enforce-module-boundaries
 import { remoteDevServerHost, remoteDevServerPort } from '../build-config';
@@ -16,10 +17,17 @@ import virtualModule from '../../vite-extensions/vite-virtual-module';
 import viteGlobalExtensions from '../../vite-extensions/vite-global-extensions';
 // eslint-disable-next-line @nx/enforce-module-boundaries
 import { isomorphicGitBrowserAlias } from '../../vite-extensions/vite-resolve-isomorphic-git';
+// eslint-disable-next-line @nx/enforce-module-boundaries
+import { vitePlaywrightHmr } from '../../vite-extensions/vite-playwright-hmr';
 
-const path = (filename: string) => new URL(filename, import.meta.url).pathname;
+// URL.pathname leaves spaces percent-encoded, so Vite cannot find files in a
+// worktree such as "WordPress Playground". Convert the file URL natively.
+const path = (filename: string) =>
+	fileURLToPath(new URL(filename, import.meta.url));
 
 const plugins = [
+	// This is inert unless the Playwright dev target opts into the Firefox fix.
+	vitePlaywrightHmr(),
 	viteTsConfigPaths({
 		root: '../../../',
 	}),
@@ -44,6 +52,25 @@ const plugins = [
 	} as Plugin,
 	...viteGlobalExtensions,
 	buildVersionPlugin('remote-config'),
+	{
+		name: 'dev-server-keep-alive',
+		apply: 'serve',
+		configureServer(server) {
+			const httpServer = server.httpServer;
+			if (
+				!httpServer ||
+				!('keepAliveTimeout' in httpServer) ||
+				!('headersTimeout' in httpServer)
+			) {
+				return;
+			}
+			// The website dev server keeps proxy sockets open. Node's five-second
+			// server default can close one just as the proxy reuses it for the next
+			// PHP-WASM boot, leaving that iframe without a WordPress archive.
+			httpServer.keepAliveTimeout = 60_000;
+			httpServer.headersTimeout = 65_000;
+		},
+	} as Plugin,
 ];
 
 export default defineConfig(({ mode }) => {
@@ -72,6 +99,18 @@ export default defineConfig(({ mode }) => {
 			'**/*.tar.zst',
 		],
 		cacheDir: '../../../node_modules/.vite/playground',
+		// Playground discovers these dependencies at different stages of boot.
+		// Pre-bundle them together so Vite does not invalidate chunks while the
+		// first PHP worker is still loading them.
+		optimizeDeps: {
+			include: [
+				'@zip.js/zip.js',
+				'ini',
+				'octokit',
+				'wasm-feature-detect',
+				'zstddec/stream',
+			],
+		},
 		resolve: {
 			alias: [isomorphicGitBrowserAlias()],
 		},
@@ -189,7 +228,8 @@ export default defineConfig(({ mode }) => {
 			sourcemap: true,
 			rollupOptions: {
 				input: {
-					wordpress: path('/remote.html'),
+					// Keep this relative so it resolves from this package, not filesystem root.
+					wordpress: path('remote.html'),
 				},
 				output: {
 					assetFileNames: (chunkInfo) => {

--- a/packages/playground/tools/vite.config.ts
+++ b/packages/playground/tools/vite.config.ts
@@ -1,4 +1,5 @@
 /// <reference types='vitest' />
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vite';
 import dts from 'vite-plugin-dts';
 // eslint-disable-next-line @nx/enforce-module-boundaries
@@ -7,7 +8,10 @@ import { viteTsConfigPaths } from '../../vite-extensions/vite-ts-config-paths';
 import { getExternalModules } from '../../vite-extensions/vite-external-modules';
 // eslint-disable-next-line @nx/enforce-module-boundaries
 import viteGlobalExtensions from '../../vite-extensions/vite-global-extensions';
-const path = (filename: string) => new URL(filename, import.meta.url).pathname;
+
+// URL.pathname leaves spaces percent-encoded, while Vite needs a native filesystem path.
+const path = (filename: string) =>
+	fileURLToPath(new URL(filename, import.meta.url));
 export default defineConfig({
 	root: __dirname,
 	cacheDir: '../../../node_modules/.vite/playground-tools',

--- a/packages/playground/website-extras/project.json
+++ b/packages/playground/website-extras/project.json
@@ -38,6 +38,13 @@
 					"buildTarget": "playground-website-extras:build:standalone:development",
 					"hmr": true
 				},
+				"development-for-playwright": {
+					"buildTarget": "playground-website-extras:build:standalone:development",
+					"hmr": {
+						"host": "127.0.0.1",
+						"clientPort": 6400
+					}
+				},
 				"production": {
 					"buildTarget": "playground-website-extras:build:standalone:production",
 					"hmr": false

--- a/packages/playground/website-extras/vite.config.ts
+++ b/packages/playground/website-extras/vite.config.ts
@@ -20,6 +20,8 @@ import virtualModule from '../../vite-extensions/vite-virtual-module';
 import viteGlobalExtensions from '../../vite-extensions/vite-global-extensions';
 // eslint-disable-next-line @nx/enforce-module-boundaries
 import { isomorphicGitBrowserAlias } from '../../vite-extensions/vite-resolve-isomorphic-git';
+// eslint-disable-next-line @nx/enforce-module-boundaries
+import { vitePlaywrightHmr } from '../../vite-extensions/vite-playwright-hmr';
 
 export default defineConfig(({ mode }) => {
 	const corsProxyUrl =
@@ -62,6 +64,8 @@ export default defineConfig(({ mode }) => {
 		},
 
 		plugins: [
+			// This is inert unless the Playwright dev target opts into the Firefox fix.
+			vitePlaywrightHmr(),
 			react({
 				jsxRuntime: 'automatic',
 			}),

--- a/packages/playground/website/playwright/README.md
+++ b/packages/playground/website/playwright/README.md
@@ -10,6 +10,9 @@ You first need to install Playwright to run the tests below:
 npx playwright install --with-deps
 ```
 
+Run this after `npm ci` or whenever the Playwright package version changes.
+Browser binaries cached for a different Playwright version are not reused.
+
 ## Run tests
 
 Runs the end-to-end tests.
@@ -21,25 +24,25 @@ npx nx run playground-website:e2e:playwright
 Starts the interactive UI mode.
 
 ```bash
-npx nx run playground-website:e2e:playwright --ui
+npx nx run playground-website:e2e:playwright -- --ui
 ```
 
 Runs the tests only on Desktop Chrome.
 
 ```bash
-npx nx run playground-website:e2e:playwright --project=chromium
+npx nx run playground-website:e2e:playwright -- --project=chromium
 ```
 
 Runs the tests in a specific file.
 
 ```bash
-npx nx run playground-website:e2e:playwright example
+npx nx run playground-website:e2e:playwright -- example
 ```
 
 Runs the tests in debug mode.
 
 ```bash
-npx nx run playground-website:e2e:playwright --debug
+npx nx run playground-website:e2e:playwright -- --debug
 ```
 
 Open the [Playwright Inspector](https://playwright.dev/docs/debug#picking-locators).
@@ -48,16 +51,77 @@ Open the [Playwright Inspector](https://playwright.dev/docs/debug#picking-locato
 npx playwright open https://playground.test/website-server/
 ```
 
+By default, the local Playwright target starts its own website dev server. To
+intentionally attach to a server you already started on port 5400, set:
+
+```bash
+PLAYWRIGHT_REUSE_EXISTING_SERVER=1 npx nx run playground-website:e2e:playwright
+```
+
+Without `PLAYWRIGHT_REUSE_EXISTING_SERVER=1`, the target fails early if any of
+the website dev-server ports are already in use. This prevents a fresh website
+server from proxying `remote.html` to a stale server from another branch or
+worktree.
+
+Local runs use one Playwright worker because concurrent dev-mode WASM boots
+contend heavily for the development server on macOS and can leave a remote
+iframe stuck before its worker starts. CI uses its built preview server and
+continues to use three workers.
+
+Every collected test runs twice, and failed tests are not retried. This makes
+either failed sample fail the command instead of allowing a later retry to hide
+an intermittent failure. Playwright records traces during both samples but
+deletes successful traces, retaining only the exact failing execution. Expect
+the repeated suite to take roughly twice as long as a single sample.
+
+The Playwright-managed development servers direct each Vite HMR client to the
+port of the server that injected it. The website proxies remote and
+website-extras HTTP traffic through port 5400, but it does not proxy their HMR
+WebSockets. Letting Vite first try the HTTP-facing port and then fall back to
+ports 4400 or 6400 can trip browser-driver network errors during iframe boot.
+The regular `npm run dev` server keeps its existing HMR configuration.
+
+The local Playwright dev servers mock Vite's internal HMR sockets at runtime in
+Firefox. Playwright's Firefox network adapter can terminate a test when an HMR
+request finishes after the socket-open event. Chromium and WebKit still use the
+native Vite HMR sockets. Application WebSockets are also unaffected, and CI
+uses the built preview server without this local server guard.
+
+Because Vite HMR is mocked in Firefox, a Firefox page that remains open in UI
+or debug mode does not pick up source changes. Reload the page or restart the
+test after making a change. Regular `npm run dev` sessions retain native HMR in
+Firefox.
+
+On macOS, the local Chromium project uses Playwright's full bundled Chromium;
+the headless shell crashes after repeated PHP-WASM contexts. Linux CI keeps its
+existing browser choice.
+
+The local macOS WebKit run executes each spec in a separate project and browser.
+Repeated PHP-WASM contexts can terminate WebKit's Networking process even
+though the current assertion completes, poisoning a later file's navigation.
+The partitions share the `webkit` project name, so selecting
+`--project=webkit` still runs the full WebKit suite. CI keeps the single WebKit
+project.
+
 ### Multisite tests
 
-Multisite tests don't work with URLs that include ports.
-To run these tests, set the `PLAYWRIGHT_TEST_BASE_URL` environment variable to the base URL of the website server.
+The front-end `My Sites` assertion does not work with a URL that includes an
+explicit port, so it is skipped with the default local URL. Other multisite
+tests still run. To include that assertion, set `PLAYWRIGHT_TEST_BASE_URL` to a
+website-server URL without a port.
 
 You can use [this guide to set up a local Multisite.](https://wordpress.github.io/wordpress-playground/contributing/code#running-a-local-multisite)
 
 ```bash
- PLAYWRIGHT_TEST_BASE_URL='https://playground.test/website-server/' npx nx run playground-website:e2e:playwright
+PLAYWRIGHT_TEST_BASE_URL='https://playground.test/website-server/' npx nx run playground-website:e2e:playwright
 ```
+
+### Direct CURLFile upload test
+
+The route-backed direct CURLFile upload test is skipped on macOS because
+Chromium does not expose its nested worker request to Playwright's page route.
+Linux CI runs that assertion. The separate CORS proxy upload regression test
+continues to run locally on macOS.
 
 ## Deployment tests
 
@@ -72,6 +136,14 @@ npx nx run playground-website:e2e:playwright:prepare-app-deploy-and-offline-mode
 
 ### Run
 
+The deployment target runs the preparation target automatically before the
+spec:
+
 ```bash
 npx nx run playground-website:e2e:playwright:deployment
 ```
+
+The screenshot assertions use Linux baselines. On other platforms, the
+deployment tests still run their behavioral assertions, but their names include
+`[WITHOUT SCREENSHOT COMPARE]` and the test prints a warning instead of
+generating local platform snapshots.

--- a/packages/playground/website/playwright/check-local-dev-server-ports.cjs
+++ b/packages/playground/website/playwright/check-local-dev-server-ports.cjs
@@ -1,0 +1,62 @@
+const net = require('node:net');
+
+// The website dev target launches and proxies this fixed-port stack. Check every
+// service up front so a partial stack cannot mix code from different worktrees.
+const ports = [
+	['playground-website', 5400],
+	['playground-remote', 4400],
+	['playground-php-cors-proxy', 5263],
+	['playground-website-extras', 6400],
+];
+
+async function main() {
+	// This escape hatch is for developers who intentionally manage the complete
+	// server stack themselves and accept responsibility for its provenance.
+	if (process.env.PLAYWRIGHT_REUSE_EXISTING_SERVER === '1') {
+		return;
+	}
+
+	const unavailable = [];
+	for (const [name, port] of ports) {
+		if (!(await canListen(port))) {
+			unavailable.push(`${name} on 127.0.0.1:${port}`);
+		}
+	}
+
+	if (unavailable.length === 0) {
+		return;
+	}
+
+	console.error(
+		`Local Playwright needs to start a clean dev-server stack, but these ` +
+			`ports are already in use:\n\n` +
+			unavailable.map((entry) => `  - ${entry}`).join('\n') +
+			`\n\nStop the existing process, or start the full dev server stack ` +
+			`yourself and set PLAYWRIGHT_REUSE_EXISTING_SERVER=1.`
+	);
+	process.exit(1);
+}
+
+function canListen(port) {
+	// Attempting the same bind that the dev server needs catches non-HTTP and
+	// half-started processes that an HTTP health probe could overlook.
+	return new Promise((resolve, reject) => {
+		const server = net.createServer();
+		server.unref();
+		server.on('error', (error) => {
+			if (error.code === 'EADDRINUSE') {
+				resolve(false);
+				return;
+			}
+			reject(error);
+		});
+		server.listen(port, '127.0.0.1', () => {
+			server.close(() => resolve(true));
+		});
+	});
+}
+
+main().catch((error) => {
+	console.error(error);
+	process.exit(1);
+});

--- a/packages/playground/website/playwright/e2e/blueprints.spec.ts
+++ b/packages/playground/website/playwright/e2e/blueprints.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '../playground-fixtures';
+import type { TestInfo } from '@playwright/test';
 import type { Blueprint } from '@wp-playground/blueprints';
 import { encodeStringAsBase64 } from '../../src/lib/base64';
 
@@ -246,13 +247,15 @@ test('enableMultisite step should enable a multisite', async ({
 	website,
 	wordpress,
 	browserName,
-}) => {
+}, testInfo) => {
 	test.skip(
 		browserName === 'firefox',
 		`The multisite tests consistently fail in CI on Firefox. The root cause is unknown, ` +
 			'but the issue does not occur in local testing or on https://playground.wordpress.net/. ' +
 			'Perhaps it is related to using Firefox nightly or something highly specific to the CI runtime.'
 	);
+	skipIfBaseURLUsesPort(testInfo);
+
 	const blueprint: Blueprint = {
 		landingPage: '/',
 		steps: [{ step: 'enableMultisite' }],
@@ -492,6 +495,12 @@ test('CURLFile uploads via curl_exec() should work', async ({
 		`The curl_exec() tests often fail in CI on Firefox and WebKit. The root cause is unknown, ` +
 			'but the issue does not occur in local testing or on https://playground.wordpress.net/. ' +
 			'Perhaps it is something highly specific to the CI runtime.'
+	);
+	test.skip(
+		process.platform === 'darwin',
+		`Playwright page routes do not intercept this nested worker request in ` +
+			`Chromium on macOS. Linux CI covers the route-backed assertion, and ` +
+			`the CORS proxy upload test below still runs locally.`
 	);
 	const uploadUrl = 'https://curlfile-upload.test/post';
 	await website.page.route(uploadUrl, async (route) => {
@@ -970,6 +979,18 @@ test('should correctly redirect to a multisite wp-admin url', async ({
 	await website.goto(`./#${encodedBlueprint}`);
 	await expect(wordpress.locator('body')).toContainText('General Settings');
 });
+
+function skipIfBaseURLUsesPort(testInfo: TestInfo) {
+	const baseURL = String(testInfo.project.use.baseURL);
+	const port = new URL(baseURL).port;
+	// This front-end toolbar assertion depends on WordPress multisite's
+	// port-sensitive URL and cookie behavior. CI covers it on port 80.
+	test.skip(
+		port !== '',
+		`This multisite assertion requires a base URL without an explicit port. ` +
+			`Current baseURL is ${baseURL}.`
+	);
+}
 
 ['latest', 'trunk', 'beta'].forEach((wpVersion) => {
 	test(`should translate WP-admin to Spanish for the ${wpVersion} WordPress build`, async ({

--- a/packages/playground/website/playwright/e2e/deployment.spec.ts
+++ b/packages/playground/website/playwright/e2e/deployment.spec.ts
@@ -1,5 +1,7 @@
 /* eslint-disable no-loop-func */
-import path from 'path';
+import { existsSync } from 'node:fs';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import type { TestInfo } from '@playwright/test';
 import { test, expect } from '../playground-fixtures.ts';
 import { startVersionSwitchingServer as startServer } from '../version-switching-server.ts';
 
@@ -21,24 +23,60 @@ url.searchParams.set('storage', 'temp');
 url.searchParams.set('theme', 'twentytwentyfour');
 
 const maxDiffPixels = 10_000;
+// Only Linux snapshots are committed. Non-Linux runs still exercise the
+// deployment behavior, but their titles and stderr make the missing visual
+// comparison explicit.
+const shouldCompareDeploymentScreenshots = process.platform === 'linux';
+const screenshotComparisonSuffix = shouldCompareDeploymentScreenshots
+	? ''
+	: ' [WITHOUT SCREENSHOT COMPARE]';
+// Preserve native worktree paths; URL.pathname would leave spaces encoded as %20.
+const deploymentSpecUrl = pathToFileURL(__filename);
+const deploymentDirectories = {
+	old: fileURLToPath(
+		new URL(
+			'../../../../../dist/packages/playground/wasm-wordpress-net-old',
+			deploymentSpecUrl
+		)
+	),
+	mid: fileURLToPath(
+		new URL(
+			'../../../../../dist/packages/playground/wasm-wordpress-net-mid',
+			deploymentSpecUrl
+		)
+	),
+	new: fileURLToPath(
+		new URL(
+			'../../../../../dist/packages/playground/wasm-wordpress-net-new',
+			deploymentSpecUrl
+		)
+	),
+};
 
 let server: Awaited<ReturnType<typeof startServer>> | null = null;
 
 test.beforeEach(async () => {
+	const missingDeploymentDirectories = getMissingDeploymentDirectories();
+	// These app builds are expensive and are prepared by a dedicated target.
+	// A clean local checkout should skip with an actionable command, not serve
+	// empty directories and time out while waiting for the nested iframe. CI
+	// prepares these builds and must fail if that preparation stops working.
+	if (missingDeploymentDirectories.length > 0) {
+		const message =
+			`Deployment tests require prepared Playground app builds. ` +
+			`Missing: ${missingDeploymentDirectories.join(', ')}. ` +
+			`Run: npx nx run playground-website:e2e:playwright:prepare-app-deploy-and-offline-mode`;
+		if (process.env.CI) {
+			throw new Error(message);
+		}
+		test.skip(true, message);
+	}
+
 	server = await startServer({
 		port,
-		oldVersionDirectory: path.join(
-			__dirname,
-			'../../../../../dist/packages/playground/wasm-wordpress-net-old'
-		),
-		midVersionDirectory: path.join(
-			__dirname,
-			'../../../../../dist/packages/playground/wasm-wordpress-net-mid'
-		),
-		newVersionDirectory: path.join(
-			__dirname,
-			'../../../../../dist/packages/playground/wasm-wordpress-net-new'
-		),
+		oldVersionDirectory: deploymentDirectories.old,
+		midVersionDirectory: deploymentDirectories.mid,
+		newVersionDirectory: deploymentDirectories.new,
 	});
 	server.switchToOldVersion();
 	server.setHttpCacheEnabled(true);
@@ -61,14 +99,22 @@ for (const cachingEnabled of [true, false]) {
 	 */
 	test(`When a new website version is deployed, it should be loaded upon a regular page refresh (with HTTP caching ${
 		cachingEnabled ? 'enabled' : 'disabled'
-	})`, async ({ website, page, wordpress }) => {
+	})${screenshotComparisonSuffix}`, async ({
+		website,
+		page,
+		wordpress,
+	}, testInfo) => {
 		server!.setHttpCacheEnabled(cachingEnabled);
 
 		await page.goto(url.href);
 		await website.waitForNestedIframes();
-		await expect(page).toHaveScreenshot('website-old.png', {
-			maxDiffPixels,
-		});
+		if (shouldCompareDeploymentScreenshots) {
+			await expect(page).toHaveScreenshot('website-old.png', {
+				maxDiffPixels,
+			});
+		} else {
+			warnWithoutDeploymentScreenshotCompare(testInfo);
+		}
 
 		server!.switchToNewVersion();
 		await page.goto(url.href);
@@ -78,6 +124,14 @@ for (const cachingEnabled of [true, false]) {
 			'My WordPress Website'
 		);
 	});
+}
+
+function warnWithoutDeploymentScreenshotCompare(testInfo: TestInfo) {
+	process.stderr.write(
+		`[playwright:e2e] WARNING: ${testInfo.title} is running ` +
+			`WITHOUT SCREENSHOT COMPARE. Deployment screenshot baselines ` +
+			`are only committed for Linux; this platform is ${process.platform}.\n`
+	);
 }
 
 /**
@@ -174,3 +228,9 @@ test('offline mode – the app should load even when the server goes offline', a
 		'My WordPress Website'
 	);
 });
+
+function getMissingDeploymentDirectories() {
+	return Object.values(deploymentDirectories).filter(
+		(directory) => !existsSync(directory)
+	);
+}

--- a/packages/playground/website/playwright/e2e/opfs.spec.ts
+++ b/packages/playground/website/playwright/e2e/opfs.spec.ts
@@ -815,8 +815,17 @@ test('should block closing and finish during a ZIP import', async ({
 	});
 	await expect(importingButton).toBeVisible();
 	const saveStatus = website.page.getByRole('button', { name: 'Unsaved' });
-	await expect(saveStatus).toBeDisabled();
-	await saveStatus.evaluate((button: HTMLButtonElement) => button.click());
+	// The import activates its saved target asynchronously, replacing this
+	// transient button with static "Saved" text. Assert and click in one browser
+	// task so Playwright does not re-resolve the stale accessible name in between.
+	const saveStatusWasDisabled = await saveStatus.evaluate(
+		(button: HTMLButtonElement) => {
+			const wasDisabled = button.disabled;
+			button.click();
+			return wasDisabled;
+		}
+	);
+	expect(saveStatusWasDisabled).toBe(true);
 	await expect(
 		website.page.getByRole('dialog', { name: 'New Playground pane' })
 	).toBeVisible();

--- a/packages/playground/website/playwright/e2e/php-code-snippet.spec.ts
+++ b/packages/playground/website/playwright/e2e/php-code-snippet.spec.ts
@@ -666,7 +666,12 @@ test.describe('php-code-snippet embed', () => {
 
 		await expect(snippet).toBeVisible();
 		await ensurePlaygroundClientIsServed(page);
-		await ensureToolkitAutoloadIsServed(page);
+		const toolkitAutoloadUrl = new URL(
+			'php-toolkit-autoload.txt',
+			page.url()
+		).href;
+		await ensureToolkitAutoloadIsServed(page, toolkitAutoloadUrl);
+		await setToolkitAutoloadUrl(page, toolkitAutoloadUrl);
 		await snippet.evaluate((element) => {
 			element.setAttribute('playground-origin', window.location.origin);
 		});
@@ -801,8 +806,7 @@ async function ensurePlaygroundClientIsServed(page: Page) {
 	});
 }
 
-async function ensureToolkitAutoloadIsServed(page: Page) {
-	const autoloadUrl = new URL('/php-toolkit-autoload.txt', page.url()).href;
+async function ensureToolkitAutoloadIsServed(page: Page, autoloadUrl: string) {
 	const response = await page.request.get(autoloadUrl);
 	if (response.ok()) {
 		return;
@@ -814,6 +818,21 @@ async function ensureToolkitAutoloadIsServed(page: Page) {
 			contentType: 'text/plain',
 		});
 	});
+}
+
+async function setToolkitAutoloadUrl(page: Page, autoloadUrl: string) {
+	await page.evaluate((url) => {
+		const setupScript = document.getElementById('toolkit-setup');
+		if (!setupScript?.textContent) {
+			throw new Error('Could not find the toolkit setup Blueprint.');
+		}
+		const blueprint = JSON.parse(setupScript.textContent);
+		// The fixture Blueprint was authored for the deployed website root.
+		// Local Playwright serves it under /website-server/, so rewrite the URL
+		// to the fixture's actual origin/path before the snippet boots.
+		blueprint.steps[1].data.url = url;
+		setupScript.textContent = JSON.stringify(blueprint);
+	}, autoloadUrl);
 }
 
 async function waitForPhpSnippetDefinition(page: Page) {

--- a/packages/playground/website/playwright/e2e/php-code-snippet.spec.ts
+++ b/packages/playground/website/playwright/e2e/php-code-snippet.spec.ts
@@ -408,9 +408,15 @@ test.describe('php-code-snippet embed', () => {
 
 		await editable.evaluate((snippet: any) => {
 			snippet._testRunCount = 0;
+			snippet._testRunGate = new Promise<void>((resolve) => {
+				snippet._releaseTestRun = resolve;
+			});
 			snippet._runOnce = async function () {
 				this._testRunCount += 1;
-				await new Promise((resolve) => setTimeout(resolve, 100));
+				if (this._testRunCount === 1) {
+					// Keep the first run active until the test has queued the second one.
+					await this._testRunGate;
+				}
 				const outputWrap = this.shadowRoot.querySelector('.output');
 				const outputBody =
 					this.shadowRoot.querySelector('.output-body');
@@ -424,11 +430,16 @@ test.describe('php-code-snippet embed', () => {
 		await expect(runButton).toHaveAttribute('aria-busy', /true/);
 		await expect(runButton).toBeEnabled();
 		await runButton.click();
+		await expect(editable.locator('.run-label')).toHaveText('Queued');
+
+		// Release the first run only after every transient queued state is observed.
+		await editable.evaluate((snippet: any) => snippet._releaseTestRun());
 
 		await expect(editable.locator('.output-body')).toContainText(
 			'run-count:2'
 		);
 		await expect(runButton).toBeEnabled();
+		await expect(runButton).not.toHaveAttribute('aria-busy', /true/);
 	});
 
 	test('Run button starts from pointer activation even if click is canceled', async ({
@@ -713,9 +724,13 @@ test.describe('php-code-snippet embed', () => {
 		const runShortcut = editable.locator('.run-shortcut');
 
 		await editable.evaluate((snippet: any) => {
+			snippet._testRunGate = new Promise<void>((resolve) => {
+				snippet._releaseTestRun = resolve;
+			});
 			snippet._runOnce = async function (code: string) {
 				this._setRunButtonProgress('Running', 42);
-				await new Promise((resolve) => setTimeout(resolve, 500));
+				// Hold this state until the test has inspected every progress indicator.
+				await this._testRunGate;
 				const outputWrap = this.shadowRoot.querySelector('.output');
 				const outputBody =
 					this.shadowRoot.querySelector('.output-body');
@@ -742,6 +757,9 @@ test.describe('php-code-snippet embed', () => {
 		await expect(runShortcut).toBeHidden();
 		await expect(runLabel).toHaveText('Running');
 		await expect(runPercent).toHaveText('42%');
+
+		// Completion is test-controlled so browser speed cannot hide the progress state.
+		await editable.evaluate((snippet: any) => snippet._releaseTestRun());
 		await expect(outputBody).toContainText('slow-run-marker', {
 			timeout: 60_000,
 		});

--- a/packages/playground/website/playwright/e2e/query-api.spec.ts
+++ b/packages/playground/website/playwright/e2e/query-api.spec.ts
@@ -149,7 +149,12 @@ test.describe('option `php-extension`', () => {
 			'php-extension': noArtifactManifestUrl,
 		});
 
-		await expectSiteBootError(website.page);
+		// Match the terminal loader error so an unrelated boot message cannot
+		// satisfy the assertion first on a slower browser.
+		await expectSiteBootError(
+			website.page,
+			'No extension artifact found for PHP 8.3.'
+		);
 	});
 });
 

--- a/packages/playground/website/playwright/e2e/sites-api.spec.ts
+++ b/packages/playground/website/playwright/e2e/sites-api.spec.ts
@@ -1,14 +1,14 @@
 import { test, expect } from '../playground-fixtures';
 
 test('window.playgroundSites is exposed after boot', async ({ website }) => {
-	await website.goto('./');
+	await website.goto(getSitesApiTestUrl());
 	await website.page.waitForFunction(() =>
 		Boolean((window as any).playgroundSites?.getClient())
 	);
 });
 
 test('playgroundSites.list() returns the active site', async ({ website }) => {
-	await website.goto('./');
+	await website.goto(getSitesApiTestUrl());
 	await website.page.waitForFunction(() =>
 		Boolean((window as any).playgroundSites?.getClient())
 	);
@@ -34,7 +34,7 @@ test('playgroundSites.saveInBrowser() persists a temporary site', async ({
 		`This test relies on OPFS which isn't available in Playwright's flavor of ${browserName}.`
 	);
 
-	await website.goto('./?storage=temp');
+	await website.goto(getSitesApiTestUrl());
 	await website.page.waitForFunction(() =>
 		Boolean((window as any).playgroundSites?.getClient())
 	);
@@ -55,7 +55,7 @@ test('playgroundSites.autosaveTemporarySite() persists without disrupting the ta
 		`This test relies on OPFS which isn't available in Playwright's flavor of ${browserName}.`
 	);
 
-	await website.goto('./?storage=temp');
+	await website.goto(getSitesApiTestUrl());
 	await website.page.waitForFunction(() =>
 		Boolean((window as any).playgroundSites?.getClient())
 	);
@@ -219,7 +219,7 @@ test('playgroundSites.createNewSavedSite() creates unique slugs for repeated Blu
 		},
 		steps: [],
 	};
-	await website.goto('./?storage=temp');
+	await website.goto(getSitesApiTestUrl());
 	await website.page.waitForFunction(() =>
 		Boolean((window as any).playgroundSites?.getClient())
 	);
@@ -279,7 +279,7 @@ test('playgroundSites.createNewSavedSite() creates an explicit OPFS site by defa
 		`This test relies on OPFS which isn't available in Playwright's flavor of ${browserName}.`
 	);
 
-	await website.goto('./?storage=temp');
+	await website.goto(getSitesApiTestUrl());
 	await website.page.waitForFunction(() =>
 		Boolean((window as any).playgroundSites?.getClient())
 	);
@@ -320,7 +320,7 @@ test('playgroundSites.rename() renames a saved site', async ({
 		`This test relies on OPFS which isn't available in Playwright's flavor of ${browserName}.`
 	);
 
-	await website.goto('./');
+	await website.goto(getSitesApiTestUrl());
 	await website.page.waitForFunction(() =>
 		Boolean((window as any).playgroundSites?.getClient())
 	);
@@ -340,7 +340,7 @@ test('playgroundSites.rename() renames a saved site', async ({
 test('playgroundSites.getClient() returns a playground client', async ({
 	website,
 }) => {
-	await website.goto('./');
+	await website.goto(getSitesApiTestUrl());
 	await website.page.waitForFunction(() =>
 		Boolean((window as any).playgroundSites?.getClient())
 	);
@@ -355,7 +355,7 @@ test('playgroundSites.getClient() returns a playground client', async ({
 test('playgroundSites.isReady() resolves once the active site is ready', async ({
 	website,
 }) => {
-	await website.goto('./');
+	await website.goto(getSitesApiTestUrl());
 	await website.page.waitForFunction(() =>
 		Boolean((window as any).playgroundSites)
 	);
@@ -373,8 +373,8 @@ test('playgroundSites.isReady() waits when the client is not in the store yet', 
 	page,
 }) => {
 	// Install a setter on window.playgroundSites BEFORE the app runs.
-	// The setter captures the moment of exposure and snapshots the client
-	// state so we can prove the test really hit the "not yet ready" path.
+	// The setter invokes isReady() at the moment of exposure so later test
+	// scheduling cannot miss the "not yet ready" path.
 	await page.addInitScript(() => {
 		let api: any;
 		Object.defineProperty(window, 'playgroundSites', {
@@ -384,44 +384,54 @@ test('playgroundSites.isReady() waits when the client is not in the store yet', 
 			},
 			set(v) {
 				api = v;
-				let clientAtExposure: unknown = 'missing';
+				const order = ['api-exposed'];
+				let hadClientWhenInvoked = false;
 				try {
-					clientAtExposure = v?.getClient();
-				} catch (e) {
-					clientAtExposure = `THREW:${(e as Error).message}`;
+					hadClientWhenInvoked = v.getClient() != null;
+				} catch {
+					// No active site has been selected yet, so no client exists.
 				}
-				(window as any).__sitesApiExposure = {
-					hadClientAtExposure:
-						clientAtExposure != null &&
-						typeof clientAtExposure !== 'string',
-					exposureSnapshot: String(clientAtExposure),
+
+				order.push('isReady-invoked');
+				const readiness = v.isReady().then(() => {
+					const hasClientWhenResolved = v.getClient() != null;
+					order.push('isReady-resolved');
+					return { hasClientWhenResolved };
+				});
+				(window as any).__sitesApiReadinessProbe = {
+					hadClientWhenInvoked,
+					order,
+					readiness,
 				};
 			},
 		});
 	});
-	await page.goto('./');
+	await page.goto(getSitesApiTestUrl());
 	await page.waitForFunction(() => Boolean((window as any).playgroundSites));
 
 	const result = await page.evaluate(async () => {
-		const api = (window as any).playgroundSites;
-		const exposure = (window as any).__sitesApiExposure;
-		const t0 = performance.now();
-		await api.isReady();
-		const isReadyMs = performance.now() - t0;
-		const clientAfter = api.getClient();
+		const probe = (window as any).__sitesApiReadinessProbe;
+		const resolution = await probe.readiness;
 		return {
-			hadClientAtExposure: exposure?.hadClientAtExposure,
-			exposureSnapshot: exposure?.exposureSnapshot,
-			isReadyMs,
-			hasClientAfter: clientAfter != null,
+			hadClientWhenInvoked: probe.hadClientWhenInvoked,
+			hasClientWhenResolved: resolution.hasClientWhenResolved,
+			order: probe.order,
 		};
 	});
 
-	// The test is only meaningful if we actually caught the unready window.
-	expect(result.hadClientAtExposure).toBe(false);
-	// After isReady() resolves, the client must be present.
-	expect(result.hasClientAfter).toBe(true);
-	// And isReady() must not have returned instantly — it had to wait for
-	// the boot to finish.
-	expect(result.isReadyMs).toBeGreaterThan(50);
+	// Event order proves isReady() waited without imposing a machine-speed
+	// threshold that can become flaky under load.
+	expect(result.hadClientWhenInvoked).toBe(false);
+	expect(result.hasClientWhenResolved).toBe(true);
+	expect(result.order).toEqual([
+		'api-exposed',
+		'isReady-invoked',
+		'isReady-resolved',
+	]);
 });
+
+function getSitesApiTestUrl() {
+	// These tests exercise the public sites API, not the live welcome Blueprint.
+	// Supplying an empty Blueprint keeps them independent of raw.githubusercontent.com.
+	return `./?storage=temp#${JSON.stringify({ steps: [] })}`;
+}

--- a/packages/playground/website/playwright/e2e/website-ui.spec.ts
+++ b/packages/playground/website/playwright/e2e/website-ui.spec.ts
@@ -92,15 +92,20 @@ async function replaceBlueprintEditorContents(
 	// Wait for CodeMirror editor to load.
 	const editor = page.locator('[class*="blueprint-editor"] .cm-editor');
 	await editor.waitFor({ timeout: 10000 });
+	const runButton = page.getByRole('button', {
+		name: /^(?:Run Blueprint|Run in a new Playground|Discard current Playground & run Blueprint)$/,
+	});
+	await expect(runButton).toHaveAttribute('aria-busy', 'false', {
+		timeout: 5000,
+	});
 
 	// Focus the editor and select all existing content before replacing it.
 	await editor.click();
-	await page.waitForTimeout(100);
+	await expect(editor.locator('.cm-content')).toBeFocused();
 	await page.keyboard.press(
 		process.platform === 'darwin' ? 'Meta+A' : 'Control+A'
 	);
 	await page.keyboard.press('Backspace');
-	await page.waitForTimeout(100);
 
 	// Use Playwright's fill method on the contenteditable .cm-content element.
 	// This is more reliable than character-by-character typing which triggers
@@ -109,12 +114,18 @@ async function replaceBlueprintEditorContents(
 	const cmContent = editor.locator('.cm-content');
 	await cmContent.fill(blueprintJson);
 
-	// Wait for validation to complete (linter has 300ms debounce), then verify
-	// the Blueprint was inserted by checking the editor content.
-	await page.waitForTimeout(500);
+	// Observe validation for this document enter and leave its semantic busy state.
+	await expect(runButton).toHaveAttribute('aria-busy', 'true', {
+		timeout: 5000,
+	});
+	await expect(runButton).toBeDisabled();
 	await expect(cmContent).toContainText('writeFile', {
 		timeout: 5000,
 	});
+	await expect(runButton).toHaveAttribute('aria-busy', 'false', {
+		timeout: 5000,
+	});
+	await expect(runButton).toBeEnabled();
 }
 
 /**
@@ -742,29 +753,44 @@ test('should edit a file on mobile and see changes in the viewport', async ({
 		.dblclick();
 
 	// Wait for CodeMirror editor to load
-	const editor = website.page.locator('[class*="file-browser"] .cm-editor');
+	const fileBrowser = website.page.locator('[class*="file-browser"]');
+	const editor = fileBrowser.locator('.cm-editor');
 	await editor.waitFor({ timeout: 10000 });
+	const cmContent = editor.locator('.cm-content');
 	const saveButton = filesPane.getByRole('button', {
 		name: /^(Save|Saved|Saving…)$/,
 	});
 
-	// Click on the editor to focus it
-	await website.page.waitForTimeout(50);
-
-	await editor.click();
-
-	await website.page.waitForTimeout(250);
-
-	// Select all content in the editor (Cmd+A or Ctrl+A)
-	await website.page.keyboard.press(
-		process.platform === 'darwin' ? 'Meta+A' : 'Control+A'
-	);
-
-	await website.page.keyboard.press('Backspace');
-	await website.page.waitForTimeout(200);
-
-	// Type the new content with a delay between keystrokes
-	await website.page.keyboard.type('Edited file', { delay: 50 });
+	// File opening schedules cursor restoration; take focus after it settles.
+	await website.page.waitForTimeout(150);
+	await cmContent.click();
+	await expect(cmContent).toBeFocused();
+	const selectionCoversEditor = () =>
+		cmContent.evaluate((element) => {
+			const normalize = (text: string) => text.replace(/\s/g, '');
+			const selectedText = normalize(
+				window.getSelection()?.toString() ?? ''
+			);
+			const editorText = normalize((element as HTMLElement).innerText);
+			return editorText.length > 0 && selectedText === editorText;
+		});
+	for (let attempt = 0; attempt < 3; attempt++) {
+		await cmContent.press('ControlOrMeta+a');
+		await cmContent.evaluate(
+			() =>
+				new Promise<void>((resolve) =>
+					requestAnimationFrame(() =>
+						requestAnimationFrame(() => resolve())
+					)
+				)
+		);
+		if (await selectionCoversEditor()) {
+			break;
+		}
+	}
+	expect(await selectionCoversEditor()).toBe(true);
+	await cmContent.pressSequentially('Edited file', { delay: 100 });
+	await expect(cmContent).toHaveText('Edited file');
 
 	await expect(saveButton).toBeEnabled();
 
@@ -833,8 +859,7 @@ test('should edit a blueprint in the blueprint editor and recreate the playgroun
 		})
 		.click();
 
-	await website.page.waitForTimeout(1500);
-	// Wait for the playground to recreate
+	// Wait for rendered WordPress content instead of assuming recreation timing.
 	await website.waitForNestedIframes();
 
 	// Verify the page shows "Blueprint test"

--- a/packages/playground/website/playwright/e2e/website-ui.spec.ts
+++ b/packages/playground/website/playwright/e2e/website-ui.spec.ts
@@ -85,6 +85,23 @@ async function getRunningPhpVersion(page: Page) {
 	});
 }
 
+/**
+ * Waits for a settings submission to replace and fully boot the temporary site.
+ */
+async function waitForTemporaryPlaygroundReset(
+	page: Page,
+	previousSiteSlug: string
+) {
+	// The settings form starts an asynchronous replacement. Waiting for the
+	// active slug prevents the old, already-ready client from satisfying isReady().
+	await expect
+		.poll(async () => (await getActivePlaygroundSite(page))?.slug, {
+			timeout: 120_000,
+		})
+		.not.toBe(previousSiteSlug);
+	await page.evaluate(() => (window as any).playgroundSites.isReady());
+}
+
 async function replaceBlueprintEditorContents(
 	page: Page,
 	blueprint: Blueprint
@@ -588,16 +605,22 @@ SupportedPHPVersions.forEach(async (version) => {
 	test(`should switch PHP version to ${version}`, async ({ website }) => {
 		await website.goto('./?storage=temp');
 		await website.ensureSiteManagerIsOpen();
-		await website.page.getByLabel('PHP version').selectOption(version);
+		const previousSite = await getActivePlaygroundSite(website.page);
+		const phpVersion = website.page.getByLabel('PHP version');
+		await phpVersion.selectOption(version);
+		// Confirm the controlled form retained the user's choice before submit.
+		await expect(phpVersion).toHaveValue(version);
 		await website.page
 			.getByText('Discard current work & create a fresh Playground')
 			.click();
-		await website.ensureSiteManagerIsClosed();
-		await website.ensureSiteManagerIsOpen();
+		await expect
+			.poll(() => new URL(website.page.url()).searchParams.get('php'), {
+				timeout: 120_000,
+			})
+			.toBe(version);
+		await waitForTemporaryPlaygroundReset(website.page, previousSite.slug);
 
-		await expect(website.page.getByLabel('PHP version')).toHaveValue(
-			version
-		);
+		await expect(phpVersion).toHaveValue(version);
 	});
 });
 
@@ -610,18 +633,20 @@ Object.keys(MinifiedWordPressVersions)
 		}) => {
 			await website.goto('./?storage=temp');
 			await website.ensureSiteManagerIsOpen();
-			await website.page
-				.getByLabel('WordPress version')
-				.selectOption(version);
+			const previousSite = await getActivePlaygroundSite(website.page);
+			const wordpressVersion =
+				website.page.getByLabel('WordPress version');
+			await wordpressVersion.selectOption(version);
+			await expect(wordpressVersion).toHaveValue(version);
 			await website.page
 				.getByText('Discard current work & create a fresh Playground')
 				.click();
-			await website.ensureSiteManagerIsClosed();
-			await website.ensureSiteManagerIsOpen();
+			await waitForTemporaryPlaygroundReset(
+				website.page,
+				previousSite.slug
+			);
 
-			await expect(
-				website.page.getByLabel('WordPress version')
-			).toHaveValue(version);
+			await expect(wordpressVersion).toHaveValue(version);
 		});
 	});
 
@@ -643,12 +668,12 @@ test('should enable networking when requested', async ({ website }) => {
 	await website.goto('./?storage=temp');
 
 	await website.ensureSiteManagerIsOpen();
+	const previousSite = await getActivePlaygroundSite(website.page);
 	await website.page.getByLabel('Network access').check();
 	await website.page
 		.getByText('Discard current work & create a fresh Playground')
 		.click();
-	await website.ensureSiteManagerIsClosed();
-	await website.ensureSiteManagerIsOpen();
+	await waitForTemporaryPlaygroundReset(website.page, previousSite.slug);
 
 	await expect(website.page.getByLabel('Network access')).toBeChecked();
 });
@@ -657,12 +682,12 @@ test('should disable networking when requested', async ({ website }) => {
 	await website.goto('./?storage=temp&networking=yes');
 
 	await website.ensureSiteManagerIsOpen();
+	const previousSite = await getActivePlaygroundSite(website.page);
 	await website.page.getByLabel('Network access').uncheck();
 	await website.page
 		.getByText('Discard current work & create a fresh Playground')
 		.click();
-	await website.ensureSiteManagerIsClosed();
-	await website.ensureSiteManagerIsOpen();
+	await waitForTemporaryPlaygroundReset(website.page, previousSite.slug);
 
 	await expect(website.page.getByLabel('Network access')).not.toBeChecked();
 });
@@ -708,11 +733,12 @@ test('should keep query arguments when updating settings', async ({
 	).toMatch('/wp-admin/');
 
 	await website.ensureSiteManagerIsOpen();
+	const previousSite = await getActivePlaygroundSite(website.page);
 	await website.page.getByLabel('Network access').check();
 	await website.page
 		.getByText('Discard current work & create a fresh Playground')
 		.click();
-	await website.waitForNestedIframes();
+	await waitForTemporaryPlaygroundReset(website.page, previousSite.slug);
 
 	const updatedParams = new URL(website.page.url()).searchParams;
 	expect(updatedParams.get('storage')).toBe('temp');

--- a/packages/playground/website/playwright/playwright.config.ts
+++ b/packages/playground/website/playwright/playwright.config.ts
@@ -4,6 +4,47 @@ import { defineConfig, devices } from '@playwright/test';
 const baseURL =
 	process.env.PLAYWRIGHT_TEST_BASE_URL ||
 	'http://127.0.0.1:5400/website-server/';
+// Reusing port 5400 by default can attach tests to a stale dev server from
+// another branch/worktree. Make that opt-in for local debugging.
+const reuseExistingServer =
+	process.env.PLAYWRIGHT_REUSE_EXISTING_SERVER === '1';
+const webkitUse = { ...devices['Desktop Safari'] };
+// The catch-all project below keeps new specs covered. Add them here as they
+// are created so each one gets its own local WebKit process too.
+const macosWebkitIsolatedSpecs = [
+	'blueprints.spec.ts',
+	'client-side-media.spec.ts',
+	'client.spec.ts',
+	'deployment.spec.ts',
+	'document-isolation-policy.spec.ts',
+	'error-handling.spec.ts',
+	'github-oauth.spec.ts',
+	'isomorphic-git-bundle.spec.ts',
+	'opfs.spec.ts',
+	'php-code-snippet.spec.ts',
+	'query-api.spec.ts',
+	'shutdown-loopback-prefetch.spec.ts',
+	'sites-api.spec.ts',
+	'standalone-pr-previewers.spec.ts',
+	'website-ui.spec.ts',
+] as const;
+const webkitProjects =
+	process.platform === 'darwin' && !process.env.CI
+		? [
+				...macosWebkitIsolatedSpecs.map((testFile) => ({
+					name: 'webkit',
+					testMatch: `**/${testFile}`,
+					use: webkitUse,
+				})),
+				{
+					name: 'webkit',
+					testIgnore: macosWebkitIsolatedSpecs.map(
+						(testFile) => `**/${testFile}`
+					),
+					use: webkitUse,
+				},
+			]
+		: [{ name: 'webkit', use: webkitUse }];
 
 export const playwrightConfig: PlaywrightTestConfig = {
 	testDir: './e2e',
@@ -11,16 +52,21 @@ export const playwrightConfig: PlaywrightTestConfig = {
 	fullyParallel: true,
 	/* Fail the build on CI if you accidentally left test.only in the source code. */
 	forbidOnly: !!process.env.CI,
-	retries: 3,
-	workers: 3,
+	// Two independent samples expose intermittent failures without allowing a retry to hide one.
+	repeatEach: 2,
+	retries: 0,
+	// Concurrent dev-mode PHP-WASM boots can stall one another before their
+	// remote workers start. CI uses a built preview server and keeps 3 workers.
+	workers: process.env.CI ? 3 : 1,
 	/* Reporter to use. See https://playwright.dev/docs/test-reporters */
 	reporter: [['html'], ['list', { printSteps: true }]],
 	/* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
 	use: {
 		/* Base URL to use in actions like `await page.goto('/')`. */
 		baseURL,
-		/* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
-		trace: 'on-first-retry',
+		// With retries disabled, on-first-retry records nothing. Capture every run,
+		// but discard successful traces so only actionable artifacts are retained.
+		trace: 'retain-on-failure',
 		actionTimeout: 120000,
 		navigationTimeout: 120000,
 	},
@@ -37,6 +83,12 @@ export const playwrightConfig: PlaywrightTestConfig = {
 				launchOptions: {
 					args: ['--js-flags=--enable-experimental-webassembly-jspi'],
 				},
+				// The macOS headless shell crashes after repeated PHP-WASM
+				// contexts. The bundled Chromium channel uses the stable full
+				// browser in new headless mode. Keep CI's existing browser choice.
+				...(process.platform === 'darwin' && !process.env.CI
+					? { channel: 'chromium' }
+					: {}),
 			},
 		},
 		{
@@ -44,10 +96,11 @@ export const playwrightConfig: PlaywrightTestConfig = {
 			use: { ...devices['Desktop Firefox'] },
 		},
 
-		{
-			name: 'webkit',
-			use: { ...devices['Desktop Safari'] },
-		},
+		// macOS WebKit can terminate its Networking process after repeated
+		// PHP-WASM contexts, poisoning later navigations. Per-spec project
+		// boundaries give each local file a fresh browser. All partitions keep
+		// the same public name, so --project=webkit remains comprehensive.
+		...webkitProjects,
 
 		/* Test against mobile viewports. */
 		// {
@@ -72,9 +125,14 @@ export const playwrightConfig: PlaywrightTestConfig = {
 
 	/* Run your local dev server before starting the tests */
 	webServer: {
-		command: 'npx nx run playground-website:dev',
+		// The website dev server proxies remote.html and website-extras through
+		// fixed local ports. If those ports belong to another worktree, tests
+		// load mixed code and fail as empty iframes or browser crashes.
+		command:
+			'node check-local-dev-server-ports.cjs && ' +
+			'npx nx run playground-website:dev:playwright',
 		url: 'http://127.0.0.1:5400/website-server/',
-		reuseExistingServer: !process.env.CI,
+		reuseExistingServer,
 	},
 };
 

--- a/packages/playground/website/playwright/website-page.ts
+++ b/packages/playground/website/playwright/website-page.ts
@@ -19,7 +19,12 @@ export class WebsitePage {
 				)
 				.frameLocator('#wp')
 				.locator('body')
-		).not.toBeEmpty();
+		).not.toBeEmpty({
+			// A serialized Firefox PHP-WASM boot can legitimately take just over
+			// one minute. Match the suite's navigation timeout instead of using the
+			// shorter default expect timeout at this boot boundary.
+			timeout: 120_000,
+		});
 	}
 
 	async waitForPlaygroundShell(page = this.page) {

--- a/packages/playground/website/project.json
+++ b/packages/playground/website/project.json
@@ -63,6 +63,20 @@
 				],
 				"parallel": true,
 				"color": true
+			},
+			"configurations": {
+				"playwright": {
+					"commands": [
+						"node packages/php-wasm/compile/sync-php-next-assets.mjs --optional --if-missing",
+						"nx run playground-php-cors-proxy:start",
+						"nx dev playground-remote --configuration=development-for-playwright",
+						"nx dev playground-website-extras --configuration=development-for-playwright",
+						"sleep 1; nx dev:standalone playground-website --configuration=development-for-playwright --output-style=stream-without-prefixes"
+					],
+					"env": {
+						"PLAYWRIGHT_MOCK_VITE_HMR_IN_FIREFOX": "true"
+					}
+				}
 			}
 		},
 		"dev:standalone": {
@@ -75,6 +89,13 @@
 				"development": {
 					"buildTarget": "playground-website:build:standalone:development",
 					"hmr": true
+				},
+				"development-for-playwright": {
+					"buildTarget": "playground-website:build:standalone:development",
+					"hmr": {
+						"host": "127.0.0.1",
+						"clientPort": 5400
+					}
 				},
 				"production": {
 					"buildTarget": "playground-website:build:standalone:production",
@@ -183,6 +204,16 @@
 				"parallel": false
 			}
 		},
+		"e2e:playwright:deployment": {
+			"executor": "nx:run-commands",
+			"options": {
+				"commands": [
+					"npx playwright test --config=packages/playground/website/playwright/playwright.config.ts packages/playground/website/playwright/e2e/deployment.spec.ts"
+				],
+				"parallel": false
+			},
+			"dependsOn": ["e2e:playwright:prepare-app-deploy-and-offline-mode"]
+		},
 		"e2e:playwright:prepare-app-deploy-and-offline-mode": {
 			"executor": "nx:noop",
 			"dependsOn": [
@@ -194,8 +225,8 @@
 			"executor": "nx:run-commands",
 			"options": {
 				"commands": [
-					"unzip ./packages/playground/website/playwright/deploy-e2e-old-release.zip",
-					"unzip ./packages/playground/website/playwright/deploy-e2e-mid-release.zip"
+					"unzip -o ./packages/playground/website/playwright/deploy-e2e-old-release.zip",
+					"unzip -o ./packages/playground/website/playwright/deploy-e2e-mid-release.zip"
 				]
 			}
 		},

--- a/packages/playground/website/src/components/blueprint-editor/BlueprintBundleEditor.spec.tsx
+++ b/packages/playground/website/src/components/blueprint-editor/BlueprintBundleEditor.spec.tsx
@@ -4,6 +4,7 @@ import { act, createRef } from 'react';
 import { createRoot } from 'react-dom/client';
 import type { Root } from 'react-dom/client';
 import type { EventedFilesystem } from '@wp-playground/storage';
+import type { BlueprintValidationResult } from '@wp-playground/blueprints';
 import type * as SliceSitesModule from '../../lib/state/redux/slice-sites';
 import type * as SliceUiModule from '../../lib/state/redux/slice-ui';
 import {
@@ -27,6 +28,9 @@ const mocks = vi.hoisted(() => ({
 	pruneAutosavedSites: vi.fn(),
 	removeSite: vi.fn(),
 	resolveRuntimeConfiguration: vi.fn(),
+	validationChange: undefined as
+		| ((result: BlueprintValidationResult | null) => void)
+		| undefined,
 	setActiveSite: vi.fn(),
 	setDockPaneOpen: vi.fn(),
 	updateSite: vi.fn(),
@@ -58,6 +62,15 @@ vi.mock('@wp-playground/components', async () => {
 
 vi.mock('../../lib/hooks/use-blueprint-url-hash', () => ({
 	useBlueprintUrlHash: () => ({ isShareable: true, urlHash: '' }),
+}));
+
+vi.mock('./json-schema-editor/blueprint-linter', () => ({
+	createBlueprintLinter: (
+		onValidationChange: (result: BlueprintValidationResult | null) => void
+	) => {
+		mocks.validationChange = onValidationChange;
+		return [];
+	},
 }));
 
 vi.mock('../../lib/state/redux/store', () => ({
@@ -141,6 +154,7 @@ describe('BlueprintBundleEditor Run barrier', () => {
 			).setDockPaneOpen
 		);
 		mocks.updateSite.mockReset();
+		mocks.validationChange = undefined;
 	});
 
 	afterEach(() => {
@@ -537,6 +551,10 @@ describe('BlueprintBundleEditor Run barrier', () => {
 					dockPresentation={dockPresentation}
 				/>
 			);
+			await Promise.resolve();
+		});
+		await act(async () => {
+			mocks.validationChange!({ valid: true, errors: [] });
 			await Promise.resolve();
 		});
 		expect(editorRef.current).not.toBeNull();

--- a/packages/playground/website/src/components/blueprint-editor/BlueprintBundleEditor.tsx
+++ b/packages/playground/website/src/components/blueprint-editor/BlueprintBundleEditor.tsx
@@ -380,6 +380,9 @@ export const BlueprintBundleEditor = forwardRef<
 	 */
 	const saveBarrierRef = useRef<Promise<boolean>>(Promise.resolve(true));
 	const runInProgressRef = useRef(false);
+	// React state may lag editor events, so saves read these synchronously updated refs.
+	const currentPathRef = useRef<string | null>(currentPath);
+	const codeRef = useRef(code);
 	const dispatch = useAppDispatch();
 
 	// Save file to filesystem
@@ -405,12 +408,18 @@ export const BlueprintBundleEditor = forwardRef<
 			if (readOnly || isBlueprintRunPending) {
 				return;
 			}
+			codeRef.current = newCode;
 			setCode(newCode);
-			if (currentPath) {
-				saveFile(currentPath, newCode);
+			const path = currentPathRef.current;
+			if (path) {
+				if (path === BLUEPRINT_JSON_PATH) {
+					// Do not run against the previous result while the linter catches up.
+					setValidationResult(null);
+				}
+				saveFile(path, newCode);
 			}
 		},
-		[currentPath, isBlueprintRunPending, readOnly, saveFile]
+		[isBlueprintRunPending, readOnly, saveFile]
 	);
 
 	// Load initial blueprint.json and focus tree
@@ -421,6 +430,8 @@ export const BlueprintBundleEditor = forwardRef<
 				const blueprintJsonContent =
 					await filesystem.readFileAsText(BLUEPRINT_JSON_PATH);
 				if (cancelled) return;
+				currentPathRef.current = BLUEPRINT_JSON_PATH;
+				codeRef.current = blueprintJsonContent;
 				setCurrentPath(BLUEPRINT_JSON_PATH);
 				setDisplayPath(BLUEPRINT_JSON_PATH);
 				setCode(blueprintJsonContent);
@@ -443,6 +454,17 @@ export const BlueprintBundleEditor = forwardRef<
 		}
 	}, [newUrl]);
 
+	const persistCurrentFile = useCallback(async () => {
+		// Replace the pending debounce with the latest visible contents, queued
+		// behind any write that has already started.
+		saveFile.cancel();
+		const path = currentPathRef.current;
+		if (path) {
+			enqueueSave(path, codeRef.current);
+		}
+		return saveBarrierRef.current;
+	}, [saveFile]);
+
 	const handleRunBlueprint = useCallback(async () => {
 		if (
 			!site ||
@@ -460,8 +482,7 @@ export const BlueprintBundleEditor = forwardRef<
 		const runInNewPlayground = isStoredSite(site);
 		try {
 			setIsRunningBlueprint(true);
-			saveFile.flush();
-			if (!(await saveBarrierRef.current)) {
+			if (!(await persistCurrentFile())) {
 				return;
 			}
 			setSaveError(null);
@@ -541,11 +562,11 @@ export const BlueprintBundleEditor = forwardRef<
 		dispatch,
 		filesystem,
 		hasValidationErrors,
-		siteIsUnfinishedBlueprintRun,
 		opfsSyncStatus,
+		persistCurrentFile,
 		readOnly,
-		saveFile,
 		site,
+		siteIsUnfinishedBlueprintRun,
 	]);
 
 	// A queued Run belongs to the current editor. Resume when no live sync remains;
@@ -577,8 +598,15 @@ export const BlueprintBundleEditor = forwardRef<
 
 	const handleFileOpened = useCallback(
 		(path: string, content: string, shouldFocus = true) => {
+			// Enqueue the old file before routing subsequent edits to the new one.
+			void saveFile.flush();
+			currentPathRef.current = path;
+			codeRef.current = content;
 			setCurrentPath(path);
 			setCode(content);
+			if (path === BLUEPRINT_JSON_PATH) {
+				setValidationResult(null);
+			}
 			setDisplayPath(path);
 			setMessageContent(null);
 			setSaveError(null);
@@ -588,16 +616,20 @@ export const BlueprintBundleEditor = forwardRef<
 				setTimeout(() => editorRef.current?.focus(), 20);
 			}
 		},
-		[]
+		[saveFile]
 	);
 
 	const handleClearSelection = useCallback(() => {
+		// Deleting a selected file must not let a pending debounce recreate it.
+		saveFile.cancel();
+		currentPathRef.current = null;
+		codeRef.current = '';
 		setCurrentPath(null);
 		setCode('');
 		setMessageContent(null);
 		setDisplayPath(null);
 		setSaveError(null);
-	}, []);
+	}, [saveFile]);
 
 	// Open the string editor modal for the string at the current cursor position
 	const openStringEditor = useCallback(() => {
@@ -672,13 +704,17 @@ export const BlueprintBundleEditor = forwardRef<
 
 	const handleShowMessage = useCallback(
 		(path: string | null, message: string | JSX.Element) => {
+			void saveFile.flush();
+			currentPathRef.current = null;
 			setCurrentPath(null);
 			setDisplayPath((prev) => path ?? prev);
 
 			if (typeof message === 'string') {
+				codeRef.current = message;
 				setCode(message);
 				setMessageContent(null);
 			} else {
+				codeRef.current = '';
 				setCode('');
 				setMessageContent(message);
 			}
@@ -686,7 +722,7 @@ export const BlueprintBundleEditor = forwardRef<
 			setSaveError(null);
 			setShowExplorerOnMobile(false);
 		},
-		[]
+		[saveFile]
 	);
 
 	const handleValidationChange = useCallback(
@@ -724,6 +760,9 @@ export const BlueprintBundleEditor = forwardRef<
 
 	const handleDownloadBundle = useCallback(async () => {
 		try {
+			if (!(await persistCurrentFile())) {
+				return;
+			}
 			const zipWriter = new ZipWriter(new BlobWriter('application/zip'));
 			const addEntries = async (dirPath: string, prefix: string) => {
 				const entries = await filesystem.listFiles(dirPath);
@@ -760,7 +799,7 @@ export const BlueprintBundleEditor = forwardRef<
 			logger.error('Failed to download bundle', error);
 			setSaveError('Could not download bundle. Try again.');
 		}
-	}, [filesystem]);
+	}, [filesystem, persistCurrentFile]);
 
 	const handleShareBlueprint = async () => {
 		if (false === newUrl) {
@@ -784,16 +823,27 @@ export const BlueprintBundleEditor = forwardRef<
 		ref,
 		() => ({
 			downloadBundle: handleDownloadBundle,
-			getBundle: async () => filesystem,
+			getBundle: async () =>
+				(await persistCurrentFile()) ? filesystem : null,
 			runBlueprint: handleRunBlueprint,
 		}),
-		[handleDownloadBundle, filesystem, handleRunBlueprint]
+		[
+			handleDownloadBundle,
+			filesystem,
+			handleRunBlueprint,
+			persistCurrentFile,
+		]
 	);
 
 	const isAutosaved = site ? isAutosavedSite(site) : false;
 	const isStored = site ? isStoredSite(site) : false;
+	const isValidationPending =
+		currentPath === BLUEPRINT_JSON_PATH && validationResult === null;
 	const disableRunButton =
-		isBlueprintRunPending || !site || hasValidationErrors;
+		isBlueprintRunPending ||
+		!site ||
+		isValidationPending ||
+		hasValidationErrors;
 	const mobileExplorerToggle = (
 		<Button
 			className={styles.mobileToggle}
@@ -1029,11 +1079,14 @@ export const BlueprintBundleEditor = forwardRef<
 										onClick={handleRunBlueprint}
 										isBusy={isBlueprintRunPending}
 										disabled={disableRunButton}
+										aria-busy={isValidationPending}
 										data-testid="run-blueprint"
 										title={
-											hasValidationErrors
-												? 'Fix validation errors before running'
-												: undefined
+											isValidationPending
+												? 'Validating Blueprint'
+												: hasValidationErrors
+													? 'Fix validation errors before running'
+													: undefined
 										}
 									>
 										<PlayIcon

--- a/packages/playground/website/src/components/site-manager/site-settings-form/unconnected-site-settings-form.tsx
+++ b/packages/playground/website/src/components/site-manager/site-settings-form/unconnected-site-settings-form.tsx
@@ -200,9 +200,9 @@ export function UnconnectedSiteSettingsForm({
 									[css.invalidInput]: !!errors.wpVersion,
 								})}
 								options={wpVersionOptions}
-								onChange={(value, extra) => {
-									onChange(extra?.event);
-								}}
+								// SelectControl's value is the stable public API. Forwarding its
+								// optional event can leave React Hook Form with the old value.
+								onChange={onChange}
 								{...rest}
 							/>
 
@@ -248,9 +248,9 @@ export function UnconnectedSiteSettingsForm({
 								[css.invalidInput]: !!errors.phpVersion,
 							})}
 							options={phpVersionOptions}
-							onChange={(value, extra) => {
-								onChange(extra?.event);
-							}}
+							// Keep the controlled value in React Hook Form even when the
+							// browser delays a later submit click across a rerender.
+							onChange={onChange}
 							{...rest}
 						/>
 					)}
@@ -516,9 +516,9 @@ export function UnconnectedSiteSettingsForm({
 									label: 'Chinese (Taiwan)',
 								},
 							].sort((a, b) => a.label.localeCompare(b.label))}
-							onChange={(value, extra) => {
-								onChange(extra?.event);
-							}}
+							// Use the selected value directly instead of depending on an
+							// optional SelectControl implementation detail.
+							onChange={onChange}
 							{...rest}
 						/>
 					)}

--- a/packages/playground/website/src/lib/hooks/use-debounced-callback.ts
+++ b/packages/playground/website/src/lib/hooks/use-debounced-callback.ts
@@ -3,10 +3,11 @@ import type { DependencyList } from 'react';
 
 type DebouncedCallback<T extends (...args: any[]) => any> = {
 	(...args: Parameters<T>): void;
+	cancel: () => void;
 	flush: () => ReturnType<T> | undefined;
 };
 
-/** Debounces a callback and exposes its latest pending call for explicit flushes. */
+/** Debounces a callback and exposes its pending call for cancellation or flushing. */
 export function useDebouncedCallback<T extends (...args: any[]) => any>(
 	callback: T,
 	delay = 250,
@@ -15,27 +16,24 @@ export function useDebouncedCallback<T extends (...args: any[]) => any>(
 	const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 	const callbackRef = useRef(callback);
 	const pendingArgsRef = useRef<Parameters<T> | null>(null);
+	const lastResultRef = useRef<ReturnType<T> | undefined>(undefined);
 
 	// Keep callback ref up to date
 	useEffect(() => {
 		callbackRef.current = callback;
 	}, [callback, ...dependencies]);
 
-	// Cleanup on unmount
-	useEffect(() => {
-		return () => {
+	const debouncedCallback = useMemo(() => {
+		function cancel() {
 			if (timeoutRef.current) {
 				clearTimeout(timeoutRef.current);
+				timeoutRef.current = null;
 			}
 			pendingArgsRef.current = null;
-		};
-	}, []);
+		}
 
-	return useMemo(() => {
 		function debounced(...args: Parameters<T>) {
-			if (timeoutRef.current) {
-				clearTimeout(timeoutRef.current);
-			}
+			cancel();
 			pendingArgsRef.current = args;
 			timeoutRef.current = setTimeout(() => {
 				flush();
@@ -49,19 +47,22 @@ export function useDebouncedCallback<T extends (...args: any[]) => any>(
 		 * @see https://lodash.com/docs/#debounce
 		 */
 		function flush(): ReturnType<T> | undefined {
-			if (timeoutRef.current) {
-				clearTimeout(timeoutRef.current);
-				timeoutRef.current = null;
-			}
 			const args = pendingArgsRef.current;
-			pendingArgsRef.current = null;
 			if (!args) {
-				return undefined;
+				return lastResultRef.current;
 			}
-			return callbackRef.current(...args);
+			cancel();
+			lastResultRef.current = callbackRef.current(...args);
+			return lastResultRef.current;
 		}
 
+		debounced.cancel = cancel;
 		debounced.flush = flush;
 		return debounced;
 	}, [delay, ...dependencies]);
+
+	// Cleanup on unmount without changing the debounced callback's identity.
+	useEffect(() => debouncedCallback.cancel, [debouncedCallback]);
+
+	return debouncedCallback;
 }

--- a/packages/playground/website/vite.config.ts
+++ b/packages/playground/website/vite.config.ts
@@ -18,6 +18,7 @@ import {
 // eslint-disable-next-line @nx/enforce-module-boundaries
 import { oAuthMiddleware } from './vite.oauth';
 import { exec as execCb } from 'node:child_process';
+import { Agent } from 'node:http';
 import { promisify } from 'node:util';
 import { fileURLToPath } from 'node:url';
 import { copyFileSync, existsSync } from 'node:fs';
@@ -33,8 +34,13 @@ import viteGlobalExtensions from '../../vite-extensions/vite-global-extensions';
 // eslint-disable-next-line @nx/enforce-module-boundaries
 import { isomorphicGitBrowserAlias } from '../../vite-extensions/vite-resolve-isomorphic-git';
 import { analyticsInjectionPlugin } from './vite-analytics-plugin';
+// eslint-disable-next-line @nx/enforce-module-boundaries
+import { vitePlaywrightHmr } from '../../vite-extensions/vite-playwright-hmr';
 
 const exec = promisify(execCb);
+// A Playground boot loads hundreds of modules through the remote proxy. Reuse
+// sockets so concurrent browser contexts do not exhaust macOS ephemeral ports.
+const remoteProxyAgent = new Agent({ keepAlive: true });
 
 // Determine if we are running in a devcontainer.
 const isDevcontainer = process.env.VITE_DEVCONTAINER === 'true';
@@ -135,7 +141,10 @@ const prPreviewMockScenarios: Record<
 	},
 };
 
-const path = (filename: string) => new URL(filename, import.meta.url).pathname;
+// URL.pathname leaves spaces percent-encoded, so Vite cannot find files in a
+// worktree such as "WordPress Playground". Convert the file URL natively.
+const path = (filename: string) =>
+	fileURLToPath(new URL(filename, import.meta.url));
 export default defineConfig(({ command, mode }) => {
 	const corsProxyUrl =
 		'CORS_PROXY_URL' in process.env
@@ -201,6 +210,7 @@ export default defineConfig(({ command, mode }) => {
 				'^[/]((?!website-server|php-next).)': {
 					target: `http://${remoteDevServerHost}:${remoteDevServerPort}`,
 					changeOrigin: true,
+					agent: remoteProxyAgent,
 				},
 			},
 			fs: {
@@ -208,6 +218,8 @@ export default defineConfig(({ command, mode }) => {
 			},
 		},
 		plugins: [
+			// This is inert unless the Playwright dev target opts into the Firefox fix.
+			vitePlaywrightHmr(),
 			// In a devcontainer, Vite prints container IP instead of host IP.
 			// Override the printed URL to show host IP instead (127.0.0.1).
 			isDevcontainer

--- a/packages/playground/wordpress-builds/vite.config.ts
+++ b/packages/playground/wordpress-builds/vite.config.ts
@@ -1,7 +1,10 @@
 /// <reference types='vitest' />
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vite';
 import type { Plugin } from 'vite';
 import dts from 'vite-plugin-dts';
+// eslint-disable-next-line @nx/enforce-module-boundaries
+import { joinPaths } from '../../php-wasm/util/src/lib/paths';
 // eslint-disable-next-line @nx/enforce-module-boundaries
 import { viteTsConfigPaths } from '../../vite-extensions/vite-ts-config-paths';
 // eslint-disable-next-line @nx/enforce-module-boundaries
@@ -9,7 +12,9 @@ import { getExternalModules } from '../../vite-extensions/vite-external-modules'
 // eslint-disable-next-line @nx/enforce-module-boundaries
 import viteGlobalExtensions from '../../vite-extensions/vite-global-extensions';
 
-const path = (filename: string) => new URL(filename, import.meta.url).pathname;
+// URL.pathname leaves spaces percent-encoded, while Vite needs a native filesystem path.
+const path = (filename: string) =>
+	fileURLToPath(new URL(filename, import.meta.url));
 export default defineConfig({
 	root: __dirname,
 	assetsInclude: ['**/*.wasm', '**/*.dat', '*.zip', '**/*.tar.zst'],
@@ -35,7 +40,11 @@ export default defineConfig({
 			 */
 			transform(code, id) {
 				if (id.match(new RegExp(`/wp-\\d.\\d\\.data\\?url`))) {
-					const fullyQualifiedPath = '/@fs' + path(id.split('?')[0]);
+					// Preserve Vite's native id and let the path utility form the /@fs URL.
+					const fullyQualifiedPath = joinPaths(
+						'/@fs',
+						id.split('?', 2)[0]
+					);
 					return `export default ${JSON.stringify(
 						fullyQualifiedPath
 					)};`;

--- a/packages/playground/wordpress/vite.config.ts
+++ b/packages/playground/wordpress/vite.config.ts
@@ -1,7 +1,10 @@
 /// <reference types='vitest' />
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vite';
 import type { Plugin } from 'vite';
 import dts from 'vite-plugin-dts';
+// eslint-disable-next-line @nx/enforce-module-boundaries
+import { joinPaths } from '../../php-wasm/util/src/lib/paths';
 // eslint-disable-next-line @nx/enforce-module-boundaries
 import { viteTsConfigPaths } from '../../vite-extensions/vite-ts-config-paths';
 // eslint-disable-next-line @nx/enforce-module-boundaries
@@ -9,7 +12,9 @@ import { getExternalModules } from '../../vite-extensions/vite-external-modules'
 // eslint-disable-next-line @nx/enforce-module-boundaries
 import viteGlobalExtensions from '../../vite-extensions/vite-global-extensions';
 
-const path = (filename: string) => new URL(filename, import.meta.url).pathname;
+// URL.pathname leaves spaces percent-encoded, while Vite needs a native filesystem path.
+const path = (filename: string) =>
+	fileURLToPath(new URL(filename, import.meta.url));
 export default defineConfig({
 	root: __dirname,
 	assetsInclude: ['**/*.wasm', '**/*.dat', '*.zip', '**/*.tar.zst'],
@@ -35,7 +40,11 @@ export default defineConfig({
 			 */
 			transform(code, id) {
 				if (id.match(new RegExp(`/wp-\\d.\\d\\.data\\?url`))) {
-					const fullyQualifiedPath = '/@fs' + path(id.split('?')[0]);
+					// Preserve Vite's native id and let the path utility form the /@fs URL.
+					const fullyQualifiedPath = joinPaths(
+						'/@fs',
+						id.split('?', 2)[0]
+					);
 					return `export default ${JSON.stringify(
 						fullyQualifiedPath
 					)};`;

--- a/packages/vite-extensions/vite-global-extensions.ts
+++ b/packages/vite-extensions/vite-global-extensions.ts
@@ -4,9 +4,9 @@ const vitePlugins = [
 	{
 		name: 'base64-loader',
 		transform(_: any, id: string) {
-			const url = new URL(id, 'file://');
-			if (!url.searchParams.has('base64')) return null;
-			const path = url.pathname;
+			// Vite ids already contain native paths; URL parsing would encode spaces as %20.
+			const [path, query = ''] = id.split('?', 2);
+			if (!new URLSearchParams(query).has('base64')) return null;
 
 			const data = fs.readFileSync(path);
 			const base64 = data.toString('base64');

--- a/packages/vite-extensions/vite-playwright-hmr.ts
+++ b/packages/vite-extensions/vite-playwright-hmr.ts
@@ -1,0 +1,101 @@
+import type { Plugin } from 'vite';
+
+const viteClientModuleSuffix = '/vite/dist/client/client.mjs';
+const nativeWebSocketConstructor = 'new WebSocket(';
+const playwrightHmrEnvironmentVariable = 'PLAYWRIGHT_MOCK_VITE_HMR_IN_FIREFOX';
+
+// Playwright 1.61's Firefox WebSocket instrumentation asserts when Vite's HMR
+// upgrade finishes without a normal HTTP response. During e2e runs, emulate only
+// Vite's handshake; application WebSockets never pass through this transform.
+const mockViteHmrWebSocket = `
+class __PlaywrightViteHmrWebSocket extends EventTarget {
+	CONNECTING = 0;
+	OPEN = 1;
+	CLOSING = 2;
+	CLOSED = 3;
+	bufferedAmount = 0;
+	extensions = '';
+	protocol = 'vite-hmr';
+	readyState = this.CONNECTING;
+
+	constructor(url, protocols) {
+		super();
+		// One transformed Vite client serves every project. Preserve native HMR in
+		// Chromium and WebKit, where Playwright handles the upgrade normally.
+		if (!navigator.userAgent.includes('Firefox/')) {
+			return new WebSocket(url, protocols);
+		}
+
+		// Test runs use frozen source, so Firefox only needs a successful handshake
+		// rather than source-update messages or reconnect attempts.
+		this.url = String(url);
+		queueMicrotask(() => {
+			if (this.readyState !== this.CONNECTING) {
+				return;
+			}
+			this.readyState = this.OPEN;
+			this.dispatchEvent(new Event('open'));
+			this.dispatchEvent(new MessageEvent('message', {
+				data: JSON.stringify({ type: 'connected' }),
+			}));
+		});
+	}
+
+	send() {}
+
+	close() {
+		if (this.readyState === this.CLOSED) {
+			return;
+		}
+		this.readyState = this.CLOSED;
+		const event = new Event('close');
+		Object.defineProperty(event, 'wasClean', { value: true });
+		this.dispatchEvent(event);
+	}
+}
+`;
+
+export function vitePlaywrightHmr(): Plugin {
+	const enabled = process.env[playwrightHmrEnvironmentVariable] === 'true';
+	let hasObjectHmrConfiguration = false;
+	return {
+		name: 'vite-playwright-hmr',
+		apply: 'serve',
+		enforce: 'post',
+		configResolved(config) {
+			hasObjectHmrConfiguration =
+				!!config.server.hmr && typeof config.server.hmr === 'object';
+		},
+		transform(code, id) {
+			if (!enabled || !id.endsWith(viteClientModuleSuffix)) {
+				return null;
+			}
+			// Nx resolves Vite once before merging executor-level server options,
+			// then resolves it again to create the server. Validate lazily when the
+			// actual server requests Vite's client module.
+			if (!hasObjectHmrConfiguration) {
+				throw new Error(
+					`${playwrightHmrEnvironmentVariable}=true requires an object ` +
+						'Vite server.hmr configuration.'
+				);
+			}
+			// Fail closed if a Vite upgrade changes the constructor being replaced.
+			const occurrences =
+				code.split(nativeWebSocketConstructor).length - 1;
+			if (occurrences !== 1) {
+				throw new Error(
+					`Expected one Vite HMR WebSocket constructor, found ${occurrences}.`
+				);
+			}
+			return {
+				code:
+					mockViteHmrWebSocket +
+					code.replace(
+						nativeWebSocketConstructor,
+						'new __PlaywrightViteHmrWebSocket('
+					),
+				map: null,
+			};
+		},
+	};
+}


### PR DESCRIPTION
## Motivation for the change, related issues

The default Playwright command was unreliable on a clean macOS checkout. Some failures came from
missing local requirements, while others came from real server, browser, path, and editor bugs.
Local tests could also connect to a stale dev server from another worktree.

This PR makes local failures actionable, keeps the prepared Linux CI coverage, and makes flaky
tests easier to find.

## Implementation details

### Find flakes instead of hiding them

The shared local and CI config now:

- Runs every test twice with repeatEach: 2.
- Uses retries: 0, so a later retry cannot hide a failure.
- Records every test but deletes successful traces, keeping only the failing recording.

This doubles the number of test executions and roughly doubles local runtime.

### Reliability and correctness fixes

- Start a clean local server stack and report occupied Playground ports before running tests.
- Use one worker with local development servers. CI keeps three workers with its built app.
- On macOS, use full Chromium and a fresh WebKit process per spec to avoid reproduced crashes.
- Add a Playwright-only Firefox workaround for Vite's live-reload connection. Normal development
  and application WebSockets are unchanged.
- Improve proxy connection reuse and server timeouts for slower browser PHP sessions.
- Fix paths containing spaces, which previously became %20 URLs and caused asset 404s.
- Fix Blueprint editor save races so Run, download, file switching, and deletion cannot use stale
  or unfinished writes.
- Replace fixed delays with checks for visible app state, iframe readiness, saved content, and
  event order.
- Add a deployment target that prepares the required builds automatically.
- Keep deployment screenshot comparisons on Linux, where the stored baselines exist. Prepared
  macOS runs still execute the behavior checks.

### Which skips are new?

For one test sample, Playwright collects 570 browser-specific entries: 444 run and 126 skip.

Of those 126 skips:

- 114 already existed before this PR.
- 12 are reported by new prerequisite guards:
  - 9 deployment entries when local builds have not been prepared.
  - 2 multisite entries that require a URL without an explicit port.
  - 1 macOS request-routing entry that Playwright cannot intercept.

Two of the 9 deployment entries were already skipped by older Firefox and WebKit offline-mode
rules. The net increase is therefore 10 skipped entries per sample.

Linux CI runs those 10 entries because it prepares the deployment builds, uses port 80, and runs
the request-routing check on Linux. Missing CI deployment builds fail the job instead of skipping.

With repeatEach: 2, Playwright reports every entry twice. Under the same conditions, that means
1,140 collected executions and 252 displayed skips.

### Developer-facing changes

- Existing-server reuse now requires PLAYWRIGHT_REUSE_EXISTING_SERVER=1.
- Local runs use one worker; CI keeps three.
- The default local and CI suite runs every test twice without retries.
- A new playground-website:e2e:playwright:deployment target prepares and runs deployment tests.
- The Playwright README explains the new commands and local limitations.

## Testing Instructions (or ideally a Blueprint)

From a clean checkout:

    nvm use
    npm ci
    npx nx run playground-website:e2e:playwright

Before repeatEach: 2 was enabled, five complete macOS runs passed with retries disabled. Every run
had 444 passed, 126 skipped, and 0 failed.

After enabling repeatEach: 2:

- Playwright collection found 1,140 executions.
- A focused repeated check passed 6/6 across Chromium, Firefox, and WebKit.
- Successful traces were removed as expected.
- The full doubled suite was not rerun.

Formatting, lint, typecheck, Blueprint build, affected Vite configuration checks, and
git diff --check also passed.
