### PR TITLE
[Website] Show Playground names in the startup progress bar

### DIFF
--- a/packages/playground/client/src/index.spec.ts
+++ b/packages/playground/client/src/index.spec.ts
@@ -52,6 +52,7 @@ describe('startPlaygroundWeb', () => {
 				remoteUrl:
 					'http://localhost/remote.html?blueprints-runner=v2&existing=1',
 				progressTracker: createProgressTracker(),
+				siteName: 'Curious Harbor',
 				blueprint: {
 					steps: [],
 				},
@@ -62,6 +63,9 @@ describe('startPlaygroundWeb', () => {
 		expect(mocks.BlueprintsV2Handler).not.toHaveBeenCalled();
 		expect(iframe.src).not.toContain('blueprints-runner');
 		expect(iframe.src).toContain('existing=1');
+		expect(new URL(iframe.src).searchParams.get('progressbarTitle')).toBe(
+			'Curious Harbor'
+		);
 	});
 
 	it('routes Blueprint v2 declarations through the v2 handler', async () => {

--- a/packages/playground/client/src/index.ts
+++ b/packages/playground/client/src/index.ts
@@ -57,6 +57,11 @@ export interface StartPlaygroundOptions {
 	remoteUrl: string;
 	progressTracker?: ProgressTracker;
 	disableProgressBar?: boolean;
+	/**
+	 * A stable label for the loading progress bar, typically the name of the
+	 * Playground being started. It stays visible while boot captions change.
+	 */
+	siteName?: string;
 	blueprint?: BlueprintV1;
 	/**
 	 * PHP extensions to install before the runtime starts.
@@ -169,6 +174,7 @@ export async function startPlaygroundWeb(
 	remoteUrlWithoutLegacyRunner.searchParams.delete('blueprints-runner');
 	remoteUrl = setQueryParams(remoteUrlWithoutLegacyRunner.toString(), {
 		progressbar: !disableProgressBar,
+		progressbarTitle: options.siteName || undefined,
 		[WITH_ADMIN_TRANSITIONS_PARAM]: new URL(
 			globalThis.location.href
 		).searchParams.has(WITH_ADMIN_TRANSITIONS_PARAM)

--- a/packages/playground/remote/src/lib/boot-playground-remote.ts
+++ b/packages/playground/remote/src/lib/boot-playground-remote.ts
@@ -66,7 +66,9 @@ export async function bootPlaygroundRemote() {
 	const hasProgressBar = query.has('progressbar');
 	let bar: ProgressBar | undefined;
 	if (hasProgressBar) {
-		bar = new ProgressBar();
+		bar = new ProgressBar({
+			title: query.get('progressbarTitle') || undefined,
+		});
 		document.body.prepend(bar.element);
 	}
 	const sw = navigator.serviceWorker;

--- a/packages/playground/remote/src/lib/progress-bar/index.spec.ts
+++ b/packages/playground/remote/src/lib/progress-bar/index.spec.ts
@@ -1,0 +1,36 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it } from 'vitest';
+import ProgressBar from '.';
+
+describe('ProgressBar', () => {
+	afterEach(() => {
+		document.body.innerHTML = '';
+	});
+
+	it('keeps the Playground name stable while its boot caption changes', () => {
+		const progressBar = new ProgressBar({
+			title: 'Curious Harbor',
+			caption: 'Preparing WordPress',
+		});
+
+		expect(progressBar.element.querySelector('p')?.textContent).toBe(
+			'Starting Your Playground:'
+		);
+		expect(progressBar.element.querySelector('h2')?.textContent).toBe(
+			'Curious Harbor'
+		);
+		expect(progressBar.element.querySelector('h3')?.textContent).toBe(
+			'Preparing WordPress'
+		);
+
+		progressBar.setOptions({ caption: 'Installing WordPress' });
+
+		expect(progressBar.element.querySelector('h2')?.textContent).toBe(
+			'Curious Harbor'
+		);
+		expect(progressBar.element.querySelector('h3')?.textContent).toBe(
+			'Installing WordPress'
+		);
+	});
+});

--- a/packages/playground/remote/src/lib/progress-bar/index.spec.ts
+++ b/packages/playground/remote/src/lib/progress-bar/index.spec.ts
@@ -14,23 +14,45 @@ describe('ProgressBar', () => {
 			caption: 'Preparing WordPress',
 		});
 
-		expect(progressBar.element.querySelector('p')?.textContent).toBe(
+		expect(progressBar.labelElement.textContent).toBe(
 			'Starting Your Playground:'
 		);
-		expect(progressBar.element.querySelector('h2')?.textContent).toBe(
-			'Curious Harbor'
-		);
-		expect(progressBar.element.querySelector('h3')?.textContent).toBe(
+		expect(progressBar.titleElement.textContent).toBe('Curious Harbor');
+		expect(progressBar.captionElement.textContent).toBe(
 			'Preparing WordPress'
+		);
+		expect(
+			progressBar.element.querySelectorAll('h1, h2, h3, h4, h5, h6')
+		).toHaveLength(0);
+		expect(progressBar.captionElement.getAttribute('role')).toBe('status');
+		expect(progressBar.captionElement.getAttribute('aria-live')).toBe(
+			'polite'
+		);
+		expect(progressBar.captionElement.getAttribute('aria-atomic')).toBe(
+			'true'
 		);
 
 		progressBar.setOptions({ caption: 'Installing WordPress' });
 
-		expect(progressBar.element.querySelector('h2')?.textContent).toBe(
-			'Curious Harbor'
-		);
-		expect(progressBar.element.querySelector('h3')?.textContent).toBe(
+		expect(progressBar.titleElement.textContent).toBe('Curious Harbor');
+		expect(progressBar.captionElement.textContent).toBe(
 			'Installing WordPress'
 		);
+	});
+
+	it('can clear the Playground name and caption', () => {
+		const progressBar = new ProgressBar({
+			title: 'Curious Harbor',
+			caption: 'Preparing WordPress',
+		});
+
+		progressBar.setOptions({ title: undefined, caption: '' });
+
+		expect(progressBar.title).toBe('');
+		expect(progressBar.titleElement.textContent).toBe('');
+		expect(progressBar.titleElement.hidden).toBe(true);
+		expect(progressBar.labelElement.hidden).toBe(true);
+		expect(progressBar.caption).toBe('');
+		expect(progressBar.captionElement.textContent).toBe('');
 	});
 });

--- a/packages/playground/remote/src/lib/progress-bar/index.ts
+++ b/packages/playground/remote/src/lib/progress-bar/index.ts
@@ -16,8 +16,8 @@ export interface ProgressBarOptions {
 class ProgressBar {
 	element: HTMLDivElement;
 	labelElement: HTMLParagraphElement;
-	titleElement: HTMLHeadingElement;
-	captionElement: HTMLHeadingElement;
+	titleElement: HTMLDivElement;
+	captionElement: HTMLDivElement;
 	title = '';
 	caption = 'Preparing WordPress';
 	progress = 0;
@@ -27,8 +27,11 @@ class ProgressBar {
 	constructor(options: ProgressBarOptions = {}) {
 		this.element = document.createElement('div');
 		this.labelElement = document.createElement('p');
-		this.titleElement = document.createElement('h2');
-		this.captionElement = document.createElement('h3');
+		this.titleElement = document.createElement('div');
+		this.captionElement = document.createElement('div');
+		this.captionElement.setAttribute('role', 'status');
+		this.captionElement.setAttribute('aria-live', 'polite');
+		this.captionElement.setAttribute('aria-atomic', 'true');
 		this.element.appendChild(this.labelElement);
 		this.element.appendChild(this.titleElement);
 		this.element.appendChild(this.captionElement);
@@ -36,11 +39,11 @@ class ProgressBar {
 	}
 
 	setOptions(options: ProgressBarOptions) {
-		if ('title' in options && options.title) {
-			this.title = options.title;
+		if ('title' in options) {
+			this.title = options.title ?? '';
 		}
-		if ('caption' in options && options.caption) {
-			this.caption = options.caption!;
+		if ('caption' in options) {
+			this.caption = options.caption ?? '';
 		}
 		if ('progress' in options) {
 			this.progress = options.progress!;
@@ -77,16 +80,12 @@ class ProgressBar {
 		this.labelElement.className = '';
 		this.labelElement.classList.add(css['label']);
 		this.labelElement.textContent = 'Starting Your Playground:';
-		if (!this.title) {
-			this.labelElement.classList.add(css['titleHidden']);
-		}
+		this.labelElement.hidden = !this.title;
 
 		this.titleElement.className = '';
 		this.titleElement.classList.add(css['title']);
 		this.titleElement.textContent = this.title;
-		if (!this.title) {
-			this.titleElement.classList.add(css['titleHidden']);
-		}
+		this.titleElement.hidden = !this.title;
 
 		this.captionElement.className = '';
 		this.captionElement.classList.add(css['caption']);

--- a/packages/playground/remote/src/lib/progress-bar/index.ts
+++ b/packages/playground/remote/src/lib/progress-bar/index.ts
@@ -2,6 +2,11 @@
 import css from './style.module.css';
 
 export interface ProgressBarOptions {
+	/**
+	 * A stable heading for the Playground being started. Unlike the caption, it
+	 * is not overwritten as boot stages advance.
+	 */
+	title?: string;
 	caption?: string;
 	progress?: number;
 	isIndefinite?: boolean;
@@ -10,7 +15,10 @@ export interface ProgressBarOptions {
 
 class ProgressBar {
 	element: HTMLDivElement;
+	labelElement: HTMLParagraphElement;
+	titleElement: HTMLHeadingElement;
 	captionElement: HTMLHeadingElement;
+	title = '';
 	caption = 'Preparing WordPress';
 	progress = 0;
 	isIndefinite = false;
@@ -18,12 +26,19 @@ class ProgressBar {
 
 	constructor(options: ProgressBarOptions = {}) {
 		this.element = document.createElement('div');
+		this.labelElement = document.createElement('p');
+		this.titleElement = document.createElement('h2');
 		this.captionElement = document.createElement('h3');
+		this.element.appendChild(this.labelElement);
+		this.element.appendChild(this.titleElement);
 		this.element.appendChild(this.captionElement);
 		this.setOptions(options);
 	}
 
 	setOptions(options: ProgressBarOptions) {
+		if ('title' in options && options.title) {
+			this.title = options.title;
+		}
 		if ('caption' in options && options.caption) {
 			this.caption = options.caption!;
 		}
@@ -57,9 +72,25 @@ class ProgressBar {
 			this.element.classList.add(css['isHidden']);
 		}
 
+		// Frame the stable site name as the Playground being started. Hide both
+		// elements when an embedding client does not provide a name.
+		this.labelElement.className = '';
+		this.labelElement.classList.add(css['label']);
+		this.labelElement.textContent = 'Starting Your Playground:';
+		if (!this.title) {
+			this.labelElement.classList.add(css['titleHidden']);
+		}
+
+		this.titleElement.className = '';
+		this.titleElement.classList.add(css['title']);
+		this.titleElement.textContent = this.title;
+		if (!this.title) {
+			this.titleElement.classList.add(css['titleHidden']);
+		}
+
 		this.captionElement.className = '';
 		this.captionElement.classList.add(css['caption']);
-		this.captionElement.textContent = this.caption + '...';
+		this.captionElement.textContent = this.caption;
 
 		const progressBarWrapper = this.element.querySelector(
 			`.${css['wrapper']}`

--- a/packages/playground/remote/src/lib/progress-bar/style.module.css
+++ b/packages/playground/remote/src/lib/progress-bar/style.module.css
@@ -141,10 +141,6 @@
 	text-align: center;
 }
 
-.title-hidden {
-	display: none;
-}
-
 .caption {
 	font-weight: 400;
 	font-family: -apple-system, BlinkMacSystemFont, sans-serif;

--- a/packages/playground/remote/src/lib/progress-bar/style.module.css
+++ b/packages/playground/remote/src/lib/progress-bar/style.module.css
@@ -23,19 +23,6 @@
 	transition: opacity ease-in 0.25s;
 }
 
-.overlay::before {
-	position: absolute;
-	width: min(640px, calc(100% - 48px));
-	height: 260px;
-	border: 1px solid rgb(0 0 0 / 0.06);
-	border-radius: 28px;
-	background: rgb(255 255 255 / 0.74);
-	box-shadow:
-		0 24px 70px rgb(0 0 0 / 0.09),
-		0 1px 0 rgb(255 255 255 / 0.7) inset;
-	content: '';
-}
-
 .overlay.is-hidden {
 	opacity: 0;
 	pointer-events: none;
@@ -141,19 +128,17 @@
 }
 
 /* The stable Playground name — larger and bolder than the caption, sitting just
-   above it. It never changes as boot stages advance. */
+   above it. It wraps in full and never changes as boot stages advance. */
 .title {
 	font-weight: 600;
 	font-family: -apple-system, BlinkMacSystemFont, sans-serif;
 	font-size: clamp(1.55rem, 3.4vw, 2.35rem);
-	line-height: 1.08;
+	line-height: 1.12;
 	margin: 0 0 0.45rem;
 	width: calc(100% - 48px);
 	max-width: 720px;
-	overflow: hidden;
+	overflow-wrap: anywhere;
 	text-align: center;
-	text-overflow: ellipsis;
-	white-space: nowrap;
 }
 
 .title-hidden {
@@ -189,14 +174,6 @@
 			),
 			linear-gradient(180deg, #191a1d 0%, #1e1e1e 100%);
 		color: #fff;
-	}
-
-	.overlay::before {
-		border-color: rgb(255 255 255 / 0.06);
-		background: rgb(31 32 36 / 0.76);
-		box-shadow:
-			0 24px 70px rgb(0 0 0 / 0.28),
-			0 1px 0 rgb(255 255 255 / 0.05) inset;
 	}
 
 	.wrapper {

--- a/packages/playground/remote/src/lib/progress-bar/style.module.css
+++ b/packages/playground/remote/src/lib/progress-bar/style.module.css
@@ -2,7 +2,13 @@
 	position: absolute;
 	top: 0;
 	left: 0;
-	background: #fff;
+	background:
+		radial-gradient(
+			circle at 50% calc(50% - 140px),
+			rgb(56 88 233 / 0.13),
+			transparent 34%
+		),
+		linear-gradient(180deg, #f7f9fc 0%, #fff 100%);
 	z-index: 5;
 	display: flex;
 	flex-direction: column;
@@ -10,8 +16,24 @@
 	height: 100%;
 	justify-content: center;
 	align-items: center;
+	box-sizing: border-box;
+	overflow: hidden;
+	padding: 24px;
 	opacity: 1;
 	transition: opacity ease-in 0.25s;
+}
+
+.overlay::before {
+	position: absolute;
+	width: min(640px, calc(100% - 48px));
+	height: 260px;
+	border: 1px solid rgb(0 0 0 / 0.06);
+	border-radius: 28px;
+	background: rgb(255 255 255 / 0.74);
+	box-shadow:
+		0 24px 70px rgb(0 0 0 / 0.09),
+		0 1px 0 rgb(255 255 255 / 0.7) inset;
+	content: '';
 }
 
 .overlay.is-hidden {
@@ -21,12 +43,30 @@
 
 .wrapper {
 	position: relative;
-	width: 512px;
-	max-width: 60vw;
-	height: 4px;
-	margin: 4px auto;
-	border-radius: 10px;
-	background: #e0e0e0;
+	width: calc(100% - 48px);
+	max-width: 420px;
+	height: 9px;
+	margin: 1.45rem auto 0;
+	overflow: hidden;
+	border-radius: 999px;
+	background: #d8dce2;
+	box-shadow:
+		0 1px 0 rgb(255 255 255 / 0.72) inset,
+		0 10px 24px rgb(0 0 0 / 0.08);
+}
+
+.wrapper::after {
+	position: absolute;
+	inset: 0;
+	background: linear-gradient(
+		90deg,
+		transparent 0%,
+		rgb(255 255 255 / 0.58) 50%,
+		transparent 100%
+	);
+	animation: track-shimmer 2.2s ease-in-out infinite;
+	content: '';
+	transform: translateX(-100%);
 }
 
 .wrapper-definite .progress-bar.is-indefinite,
@@ -45,14 +85,23 @@
 	left: 0;
 	bottom: 0;
 	right: 100%;
+	z-index: 1;
 	width: 0;
-	background: #3858e9;
-	border-radius: 2px;
-	transition: opacity linear 0.2s, width ease-in 0.2s;
+	background: linear-gradient(90deg, #3858e9 0%, #6f7dff 100%);
+	border-radius: inherit;
+	transition:
+		opacity linear 0.2s,
+		width ease-in 0.2s;
 }
 
 .progress-bar.is-indefinite {
 	animation: indefinite-loading 2s linear infinite;
+}
+
+@keyframes track-shimmer {
+	100% {
+		transform: translateX(100%);
+	}
 }
 
 @keyframes indefinite-loading {
@@ -78,19 +127,93 @@
 	}
 }
 
+/* A quiet prefix above the name, so the big text below reads as the Playground
+   being started, not a page title. */
+.label {
+	color: #757575;
+	font-family: -apple-system, BlinkMacSystemFont, sans-serif;
+	font-size: clamp(0.9rem, 1.45vw, 1rem);
+	font-weight: 500;
+	letter-spacing: 0.01em;
+	line-height: 1.3;
+	margin: 0 0 0.45rem;
+	text-align: center;
+}
+
+/* The stable Playground name — larger and bolder than the caption, sitting just
+   above it. It never changes as boot stages advance. */
+.title {
+	font-weight: 600;
+	font-family: -apple-system, BlinkMacSystemFont, sans-serif;
+	font-size: clamp(1.55rem, 3.4vw, 2.35rem);
+	line-height: 1.08;
+	margin: 0 0 0.45rem;
+	width: calc(100% - 48px);
+	max-width: 720px;
+	overflow: hidden;
+	text-align: center;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.title-hidden {
+	display: none;
+}
+
 .caption {
 	font-weight: 400;
 	font-family: -apple-system, BlinkMacSystemFont, sans-serif;
-	font-size: 1.1rem;
+	font-size: clamp(0.95rem, 1.75vw, 1.12rem);
+	/* With the name carrying identity above, the changing stage caption reads as
+	   secondary status. */
+	color: #757575;
+	line-height: 1.3;
+	margin: 0;
+	text-align: center;
+}
+
+.label,
+.title,
+.caption,
+.wrapper {
+	z-index: 1;
 }
 
 @media (prefers-color-scheme: dark) {
 	.overlay {
-		background: #1e1e1e;
+		background:
+			radial-gradient(
+				circle at 50% calc(50% - 140px),
+				rgb(56 88 233 / 0.2),
+				transparent 34%
+			),
+			linear-gradient(180deg, #191a1d 0%, #1e1e1e 100%);
 		color: #fff;
 	}
 
+	.overlay::before {
+		border-color: rgb(255 255 255 / 0.06);
+		background: rgb(31 32 36 / 0.76);
+		box-shadow:
+			0 24px 70px rgb(0 0 0 / 0.28),
+			0 1px 0 rgb(255 255 255 / 0.05) inset;
+	}
+
 	.wrapper {
-		background: #32363a;
+		background: #2f3338;
+		box-shadow:
+			inset 0 0 0 1px rgb(255 255 255 / 0.04),
+			0 10px 28px rgb(0 0 0 / 0.22);
+	}
+
+	.progress-bar {
+		box-shadow: 0 0 18px rgb(72 103 255 / 0.45);
+	}
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.wrapper::after,
+	.progress-bar.is-indefinite {
+		animation: none;
 	}
 }

--- a/packages/playground/website/src/lib/state/redux/boot-site-client.ts
+++ b/packages/playground/website/src/lib/state/redux/boot-site-client.ts
@@ -232,6 +232,8 @@ export function bootSiteClient(
 				iframe: iframe!,
 				remoteUrl: getRemoteUrl().toString(),
 				scope: site.slug,
+				// Keep the Playground identified while its boot-stage caption changes.
+				siteName: site.metadata.name,
 				blueprint,
 				extensions: phpExtensions,
 				// Intercept the Playground client even if the


### PR DESCRIPTION
The startup progress bar only shows changing boot captions. A saved Playground can therefore lose its identity while WordPress starts, especially when the user switches between Playgrounds.

This passes the saved site name through `startPlaygroundWeb()` and keeps it visible while the boot caption advances. Long names wrap in full instead of ending in an ellipsis. The progress UI sits directly on the startup surface instead of inside a shadowed card.

![A long Playground name wrapping across two lines in the startup progress UI](https://raw.githubusercontent.com/WordPress/wordpress-playground/dock-ui-product-wiring-media/pr-media/4029/startup-progress-long-name.png)

Tested with:

- `npm exec nx -- test playground-remote --testFile=progress-bar/index.spec.ts`
- `npm exec nx -- run playground-remote:lint`
- `npm exec nx -- run playground-remote:typecheck`
- Chromium at 1280×800 with the long name shown above; computed styles confirmed normal wrapping, visible overflow, and no overlay frame pseudo-element
