### PR TITLE
[Website] Fix mobile site info header wrapping

### DIFF
--- a/packages/playground/website/src/components/site-manager/site-info-panel/index.tsx
+++ b/packages/playground/website/src/components/site-manager/site-info-panel/index.tsx
@@ -174,7 +174,7 @@ export function SiteInfoPanel({
 						gap={2}
 						justify="space-between"
 						align="flex-start"
-						wrap={mobileUi}
+						wrap={true}
 						expanded={true}
 						className={`${css.padded} ${css.siteInfoHeader}`}
 						style={{ paddingBottom: 10 }}
@@ -206,10 +206,7 @@ export function SiteInfoPanel({
 								/>
 							)}
 						</FlexItem>
-						<FlexItem
-							className={css.siteInfoHeaderDetails}
-							style={{ flexGrow: 1 }}
-						>
+						<FlexItem className={css.siteInfoHeaderDetails}>
 							<Flex direction="column" gap={0.25} expanded={true}>
 								<Flex
 									direction="row"
@@ -305,90 +302,104 @@ export function SiteInfoPanel({
 								)}
 							</Flex>
 						</FlexItem>
-						{isAutosaved && (
+						<Flex
+							gap={2}
+							justify="flex-end"
+							align="stretch"
+							expanded={false}
+							className={css.siteInfoHeaderPrimaryActions}
+						>
+							{isAutosaved && (
+								<FlexItem className={css.siteInfoHeaderAction}>
+									<Button
+										variant="primary"
+										onClick={openSaveModal}
+									>
+										Store permanently
+									</Button>
+								</FlexItem>
+							)}
+							{mobileUi ? (
+								<FlexItem className={css.siteInfoHeaderAction}>
+									<Button
+										variant="primary"
+										onClick={() => {
+											dispatch(setSiteManagerOpen(false));
+										}}
+									>
+										Open site
+									</Button>
+								</FlexItem>
+							) : (
+								<>
+									<FlexItem
+										className={css.siteInfoHeaderAction}
+									>
+										<Button
+											variant="tertiary"
+											disabled={!playground}
+											onClick={() =>
+												navigateTo('/wp-admin/')
+											}
+										>
+											WP Admin
+										</Button>
+									</FlexItem>
+									<FlexItem
+										className={css.siteInfoHeaderAction}
+									>
+										<Button
+											variant="secondary"
+											disabled={!playground}
+											onClick={() => navigateTo('/')}
+										>
+											Homepage
+										</Button>
+									</FlexItem>
+								</>
+							)}
 							<FlexItem className={css.siteInfoHeaderAction}>
-								<Button
-									variant="primary"
-									onClick={openSaveModal}
-								>
-									Store permanently
-								</Button>
-							</FlexItem>
-						)}
-						{mobileUi ? (
-							<FlexItem className={css.siteInfoHeaderAction}>
-								<Button
-									variant="primary"
-									onClick={() => {
-										dispatch(setSiteManagerOpen(false));
+								<DropdownMenu
+									icon={moreVertical}
+									label="Additional actions"
+									popoverProps={{
+										placement: 'bottom-end',
 									}}
 								>
-									Open site
-								</Button>
-							</FlexItem>
-						) : (
-							<>
-								<FlexItem className={css.siteInfoHeaderAction}>
-									<Button
-										variant="tertiary"
-										disabled={!playground}
-										onClick={() => navigateTo('/wp-admin/')}
-									>
-										WP Admin
-									</Button>
-								</FlexItem>
-								<FlexItem className={css.siteInfoHeaderAction}>
-									<Button
-										variant="secondary"
-										disabled={!playground}
-										onClick={() => navigateTo('/')}
-									>
-										Homepage
-									</Button>
-								</FlexItem>
-							</>
-						)}
-						<FlexItem className={css.siteInfoHeaderAction}>
-							<DropdownMenu
-								icon={moreVertical}
-								label="Additional actions"
-								popoverProps={{
-									placement: 'bottom-end',
-								}}
-							>
-								{({ onClose }) => (
-									<>
-										{!isTemporary && (
+									{({ onClose }) => (
+										<>
+											{!isTemporary && (
+												<MenuGroup>
+													<MenuItem
+														aria-label="Delete this Playground"
+														className={css.danger}
+														onClick={() =>
+															removeSiteAndCloseMenu(
+																onClose
+															)
+														}
+													>
+														Delete
+													</MenuItem>
+												</MenuGroup>
+											)}
 											<MenuGroup>
-												<MenuItem
-													aria-label="Delete this Playground"
-													className={css.danger}
-													onClick={() =>
-														removeSiteAndCloseMenu(
-															onClose
-														)
+												<GithubExportMenuItem
+													onClose={onClose}
+													disabled={
+														offline || !playground
 													}
-												>
-													Delete
-												</MenuItem>
+												/>
+												<DownloadAsZipMenuItem
+													onClose={onClose}
+													disabled={!playground}
+												/>
 											</MenuGroup>
-										)}
-										<MenuGroup>
-											<GithubExportMenuItem
-												onClose={onClose}
-												disabled={
-													offline || !playground
-												}
-											/>
-											<DownloadAsZipMenuItem
-												onClose={onClose}
-												disabled={!playground}
-											/>
-										</MenuGroup>
-									</>
-								)}
-							</DropdownMenu>
-						</FlexItem>
+										</>
+									)}
+								</DropdownMenu>
+							</FlexItem>
+						</Flex>
 					</Flex>
 				</FlexItem>
 				<FlexItem style={{ flexGrow: 1 }}>

--- a/packages/playground/website/src/components/site-manager/site-info-panel/index.tsx
+++ b/packages/playground/website/src/components/site-manager/site-info-panel/index.tsx
@@ -174,6 +174,7 @@ export function SiteInfoPanel({
 						gap={2}
 						justify="space-between"
 						align="flex-start"
+						wrap={mobileUi}
 						expanded={true}
 						className={`${css.padded} ${css.siteInfoHeader}`}
 						style={{ paddingBottom: 10 }}
@@ -205,7 +206,10 @@ export function SiteInfoPanel({
 								/>
 							)}
 						</FlexItem>
-						<FlexItem style={{ flexGrow: 1 }}>
+						<FlexItem
+							className={css.siteInfoHeaderDetails}
+							style={{ flexGrow: 1 }}
+						>
 							<Flex direction="column" gap={0.25} expanded={true}>
 								<Flex
 									direction="row"
@@ -312,7 +316,7 @@ export function SiteInfoPanel({
 							</FlexItem>
 						)}
 						{mobileUi ? (
-							<FlexItem style={{ flexShrink: 0 }}>
+							<FlexItem className={css.siteInfoHeaderAction}>
 								<Button
 									variant="primary"
 									onClick={() => {

--- a/packages/playground/website/src/components/site-manager/site-info-panel/style.module.css
+++ b/packages/playground/website/src/components/site-manager/site-info-panel/style.module.css
@@ -11,6 +11,7 @@
 	display: flex;
 	flex-direction: column;
 	flex-grow: 1;
+	container-type: inline-size;
 }
 
 .site-info-panel-content {
@@ -204,17 +205,21 @@
 }
 
 .siteInfoHeaderPrimaryActions {
-	display: flex;
-	flex-wrap: wrap;
-	justify-content: flex-end;
-	align-items: stretch;
-	gap: 8px;
-	flex: 0 1 auto;
+	flex: 0 0 max-content;
 	min-width: 0;
+	max-width: 100%;
+	margin-left: auto;
 }
 
-.is-mobile .site-info-header-details {
-	flex-basis: 0;
+@container (max-width: 420px) {
+	.siteInfoHeaderPrimaryActions {
+		flex-basis: 100%;
+		flex-wrap: wrap;
+	}
+}
+
+.site-info-header-details {
+	flex: 1 1 200px;
 	min-width: 200px;
 }
 

--- a/packages/playground/website/src/components/site-manager/site-info-panel/style.module.css
+++ b/packages/playground/website/src/components/site-manager/site-info-panel/style.module.css
@@ -213,7 +213,12 @@
 	min-width: 0;
 }
 
-.siteInfoHeaderAction {
+.is-mobile .site-info-header-details {
+	flex-basis: 0;
+	min-width: 200px;
+}
+
+.site-info-header-action {
 	flex: none;
 	flex-shrink: 0;
 }


### PR DESCRIPTION
## Summary

Makes the Site Manager header respond to the panel's available width instead of
the browser viewport. Site details keep a readable minimum width while the
action buttons move to a new row and wrap when the panel gets narrow.

## Before and after

| View | Before | After |
| --- | --- | --- |
| Desktop — 1440×900 viewport, 400px panel | <img width="400" alt="Desktop before: site title collapsed into a vertical column in a narrow Site Manager panel" src="https://gist.githubusercontent.com/bgrgicak/2f6863ba26c32ce6e2e985f49a26e4d3/raw/ae437497959eda7793a550f437812e6ab252507c/desktop-before.png"> | <img width="400" alt="Desktop after: readable site title with actions wrapped below in a narrow Site Manager panel" src="https://gist.githubusercontent.com/bgrgicak/2f6863ba26c32ce6e2e985f49a26e4d3/raw/ae437497959eda7793a550f437812e6ab252507c/desktop-after.png"> |
| Mobile — 390×844 viewport | <img width="260" alt="Mobile before: site title collapsed into a vertical column" src="https://gist.githubusercontent.com/bgrgicak/2f6863ba26c32ce6e2e985f49a26e4d3/raw/ae437497959eda7793a550f437812e6ab252507c/mobile-before.png"> | <img width="260" alt="Mobile after: readable site title with actions wrapped below" src="https://gist.githubusercontent.com/bgrgicak/2f6863ba26c32ce6e2e985f49a26e4d3/raw/ae437497959eda7793a550f437812e6ab252507c/mobile-after.png"> |

## Testing Instructions

1. Run `npm run dev`.
2. Open `http://localhost:5400/website-server/`.
3. Open **Site Manager** and select an autosaved Playground.
4. In a wide desktop viewport, resize the Site Manager panel between roughly
   400px and 800px. Confirm the title remains readable and the action row
   reflows based on the panel width.
5. At a 390×844 viewport, confirm the title remains readable and all actions
   stay fully visible.
