### PR TITLE
[Website] Render Playground logs as escaped text

### DIFF
--- a/packages/playground/website/src/components/log-modal/index.tsx
+++ b/packages/playground/website/src/components/log-modal/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { Fragment, useEffect, useState } from 'react';
 import { logEventType, logger } from '@php-wasm/logger';
 
 import classNames from 'classnames';
@@ -11,6 +11,7 @@ import type {
 } from '../../lib/state/redux/store';
 import { useDispatch, useSelector } from 'react-redux';
 import { setActiveModal } from '../../lib/state/redux/slice-ui';
+import { splitLogHighlights } from './log-highlights';
 
 export function LogModal(props: { description?: JSX.Element; title?: string }) {
 	const activeModal = useSelector(
@@ -34,9 +35,12 @@ export function SiteLogs({ className }: { className?: string }) {
 	const [logs, setLogs] = useState<string[]>([]);
 	const [searchTerm, setSearchTerm] = useState('');
 
-	const filteredLogs = logs.filter((log) =>
-		log.toLowerCase().includes(searchTerm.toLowerCase())
-	);
+	// Keep each entry's original append-only index as its stable React key.
+	const filteredLogs = logs
+		.map((log, index) => ({ log, index }))
+		.filter(({ log }) =>
+			log.toLowerCase().includes(searchTerm.toLowerCase())
+		);
 
 	useEffect(() => {
 		getLogs();
@@ -52,15 +56,22 @@ export function SiteLogs({ className }: { className?: string }) {
 	}
 
 	function logList() {
-		return filteredLogs.reverse().map((log, index) => (
-			<div
-				className={css.logEntry}
-				key={index}
-				dangerouslySetInnerHTML={{
-					__html: log.replace(/Error:|Fatal:/, '<mark>$&</mark>'),
-				}}
-			/>
-		));
+		return filteredLogs
+			.slice()
+			.reverse()
+			.map(({ log, index }) => (
+				<div className={css.logEntry} key={index}>
+					{splitLogHighlights(log).map((segment, segmentIndex) =>
+						segment.highlight ? (
+							<mark key={segmentIndex}>{segment.text}</mark>
+						) : (
+							<Fragment key={segmentIndex}>
+								{segment.text}
+							</Fragment>
+						)
+					)}
+				</div>
+			));
 	}
 
 	return (

--- a/packages/playground/website/src/components/log-modal/log-highlights.spec.ts
+++ b/packages/playground/website/src/components/log-modal/log-highlights.spec.ts
@@ -20,6 +20,12 @@ describe('splitLogHighlights', () => {
 		]);
 	});
 
+	it('does not highlight lowercase words that resemble severity markers', () => {
+		expect(splitLogHighlights('error: nope fatal: nope')).toEqual([
+			{ text: 'error: nope fatal: nope', highlight: false },
+		]);
+	});
+
 	it('keeps punctuation before a marker in the plain segment', () => {
 		expect(splitLogHighlights('(Error: failed)')).toEqual([
 			{ text: '(', highlight: false },

--- a/packages/playground/website/src/components/log-modal/log-highlights.spec.ts
+++ b/packages/playground/website/src/components/log-modal/log-highlights.spec.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { splitLogHighlights } from './log-highlights';
+
+describe('splitLogHighlights', () => {
+	it('highlights standalone Error and Fatal markers', () => {
+		expect(splitLogHighlights('PHP Fatal: boom')).toEqual([
+			{ text: 'PHP ', highlight: false },
+			{ text: 'Fatal:', highlight: true },
+			{ text: ' boom', highlight: false },
+		]);
+		expect(splitLogHighlights('Error: failed')).toEqual([
+			{ text: 'Error:', highlight: true },
+			{ text: ' failed', highlight: false },
+		]);
+	});
+
+	it('does not highlight markers embedded in words or class names', () => {
+		expect(splitLogHighlights('ParseError: nope terror: nope')).toEqual([
+			{ text: 'ParseError: nope terror: nope', highlight: false },
+		]);
+	});
+
+	it('keeps punctuation before a marker in the plain segment', () => {
+		expect(splitLogHighlights('(Error: failed)')).toEqual([
+			{ text: '(', highlight: false },
+			{ text: 'Error:', highlight: true },
+			{ text: ' failed)', highlight: false },
+		]);
+	});
+
+	it('keeps log markup as plain text', () => {
+		expect(splitLogHighlights('<img src=x> Error: failed')).toEqual([
+			{ text: '<img src=x> ', highlight: false },
+			{ text: 'Error:', highlight: true },
+			{ text: ' failed', highlight: false },
+		]);
+	});
+});

--- a/packages/playground/website/src/components/log-modal/log-highlights.ts
+++ b/packages/playground/website/src/components/log-modal/log-highlights.ts
@@ -1,0 +1,27 @@
+/**
+ * Splits a log line into plain-text segments, marking `Error:`/`Fatal:` tokens
+ * for emphasis. Returning data instead of HTML ensures React escapes log text.
+ */
+export function splitLogHighlights(
+	log: string
+): Array<{ text: string; highlight: boolean }> {
+	const segments: Array<{ text: string; highlight: boolean }> = [];
+	// Only match standalone severity markers, not names such as `ParseError:`.
+	const pattern = /(?<![\w])(Error:|Fatal:)/gi;
+	let lastIndex = 0;
+	let match: RegExpExecArray | null;
+	while ((match = pattern.exec(log)) !== null) {
+		if (match.index > lastIndex) {
+			segments.push({
+				text: log.slice(lastIndex, match.index),
+				highlight: false,
+			});
+		}
+		segments.push({ text: match[0], highlight: true });
+		lastIndex = pattern.lastIndex;
+	}
+	if (lastIndex < log.length) {
+		segments.push({ text: log.slice(lastIndex), highlight: false });
+	}
+	return segments;
+}

--- a/packages/playground/website/src/components/log-modal/log-highlights.ts
+++ b/packages/playground/website/src/components/log-modal/log-highlights.ts
@@ -7,10 +7,13 @@ export function splitLogHighlights(
 ): Array<{ text: string; highlight: boolean }> {
 	const segments: Array<{ text: string; highlight: boolean }> = [];
 	// Only match standalone severity markers, not names such as `ParseError:`.
-	const pattern = /(?<![\w])(Error:|Fatal:)/gi;
+	const pattern = /Error:|Fatal:/g;
 	let lastIndex = 0;
 	let match: RegExpExecArray | null;
 	while ((match = pattern.exec(log)) !== null) {
+		if (match.index > 0 && /\w/.test(log[match.index - 1])) {
+			continue;
+		}
 		if (match.index > lastIndex) {
 			segments.push({
 				text: log.slice(lastIndex, match.index),


### PR DESCRIPTION
Playground logs are currently passed through `dangerouslySetInnerHTML()` so `Error:` and `Fatal:` can be marked. A log entry containing HTML is therefore interpreted as page markup instead of displayed as log text.

This splits severity markers into plain data and lets React render every segment. Log text is escaped, the markers remain highlighted, and entries keep their original append-only index when filtering or reversing the list.

Tested with:

- `npm exec nx -- test playground-website --testFile=log-highlights.spec.ts`
- `npm exec nx -- run playground-website:lint`
- `npm exec nx -- run playground-website:typecheck`
