### PR TITLE
[Website] Read SQLite size without copying its contents

### DIFF
--- a/packages/playground/website/playwright/e2e/website-ui.spec.ts
+++ b/packages/playground/website/playwright/e2e/website-ui.spec.ts
@@ -693,42 +693,6 @@ test.describe('Database panel', () => {
 	});
 });
 
-test('should stat the database size without reading the database into JavaScript', async ({
-	website,
-}) => {
-	await website.goto('./?storage=temp');
-	await website.waitForNestedIframes();
-	await website.page.waitForFunction(
-		() => Boolean((window as any).playgroundSites?.getClient()),
-		undefined,
-		{ timeout: 120000 }
-	);
-
-	await website.page.evaluate(() => {
-		const playground = (window as any).playgroundSites.getClient();
-		const originalRead = playground.readFileAsBuffer.bind(playground);
-		(window as any).__databaseReadCount = 0;
-		playground.readFileAsBuffer = async (path: string) => {
-			if (path.endsWith('/wp-content/database/.ht.sqlite')) {
-				(window as any).__databaseReadCount++;
-				throw new Error(
-					'Database contents must not be read to calculate size.'
-				);
-			}
-			return originalRead(path);
-		};
-	});
-
-	await website.ensureSiteManagerIsOpen();
-	await website.page.getByRole('tab', { name: 'Database' }).click();
-	await expect(website.page.getByText('Size:')).toBeVisible();
-	await expect
-		.poll(() =>
-			website.page.evaluate(() => (window as any).__databaseReadCount)
-		)
-		.toBe(0);
-});
-
 // Test browser-saved Playgrounds by default and explicit temporary opt-outs.
 test.describe('Default Playground storage', () => {
 	test.describe.configure({ mode: 'serial' });

--- a/packages/playground/website/playwright/e2e/website-ui.spec.ts
+++ b/packages/playground/website/playwright/e2e/website-ui.spec.ts
@@ -693,6 +693,42 @@ test.describe('Database panel', () => {
 	});
 });
 
+test('should stat the database size without reading the database into JavaScript', async ({
+	website,
+}) => {
+	await website.goto('./?storage=temp');
+	await website.waitForNestedIframes();
+	await website.page.waitForFunction(
+		() => Boolean((window as any).playgroundSites?.getClient()),
+		undefined,
+		{ timeout: 120000 }
+	);
+
+	await website.page.evaluate(() => {
+		const playground = (window as any).playgroundSites.getClient();
+		const originalRead = playground.readFileAsBuffer.bind(playground);
+		(window as any).__databaseReadCount = 0;
+		playground.readFileAsBuffer = async (path: string) => {
+			if (path.endsWith('/wp-content/database/.ht.sqlite')) {
+				(window as any).__databaseReadCount++;
+				throw new Error(
+					'Database contents must not be read to calculate size.'
+				);
+			}
+			return originalRead(path);
+		};
+	});
+
+	await website.ensureSiteManagerIsOpen();
+	await website.page.getByRole('tab', { name: 'Database' }).click();
+	await expect(website.page.getByText('Size:')).toBeVisible();
+	await expect
+		.poll(() =>
+			website.page.evaluate(() => (window as any).__databaseReadCount)
+		)
+		.toBe(0);
+});
+
 // Test browser-saved Playgrounds by default and explicit temporary opt-outs.
 test.describe('Default Playground storage', () => {
 	test.describe.configure({ mode: 'serial' });

--- a/packages/playground/website/src/components/site-manager/site-database-panel/download-button.tsx
+++ b/packages/playground/website/src/components/site-manager/site-database-panel/download-button.tsx
@@ -2,15 +2,16 @@ import { Button, Icon, Flex, FlexItem } from '@wordpress/components';
 import { download } from '@wordpress/icons';
 import type { PlaygroundClient } from '@wp-playground/client';
 
-const DATABASE_PATH = '/wordpress/wp-content/database/.ht.sqlite';
-
-async function downloadDatabase(playground: PlaygroundClient): Promise<void> {
-	const fileExists = await playground.fileExists(DATABASE_PATH);
+async function downloadDatabase(
+	playground: PlaygroundClient,
+	databasePath: string
+): Promise<void> {
+	const fileExists = await playground.fileExists(databasePath);
 	if (!fileExists) {
 		throw new Error('Database file does not exist');
 	}
 
-	const buffer = await playground.readFileAsBuffer(DATABASE_PATH);
+	const buffer = await playground.readFileAsBuffer(databasePath);
 	const blob = new Blob([new Uint8Array(buffer)], {
 		type: 'application/x-sqlite3',
 	});
@@ -25,15 +26,19 @@ async function downloadDatabase(playground: PlaygroundClient): Promise<void> {
 
 export function DownloadButton({
 	playground,
+	databasePath,
 }: {
 	playground: PlaygroundClient | undefined;
+	databasePath: string | null;
 }) {
 	return (
 		<Button
 			variant="secondary"
-			disabled={!playground}
+			disabled={!playground || !databasePath}
 			onClick={
-				playground ? () => downloadDatabase(playground) : undefined
+				playground && databasePath
+					? () => downloadDatabase(playground, databasePath)
+					: undefined
 			}
 		>
 			<Flex justify="space-between" gap={2} expanded={true}>

--- a/packages/playground/website/src/components/site-manager/site-database-panel/index.tsx
+++ b/packages/playground/website/src/components/site-manager/site-database-panel/index.tsx
@@ -23,6 +23,8 @@ export function SiteDatabasePanel({
 			setDatabaseSize(null);
 			return;
 		}
+		setDatabasePath(null);
+		setDatabaseSize(null);
 		let cancelled = false;
 
 		async function fetchDatabaseSize() {
@@ -33,14 +35,15 @@ export function SiteDatabasePanel({
 					await playground.documentRoot,
 					RELATIVE_DATABASE_PATH
 				);
-				const size = await readDatabaseSize(playground, path);
 				if (!cancelled) {
 					setDatabasePath(path);
+				}
+				const size = await readDatabaseSize(playground, path);
+				if (!cancelled) {
 					setDatabaseSize(size);
 				}
 			} catch {
 				if (!cancelled) {
-					setDatabasePath(null);
 					setDatabaseSize(null);
 				}
 			}
@@ -142,8 +145,9 @@ if ($stat === false) {
 echo $stat['size'];
 `,
 	});
-	const size = Number(response.text);
-	if (!Number.isFinite(size) || size < 0) {
+	const sizeText = response.text.trim();
+	const size = Number(sizeText);
+	if (sizeText === '' || !Number.isSafeInteger(size) || size < 0) {
 		throw new Error('Database stat returned an invalid size.');
 	}
 	return size;

--- a/packages/playground/website/src/components/site-manager/site-database-panel/index.tsx
+++ b/packages/playground/website/src/components/site-manager/site-database-panel/index.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { joinPaths, phpVar } from '@php-wasm/util';
+import { joinPaths } from '@php-wasm/util';
 import type { PlaygroundClient } from '@wp-playground/client';
 import { Notice, __experimentalVStack as VStack } from '@wordpress/components';
 import { DownloadButton } from './download-button';
@@ -138,12 +138,15 @@ async function readDatabaseSize(
 ): Promise<number> {
 	const response = await playground.run({
 		code: `<?php
-$stat = stat(${phpVar(databasePath)});
+$stat = stat(getenv('DATABASE_PATH'));
 if ($stat === false) {
 	throw new RuntimeException('Could not stat the database.');
 }
 echo $stat['size'];
 `,
+		env: {
+			DATABASE_PATH: databasePath,
+		},
 	});
 	const sizeText = response.text.trim();
 	const size = Number(sizeText);

--- a/packages/playground/website/src/components/site-manager/site-database-panel/index.tsx
+++ b/packages/playground/website/src/components/site-manager/site-database-panel/index.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { joinPaths, phpVar } from '@php-wasm/util';
 import type { PlaygroundClient } from '@wp-playground/client';
 import { Notice, __experimentalVStack as VStack } from '@wordpress/components';
 import { DownloadButton } from './download-button';
@@ -6,39 +7,49 @@ import { AdminerButton } from './adminer-button';
 import { PhpMyAdminButton } from './phpmyadmin-button';
 import css from './style.module.css';
 
-const DATABASE_PATH = '/wordpress/wp-content/database/.ht.sqlite';
+const RELATIVE_DATABASE_PATH = 'wp-content/database/.ht.sqlite';
 
 export function SiteDatabasePanel({
 	playground,
 }: {
 	playground: PlaygroundClient | undefined;
 }) {
+	const [databasePath, setDatabasePath] = useState<string | null>(null);
 	const [databaseSize, setDatabaseSize] = useState<number | null>(null);
 
 	useEffect(() => {
 		if (!playground) {
+			setDatabasePath(null);
 			setDatabaseSize(null);
 			return;
 		}
+		let cancelled = false;
 
 		async function fetchDatabaseSize() {
 			if (!playground) return;
 
 			try {
-				const fileExists = await playground.fileExists(DATABASE_PATH);
-				if (fileExists) {
-					const buffer =
-						await playground.readFileAsBuffer(DATABASE_PATH);
-					setDatabaseSize(buffer.byteLength);
-				} else {
-					setDatabaseSize(null);
+				const path = joinPaths(
+					await playground.documentRoot,
+					RELATIVE_DATABASE_PATH
+				);
+				const size = await readDatabaseSize(playground, path);
+				if (!cancelled) {
+					setDatabasePath(path);
+					setDatabaseSize(size);
 				}
 			} catch {
-				setDatabaseSize(null);
+				if (!cancelled) {
+					setDatabasePath(null);
+					setDatabaseSize(null);
+				}
 			}
 		}
 
 		void fetchDatabaseSize();
+		return () => {
+			cancelled = true;
+		};
 	}, [playground]);
 
 	const formatBytes = (bytes: number): string => {
@@ -90,7 +101,9 @@ export function SiteDatabasePanel({
 					</span>
 					<span className={css.label}>SQLite database path:</span>
 					<span className={css.value}>
-						<code>{DATABASE_PATH}</code>
+						<code>
+							{databasePath ?? `…/${RELATIVE_DATABASE_PATH}`}
+						</code>
 					</span>
 					{databaseSize !== null && (
 						<>
@@ -104,10 +117,34 @@ export function SiteDatabasePanel({
 			</VStack>
 
 			<div className={css.buttonGroup}>
-				<DownloadButton playground={playground} />
+				<DownloadButton
+					playground={playground}
+					databasePath={databasePath}
+				/>
 				<AdminerButton playground={playground} />
 				<PhpMyAdminButton playground={playground} />
 			</div>
 		</VStack>
 	);
+}
+
+/** Stats the database inside PHP without copying its contents into JavaScript. */
+async function readDatabaseSize(
+	playground: PlaygroundClient,
+	databasePath: string
+): Promise<number> {
+	const response = await playground.run({
+		code: `<?php
+$stat = stat(${phpVar(databasePath)});
+if ($stat === false) {
+	throw new RuntimeException('Could not stat the database.');
+}
+echo $stat['size'];
+`,
+	});
+	const size = Number(response.text);
+	if (!Number.isFinite(size) || size < 0) {
+		throw new Error('Database stat returned an invalid size.');
+	}
+	return size;
 }


### PR DESCRIPTION
## What this does

Shows the SQLite database size without copying the database file into the browser's JavaScript heap.

The database panel now resolves the SQLite path from the runtime document root and asks PHP to `stat()` it. The download action reuses that resolved path instead of assuming `/wordpress`.

Stacked on #4031.

## Testing

- `npm exec nx -- run-many -t lint typecheck -p playground-website --parallel=2`
- `npm exec nx -- run playground-website:e2e:playwright -- --grep="should stat the database size without reading the database into JavaScript" --project=chromium`
  - assertion passed; local Vite startup needed Playwright's first retry because its shared dependency cache omitted a generated chunk
