### PR TITLE
[Website] Separate in-place and fresh-site settings actions

### DIFF
--- a/packages/playground/website/playwright/e2e/website-ui.spec.ts
+++ b/packages/playground/website/playwright/e2e/website-ui.spec.ts
@@ -960,9 +960,16 @@ test.describe('Default Playground storage', () => {
 		).toBeEnabled();
 		await expect(
 			website.page.getByRole('button', {
-				name: 'Apply to this Playground',
+				name: 'Create a fresh Playground',
+				exact: true,
 			})
-		).toBeDisabled();
+		).toBeEnabled();
+		await expect(
+			website.page.getByRole('button', {
+				name: 'Apply to this Playground',
+				exact: true,
+			})
+		).toHaveCount(0);
 
 		await website.page
 			.getByRole('button', { name: 'More settings actions' })
@@ -976,8 +983,10 @@ test.describe('Default Playground storage', () => {
 		await expect(freshMenuItem).toContainText(
 			`“${autosavedSite.name}” stays in Recent autosaves until 5 newer autosaves replace it.`
 		);
-		await expect(applyMenuItem).toBeFocused();
+		await expect(freshMenuItem).toBeFocused();
 		await expect(applyMenuItem).toHaveAttribute('aria-disabled', 'true');
+		await website.page.keyboard.press('ArrowUp');
+		await expect(applyMenuItem).toBeFocused();
 		await website.page.keyboard.press('ArrowDown');
 		await expect(freshMenuItem).toBeFocused();
 		await website.page.keyboard.press('Home');

--- a/packages/playground/website/playwright/e2e/website-ui.spec.ts
+++ b/packages/playground/website/playwright/e2e/website-ui.spec.ts
@@ -66,6 +66,25 @@ async function getActivePlaygroundSite(page: Page) {
 	);
 }
 
+async function getRunningPhpVersion(page: Page) {
+	return page.evaluate(async () => {
+		const playground = (window as any).playgroundSites?.getClient();
+		if (!playground) {
+			return undefined;
+		}
+		return Promise.race([
+			playground
+				.run({
+					code: '<?php echo PHP_MAJOR_VERSION . "." . PHP_MINOR_VERSION;',
+				})
+				.then((response: { text: string }) => response.text),
+			new Promise<undefined>((resolve) =>
+				window.setTimeout(() => resolve(undefined), 1000)
+			),
+		]);
+	});
+}
+
 async function replaceBlueprintEditorContents(
 	page: Page,
 	blueprint: Blueprint
@@ -133,7 +152,7 @@ SupportedPHPVersions.forEach(async (version) => {
 		await website.ensureSiteManagerIsOpen();
 		await website.page.getByLabel('PHP version').selectOption(version);
 		await website.page
-			.getByText('Apply Settings & Reset Playground')
+			.getByText('Discard current work & create a fresh Playground')
 			.click();
 		await website.ensureSiteManagerIsClosed();
 		await website.ensureSiteManagerIsOpen();
@@ -157,7 +176,7 @@ Object.keys(MinifiedWordPressVersions)
 				.getByLabel('WordPress version')
 				.selectOption(version);
 			await website.page
-				.getByText('Apply Settings & Reset Playground')
+				.getByText('Discard current work & create a fresh Playground')
 				.click();
 			await website.ensureSiteManagerIsClosed();
 			await website.ensureSiteManagerIsOpen();
@@ -167,6 +186,24 @@ Object.keys(MinifiedWordPressVersions)
 			).toHaveValue(version);
 		});
 	});
+
+test('should offer only the destructive fresh-site action for a temporary Playground', async ({
+	website,
+}) => {
+	await website.goto('./?storage=temp');
+	await website.ensureSiteManagerIsOpen();
+	await expect(
+		website.page.getByRole('button', {
+			name: 'Discard current work & create a fresh Playground',
+		})
+	).toBeVisible();
+	await expect(
+		website.page.getByRole('button', { name: 'More settings actions' })
+	).toHaveCount(0);
+	await expect(
+		website.page.getByRole('button', { name: 'Apply to this Playground' })
+	).toHaveCount(0);
+});
 
 test('should display networking as active by default', async ({ website }) => {
 	await website.goto('./?storage=temp');
@@ -187,7 +224,9 @@ test('should enable networking when requested', async ({ website }) => {
 
 	await website.ensureSiteManagerIsOpen();
 	await website.page.getByLabel('Network access').check();
-	await website.page.getByText('Apply Settings & Reset Playground').click();
+	await website.page
+		.getByText('Discard current work & create a fresh Playground')
+		.click();
 	await website.ensureSiteManagerIsClosed();
 	await website.ensureSiteManagerIsOpen();
 
@@ -199,7 +238,9 @@ test('should disable networking when requested', async ({ website }) => {
 
 	await website.ensureSiteManagerIsOpen();
 	await website.page.getByLabel('Network access').uncheck();
-	await website.page.getByText('Apply Settings & Reset Playground').click();
+	await website.page
+		.getByText('Discard current work & create a fresh Playground')
+		.click();
 	await website.ensureSiteManagerIsClosed();
 	await website.ensureSiteManagerIsOpen();
 
@@ -248,7 +289,9 @@ test('should keep query arguments when updating settings', async ({
 
 	await website.ensureSiteManagerIsOpen();
 	await website.page.getByLabel('Network access').check();
-	await website.page.getByText('Apply Settings & Reset Playground').click();
+	await website.page
+		.getByText('Discard current work & create a fresh Playground')
+		.click();
 	await website.waitForNestedIframes();
 
 	const updatedParams = new URL(website.page.url()).searchParams;
@@ -882,7 +925,7 @@ test.describe('Default Playground storage', () => {
 			});
 	});
 
-	test('should offer full settings for an autosaved Playground', async ({
+	test('should offer full settings and keyboard-accessible actions for an autosaved Playground', async ({
 		website,
 		browserName,
 	}) => {
@@ -891,12 +934,13 @@ test.describe('Default Playground storage', () => {
 			`Saved-by-default Playgrounds rely on OPFS, which is not available in Playwright's ${browserName}.`
 		);
 
-		await website.page.goto('./');
+		await website.goto(
+			getUniqueSavedPlaygroundSetupUrl('settings-actions')
+		);
 		await expect(
 			website.page.getByRole('button', { name: 'Autosaved' })
-		).toBeVisible({
-			timeout: 120000,
-		});
+		).toBeVisible({ timeout: 120000 });
+		const autosavedSite = await getActivePlaygroundSite(website.page);
 
 		await website.page
 			.getByRole('button', { name: 'Edit Playground settings' })
@@ -915,11 +959,34 @@ test.describe('Default Playground storage', () => {
 			website.page.getByLabel('Create a multisite network')
 		).toBeEnabled();
 		await expect(
-			website.page.getByText('Apply Settings & Recreate Playground')
-		).toBeVisible();
+			website.page.getByRole('button', {
+				name: 'Apply to this Playground',
+			})
+		).toBeDisabled();
+
+		await website.page
+			.getByRole('button', { name: 'More settings actions' })
+			.click();
+		const applyMenuItem = website.page.getByRole('menuitem', {
+			name: /Apply to this Playground/,
+		});
+		const freshMenuItem = website.page.getByRole('menuitem', {
+			name: /Create a fresh Playground/,
+		});
+		await expect(freshMenuItem).toContainText(
+			`“${autosavedSite.name}” stays in Recent autosaves until 5 newer autosaves replace it.`
+		);
+		await expect(applyMenuItem).toBeFocused();
+		await expect(applyMenuItem).toHaveAttribute('aria-disabled', 'true');
+		await website.page.keyboard.press('ArrowDown');
+		await expect(freshMenuItem).toBeFocused();
+		await website.page.keyboard.press('Home');
+		await expect(applyMenuItem).toBeFocused();
+		await website.page.keyboard.press('End');
+		await expect(freshMenuItem).toBeFocused();
 	});
 
-	test('should apply settings to an autosaved Playground under the same slug', async ({
+	test('should atomically apply PHP and network settings to the current autosave', async ({
 		website,
 		browserName,
 	}) => {
@@ -928,9 +995,7 @@ test.describe('Default Playground storage', () => {
 			`Saved-by-default Playgrounds rely on OPFS, which is not available in Playwright's ${browserName}.`
 		);
 
-		await website.goto(
-			getUniqueSavedPlaygroundSetupUrl('settings-recreate')
-		);
+		await website.goto(getUniqueSavedPlaygroundSetupUrl('settings-apply'));
 		await expect(
 			website.page.getByRole('button', { name: 'Autosaved' })
 		).toBeVisible({ timeout: 120000 });
@@ -941,24 +1006,17 @@ test.describe('Default Playground storage', () => {
 			.click();
 		const phpSelect = website.page.getByLabel('PHP version');
 		const currentPhpVersion = await phpSelect.inputValue();
-		const nextPhpVersion = SupportedPHPVersions.find(
-			(version) => version !== currentPhpVersion
-		)!;
+		const nextPhpVersion = currentPhpVersion === '8.4' ? '8.3' : '8.4';
 		await phpSelect.selectOption(nextPhpVersion);
+		await website.page.getByLabel('Allow network access').uncheck();
 		const applySettingsButton = website.page.getByRole('button', {
-			name: 'Apply Settings & Recreate Playground',
+			name: 'Apply to this Playground',
 		});
-		// The settings popover should close when recreation starts. If the click
-		// is lost, retry the user action before asserting on the new setup URL.
-		await expect(async () => {
-			await applySettingsButton.click();
-			await expect(applySettingsButton).toBeHidden({ timeout: 10000 });
-		}).toPass({ timeout: 120000 });
+		await expect(applySettingsButton).toBeEnabled();
+		await applySettingsButton.click();
 
 		await expect
-			.poll(() => new URL(website.page.url()).searchParams.get('php'), {
-				timeout: 120000,
-			})
+			.poll(() => getRunningPhpVersion(website.page), { timeout: 120000 })
 			.toBe(nextPhpVersion);
 		await expect(
 			website.page.getByRole('button', { name: 'Autosaved' })
@@ -983,6 +1041,169 @@ test.describe('Default Playground storage', () => {
 				)
 			)
 			.toBe(1);
+
+		await website.page
+			.getByRole('button', { name: 'Edit Playground settings' })
+			.click();
+		await expect(website.page.getByLabel('PHP version')).toHaveValue(
+			nextPhpVersion
+		);
+		await expect(
+			website.page.getByLabel('Allow network access')
+		).not.toBeChecked();
+	});
+
+	test('should create exactly one fresh Playground for structural settings', async ({
+		website,
+		browserName,
+	}) => {
+		test.skip(
+			browserName !== 'chromium',
+			`Saved-by-default Playgrounds rely on OPFS, which is not available in Playwright's ${browserName}.`
+		);
+
+		await website.goto(getUniqueSavedPlaygroundSetupUrl('settings-fresh'));
+		await expect(
+			website.page.getByRole('button', { name: 'Autosaved' })
+		).toBeVisible({ timeout: 120000 });
+		const originalSite = await getActivePlaygroundSite(website.page);
+		const sitesBefore = await website.page.evaluate(
+			() => (window as any).playgroundSites.list().length
+		);
+
+		await website.page
+			.getByRole('button', { name: 'Edit Playground settings' })
+			.click();
+		const wpSelect = website.page.getByLabel('WordPress version');
+		const currentWpVersion = await wpSelect.inputValue();
+		const nextWpVersion = Object.keys(MinifiedWordPressVersions).find(
+			(version) =>
+				!['beta', 'default', currentWpVersion].includes(version)
+		)!;
+		await wpSelect.selectOption(nextWpVersion);
+
+		const mainAction = website.page.getByRole('button', {
+			name: 'Create a fresh Playground',
+			exact: true,
+		});
+		await expect(mainAction).toBeEnabled();
+		await website.page
+			.getByRole('button', { name: 'More settings actions' })
+			.click();
+		const applyMenuItem = website.page.getByRole('menuitem', {
+			name: /Apply to this Playground/,
+		});
+		await expect(applyMenuItem).toHaveAttribute('aria-disabled', 'true');
+		await expect(applyMenuItem).toContainText(
+			'Changing WordPress version requires a fresh Playground.'
+		);
+		await website.page.keyboard.press('Escape');
+
+		// Two same-task clicks exercise the gap before React can paint disabled.
+		await mainAction.evaluate((button: HTMLButtonElement) => {
+			button.click();
+			button.click();
+		});
+		await expect(mainAction).toBeHidden({ timeout: 120000 });
+
+		await expect
+			.poll(
+				() =>
+					website.page.evaluate(
+						() => (window as any).playgroundSites.list().length
+					),
+				{ timeout: 120000 }
+			)
+			.toBe(sitesBefore + 1);
+		const freshSite = await getActivePlaygroundSite(website.page);
+		expect(freshSite.slug).not.toBe(originalSite.slug);
+		await expect
+			.poll(() =>
+				website.page.evaluate(
+					(slug) =>
+						(window as any).playgroundSites
+							.list()
+							.some((site: any) => site.slug === slug),
+					originalSite.slug
+				)
+			)
+			.toBe(true);
+	});
+
+	test('should preserve an explicitly saved Playground when creating a fresh site', async ({
+		website,
+		browserName,
+	}) => {
+		test.skip(
+			browserName !== 'chromium',
+			`Saved-by-default Playgrounds rely on OPFS, which is not available in Playwright's ${browserName}.`
+		);
+
+		await website.goto(getUniqueSavedPlaygroundSetupUrl('stored-settings'));
+		const statusButton = website.page.getByRole('button', {
+			name: 'Autosaved',
+		});
+		await expect(statusButton).toBeVisible({ timeout: 120000 });
+		await statusButton.click();
+		await website.page
+			.getByRole('button', { name: 'Store permanently' })
+			.click();
+		const saveDialog = website.page.getByRole('dialog', {
+			name: 'Save Playground',
+		});
+		await saveDialog.getByRole('button', { name: 'Save' }).click();
+		await expect
+			.poll(() => getActivePlaygroundSite(website.page))
+			.toMatchObject({ persistence: 'explicit' });
+		const storedSite = await getActivePlaygroundSite(website.page);
+
+		await website.page
+			.getByRole('button', { name: 'Edit Playground settings' })
+			.click();
+		await expect(
+			website.page.getByLabel('WordPress version')
+		).toBeEnabled();
+		await expect(website.page.getByLabel('Language')).toBeEnabled();
+		await expect(
+			website.page.getByLabel('Create a multisite network')
+		).toBeEnabled();
+		await website.page
+			.getByRole('button', { name: 'More settings actions' })
+			.click();
+		await expect(
+			website.page.getByRole('menuitem', {
+				name: /Create a fresh Playground/,
+			})
+		).toContainText(`“${storedSite.name}” stays in Saved Playgrounds.`);
+		await website.page.keyboard.press('Escape');
+		await website.page.getByLabel('Language').selectOption('pl_PL');
+		await website.page
+			.getByRole('button', {
+				name: 'Create a fresh Playground',
+				exact: true,
+			})
+			.click();
+
+		await expect
+			.poll(() => getActivePlaygroundSite(website.page), {
+				timeout: 120000,
+			})
+			.not.toMatchObject({ slug: storedSite.slug });
+		await expect
+			.poll(() =>
+				website.page.evaluate(
+					(slug) =>
+						(window as any).playgroundSites
+							.list()
+							.some(
+								(site: any) =>
+									site.slug === slug &&
+									site.persistence === 'explicit'
+							),
+					storedSite.slug
+				)
+			)
+			.toBe(true);
 	});
 
 	test('should show intent-driven creation actions in the overlay', async ({

--- a/packages/playground/website/playwright/e2e/website-ui.spec.ts
+++ b/packages/playground/website/playwright/e2e/website-ui.spec.ts
@@ -927,6 +927,7 @@ test.describe('Default Playground storage', () => {
 
 	test('should offer full settings and keyboard-accessible actions for an autosaved Playground', async ({
 		website,
+		wordpress,
 		browserName,
 	}) => {
 		test.skip(
@@ -960,16 +961,10 @@ test.describe('Default Playground storage', () => {
 		).toBeEnabled();
 		await expect(
 			website.page.getByRole('button', {
-				name: 'Create a fresh Playground',
-				exact: true,
-			})
-		).toBeEnabled();
-		await expect(
-			website.page.getByRole('button', {
 				name: 'Apply to this Playground',
 				exact: true,
 			})
-		).toHaveCount(0);
+		).toBeEnabled();
 
 		await website.page
 			.getByRole('button', { name: 'More settings actions' })
@@ -983,16 +978,30 @@ test.describe('Default Playground storage', () => {
 		await expect(freshMenuItem).toContainText(
 			`“${autosavedSite.name}” stays in Recent autosaves until 5 newer autosaves replace it.`
 		);
-		await expect(freshMenuItem).toBeFocused();
-		await expect(applyMenuItem).toHaveAttribute('aria-disabled', 'true');
-		await website.page.keyboard.press('ArrowUp');
 		await expect(applyMenuItem).toBeFocused();
+		await expect(applyMenuItem).toHaveAttribute('aria-disabled', 'false');
 		await website.page.keyboard.press('ArrowDown');
 		await expect(freshMenuItem).toBeFocused();
 		await website.page.keyboard.press('Home');
 		await expect(applyMenuItem).toBeFocused();
 		await website.page.keyboard.press('End');
 		await expect(freshMenuItem).toBeFocused();
+
+		await website.page.keyboard.press('Escape');
+		const body = wordpress.locator('body');
+		await body.evaluate((element) =>
+			element.setAttribute('data-settings-no-op-marker', 'present')
+		);
+		await website.page
+			.getByRole('button', {
+				name: 'Apply to this Playground',
+				exact: true,
+			})
+			.click();
+		await expect(body).not.toHaveAttribute(
+			'data-settings-no-op-marker',
+			'present'
+		);
 	});
 
 	test('should atomically apply PHP and network settings to the current autosave', async ({

--- a/packages/playground/website/src/components/site-manager/site-settings-form/active-site-settings-form.spec.tsx
+++ b/packages/playground/website/src/components/site-manager/site-settings-form/active-site-settings-form.spec.tsx
@@ -1,0 +1,135 @@
+// @vitest-environment jsdom
+
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import type { Root } from 'react-dom/client';
+import { ActiveSiteSettingsForm } from './active-site-settings-form';
+import type { SiteFormData } from './unconnected-site-settings-form';
+import type { SiteSettingsSubmission } from './use-site-settings-submission';
+
+const mocks = vi.hoisted(() => ({
+	activeSite: undefined as
+		| {
+				slug: string;
+				metadata: { storage: string; persistence: string };
+		  }
+		| undefined,
+	renderedForm: '',
+	submission: undefined as SiteSettingsSubmission | undefined,
+}));
+
+vi.mock('../../../lib/state/redux/store', () => ({
+	useActiveSite: () => mocks.activeSite,
+}));
+
+vi.mock('../../../lib/state/redux/slice-sites', () => ({
+	isAutosavedSite: (site: { metadata: { persistence: string } }) =>
+		site.metadata.persistence === 'autosave',
+}));
+
+vi.mock('./autosaved-site-settings-form', () => ({
+	AutosavedSiteSettingsForm: ({
+		submission,
+	}: {
+		submission: SiteSettingsSubmission;
+	}) => {
+		mocks.renderedForm = 'autosaved';
+		mocks.submission = submission;
+		return null;
+	},
+}));
+
+vi.mock('./stored-site-settings-form', () => ({
+	StoredSiteSettingsForm: ({
+		submission,
+	}: {
+		submission: SiteSettingsSubmission;
+	}) => {
+		mocks.renderedForm = 'stored';
+		mocks.submission = submission;
+		return null;
+	},
+}));
+
+vi.mock('./temporary-site-settings-form', () => ({
+	TemporarySiteSettingsForm: ({
+		submission,
+	}: {
+		submission: SiteSettingsSubmission;
+	}) => {
+		mocks.renderedForm = 'temporary';
+		mocks.submission = submission;
+		return null;
+	},
+}));
+
+const formData: SiteFormData = {
+	phpVersion: '8.3',
+	wpVersion: 'latest',
+	language: '',
+	withNetworking: true,
+	multisite: false,
+};
+
+describe('ActiveSiteSettingsForm', () => {
+	let container: HTMLDivElement;
+	let root: Root;
+
+	beforeAll(() => {
+		vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+	});
+
+	afterAll(() => {
+		vi.unstubAllGlobals();
+	});
+
+	beforeEach(() => {
+		container = document.createElement('div');
+		document.body.append(container);
+		root = createRoot(container);
+	});
+
+	afterEach(() => {
+		act(() => root.unmount());
+		container.remove();
+	});
+
+	it('keeps a submission locked when a saved site activates a fresh autosave', async () => {
+		mocks.activeSite = {
+			slug: 'saved-site',
+			metadata: { storage: 'opfs', persistence: 'explicit' },
+		};
+		const onSuccess = vi.fn();
+		act(() => root.render(<ActiveSiteSettingsForm onSubmit={onSuccess} />));
+		expect(mocks.renderedForm).toBe('stored');
+
+		let finish!: () => void;
+		const firstAction = vi.fn(
+			() => new Promise<void>((resolve) => (finish = resolve))
+		);
+		let firstRun!: Promise<void>;
+		act(() => {
+			firstRun = mocks.submission!.run(firstAction, formData);
+		});
+		expect(mocks.submission?.isPending).toBe(true);
+
+		mocks.activeSite = {
+			slug: 'fresh-site',
+			metadata: { storage: 'opfs', persistence: 'autosave' },
+		};
+		act(() => root.render(<ActiveSiteSettingsForm onSubmit={onSuccess} />));
+		expect(mocks.renderedForm).toBe('autosaved');
+		expect(mocks.submission?.isPending).toBe(true);
+
+		const duplicateAction = vi.fn().mockResolvedValue(undefined);
+		await act(() => mocks.submission!.run(duplicateAction, formData));
+		expect(duplicateAction).not.toHaveBeenCalled();
+
+		await act(async () => {
+			finish();
+			await firstRun;
+		});
+		expect(mocks.submission?.isPending).toBe(false);
+		expect(onSuccess).toHaveBeenCalledOnce();
+	});
+});

--- a/packages/playground/website/src/components/site-manager/site-settings-form/active-site-settings-form.tsx
+++ b/packages/playground/website/src/components/site-manager/site-settings-form/active-site-settings-form.tsx
@@ -3,6 +3,7 @@ import { AutosavedSiteSettingsForm } from './autosaved-site-settings-form';
 import { useActiveSite } from '../../../lib/state/redux/store';
 import { StoredSiteSettingsForm } from './stored-site-settings-form';
 import { TemporarySiteSettingsForm } from './temporary-site-settings-form';
+import { useSiteSettingsSubmission } from './use-site-settings-submission';
 
 export function ActiveSiteSettingsForm({
 	onSubmit,
@@ -10,6 +11,10 @@ export function ActiveSiteSettingsForm({
 	onSubmit?: () => void;
 }) {
 	const activeSite = useActiveSite();
+	// Keep one submission guard above the site-type switch. Creating a fresh
+	// autosave from an explicitly saved Playground changes the rendered form
+	// before the new runtime finishes booting, but it must not unlock the action.
+	const submission = useSiteSettingsSubmission(onSubmit);
 
 	if (!activeSite) {
 		return null;
@@ -20,7 +25,7 @@ export function ActiveSiteSettingsForm({
 			return (
 				<TemporarySiteSettingsForm
 					siteSlug={activeSite.slug}
-					onSubmit={onSubmit}
+					submission={submission}
 				/>
 			);
 		case 'opfs':
@@ -31,7 +36,7 @@ export function ActiveSiteSettingsForm({
 				return (
 					<AutosavedSiteSettingsForm
 						siteSlug={activeSite.slug}
-						onSubmit={onSubmit}
+						submission={submission}
 					/>
 				);
 			}
@@ -39,14 +44,14 @@ export function ActiveSiteSettingsForm({
 			return (
 				<StoredSiteSettingsForm
 					siteSlug={activeSite.slug}
-					onSubmit={onSubmit}
+					submission={submission}
 				/>
 			);
 		case 'local-fs':
 			return (
 				<StoredSiteSettingsForm
 					siteSlug={activeSite.slug}
-					onSubmit={onSubmit}
+					submission={submission}
 				/>
 			);
 		default:

--- a/packages/playground/website/src/components/site-manager/site-settings-form/active-site-settings-form.tsx
+++ b/packages/playground/website/src/components/site-manager/site-settings-form/active-site-settings-form.tsx
@@ -24,9 +24,9 @@ export function ActiveSiteSettingsForm({
 				/>
 			);
 		case 'opfs':
-			// Autosaved Playgrounds are recoverable unsaved work, so keep the
-			// full setup form available. Explicitly saved OPFS Playgrounds are
-			// user-confirmed artifacts, so they keep the limited stored-site form.
+			// Autosaved Playgrounds need recovery-specific action copy and
+			// retention behavior. Explicit OPFS Playgrounds share the stored-site
+			// flow with local directory Playgrounds.
 			if (isAutosavedSite(activeSite)) {
 				return (
 					<AutosavedSiteSettingsForm

--- a/packages/playground/website/src/components/site-manager/site-settings-form/autosaved-site-settings-form.tsx
+++ b/packages/playground/website/src/components/site-manager/site-settings-form/autosaved-site-settings-form.tsx
@@ -9,7 +9,7 @@ import {
 	getSiteSettingsFromFormData,
 } from './setup-form-values';
 import { SiteSettingsActionFooter } from './site-settings-action-footer';
-import { useSiteSettingsSubmission } from './use-site-settings-submission';
+import type { SiteSettingsSubmission } from './use-site-settings-submission';
 
 /**
  * Renders the setup settings form for an autosaved Playground.
@@ -19,16 +19,15 @@ import { useSiteSettingsSubmission } from './use-site-settings-submission';
  */
 export function AutosavedSiteSettingsForm({
 	siteSlug,
-	onSubmit,
+	submission,
 }: {
 	siteSlug: string;
-	onSubmit?: () => void;
+	submission: SiteSettingsSubmission;
 }) {
 	const siteInfo = useAppSelector((state) =>
 		selectSiteBySlug(state, siteSlug)
 	)!;
 	const sitesAPI = useSitesAPI();
-	const submission = useSiteSettingsSubmission(onSubmit);
 	const updateSite = async (data: SiteFormData) => {
 		await sitesAPI.updateRuntimeSettings({
 			phpVersion: data.phpVersion,

--- a/packages/playground/website/src/components/site-manager/site-settings-form/autosaved-site-settings-form.tsx
+++ b/packages/playground/website/src/components/site-manager/site-settings-form/autosaved-site-settings-form.tsx
@@ -1,6 +1,4 @@
 import { useMemo } from 'react';
-import css from './style.module.css';
-import { Button, __experimentalVStack as VStack } from '@wordpress/components';
 import { useAppSelector } from '../../../lib/state/redux/store';
 import { selectSiteBySlug } from '../../../lib/state/redux/slice-sites';
 import type { SiteFormData } from './unconnected-site-settings-form';
@@ -10,13 +8,14 @@ import {
 	getSetupFormDefaultValues,
 	getSiteSettingsFromFormData,
 } from './setup-form-values';
+import { SiteSettingsActionFooter } from './site-settings-action-footer';
+import { useSiteSettingsSubmission } from './use-site-settings-submission';
 
 /**
  * Renders the setup settings form for an autosaved Playground.
  *
- * Autosaved Playgrounds represent recoverable unsaved work, so changing setup
- * fields recreates the same autosaved site instead of creating a second site or
- * preserving the previous WordPress files.
+ * PHP and networking can be applied to the current Playground. Setup changes
+ * create a fresh autosaved Playground while preserving the current one.
  */
 export function AutosavedSiteSettingsForm({
 	siteSlug,
@@ -29,9 +28,22 @@ export function AutosavedSiteSettingsForm({
 		selectSiteBySlug(state, siteSlug)
 	)!;
 	const sitesAPI = useSitesAPI();
+	const submission = useSiteSettingsSubmission(onSubmit);
 	const updateSite = async (data: SiteFormData) => {
-		await sitesAPI.recreateAutosavedSite(getSiteSettingsFromFormData(data));
-		onSubmit?.();
+		await sitesAPI.updateRuntimeSettings({
+			phpVersion: data.phpVersion,
+			networking: data.withNetworking,
+		});
+	};
+	const createFreshSite = async (data: SiteFormData) => {
+		await sitesAPI.createNewSavedSite(
+			undefined,
+			getSiteSettingsFromFormData(data),
+			{
+				persistence: 'autosave',
+				excludeFromPruning: [siteSlug],
+			}
+		);
 	};
 	const defaultValues = useMemo(
 		() => getSetupFormDefaultValues(siteInfo),
@@ -41,25 +53,21 @@ export function AutosavedSiteSettingsForm({
 	return (
 		<UnconnectedSiteSettingsForm
 			className="is-autosaved-site"
-			onSubmit={updateSite}
+			onSubmit={(data) => submission.run(updateSite, data)}
 			defaultValues={defaultValues}
-			footer={
-				<VStack
-					justify="flex-end"
-					spacing={6}
-					style={{ margin: 0 }}
-					className={`${css.footer} ${css.formSection}`}
-				>
-					<p>
-						<b>Destructive action!</b> Applying these settings will
-						recreate this autosaved Playground under the same name
-						and replace its current WordPress files.
-					</p>
-					<Button type="submit" variant="primary">
-						Apply Settings & Recreate Playground
-					</Button>
-				</VStack>
-			}
+			footer={(context) => (
+				<SiteSettingsActionFooter
+					{...context}
+					siteName={siteInfo.metadata.name}
+					sitePersistence="autosave"
+					onApply={(data) => submission.run(updateSite, data)}
+					onCreateFresh={(data) =>
+						submission.run(createFreshSite, data)
+					}
+					isPending={submission.isPending}
+					error={submission.error}
+				/>
+			)}
 		/>
 	);
 }

--- a/packages/playground/website/src/components/site-manager/site-settings-form/setup-form-values.ts
+++ b/packages/playground/website/src/components/site-manager/site-settings-form/setup-form-values.ts
@@ -9,8 +9,8 @@ import type { SiteFormData } from './unconnected-site-settings-form';
  * `metadata.runtimeConfiguration`, which records boot settings such as PHP,
  * WordPress, and networking. Raw setup URL fields that are not part of runtime
  * configuration, such as `language` and `multisite`, stay in
- * `originalUrlParams`. The form reads both so it shows the setup that will be
- * used when recreating a temporary or autosaved Playground.
+ * `originalUrlParams`. The form reads both so it can compare edits with the
+ * current setup before applying runtime changes or creating a fresh Playground.
  */
 export function getSetupFormDefaultValues(
 	siteInfo: SiteInfo
@@ -20,6 +20,7 @@ export function getSetupFormDefaultValues(
 	const language = searchParams.language;
 	const multisite = searchParams.multisite;
 	return {
+		// @TODO: Handle an unsupported PHP version coming up here.
 		phpVersion: runtimeConf?.phpVersion as any,
 		wpVersion: runtimeConf?.wpVersion as any,
 		withNetworking: runtimeConf?.networking,

--- a/packages/playground/website/src/components/site-manager/site-settings-form/site-settings-action-footer.spec.tsx
+++ b/packages/playground/website/src/components/site-manager/site-settings-form/site-settings-action-footer.spec.tsx
@@ -99,6 +99,29 @@ describe('settings action footer', () => {
 		expect(onCreateFresh).toHaveBeenCalledWith(defaults);
 	});
 
+	it('focuses the only available action when the menu opens', async () => {
+		await act(async () => {
+			root.render(
+				<SiteSettingsActionFooter
+					values={defaults}
+					defaultValues={defaults}
+					submit={submit}
+					siteName="Test Playground"
+					sitePersistence="autosave"
+					onApply={vi.fn()}
+					onCreateFresh={vi.fn()}
+					isPending={false}
+				/>
+			);
+		});
+
+		await act(async () => getButton('More settings actions').click());
+
+		expect(document.activeElement?.textContent).toContain(
+			'Create a fresh Playground'
+		);
+	});
+
 	it('keeps a temporary-Playground failure beside its disabled action', () => {
 		act(() => {
 			root.render(

--- a/packages/playground/website/src/components/site-manager/site-settings-form/site-settings-action-footer.spec.tsx
+++ b/packages/playground/website/src/components/site-manager/site-settings-form/site-settings-action-footer.spec.tsx
@@ -81,7 +81,7 @@ describe('settings action footer', () => {
 		act(() => {
 			root.render(
 				<SiteSettingsActionFooter
-					values={defaults}
+					values={{ ...defaults, wpVersion: '6.7' }}
 					defaultValues={defaults}
 					submit={submit}
 					siteName="Test Playground"
@@ -99,11 +99,30 @@ describe('settings action footer', () => {
 		expect(onCreateFresh).toHaveBeenCalledWith(defaults);
 	});
 
+	it('keeps apply available when the form is unchanged', () => {
+		act(() => {
+			root.render(
+				<SiteSettingsActionFooter
+					values={defaults}
+					defaultValues={defaults}
+					submit={submit}
+					siteName="Test Playground"
+					sitePersistence="autosave"
+					onApply={vi.fn()}
+					onCreateFresh={vi.fn()}
+					isPending={false}
+				/>
+			);
+		});
+
+		expect(getButton('Apply to this Playground').disabled).toBe(false);
+	});
+
 	it('focuses the only available action when the menu opens', async () => {
 		await act(async () => {
 			root.render(
 				<SiteSettingsActionFooter
-					values={defaults}
+					values={{ ...defaults, wpVersion: '6.7' }}
 					defaultValues={defaults}
 					submit={submit}
 					siteName="Test Playground"

--- a/packages/playground/website/src/components/site-manager/site-settings-form/site-settings-action-footer.spec.tsx
+++ b/packages/playground/website/src/components/site-manager/site-settings-form/site-settings-action-footer.spec.tsx
@@ -1,0 +1,112 @@
+// @vitest-environment jsdom
+
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import type { Root } from 'react-dom/client';
+import {
+	SiteSettingsActionFooter,
+	TemporarySiteSettingsActionFooter,
+} from './site-settings-action-footer';
+import type {
+	SiteFormData,
+	SiteSettingsFormFooterContext,
+} from './unconnected-site-settings-form';
+
+const defaults: SiteFormData = {
+	phpVersion: '8.3',
+	wpVersion: 'latest',
+	language: '',
+	withNetworking: true,
+	multisite: false,
+};
+
+describe('settings action pending state', () => {
+	let container: HTMLDivElement;
+	let root: Root;
+
+	beforeAll(() => {
+		vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+		vi.stubGlobal(
+			'matchMedia',
+			vi.fn((query: string) => ({
+				matches: false,
+				media: query,
+				onchange: null,
+				addEventListener: vi.fn(),
+				removeEventListener: vi.fn(),
+				addListener: vi.fn(),
+				removeListener: vi.fn(),
+				dispatchEvent: vi.fn(),
+			}))
+		);
+	});
+
+	afterAll(() => {
+		vi.unstubAllGlobals();
+	});
+
+	beforeEach(() => {
+		container = document.createElement('div');
+		document.body.append(container);
+		root = createRoot(container);
+	});
+
+	afterEach(() => {
+		act(() => root.unmount());
+		container.remove();
+	});
+
+	it('disables both halves of the saved-Playground action', () => {
+		act(() => {
+			root.render(
+				<SiteSettingsActionFooter
+					values={{ ...defaults, phpVersion: '8.4' }}
+					defaultValues={defaults}
+					submit={submit}
+					siteName="Test Playground"
+					sitePersistence="autosave"
+					onApply={vi.fn()}
+					onCreateFresh={vi.fn()}
+					isPending
+				/>
+			);
+		});
+
+		expect(getButton('Apply to this Playground').disabled).toBe(true);
+		expect(getButton('More settings actions').disabled).toBe(true);
+	});
+
+	it('keeps a temporary-Playground failure beside its disabled action', () => {
+		act(() => {
+			root.render(
+				<TemporarySiteSettingsActionFooter
+					isPending
+					error="Browser storage is full."
+				/>
+			);
+		});
+
+		expect(
+			getButton('Discard current work & create a fresh Playground')
+				.disabled
+		).toBe(true);
+		expect(container.querySelector('[role="alert"]')?.textContent).toBe(
+			'Browser storage is full.'
+		);
+	});
+
+	const submit = ((callback: (data: SiteFormData) => void) => () =>
+		callback(defaults)) as SiteSettingsFormFooterContext['submit'];
+
+	function getButton(name: string): HTMLButtonElement {
+		const button = Array.from(container.querySelectorAll('button')).find(
+			(candidate) =>
+				candidate.textContent?.trim() === name ||
+				candidate.getAttribute('aria-label') === name
+		);
+		if (!button) {
+			throw new Error(`Button not found: ${name}`);
+		}
+		return button;
+	}
+});

--- a/packages/playground/website/src/components/site-manager/site-settings-form/site-settings-action-footer.spec.tsx
+++ b/packages/playground/website/src/components/site-manager/site-settings-form/site-settings-action-footer.spec.tsx
@@ -20,7 +20,7 @@ const defaults: SiteFormData = {
 	multisite: false,
 };
 
-describe('settings action pending state', () => {
+describe('settings action footer', () => {
 	let container: HTMLDivElement;
 	let root: Root;
 
@@ -74,6 +74,29 @@ describe('settings action pending state', () => {
 
 		expect(getButton('Apply to this Playground').disabled).toBe(true);
 		expect(getButton('More settings actions').disabled).toBe(true);
+	});
+
+	it('uses the only available action as the primary action', () => {
+		const onCreateFresh = vi.fn();
+		act(() => {
+			root.render(
+				<SiteSettingsActionFooter
+					values={defaults}
+					defaultValues={defaults}
+					submit={submit}
+					siteName="Test Playground"
+					sitePersistence="autosave"
+					onApply={vi.fn()}
+					onCreateFresh={onCreateFresh}
+					isPending={false}
+				/>
+			);
+		});
+
+		const primaryAction = getButton('Create a fresh Playground');
+		expect(primaryAction.disabled).toBe(false);
+		act(() => primaryAction.click());
+		expect(onCreateFresh).toHaveBeenCalledWith(defaults);
 	});
 
 	it('keeps a temporary-Playground failure beside its disabled action', () => {

--- a/packages/playground/website/src/components/site-manager/site-settings-form/site-settings-action-footer.tsx
+++ b/packages/playground/website/src/components/site-manager/site-settings-form/site-settings-action-footer.tsx
@@ -79,6 +79,7 @@ export function SiteSettingsActionFooter({
 				</Button>
 				<Dropdown
 					className={css.splitButtonDropdown}
+					focusOnMount={false}
 					popoverProps={{
 						placement: 'top-end',
 						className: css.actionMenuPopover,
@@ -148,8 +149,8 @@ function SettingsActionMenu({
 	const items = [applyRef, freshRef];
 
 	useEffect(() => {
-		applyRef.current?.focus();
-	}, []);
+		(canApplyToCurrent ? applyRef : freshRef).current?.focus();
+	}, [canApplyToCurrent]);
 
 	const moveFocus = (event: React.KeyboardEvent, nextIndex: number) => {
 		event.preventDefault();

--- a/packages/playground/website/src/components/site-manager/site-settings-form/site-settings-action-footer.tsx
+++ b/packages/playground/website/src/components/site-manager/site-settings-form/site-settings-action-footer.tsx
@@ -202,9 +202,7 @@ function SettingsActionMenu({
 				ref={freshRef}
 				type="button"
 				role="menuitem"
-				className={`${css.actionMenuItem} ${css.createFreshMenuItem} ${
-					canApplyToCurrent ? '' : css.selectedFreshMenuItem
-				}`}
+				className={`${css.actionMenuItem} ${css.createFreshMenuItem}`}
 				onClick={onCreateFresh}
 			>
 				<span className={css.actionMenuTitle}>

--- a/packages/playground/website/src/components/site-manager/site-settings-form/site-settings-action-footer.tsx
+++ b/packages/playground/website/src/components/site-manager/site-settings-form/site-settings-action-footer.tsx
@@ -1,0 +1,271 @@
+import {
+	Button,
+	Dropdown,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { useEffect, useRef } from 'react';
+import {
+	MAX_AUTOSAVED_SITES,
+	type SitePersistence,
+} from '../../../lib/state/redux/site-lifecycle';
+import type { SiteFormData } from './unconnected-site-settings-form';
+import type { SiteSettingsFormFooterContext } from './unconnected-site-settings-form';
+import {
+	getFreshPlaygroundReason,
+	hasApplicableRuntimeChanges,
+} from './site-settings-actions';
+import css from './style.module.css';
+
+export function SiteSettingsActionFooter({
+	siteName,
+	sitePersistence,
+	values,
+	defaultValues,
+	submit,
+	onApply,
+	onCreateFresh,
+	isPending,
+	error,
+}: SiteSettingsFormFooterContext & {
+	siteName: string;
+	sitePersistence: SitePersistence;
+	onApply: (data: SiteFormData) => void | Promise<void>;
+	onCreateFresh: (data: SiteFormData) => void | Promise<void>;
+	isPending: boolean;
+	error?: string;
+}) {
+	const freshPlaygroundReason = getFreshPlaygroundReason(
+		values,
+		defaultValues
+	);
+	const canApplyToCurrent = !freshPlaygroundReason;
+	const hasRuntimeChanges = hasApplicableRuntimeChanges(
+		values,
+		defaultValues
+	);
+	const applyUnavailableReason =
+		freshPlaygroundReason ??
+		(!hasRuntimeChanges
+			? 'Change PHP version or network access to apply.'
+			: undefined);
+
+	return (
+		<VStack
+			justify="flex-end"
+			spacing={4}
+			style={{ margin: 0 }}
+			className={`${css.footer} ${css.formSection}`}
+		>
+			<div className={css.splitButton}>
+				<Button
+					type={canApplyToCurrent ? 'submit' : 'button'}
+					variant="primary"
+					className={
+						canApplyToCurrent
+							? css.applyButton
+							: css.createFreshButton
+					}
+					onClick={
+						canApplyToCurrent
+							? undefined
+							: () => void submit(onCreateFresh)()
+					}
+					disabled={
+						isPending || (canApplyToCurrent && !hasRuntimeChanges)
+					}
+					isBusy={isPending}
+				>
+					{canApplyToCurrent
+						? 'Apply to this Playground'
+						: 'Create a fresh Playground'}
+				</Button>
+				<Dropdown
+					className={css.splitButtonDropdown}
+					popoverProps={{
+						placement: 'top-end',
+						className: css.actionMenuPopover,
+					}}
+					renderToggle={({ isOpen, onToggle }) => (
+						<Button
+							type="button"
+							variant="primary"
+							className={
+								canApplyToCurrent
+									? css.splitButtonToggle
+									: `${css.splitButtonToggle} ${css.createFreshButton}`
+							}
+							onClick={onToggle}
+							aria-expanded={isOpen}
+							aria-haspopup="menu"
+							aria-label="More settings actions"
+							disabled={isPending}
+						>
+							<span className={css.caret} aria-hidden="true" />
+						</Button>
+					)}
+					renderContent={({ onClose }) => (
+						<SettingsActionMenu
+							canApplyToCurrent={canApplyToCurrent}
+							applyUnavailableReason={applyUnavailableReason}
+							siteName={siteName}
+							sitePersistence={sitePersistence}
+							onApply={() => {
+								onClose();
+								void submit(onApply)();
+							}}
+							onCreateFresh={() => {
+								onClose();
+								void submit(onCreateFresh)();
+							}}
+						/>
+					)}
+				/>
+			</div>
+			{error && (
+				<p className={css.actionError} role="alert">
+					{error}
+				</p>
+			)}
+		</VStack>
+	);
+}
+
+function SettingsActionMenu({
+	canApplyToCurrent,
+	applyUnavailableReason,
+	siteName,
+	sitePersistence,
+	onApply,
+	onCreateFresh,
+}: {
+	canApplyToCurrent: boolean;
+	applyUnavailableReason?: string;
+	siteName: string;
+	sitePersistence: SitePersistence;
+	onApply: () => void;
+	onCreateFresh: () => void;
+}) {
+	const applyRef = useRef<HTMLButtonElement>(null);
+	const freshRef = useRef<HTMLButtonElement>(null);
+	const items = [applyRef, freshRef];
+
+	useEffect(() => {
+		applyRef.current?.focus();
+	}, []);
+
+	const moveFocus = (event: React.KeyboardEvent, nextIndex: number) => {
+		event.preventDefault();
+		items[nextIndex].current?.focus();
+	};
+
+	return (
+		<div
+			className={css.actionMenu}
+			role="menu"
+			onKeyDown={(event) => {
+				const currentIndex = items.findIndex(
+					(ref) => ref.current === document.activeElement
+				);
+				if (event.key === 'ArrowDown') {
+					moveFocus(event, (currentIndex + 1) % items.length);
+				} else if (event.key === 'ArrowUp') {
+					moveFocus(
+						event,
+						(currentIndex - 1 + items.length) % items.length
+					);
+				} else if (event.key === 'Home') {
+					moveFocus(event, 0);
+				} else if (event.key === 'End') {
+					moveFocus(event, items.length - 1);
+				}
+			}}
+		>
+			<button
+				ref={applyRef}
+				type="button"
+				role="menuitem"
+				aria-disabled={!!applyUnavailableReason}
+				className={`${css.actionMenuItem} ${
+					canApplyToCurrent ? css.selectedApplyMenuItem : ''
+				}`}
+				onClick={() => !applyUnavailableReason && onApply()}
+			>
+				<span className={css.actionMenuTitle}>
+					Apply to this Playground
+				</span>
+				{applyUnavailableReason && (
+					<span className={css.actionMenuDescription}>
+						{applyUnavailableReason}
+					</span>
+				)}
+			</button>
+			<button
+				ref={freshRef}
+				type="button"
+				role="menuitem"
+				className={`${css.actionMenuItem} ${css.createFreshMenuItem} ${
+					canApplyToCurrent ? '' : css.selectedFreshMenuItem
+				}`}
+				onClick={onCreateFresh}
+			>
+				<span className={css.actionMenuTitle}>
+					Create a fresh Playground
+				</span>
+				<span className={css.actionMenuDescription}>
+					{sitePersistence === 'explicit' ? (
+						<>
+							Start a clean site. “{siteName}” stays in Saved
+							Playgrounds.
+						</>
+					) : (
+						<>
+							Start a clean site. “{siteName}” stays in Recent
+							autosaves until {MAX_AUTOSAVED_SITES} newer
+							autosaves replace it.
+						</>
+					)}
+				</span>
+			</button>
+		</div>
+	);
+}
+
+export function TemporarySiteSettingsActionFooter({
+	isPending,
+	error,
+}: {
+	isPending: boolean;
+	error?: string;
+}) {
+	return (
+		<VStack
+			justify="flex-end"
+			spacing={4}
+			style={{ margin: 0 }}
+			className={`${css.footer} ${css.formSection}`}
+		>
+			<p className={css.temporaryWarning}>
+				<strong>This temporary Playground will be lost forever.</strong>
+				<span>
+					Continuing permanently discards all of its files and
+					changes.
+				</span>
+			</p>
+			<Button
+				type="submit"
+				variant="primary"
+				isDestructive
+				className={css.temporaryActionButton}
+				disabled={isPending}
+				isBusy={isPending}
+			>
+				Discard current work &amp; create a fresh Playground
+			</Button>
+			{error && (
+				<p className={css.actionError} role="alert">
+					{error}
+				</p>
+			)}
+		</VStack>
+	);
+}

--- a/packages/playground/website/src/components/site-manager/site-settings-form/site-settings-action-footer.tsx
+++ b/packages/playground/website/src/components/site-manager/site-settings-form/site-settings-action-footer.tsx
@@ -10,10 +10,7 @@ import {
 } from '../../../lib/state/redux/site-lifecycle';
 import type { SiteFormData } from './unconnected-site-settings-form';
 import type { SiteSettingsFormFooterContext } from './unconnected-site-settings-form';
-import {
-	getFreshPlaygroundReason,
-	hasApplicableRuntimeChanges,
-} from './site-settings-actions';
+import { getFreshPlaygroundReason } from './site-settings-actions';
 import css from './style.module.css';
 
 export function SiteSettingsActionFooter({
@@ -38,15 +35,7 @@ export function SiteSettingsActionFooter({
 		values,
 		defaultValues
 	);
-	const hasRuntimeChanges = hasApplicableRuntimeChanges(
-		values,
-		defaultValues
-	);
-	const applyUnavailableReason =
-		freshPlaygroundReason ??
-		(!hasRuntimeChanges
-			? 'Change PHP version or network access to apply.'
-			: undefined);
+	const applyUnavailableReason = freshPlaygroundReason;
 	const canApplyToCurrent = !applyUnavailableReason;
 
 	return (

--- a/packages/playground/website/src/components/site-manager/site-settings-form/site-settings-action-footer.tsx
+++ b/packages/playground/website/src/components/site-manager/site-settings-form/site-settings-action-footer.tsx
@@ -38,7 +38,6 @@ export function SiteSettingsActionFooter({
 		values,
 		defaultValues
 	);
-	const canApplyToCurrent = !freshPlaygroundReason;
 	const hasRuntimeChanges = hasApplicableRuntimeChanges(
 		values,
 		defaultValues
@@ -48,6 +47,7 @@ export function SiteSettingsActionFooter({
 		(!hasRuntimeChanges
 			? 'Change PHP version or network access to apply.'
 			: undefined);
+	const canApplyToCurrent = !applyUnavailableReason;
 
 	return (
 		<VStack
@@ -70,9 +70,7 @@ export function SiteSettingsActionFooter({
 							? undefined
 							: () => void submit(onCreateFresh)()
 					}
-					disabled={
-						isPending || (canApplyToCurrent && !hasRuntimeChanges)
-					}
+					disabled={isPending}
 					isBusy={isPending}
 				>
 					{canApplyToCurrent

--- a/packages/playground/website/src/components/site-manager/site-settings-form/site-settings-actions.spec.ts
+++ b/packages/playground/website/src/components/site-manager/site-settings-form/site-settings-actions.spec.ts
@@ -1,9 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { SiteFormData } from './unconnected-site-settings-form';
-import {
-	getFreshPlaygroundReason,
-	hasApplicableRuntimeChanges,
-} from './site-settings-actions';
+import { getFreshPlaygroundReason } from './site-settings-actions';
 
 const defaults: SiteFormData = {
 	phpVersion: '8.3',
@@ -50,26 +47,5 @@ describe('getFreshPlaygroundReason', () => {
 		).toBe(
 			'Changing WordPress version, language, and multisite requires a fresh Playground.'
 		);
-	});
-});
-
-describe('hasApplicableRuntimeChanges', () => {
-	it('rejects a no-op submission', () => {
-		expect(hasApplicableRuntimeChanges(defaults, defaults)).toBe(false);
-	});
-
-	it('accepts either PHP or networking changes', () => {
-		expect(
-			hasApplicableRuntimeChanges(
-				{ ...defaults, phpVersion: '8.4' },
-				defaults
-			)
-		).toBe(true);
-		expect(
-			hasApplicableRuntimeChanges(
-				{ ...defaults, withNetworking: false },
-				defaults
-			)
-		).toBe(true);
 	});
 });

--- a/packages/playground/website/src/components/site-manager/site-settings-form/site-settings-actions.spec.ts
+++ b/packages/playground/website/src/components/site-manager/site-settings-form/site-settings-actions.spec.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import type { SiteFormData } from './unconnected-site-settings-form';
+import {
+	getFreshPlaygroundReason,
+	hasApplicableRuntimeChanges,
+} from './site-settings-actions';
+
+const defaults: SiteFormData = {
+	phpVersion: '8.3',
+	wpVersion: '6.8',
+	language: '',
+	withNetworking: true,
+	multisite: false,
+};
+
+describe('getFreshPlaygroundReason', () => {
+	it('allows PHP and networking changes on the current Playground', () => {
+		expect(
+			getFreshPlaygroundReason(
+				{
+					...defaults,
+					phpVersion: '8.4',
+					withNetworking: false,
+				},
+				defaults
+			)
+		).toBeUndefined();
+	});
+
+	it('requires a fresh Playground for a WordPress version change', () => {
+		expect(
+			getFreshPlaygroundReason(
+				{ ...defaults, wpVersion: '6.7' },
+				defaults
+			)
+		).toBe('Changing WordPress version requires a fresh Playground.');
+	});
+
+	it('names every setting that prevents applying to the current Playground', () => {
+		expect(
+			getFreshPlaygroundReason(
+				{
+					...defaults,
+					wpVersion: '6.7',
+					language: 'pl_PL',
+					multisite: true,
+				},
+				defaults
+			)
+		).toBe(
+			'Changing WordPress version, language, and multisite requires a fresh Playground.'
+		);
+	});
+});
+
+describe('hasApplicableRuntimeChanges', () => {
+	it('rejects a no-op submission', () => {
+		expect(hasApplicableRuntimeChanges(defaults, defaults)).toBe(false);
+	});
+
+	it('accepts either PHP or networking changes', () => {
+		expect(
+			hasApplicableRuntimeChanges(
+				{ ...defaults, phpVersion: '8.4' },
+				defaults
+			)
+		).toBe(true);
+		expect(
+			hasApplicableRuntimeChanges(
+				{ ...defaults, withNetworking: false },
+				defaults
+			)
+		).toBe(true);
+	});
+});

--- a/packages/playground/website/src/components/site-manager/site-settings-form/site-settings-actions.ts
+++ b/packages/playground/website/src/components/site-manager/site-settings-form/site-settings-actions.ts
@@ -38,19 +38,6 @@ export function getFreshPlaygroundReason(
 	return `Changing ${formatList(changedFields)} requires a fresh Playground.`;
 }
 
-export function hasApplicableRuntimeChanges(
-	values: SiteFormData,
-	defaultValues: SiteFormData
-): boolean {
-	return Object.keys(siteSettingActions)
-		.map((field) => field as keyof SiteFormData)
-		.some(
-			(field) =>
-				siteSettingActions[field].action === 'apply' &&
-				values[field] !== defaultValues[field]
-		);
-}
-
 function formatList(items: string[]): string {
 	if (items.length === 1) {
 		return items[0];

--- a/packages/playground/website/src/components/site-manager/site-settings-form/site-settings-actions.ts
+++ b/packages/playground/website/src/components/site-manager/site-settings-form/site-settings-actions.ts
@@ -1,0 +1,62 @@
+import type { SiteFormData } from './unconnected-site-settings-form';
+
+type SiteSettingAction =
+	| { action: 'apply' }
+	| { action: 'fresh'; label: string };
+
+// Classifying every field here makes a new setting a type error until its
+// lifecycle behavior is deliberate.
+const siteSettingActions: Record<keyof SiteFormData, SiteSettingAction> = {
+	phpVersion: { action: 'apply' },
+	withNetworking: { action: 'apply' },
+	wpVersion: { action: 'fresh', label: 'WordPress version' },
+	language: { action: 'fresh', label: 'language' },
+	multisite: { action: 'fresh', label: 'multisite' },
+};
+
+export function getFreshPlaygroundReason(
+	values: SiteFormData,
+	defaultValues: SiteFormData
+): string | undefined {
+	const changedFields = Object.keys(siteSettingActions)
+		.map((field) => field as keyof SiteFormData)
+		.filter((field) => {
+			return (
+				siteSettingActions[field].action === 'fresh' &&
+				values[field] !== defaultValues[field]
+			);
+		})
+		.map((field) => {
+			const setting = siteSettingActions[field];
+			return setting.action === 'fresh' ? setting.label : '';
+		});
+
+	if (changedFields.length === 0) {
+		return undefined;
+	}
+
+	return `Changing ${formatList(changedFields)} requires a fresh Playground.`;
+}
+
+export function hasApplicableRuntimeChanges(
+	values: SiteFormData,
+	defaultValues: SiteFormData
+): boolean {
+	return Object.keys(siteSettingActions)
+		.map((field) => field as keyof SiteFormData)
+		.some(
+			(field) =>
+				siteSettingActions[field].action === 'apply' &&
+				values[field] !== defaultValues[field]
+		);
+}
+
+function formatList(items: string[]): string {
+	if (items.length === 1) {
+		return items[0];
+	}
+	if (items.length === 2) {
+		return items.join(' and ');
+	}
+	return `${items.slice(0, -1).join(', ')}, and ${items.at(-1)}`;
+}

--- a/packages/playground/website/src/components/site-manager/site-settings-form/stored-site-settings-form.tsx
+++ b/packages/playground/website/src/components/site-manager/site-settings-form/stored-site-settings-form.tsx
@@ -9,20 +9,19 @@ import {
 	getSiteSettingsFromFormData,
 } from './setup-form-values';
 import { SiteSettingsActionFooter } from './site-settings-action-footer';
-import { useSiteSettingsSubmission } from './use-site-settings-submission';
+import type { SiteSettingsSubmission } from './use-site-settings-submission';
 
 export function StoredSiteSettingsForm({
 	siteSlug,
-	onSubmit,
+	submission,
 }: {
 	siteSlug: string;
-	onSubmit?: () => void;
+	submission: SiteSettingsSubmission;
 }) {
 	const siteInfo = useAppSelector((state) =>
 		selectSiteBySlug(state, siteSlug)
 	)!;
 	const sitesAPI = useSitesAPI();
-	const submission = useSiteSettingsSubmission(onSubmit);
 	const updateSite = async (data: SiteFormData) => {
 		await sitesAPI.updateRuntimeSettings({
 			phpVersion: data.phpVersion,

--- a/packages/playground/website/src/components/site-manager/site-settings-form/stored-site-settings-form.tsx
+++ b/packages/playground/website/src/components/site-manager/site-settings-form/stored-site-settings-form.tsx
@@ -1,17 +1,15 @@
 import { useMemo } from 'react';
 import { useAppSelector } from '../../../lib/state/redux/store';
-import css from './style.module.css';
-import {
-	Icon,
-	Button,
-	__experimentalVStack as VStack,
-	__experimentalHStack as HStack,
-} from '@wordpress/components';
-import { info } from '@wordpress/icons';
 import { selectSiteBySlug } from '../../../lib/state/redux/slice-sites';
 import type { SiteFormData } from './unconnected-site-settings-form';
 import { UnconnectedSiteSettingsForm } from './unconnected-site-settings-form';
 import { useSitesAPI } from '../../../lib/state/redux/site-management-api-middleware';
+import {
+	getSetupFormDefaultValues,
+	getSiteSettingsFromFormData,
+} from './setup-form-values';
+import { SiteSettingsActionFooter } from './site-settings-action-footer';
+import { useSiteSettingsSubmission } from './use-site-settings-submission';
 
 export function StoredSiteSettingsForm({
 	siteSlug,
@@ -24,64 +22,47 @@ export function StoredSiteSettingsForm({
 		selectSiteBySlug(state, siteSlug)
 	)!;
 	const sitesAPI = useSitesAPI();
+	const submission = useSiteSettingsSubmission(onSubmit);
 	const updateSite = async (data: SiteFormData) => {
-		await sitesAPI.setPhpVersion(data.phpVersion);
-		await sitesAPI.setNetworking(data.withNetworking);
-		onSubmit?.();
+		await sitesAPI.updateRuntimeSettings({
+			phpVersion: data.phpVersion,
+			networking: data.withNetworking,
+		});
+	};
+	const createFreshSite = async (data: SiteFormData) => {
+		await sitesAPI.createNewSavedSite(
+			undefined,
+			getSiteSettingsFromFormData(data),
+			{
+				persistence: 'autosave',
+				excludeFromPruning: [siteSlug],
+			}
+		);
 	};
 
 	const defaultValues = useMemo<Partial<SiteFormData>>(
-		() => ({
-			name: siteInfo.metadata.name,
-			// @TODO: Handle an unsupported PHP version coming up here
-			phpVersion: siteInfo.metadata.runtimeConfiguration
-				.phpVersion as any,
-			withNetworking: !!siteInfo.metadata.runtimeConfiguration.networking,
-		}),
+		() => getSetupFormDefaultValues(siteInfo),
 		[siteInfo]
 	);
 
 	return (
 		<UnconnectedSiteSettingsForm
 			className="is-stored-site"
-			onSubmit={updateSite}
+			onSubmit={(data) => submission.run(updateSite, data)}
 			defaultValues={defaultValues}
-			enabledFields={{
-				wpVersion: false,
-				language: false,
-				multisite: false,
-			}}
-			header={
-				<HStack
-					as="p"
-					spacing={3}
-					className={`${css.notice} ${css.formSection}`}
-					style={{ margin: 0 }}
-					alignment="center"
-					justify="flex-start"
-				>
-					<Icon icon={info} size={16} />
-					<span>
-						Stored Playgrounds have limited configuration options.
-					</span>
-				</HStack>
-			}
-			footer={
-				<VStack
-					justify="flex-end"
-					spacing={6}
-					className={css.formSection}
-					style={{ paddingTop: 0 }}
-				>
-					<Button
-						type="submit"
-						variant="primary"
-						style={{ justifyContent: 'center' }}
-					>
-						Save & Reload
-					</Button>
-				</VStack>
-			}
+			footer={(context) => (
+				<SiteSettingsActionFooter
+					{...context}
+					siteName={siteInfo.metadata.name}
+					sitePersistence="explicit"
+					onApply={(data) => submission.run(updateSite, data)}
+					onCreateFresh={(data) =>
+						submission.run(createFreshSite, data)
+					}
+					isPending={submission.isPending}
+					error={submission.error}
+				/>
+			)}
 		/>
 	);
 }

--- a/packages/playground/website/src/components/site-manager/site-settings-form/style.module.css
+++ b/packages/playground/website/src/components/site-manager/site-settings-form/style.module.css
@@ -114,6 +114,7 @@
 .action-menu-item {
 	--action-menu-item-background: #fff;
 
+	position: relative;
 	display: block;
 	box-sizing: border-box;
 	width: 100%;
@@ -142,7 +143,7 @@
 	border-radius: 2px;
 	outline: none;
 	box-shadow:
-		0 0 0 7px var(--action-menu-item-background),
+		0 0 0 6px var(--action-menu-item-background),
 		0 0 0 8px #3858e9;
 }
 
@@ -169,6 +170,8 @@
 }
 
 .action-menu-title {
+	position: relative;
+	z-index: 1;
 	display: block;
 	font-weight: 500;
 	line-height: 1.4;
@@ -176,6 +179,8 @@
 }
 
 .action-menu-description {
+	position: relative;
+	z-index: 1;
 	display: block;
 	max-width: 100%;
 	margin-top: 2px;
@@ -204,6 +209,25 @@
 	color: #304bd1;
 }
 
+.action-menu-item.selected-apply-menu-item:not(:focus-visible)::before,
+.action-menu-item.selected-fresh-menu-item:not(:focus-visible)::before {
+	position: absolute;
+	z-index: 0;
+	background: var(--action-menu-item-background);
+	content: '';
+	pointer-events: none;
+}
+
+.action-menu-item.selected-apply-menu-item:not(:focus-visible)::before {
+	inset: -8px -8px 0;
+	border-radius: 10px 10px 7px 7px;
+}
+
+.action-menu-item.selected-fresh-menu-item:not(:focus-visible)::before {
+	inset: 0 -8px -8px;
+	border-radius: 7px 7px 10px 10px;
+}
+
 .action-menu-item[aria-disabled='true'] {
 	--action-menu-item-background: #f3f3f1;
 
@@ -217,13 +241,13 @@
 
 .action-menu-item[aria-disabled='true']:focus-visible {
 	box-shadow:
-		0 0 0 7px var(--action-menu-item-background),
+		0 0 0 6px var(--action-menu-item-background),
 		0 0 0 8px #949494;
 }
 
 @media (forced-colors: active) {
 	.action-menu-item:focus-visible {
-		outline: 1px solid CanvasText;
+		outline: 2px solid CanvasText;
 		outline-offset: 6px;
 		box-shadow: none;
 	}

--- a/packages/playground/website/src/components/site-manager/site-settings-form/style.module.css
+++ b/packages/playground/website/src/components/site-manager/site-settings-form/style.module.css
@@ -136,6 +136,10 @@
 	border-radius: 0 0 9px 9px;
 }
 
+.action-menu-item + .action-menu-item {
+	border-top: 1px solid #d6d6d9;
+}
+
 .action-menu-item:focus-visible {
 	outline: none;
 	box-shadow: inset 0 0 0 2px #3858e9;

--- a/packages/playground/website/src/components/site-manager/site-settings-form/style.module.css
+++ b/packages/playground/website/src/components/site-manager/site-settings-form/style.module.css
@@ -112,13 +112,15 @@
 }
 
 .action-menu-item {
+	--action-menu-item-background: #fff;
+
 	display: block;
 	box-sizing: border-box;
 	width: 100%;
 	padding: 10px 12px;
 	border: 0;
 	border-radius: 7px;
-	background: #fff;
+	background: var(--action-menu-item-background);
 	color: var(--ink, #21201d);
 	cursor: pointer;
 	font: inherit;
@@ -127,18 +129,21 @@
 }
 
 .action-menu-item + .action-menu-item {
-	margin-top: 2px;
+	margin-top: 10px;
 }
 
 .action-menu-item:hover,
 .action-menu-item:focus-visible {
-	background: #f3f3f1;
+	--action-menu-item-background: #f3f3f1;
 }
 
 .action-menu-item:focus-visible {
-	outline: 2px solid #3858e9;
-	outline-offset: 6px;
-	box-shadow: none;
+	/* The 8px ring extends this radius to match the popover's 10px corners. */
+	border-radius: 2px;
+	outline: none;
+	box-shadow:
+		0 0 0 6px var(--action-menu-item-background),
+		0 0 0 8px #3858e9;
 }
 
 .action-menu-item[aria-disabled='true'] {
@@ -193,12 +198,14 @@
 .create-fresh-menu-item:hover,
 .create-fresh-menu-item:focus-visible,
 .selected-fresh-menu-item {
-	background: #f1edff;
+	--action-menu-item-background: #f1edff;
+
 	color: #573eb5;
 }
 
 .selected-apply-menu-item {
-	background: #f1f3ff;
+	--action-menu-item-background: #f1f3ff;
+
 	color: #304bd1;
 }
 

--- a/packages/playground/website/src/components/site-manager/site-settings-form/style.module.css
+++ b/packages/playground/website/src/components/site-manager/site-settings-form/style.module.css
@@ -146,15 +146,6 @@
 		0 0 0 8px #3858e9;
 }
 
-.action-menu-item[aria-disabled='true'] {
-	cursor: not-allowed;
-}
-
-.action-menu-item[aria-disabled='true'] .action-menu-title,
-.action-menu-item[aria-disabled='true'] .action-menu-description {
-	opacity: 0.52;
-}
-
 .action-error {
 	animation: action-error-in 120ms ease-out;
 	color: var(--color-alert-red, #cc1818);
@@ -174,14 +165,6 @@
 @media (prefers-reduced-motion: reduce) {
 	.action-error {
 		animation: none;
-	}
-}
-
-@media (forced-colors: active) {
-	.action-menu-item:focus-visible {
-		outline: 2px solid CanvasText;
-		outline-offset: 6px;
-		box-shadow: none;
 	}
 }
 
@@ -219,6 +202,31 @@
 	--action-menu-item-background: #f1f3ff;
 
 	color: #304bd1;
+}
+
+.action-menu-item[aria-disabled='true'] {
+	--action-menu-item-background: #f3f3f1;
+
+	color: #757575;
+	cursor: not-allowed;
+}
+
+.action-menu-item[aria-disabled='true'] .action-menu-description {
+	color: inherit;
+}
+
+.action-menu-item[aria-disabled='true']:focus-visible {
+	box-shadow:
+		0 0 0 6px var(--action-menu-item-background),
+		0 0 0 8px #949494;
+}
+
+@media (forced-colors: active) {
+	.action-menu-item:focus-visible {
+		outline: 2px solid CanvasText;
+		outline-offset: 6px;
+		box-shadow: none;
+	}
 }
 
 .temporary-warning {

--- a/packages/playground/website/src/components/site-manager/site-settings-form/style.module.css
+++ b/packages/playground/website/src/components/site-manager/site-settings-form/style.module.css
@@ -46,7 +46,6 @@
 
 .footer {
 	background-color: #f3f6fd;
-	position: relative;
 	button {
 		width: 100%;
 		align-self: center;
@@ -148,13 +147,9 @@
 
 .action-error {
 	animation: action-error-in 120ms ease-out;
-	bottom: 3px;
 	color: var(--color-alert-red, #cc1818);
 	font-size: 13px;
-	left: 24px;
 	line-height: 1.4;
-	position: absolute;
-	right: 24px;
 }
 
 @keyframes action-error-in {

--- a/packages/playground/website/src/components/site-manager/site-settings-form/style.module.css
+++ b/packages/playground/website/src/components/site-manager/site-settings-form/style.module.css
@@ -129,7 +129,7 @@
 }
 
 .action-menu-item + .action-menu-item {
-	margin-top: 10px;
+	margin-top: 12px;
 }
 
 .action-menu-item:hover,
@@ -148,6 +148,10 @@
 
 .action-menu-item[aria-disabled='true'] {
 	cursor: not-allowed;
+}
+
+.action-menu-item[aria-disabled='true'] .action-menu-title,
+.action-menu-item[aria-disabled='true'] .action-menu-description {
 	opacity: 0.52;
 }
 
@@ -170,6 +174,14 @@
 @media (prefers-reduced-motion: reduce) {
 	.action-error {
 		animation: none;
+	}
+}
+
+@media (forced-colors: active) {
+	.action-menu-item:focus-visible {
+		outline: 2px solid CanvasText;
+		outline-offset: 6px;
+		box-shadow: none;
 	}
 }
 
@@ -203,7 +215,7 @@
 	color: #573eb5;
 }
 
-.selected-apply-menu-item {
+.action-menu-item.selected-apply-menu-item {
 	--action-menu-item-background: #f1f3ff;
 
 	color: #304bd1;

--- a/packages/playground/website/src/components/site-manager/site-settings-form/style.module.css
+++ b/packages/playground/website/src/components/site-manager/site-settings-form/style.module.css
@@ -101,10 +101,10 @@
 .action-menu {
 	box-sizing: border-box;
 	width: min(330px, calc(100vw - 24px));
-	padding: 8px;
 }
 
 .action-menu-popover :global(.components-popover__content) {
+	overflow: hidden;
 	padding: 0;
 	border: 1px solid #d6d6d9;
 	border-radius: 10px;
@@ -114,13 +114,14 @@
 .action-menu-item {
 	--action-menu-item-background: #fff;
 
-	position: relative;
-	display: block;
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
 	box-sizing: border-box;
 	width: 100%;
-	padding: 10px 12px;
+	padding: 16px 20px;
 	border: 0;
-	border-radius: 7px;
+	border-radius: 0;
 	background: var(--action-menu-item-background);
 	color: var(--ink, #21201d);
 	cursor: pointer;
@@ -129,8 +130,12 @@
 	white-space: normal;
 }
 
-.action-menu-item + .action-menu-item {
-	margin-top: 12px;
+.action-menu-item:first-child {
+	border-radius: 9px 9px 0 0;
+}
+
+.action-menu-item:last-child {
+	border-radius: 0 0 9px 9px;
 }
 
 .action-menu-item:hover,
@@ -139,12 +144,8 @@
 }
 
 .action-menu-item:focus-visible {
-	/* The 8px ring extends this radius to match the popover's 10px corners. */
-	border-radius: 2px;
 	outline: none;
-	box-shadow:
-		0 0 0 6px var(--action-menu-item-background),
-		0 0 0 8px #3858e9;
+	box-shadow: inset 0 0 0 2px #3858e9;
 }
 
 .action-error {
@@ -170,8 +171,6 @@
 }
 
 .action-menu-title {
-	position: relative;
-	z-index: 1;
 	display: block;
 	font-weight: 500;
 	line-height: 1.4;
@@ -179,8 +178,6 @@
 }
 
 .action-menu-description {
-	position: relative;
-	z-index: 1;
 	display: block;
 	max-width: 100%;
 	margin-top: 2px;
@@ -209,25 +206,6 @@
 	color: #304bd1;
 }
 
-.action-menu-item.selected-apply-menu-item:not(:focus-visible)::before,
-.action-menu-item.selected-fresh-menu-item:not(:focus-visible)::before {
-	position: absolute;
-	z-index: 0;
-	background: var(--action-menu-item-background);
-	content: '';
-	pointer-events: none;
-}
-
-.action-menu-item.selected-apply-menu-item:not(:focus-visible)::before {
-	inset: -8px -8px 0;
-	border-radius: 10px 10px 7px 7px;
-}
-
-.action-menu-item.selected-fresh-menu-item:not(:focus-visible)::before {
-	inset: 0 -8px -8px;
-	border-radius: 7px 7px 10px 10px;
-}
-
 .action-menu-item[aria-disabled='true'] {
 	--action-menu-item-background: #f3f3f1;
 
@@ -240,15 +218,13 @@
 }
 
 .action-menu-item[aria-disabled='true']:focus-visible {
-	box-shadow:
-		0 0 0 6px var(--action-menu-item-background),
-		0 0 0 8px #949494;
+	box-shadow: inset 0 0 0 2px #949494;
 }
 
 @media (forced-colors: active) {
 	.action-menu-item:focus-visible {
 		outline: 2px solid CanvasText;
-		outline-offset: 6px;
+		outline-offset: -2px;
 		box-shadow: none;
 	}
 }

--- a/packages/playground/website/src/components/site-manager/site-settings-form/style.module.css
+++ b/packages/playground/website/src/components/site-manager/site-settings-form/style.module.css
@@ -46,9 +46,184 @@
 
 .footer {
 	background-color: #f3f6fd;
+	position: relative;
 	button {
 		width: 100%;
 		align-self: center;
 		justify-content: center;
 	}
+}
+
+.split-button {
+	display: flex;
+	width: 100%;
+}
+
+.split-button > .apply-button,
+.split-button > .create-fresh-button {
+	flex: 1;
+	width: auto;
+	border-radius: 4px 0 0 4px;
+}
+
+.split-button-dropdown,
+.split-button-dropdown > div {
+	display: flex;
+}
+
+.footer .split-button-toggle {
+	box-sizing: border-box;
+	width: 40px;
+	min-width: 40px;
+	padding: 0;
+	border-left: 1px solid rgb(255 255 255 / 35%);
+	border-radius: 0 4px 4px 0;
+}
+
+.create-fresh-button {
+	background: #6c4fd3 !important;
+	color: #fff !important;
+}
+
+.create-fresh-button:hover {
+	background: #573eb5 !important;
+}
+
+.caret {
+	display: block;
+	width: 0;
+	height: 0;
+	margin: auto;
+	border-top: 5px solid currentColor;
+	border-right: 4px solid transparent;
+	border-left: 4px solid transparent;
+}
+
+.action-menu {
+	box-sizing: border-box;
+	width: min(330px, calc(100vw - 24px));
+	padding: 4px;
+}
+
+.action-menu-popover :global(.components-popover__content) {
+	padding: 0;
+	border: 1px solid #d6d6d9;
+	border-radius: 10px;
+	box-shadow: 0 16px 38px rgb(0 0 0 / 20%);
+}
+
+.action-menu-item {
+	display: block;
+	box-sizing: border-box;
+	width: 100%;
+	padding: 10px 12px;
+	border: 0;
+	border-radius: 7px;
+	background: #fff;
+	color: var(--ink, #21201d);
+	cursor: pointer;
+	font: inherit;
+	text-align: left;
+	white-space: normal;
+}
+
+.action-menu-item + .action-menu-item {
+	margin-top: 2px;
+}
+
+.action-menu-item:hover,
+.action-menu-item:focus-visible {
+	background: #f3f3f1;
+}
+
+.action-menu-item:focus-visible {
+	outline: none;
+	box-shadow: inset 0 0 0 1px rgb(56 88 233 / 22%);
+}
+
+.action-menu-item[aria-disabled='true'] {
+	cursor: not-allowed;
+	opacity: 0.52;
+}
+
+.action-error {
+	animation: action-error-in 120ms ease-out;
+	bottom: 3px;
+	color: var(--color-alert-red, #cc1818);
+	font-size: 13px;
+	left: 24px;
+	line-height: 1.4;
+	position: absolute;
+	right: 24px;
+}
+
+@keyframes action-error-in {
+	from {
+		opacity: 0;
+	}
+	to {
+		opacity: 1;
+	}
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.action-error {
+		animation: none;
+	}
+}
+
+.action-menu-title {
+	display: block;
+	font-weight: 500;
+	line-height: 1.4;
+	white-space: normal;
+}
+
+.action-menu-description {
+	display: block;
+	max-width: 100%;
+	margin-top: 2px;
+	color: var(--ink-muted, #5f5b54);
+	font-size: 12px;
+	line-height: 1.4;
+	overflow-wrap: anywhere;
+	white-space: normal;
+}
+
+.create-fresh-menu-item {
+	color: #573eb5;
+}
+
+.create-fresh-menu-item:hover,
+.create-fresh-menu-item:focus-visible,
+.selected-fresh-menu-item {
+	background: #f1edff;
+	color: #573eb5;
+}
+
+.selected-apply-menu-item {
+	background: #f1f3ff;
+	color: #304bd1;
+}
+
+.temporary-warning {
+	color: var(--ink-muted, #5f5b54);
+	font-size: 13px;
+	line-height: 1.5;
+}
+
+.temporary-warning strong,
+.temporary-warning span {
+	display: block;
+}
+
+.temporary-warning strong {
+	color: var(--color-alert-red, #cc1818);
+}
+
+.footer .temporary-action-button {
+	height: auto;
+	min-height: 36px;
+	padding: 8px 12px;
+	justify-content: center;
 }

--- a/packages/playground/website/src/components/site-manager/site-settings-form/style.module.css
+++ b/packages/playground/website/src/components/site-manager/site-settings-form/style.module.css
@@ -142,7 +142,7 @@
 	border-radius: 2px;
 	outline: none;
 	box-shadow:
-		0 0 0 6px var(--action-menu-item-background),
+		0 0 0 7px var(--action-menu-item-background),
 		0 0 0 8px #3858e9;
 }
 
@@ -217,13 +217,13 @@
 
 .action-menu-item[aria-disabled='true']:focus-visible {
 	box-shadow:
-		0 0 0 6px var(--action-menu-item-background),
+		0 0 0 7px var(--action-menu-item-background),
 		0 0 0 8px #949494;
 }
 
 @media (forced-colors: active) {
 	.action-menu-item:focus-visible {
-		outline: 2px solid CanvasText;
+		outline: 1px solid CanvasText;
 		outline-offset: 6px;
 		box-shadow: none;
 	}

--- a/packages/playground/website/src/components/site-manager/site-settings-form/style.module.css
+++ b/packages/playground/website/src/components/site-manager/site-settings-form/style.module.css
@@ -101,7 +101,7 @@
 .action-menu {
 	box-sizing: border-box;
 	width: min(330px, calc(100vw - 24px));
-	padding: 4px;
+	padding: 8px;
 }
 
 .action-menu-popover :global(.components-popover__content) {
@@ -136,8 +136,9 @@
 }
 
 .action-menu-item:focus-visible {
-	outline: none;
-	box-shadow: inset 0 0 0 1px rgb(56 88 233 / 22%);
+	outline: 2px solid #3858e9;
+	outline-offset: 0;
+	box-shadow: none;
 }
 
 .action-menu-item[aria-disabled='true'] {

--- a/packages/playground/website/src/components/site-manager/site-settings-form/style.module.css
+++ b/packages/playground/website/src/components/site-manager/site-settings-form/style.module.css
@@ -137,7 +137,7 @@
 
 .action-menu-item:focus-visible {
 	outline: 2px solid #3858e9;
-	outline-offset: 0;
+	outline-offset: 6px;
 	box-shadow: none;
 }
 

--- a/packages/playground/website/src/components/site-manager/site-settings-form/style.module.css
+++ b/packages/playground/website/src/components/site-manager/site-settings-form/style.module.css
@@ -112,8 +112,6 @@
 }
 
 .action-menu-item {
-	--action-menu-item-background: #fff;
-
 	display: flex;
 	flex-direction: column;
 	justify-content: center;
@@ -122,7 +120,7 @@
 	padding: 16px 20px;
 	border: 0;
 	border-radius: 0;
-	background: var(--action-menu-item-background);
+	background: #fff;
 	color: var(--ink, #21201d);
 	cursor: pointer;
 	font: inherit;
@@ -136,11 +134,6 @@
 
 .action-menu-item:last-child {
 	border-radius: 0 0 9px 9px;
-}
-
-.action-menu-item:hover,
-.action-menu-item:focus-visible {
-	--action-menu-item-background: #f3f3f1;
 }
 
 .action-menu-item:focus-visible {
@@ -192,23 +185,11 @@
 	color: #573eb5;
 }
 
-.create-fresh-menu-item:hover,
-.create-fresh-menu-item:focus-visible,
-.selected-fresh-menu-item {
-	--action-menu-item-background: #f1edff;
-
-	color: #573eb5;
-}
-
 .action-menu-item.selected-apply-menu-item {
-	--action-menu-item-background: #f1f3ff;
-
 	color: #304bd1;
 }
 
 .action-menu-item[aria-disabled='true'] {
-	--action-menu-item-background: #f3f3f1;
-
 	color: #757575;
 	cursor: not-allowed;
 }

--- a/packages/playground/website/src/components/site-manager/site-settings-form/temporary-site-settings-form.tsx
+++ b/packages/playground/website/src/components/site-manager/site-settings-form/temporary-site-settings-form.tsx
@@ -1,6 +1,4 @@
 import { useMemo } from 'react';
-import css from './style.module.css';
-import { Button, __experimentalVStack as VStack } from '@wordpress/components';
 import { useAppSelector } from '../../../lib/state/redux/store';
 import { selectSiteBySlug } from '../../../lib/state/redux/slice-sites';
 import type { SiteFormData } from './unconnected-site-settings-form';
@@ -10,6 +8,8 @@ import {
 	getSetupFormDefaultValues,
 	getSiteSettingsFromFormData,
 } from './setup-form-values';
+import { TemporarySiteSettingsActionFooter } from './site-settings-action-footer';
+import { useSiteSettingsSubmission } from './use-site-settings-submission';
 
 export function TemporarySiteSettingsForm({
 	siteSlug,
@@ -22,12 +22,12 @@ export function TemporarySiteSettingsForm({
 		selectSiteBySlug(state, siteSlug)
 	)!;
 	const sitesAPI = useSitesAPI();
+	const submission = useSiteSettingsSubmission(onSubmit);
 	const updateSite = async (data: SiteFormData) => {
 		await sitesAPI.createNewTemporarySite(
 			undefined,
 			getSiteSettingsFromFormData(data)
 		);
-		onSubmit?.();
 	};
 	const defaultValues = useMemo(
 		() => getSetupFormDefaultValues(siteInfo),
@@ -37,23 +37,13 @@ export function TemporarySiteSettingsForm({
 	return (
 		<UnconnectedSiteSettingsForm
 			className="is-temporary-site"
-			onSubmit={updateSite}
+			onSubmit={(data) => submission.run(updateSite, data)}
 			defaultValues={defaultValues}
 			footer={
-				<VStack
-					justify="flex-end"
-					spacing={6}
-					style={{ margin: 0 }}
-					className={`${css.footer} ${css.formSection}`}
-				>
-					<p>
-						<b>Destructive action!</b> Applying these settings will
-						reset the WordPress site to its initial state.
-					</p>
-					<Button type="submit" variant="primary">
-						Apply Settings & Reset Playground
-					</Button>
-				</VStack>
+				<TemporarySiteSettingsActionFooter
+					isPending={submission.isPending}
+					error={submission.error}
+				/>
 			}
 		/>
 	);

--- a/packages/playground/website/src/components/site-manager/site-settings-form/temporary-site-settings-form.tsx
+++ b/packages/playground/website/src/components/site-manager/site-settings-form/temporary-site-settings-form.tsx
@@ -9,20 +9,19 @@ import {
 	getSiteSettingsFromFormData,
 } from './setup-form-values';
 import { TemporarySiteSettingsActionFooter } from './site-settings-action-footer';
-import { useSiteSettingsSubmission } from './use-site-settings-submission';
+import type { SiteSettingsSubmission } from './use-site-settings-submission';
 
 export function TemporarySiteSettingsForm({
 	siteSlug,
-	onSubmit,
+	submission,
 }: {
 	siteSlug: string;
-	onSubmit?: () => void;
+	submission: SiteSettingsSubmission;
 }) {
 	const siteInfo = useAppSelector((state) =>
 		selectSiteBySlug(state, siteSlug)
 	)!;
 	const sitesAPI = useSitesAPI();
-	const submission = useSiteSettingsSubmission(onSubmit);
 	const updateSite = async (data: SiteFormData) => {
 		await sitesAPI.createNewTemporarySite(
 			undefined,

--- a/packages/playground/website/src/components/site-manager/site-settings-form/unconnected-site-settings-form.tsx
+++ b/packages/playground/website/src/components/site-manager/site-settings-form/unconnected-site-settings-form.tsx
@@ -3,7 +3,12 @@ import { PHPNextVersion, SupportedPHPVersionsList } from '@php-wasm/universal';
 import css from './style.module.css';
 import { CheckboxControl, SelectControl } from '@wordpress/components';
 import { useEffect, useMemo, useState } from 'react';
-import { Controller, useForm, useWatch } from 'react-hook-form';
+import {
+	Controller,
+	type UseFormHandleSubmit,
+	useForm,
+	useWatch,
+} from 'react-hook-form';
 import classNames from 'classnames';
 import { __experimentalVStack as VStack } from '@wordpress/components';
 import { useSupportedWordPressVersions } from './use-supported-wordpress-versions';
@@ -23,7 +28,9 @@ type ConfigurableFields = Record<
 export interface SiteSettingsFormProps {
 	onSubmit: (data: any) => void;
 	header?: React.ReactNode;
-	footer?: React.ReactNode;
+	footer?:
+		| React.ReactNode
+		| ((context: SiteSettingsFormFooterContext) => React.ReactNode);
 	className?: string;
 	enabledFields?: ConfigurableFields;
 	defaultValues?: Partial<SiteFormData>;
@@ -35,6 +42,12 @@ export interface SiteFormData {
 	language: string;
 	withNetworking: boolean;
 	multisite: boolean;
+}
+
+export interface SiteSettingsFormFooterContext {
+	values: SiteFormData;
+	defaultValues: SiteFormData;
+	submit: UseFormHandleSubmit<SiteFormData>;
 }
 
 export function UnconnectedSiteSettingsForm({
@@ -73,6 +86,17 @@ export function UnconnectedSiteSettingsForm({
 
 	const { supportedWPVersions, latestWPVersion } =
 		useSupportedWordPressVersions();
+	const comparableDefaults = useMemo<SiteFormData>(
+		() => ({
+			...mergedDefaults,
+			wpVersion:
+				latestWPVersion &&
+				['', 'latest'].includes(mergedDefaults.wpVersion)
+					? latestWPVersion
+					: mergedDefaults.wpVersion,
+		}),
+		[latestWPVersion, mergedDefaults]
+	);
 
 	// If the caller restored a stored site running an older WP
 	// version, expand the dropdown automatically so the current
@@ -81,7 +105,8 @@ export function UnconnectedSiteSettingsForm({
 		isOlderWordPressVersion(mergedDefaults.wpVersion)
 	);
 
-	const currentWpVersion = useWatch({ control, name: 'wpVersion' });
+	const values = useWatch({ control }) as SiteFormData;
+	const currentWpVersion = values.wpVersion;
 	const forcedPhpVersion = getForcedPhpVersionForWordPress(currentWpVersion);
 
 	useEffect(() => {
@@ -562,7 +587,13 @@ export function UnconnectedSiteSettingsForm({
 					)}
 				/>
 			</VStack>
-			{footer}
+			{typeof footer === 'function'
+				? footer({
+						values,
+						defaultValues: comparableDefaults,
+						submit: handleSubmit,
+					})
+				: footer}
 		</form>
 	);
 }

--- a/packages/playground/website/src/components/site-manager/site-settings-form/use-site-settings-submission.spec.tsx
+++ b/packages/playground/website/src/components/site-manager/site-settings-form/use-site-settings-submission.spec.tsx
@@ -82,6 +82,22 @@ describe('useSiteSettingsSubmission', () => {
 		expect(onSuccess).toHaveBeenCalledTimes(1);
 	});
 
+	it('does not report an onSuccess failure as a submission failure', async () => {
+		const action = vi
+			.fn<(_: SiteFormData) => Promise<void>>()
+			.mockResolvedValue();
+		const onSuccess = vi.fn(() => {
+			throw new Error('Could not close the settings panel.');
+		});
+		act(() => root.render(<Probe onSuccess={onSuccess} />));
+
+		await expect(act(() => state.run(action, formData))).rejects.toThrow(
+			'Could not close the settings panel.'
+		);
+		expect(state.error).toBeUndefined();
+		expect(state.isPending).toBe(false);
+	});
+
 	function Probe({ onSuccess }: { onSuccess: () => void }) {
 		state = useSiteSettingsSubmission(onSuccess);
 		return null;

--- a/packages/playground/website/src/components/site-manager/site-settings-form/use-site-settings-submission.spec.tsx
+++ b/packages/playground/website/src/components/site-manager/site-settings-form/use-site-settings-submission.spec.tsx
@@ -1,0 +1,89 @@
+// @vitest-environment jsdom
+
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import type { Root } from 'react-dom/client';
+import type { SiteFormData } from './unconnected-site-settings-form';
+import { useSiteSettingsSubmission } from './use-site-settings-submission';
+
+const formData: SiteFormData = {
+	phpVersion: '8.3',
+	wpVersion: 'latest',
+	language: '',
+	withNetworking: true,
+	multisite: false,
+};
+
+describe('useSiteSettingsSubmission', () => {
+	let container: HTMLDivElement;
+	let root: Root;
+	let state: ReturnType<typeof useSiteSettingsSubmission>;
+
+	beforeAll(() => {
+		vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+	});
+
+	afterAll(() => {
+		vi.unstubAllGlobals();
+	});
+
+	beforeEach(() => {
+		container = document.createElement('div');
+		document.body.append(container);
+		root = createRoot(container);
+	});
+
+	afterEach(() => {
+		act(() => root.unmount());
+		container.remove();
+	});
+
+	it('rejects a second submission before React can paint the pending state', async () => {
+		let finish!: () => void;
+		const action = vi.fn(
+			() => new Promise<void>((resolve) => (finish = resolve))
+		);
+		const onSuccess = vi.fn();
+		act(() => root.render(<Probe onSuccess={onSuccess} />));
+
+		let first!: Promise<void>;
+		let second!: Promise<void>;
+		act(() => {
+			first = state.run(action, formData);
+			second = state.run(action, formData);
+		});
+
+		expect(action).toHaveBeenCalledTimes(1);
+		expect(state.isPending).toBe(true);
+		await second;
+		await act(async () => {
+			finish();
+			await first;
+		});
+		expect(state.isPending).toBe(false);
+		expect(onSuccess).toHaveBeenCalledTimes(1);
+	});
+
+	it('keeps a failure on the form and permits a retry', async () => {
+		const action = vi
+			.fn<(_: SiteFormData) => Promise<void>>()
+			.mockRejectedValueOnce(new Error('Browser storage is full.'))
+			.mockResolvedValueOnce();
+		const onSuccess = vi.fn();
+		act(() => root.render(<Probe onSuccess={onSuccess} />));
+
+		await act(() => state.run(action, formData));
+		expect(state.error).toBe('Browser storage is full.');
+		expect(state.isPending).toBe(false);
+		expect(onSuccess).not.toHaveBeenCalled();
+
+		await act(() => state.run(action, formData));
+		expect(state.error).toBeUndefined();
+		expect(onSuccess).toHaveBeenCalledTimes(1);
+	});
+
+	function Probe({ onSuccess }: { onSuccess: () => void }) {
+		state = useSiteSettingsSubmission(onSuccess);
+		return null;
+	}
+});

--- a/packages/playground/website/src/components/site-manager/site-settings-form/use-site-settings-submission.ts
+++ b/packages/playground/website/src/components/site-manager/site-settings-form/use-site-settings-submission.ts
@@ -42,3 +42,7 @@ export function useSiteSettingsSubmission(onSuccess?: () => void) {
 
 	return { error, isPending, run };
 }
+
+export type SiteSettingsSubmission = ReturnType<
+	typeof useSiteSettingsSubmission
+>;

--- a/packages/playground/website/src/components/site-manager/site-settings-form/use-site-settings-submission.ts
+++ b/packages/playground/website/src/components/site-manager/site-settings-form/use-site-settings-submission.ts
@@ -24,17 +24,18 @@ export function useSiteSettingsSubmission(onSuccess?: () => void) {
 			setError(undefined);
 			try {
 				await action(data);
-				onSuccess?.();
 			} catch (cause) {
 				setError(
 					cause instanceof Error
 						? cause.message
 						: 'Could not update Playground settings. Please try again.'
 				);
+				return;
 			} finally {
 				pendingRef.current = false;
 				setIsPending(false);
 			}
+			onSuccess?.();
 		},
 		[onSuccess]
 	);

--- a/packages/playground/website/src/components/site-manager/site-settings-form/use-site-settings-submission.ts
+++ b/packages/playground/website/src/components/site-manager/site-settings-form/use-site-settings-submission.ts
@@ -1,0 +1,43 @@
+import { useCallback, useRef, useState } from 'react';
+import type { SiteFormData } from './unconnected-site-settings-form';
+
+/**
+ * Serializes settings submissions and keeps failures on the form that caused
+ * them. A ref closes the same-render double-click window before React can paint
+ * the disabled state.
+ */
+export function useSiteSettingsSubmission(onSuccess?: () => void) {
+	const pendingRef = useRef(false);
+	const [isPending, setIsPending] = useState(false);
+	const [error, setError] = useState<string>();
+
+	const run = useCallback(
+		async (
+			action: (data: SiteFormData) => Promise<void>,
+			data: SiteFormData
+		) => {
+			if (pendingRef.current) {
+				return;
+			}
+			pendingRef.current = true;
+			setIsPending(true);
+			setError(undefined);
+			try {
+				await action(data);
+				onSuccess?.();
+			} catch (cause) {
+				setError(
+					cause instanceof Error
+						? cause.message
+						: 'Could not update Playground settings. Please try again.'
+				);
+			} finally {
+				pendingRef.current = false;
+				setIsPending(false);
+			}
+		},
+		[onSuccess]
+	);
+
+	return { error, isPending, run };
+}

--- a/packages/playground/website/src/lib/state/redux/site-management-api-middleware.ts
+++ b/packages/playground/website/src/lib/state/redux/site-management-api-middleware.ts
@@ -396,9 +396,9 @@ export function createSitesAPI(
 		/**
 		 * Recreates the active autosaved Playground with new setup settings.
 		 *
-		 * Today this keeps the same sidebar entry and replaces the WordPress
-		 * files under that site's OPFS directory. The future Dock flow should
-		 * create a separate Playground for setup changes instead.
+		 * This public API keeps its same-site replacement behavior for existing
+		 * callers. The settings UI creates a separate Playground for setup changes
+		 * so the current site's files remain available.
 		 *
 		 * @param settings Optional site settings.
 		 * @throws When no site is selected, the active site is not autosaved, or

--- a/packages/playground/website/src/lib/state/redux/site-management-api-middleware.ts
+++ b/packages/playground/website/src/lib/state/redux/site-management-api-middleware.ts
@@ -486,6 +486,39 @@ export function createSitesAPI(
 		},
 
 		/**
+		 * Applies the runtime settings that can change without replacing WordPress.
+		 *
+		 * PHP and networking share one metadata write so changing both cannot boot an
+		 * intermediate runtime and then immediately tear it down for the second change.
+		 */
+		async updateRuntimeSettings(settings: {
+			phpVersion: AllPHPVersion;
+			networking: boolean;
+		}): Promise<void> {
+			const site = selectActiveSite(getState());
+			if (!site) {
+				throw new Error('No active site selected');
+			}
+			if (site.metadata.storage === 'none') {
+				throw new Error(
+					'Cannot update settings on a temporary site. Save it first.'
+				);
+			}
+			await dispatch(
+				updateSiteMetadata({
+					slug: site.slug,
+					changes: {
+						runtimeConfiguration: {
+							...site.metadata.runtimeConfiguration,
+							phpVersion: settings.phpVersion,
+							networking: settings.networking,
+						},
+					},
+				})
+			);
+		},
+
+		/**
 		 * Deletes a saved site by slug.
 		 *
 		 * @param siteSlug The slug of the site to delete.

--- a/packages/playground/website/src/lib/state/redux/site-management-api-middleware.ts
+++ b/packages/playground/website/src/lib/state/redux/site-management-api-middleware.ts
@@ -487,6 +487,7 @@ export function createSitesAPI(
 
 		/**
 		 * Applies the runtime settings that can change without replacing WordPress.
+		 * When the settings already match, reloads the current WordPress page.
 		 *
 		 * PHP and networking share one metadata write so changing both cannot boot an
 		 * intermediate runtime and then immediately tear it down for the second change.
@@ -503,6 +504,22 @@ export function createSitesAPI(
 				throw new Error(
 					'Cannot update settings on a temporary site. Save it first.'
 				);
+			}
+			const currentRuntimeConfiguration =
+				site.metadata.runtimeConfiguration;
+			if (
+				currentRuntimeConfiguration.phpVersion ===
+					settings.phpVersion &&
+				currentRuntimeConfiguration.networking === settings.networking
+			) {
+				const client = selectClientBySiteSlug(getState(), site.slug);
+				if (!client) {
+					throw new Error(
+						'Cannot reload a Playground that is not running.'
+					);
+				}
+				await client.goTo(await client.getCurrentURL());
+				return;
 			}
 			await dispatch(
 				updateSiteMetadata({

--- a/packages/playground/website/src/lib/state/redux/slice-sites.ts
+++ b/packages/playground/website/src/lib/state/redux/slice-sites.ts
@@ -671,17 +671,15 @@ export const setStoredSiteSpec = createStoredSite;
 /**
  * Replaces an autosaved Playground's WordPress files with files from a new setup.
  *
- * This is used after the user clicks "Apply Settings & Recreate Playground"
- * in the autosaved settings form. The site keeps the same slug and name in the
- * sidebar, but the old WordPress directory is deleted and the next boot
- * installs WordPress from `playgroundUrlWithQueryApiArgs`.
+ * This supports the public site-management API's same-site replacement
+ * behavior. The settings UI creates a separate Playground instead. Here, the
+ * site keeps the same slug and name, but the old WordPress directory is deleted
+ * and the next boot installs WordPress from `playgroundUrlWithQueryApiArgs`.
  *
  * Callers must not use this for edits that can keep the existing files, such as
  * changing PHP version or networking. Those should update site metadata and
- * reboot. Longer term, the Dock UI should create a new Playground for setup
- * changes and leave the previous Playground untouched. Until that UX exists,
- * this function writes `opfsSiteRemovalPending` so a reload can finish deleting old
- * WordPress files if the tab closes during the deletion.
+ * reboot. This function writes `opfsSiteRemovalPending` so a reload can finish
+ * deleting old WordPress files if the tab closes during the deletion.
  */
 export function resetAutosavedSiteSpec(
 	siteSlug: string,


### PR DESCRIPTION
## What this does

This PR adds a choice to the Site Settings form. When you change the settings, you may either:

* Clone with the current Playground with new settings (when the current Playground is saved)
* Apply the new settings to the currently Playground (only applicable to PHP and networking and only if Playground is saved or autosaved)
* Discard the current Playground and start a new one with these settings (when the current Playground is unsaved)

Before this PR, you could only start a new Playground with the new settings. Sometimes that's useful, sometimes that's confusing. Ideally we'd offer a way to change any setting on the active site, but it's not really possible to seamlessly downgrade or upgrade the WordPress version on an existing site. The plugins, compatibility etc. will all likely be affected. Therefore, Playground does the next best thing and offers every viable option for every combination of choices.

## Implementation

Saved and autosaved Playgrounds can apply PHP and network changes in place. WordPress version, language, and multisite changes switch the primary action to **Create a fresh Playground** while keeping the current site. Temporary Playgrounds get one destructive fresh-site action because they cannot be updated in place.

Runtime settings are written together, so a PHP-and-network submission triggers one metadata transition instead of two consecutive reboots. Submissions are serialized before React paints the pending state, failures stay with the form instead of overlapping its actions, and the action menu implements standard arrow/Home/End keyboard navigation.

## Testing

- 13 focused Vitest tests for classification, pending submission, retry, and footer state
- 5 Chromium E2E flows covering temporary sites, keyboard behavior, atomic runtime updates, structural changes, same-task double clicks, and preservation of saved sites
- `npm exec nx -- run-many -t lint typecheck -p playground-website --parallel=2`


## UI walkthrough

**Apply runtime changes in place, then create a fresh Playground for a structural change** — [MP4 recording](https://raw.githubusercontent.com/WordPress/wordpress-playground/86f56b07d6777832452ce64d248809321df31334/pr-media/4034/settings-flows.mp4)

| Apply runtime changes to this Playground | Create a fresh Playground for structural changes |
| --- | --- |
| ![PHP and network changes can be applied to the current Playground](https://raw.githubusercontent.com/WordPress/wordpress-playground/86f56b07d6777832452ce64d248809321df31334/pr-media/4034/01-apply-in-place.png) | ![Changing the WordPress version requires a fresh Playground](https://raw.githubusercontent.com/WordPress/wordpress-playground/86f56b07d6777832452ce64d248809321df31334/pr-media/4034/02-create-fresh.png) |


