### PR TITLE
[Reference] Original OPFS bridge export implementation

### DIFF
--- a/packages/playground/client/src/index.spec.ts
+++ b/packages/playground/client/src/index.spec.ts
@@ -11,6 +11,7 @@ const mocks = vi.hoisted(() => {
 		bootPlaygroundV2: vi.fn(),
 		BlueprintsV1Handler: vi.fn(),
 		BlueprintsV2Handler: vi.fn(),
+		consumeAPI: vi.fn(),
 		createBlueprintReflection: vi.fn(),
 	};
 });
@@ -30,7 +31,15 @@ vi.mock('./blueprints-v2-handler', () => ({
 	BlueprintsV2Handler: mocks.BlueprintsV2Handler,
 }));
 
-import { startPlaygroundWeb } from './index';
+vi.mock('@php-wasm/universal', async (importActual) => {
+	const actual = await importActual();
+	return {
+		...(actual as object),
+		consumeAPI: mocks.consumeAPI,
+	};
+});
+
+import { startOpfsBridge, startPlaygroundWeb } from './index';
 
 describe('startPlaygroundWeb', () => {
 	afterEach(() => {
@@ -87,11 +96,46 @@ describe('startPlaygroundWeb', () => {
 		expect(mocks.BlueprintsV1Handler).not.toHaveBeenCalled();
 		expect(iframe.src).toContain('blueprints-runner=v1');
 	});
+
+	it('loads the OPFS bridge iframe and returns the bridge API', async () => {
+		const bridge = {
+			isConnected: vi.fn(async () => undefined),
+			isReady: vi.fn(async () => undefined),
+			zipSite: vi.fn(),
+		};
+		mocks.consumeAPI.mockReturnValue(bridge);
+		const iframe = createIframe();
+
+		await expect(startOpfsBridge({ iframe })).resolves.toBe(bridge);
+
+		expect(iframe.src).toBe('http://localhost/bridge.html');
+		expect(mocks.consumeAPI).toHaveBeenCalledWith(
+			iframe.contentWindow,
+			iframe.ownerDocument!.defaultView
+		);
+		expect(bridge.isConnected).toHaveBeenCalledTimes(1);
+		expect(bridge.isReady).toHaveBeenCalledTimes(1);
+	});
+
+	it('requires OPFS bridge URLs to point to bridge.html', async () => {
+		const iframe = createIframe();
+
+		await expect(
+			startOpfsBridge({
+				iframe,
+				bridgeUrl: 'http://localhost/remote.html',
+			})
+		).rejects.toThrow('/bridge.html');
+	});
 });
 
 function createIframe() {
 	return {
 		src: '',
+		contentWindow: {},
+		ownerDocument: {
+			defaultView: {},
+		},
 		addEventListener: vi.fn((_event, callback: () => void) => {
 			callback();
 		}),

--- a/packages/playground/client/src/index.ts
+++ b/packages/playground/client/src/index.ts
@@ -26,7 +26,12 @@ export {
 	LatestSupportedPHPVersion,
 } from '@php-wasm/universal';
 export { phpVar, phpVars } from '@php-wasm/util';
-export type { PlaygroundClient, MountDescriptor };
+export type {
+	PlaygroundClient,
+	MountDescriptor,
+	OpfsBridgeClient,
+	ZipOpfsSiteOptions,
+};
 
 import {
 	BlueprintReflection,
@@ -41,7 +46,13 @@ import type {
 } from '@wp-playground/blueprints';
 import type { WordPressInstallMode } from '@wp-playground/wordpress';
 import { ProgressTracker } from '@php-wasm/progress';
-import type { MountDescriptor, PlaygroundClient } from '@wp-playground/remote';
+import { consumeAPI } from '@php-wasm/universal';
+import type {
+	MountDescriptor,
+	OpfsBridgeClient,
+	PlaygroundClient,
+	ZipOpfsSiteOptions,
+} from '@wp-playground/remote';
 import type { PathAlias } from '@php-wasm/universal';
 import type { PHPWebExtension } from '@php-wasm/web';
 import { additionalRemoteOrigins } from './additional-remote-origins';
@@ -148,6 +159,11 @@ export interface StartPlaygroundWebOptions extends Omit<
 	onBlueprintValidated?: (blueprint: BlueprintDeclaration) => void;
 }
 
+export interface StartOpfsBridgeOptions {
+	iframe: HTMLIFrameElement;
+	bridgeUrl?: string;
+}
+
 /**
  * Loads playground in iframe and returns a PlaygroundClient instance.
  *
@@ -194,6 +210,37 @@ export async function startPlaygroundWeb(
 	progressTracker.finish();
 
 	return playground;
+}
+
+/**
+ * Loads the OPFS bridge in an iframe and returns an OpfsBridgeClient instance.
+ *
+ * The bridge can read saved OPFS-backed Playground sites without booting
+ * Playground, WordPress, PHP, workers, or service workers.
+ */
+export async function startOpfsBridge(
+	options: StartOpfsBridgeOptions
+): Promise<OpfsBridgeClient> {
+	const { iframe } = options;
+	const bridgeUrl =
+		options.bridgeUrl ??
+		new URL('/bridge.html', location.origin).toString();
+	assertLikelyCompatibleBridgeOrigin(bridgeUrl);
+	allowStorageAccessByUserActivation(iframe);
+
+	await new Promise((resolve) => {
+		iframe.src = bridgeUrl;
+		iframe.addEventListener('load', resolve, false);
+	});
+
+	const bridge = consumeAPI<OpfsBridgeClient>(
+		iframe.contentWindow!,
+		iframe.ownerDocument!.defaultView!
+	);
+	await bridge.isConnected();
+	await bridge.isReady();
+
+	return bridge;
 }
 
 async function shouldUseBlueprintV2Handler(options: StartPlaygroundWebOptions) {
@@ -267,16 +314,27 @@ const remoteOrigin =
  * @param remoteHtmlUrl The URL for remote.html
  */
 function assertLikelyCompatibleRemoteOrigin(remoteHtmlUrl: string) {
-	const url = new URL(remoteHtmlUrl, remoteOrigin);
+	assertLikelyCompatibleRemotePath(remoteHtmlUrl, '/remote.html');
+}
+
+function assertLikelyCompatibleBridgeOrigin(bridgeUrl: string) {
+	assertLikelyCompatibleRemotePath(bridgeUrl, '/bridge.html');
+}
+
+function assertLikelyCompatibleRemotePath(
+	urlString: string,
+	expectedPath: string
+) {
+	const url = new URL(urlString, remoteOrigin);
 
 	const validRemote =
 		validRemoteOrigins.includes(url.origin) &&
-		url.pathname === '/remote.html';
+		url.pathname === expectedPath;
 
 	if (!validRemote) {
 		throw new Error(
 			`Invalid remote URL: ${url}. ` +
-				'Expected remote URL to have a path of "/remote.html" based ' +
+				`Expected remote URL to have a path of "${expectedPath}" based ` +
 				`on one of the following origins:\n ${validRemoteOrigins.join(
 					'\n'
 				)}`

--- a/packages/playground/personal-wp/src/components/site-manager/site-file-browser/index.tsx
+++ b/packages/playground/personal-wp/src/components/site-manager/site-file-browser/index.tsx
@@ -5,11 +5,11 @@ import {
 	type AsyncWritableFilesystem,
 	OpfsFilesystemBackend,
 	EventedFilesystem,
+	getDirectoryPathForSlug,
 } from '@wp-playground/storage';
 import type { PlaygroundClient } from '@wp-playground/remote';
 import { PlaygroundFileEditor } from '@wp-playground/components';
 import { logger } from '@php-wasm/logger';
-import { getDirectoryPathForSlug } from '../../../lib/state/opfs/opfs-site-storage';
 
 export function SiteFileBrowser({
 	site,

--- a/packages/playground/personal-wp/src/lib/state/opfs/opfs-blueprint-bundle-storage.ts
+++ b/packages/playground/personal-wp/src/lib/state/opfs/opfs-blueprint-bundle-storage.ts
@@ -9,9 +9,9 @@
 import {
 	OpfsFilesystemBackend,
 	copyFilesystem,
+	getDirectoryPathForSlug,
 	type TraversableFilesystemBackend,
 } from '@wp-playground/storage';
-import { getDirectoryPathForSlug } from './opfs-site-storage';
 
 const BUNDLE_DIR_NAME = 'blueprint-bundle';
 

--- a/packages/playground/personal-wp/src/lib/state/opfs/opfs-site-storage.spec.ts
+++ b/packages/playground/personal-wp/src/lib/state/opfs/opfs-site-storage.spec.ts
@@ -1,0 +1,204 @@
+import type { SiteMetadata } from '../redux/slice-sites';
+import type { opfsSiteStorage as exportedOpfsSiteStorage } from './opfs-site-storage';
+
+describe('opfsSiteStorage', () => {
+	let opfsRoot: MemoryDirectoryHandle;
+	let storage: NonNullable<typeof exportedOpfsSiteStorage>;
+	let legacyOpfsPathSymbol: symbol;
+	let loadPersistedBlueprintBundle: ReturnType<typeof vi.fn>;
+
+	beforeEach(async () => {
+		vi.resetModules();
+		loadPersistedBlueprintBundle = vi.fn();
+		opfsRoot = new MemoryDirectoryHandle('');
+		vi.stubGlobal('navigator', {
+			storage: {
+				getDirectory: vi.fn(async () => opfsRoot),
+			},
+		});
+		vi.doMock('./opfs-blueprint-bundle-storage', () => ({
+			loadPersistedBlueprintBundle,
+		}));
+		vi.doMock('@wp-playground/blueprints', () => ({
+			getBlueprintDeclaration: vi.fn(async (blueprint) => blueprint),
+		}));
+
+		const module = await import('./opfs-site-storage');
+		storage = module.opfsSiteStorage!;
+		legacyOpfsPathSymbol = module.legacyOpfsPathSymbol;
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('preserves the legacy OPFS mount path for legacy site directories', async () => {
+		const sitesRoot = await getSitesRoot(opfsRoot);
+		await sitesRoot.getDirectoryHandle('site-example.com', {
+			create: true,
+		});
+		await writeSiteMetadata(sitesRoot, 'site-example-com', 'example.com');
+
+		const site = await storage.read('example.com');
+
+		expect(site).toMatchObject({
+			slug: 'example.com',
+			metadata: {
+				name: 'Test Playground',
+			},
+		});
+		expect((site!.metadata as any)[legacyOpfsPathSymbol]).toBe(
+			'/sites/site-example-com'
+		);
+	});
+
+	it('does not add a legacy OPFS mount path for canonical directories', async () => {
+		const sitesRoot = await getSitesRoot(opfsRoot);
+		await writeSiteMetadata(sitesRoot, 'site-example.com', 'example.com');
+
+		const site = await storage.read('example.com');
+
+		expect((site!.metadata as any)[legacyOpfsPathSymbol]).toBeUndefined();
+	});
+
+	it('loads persisted Blueprint bundles for stored bundle metadata', async () => {
+		const bundle = { read: vi.fn(), listFiles: vi.fn(), isDir: vi.fn() };
+		loadPersistedBlueprintBundle.mockResolvedValue(bundle);
+		const sitesRoot = await getSitesRoot(opfsRoot);
+		await writeSiteMetadata(sitesRoot, 'site-bundle', 'bundle', {
+			originalBlueprintSource: {
+				type: 'opfs-site',
+			},
+		});
+
+		const site = await storage.read('bundle');
+
+		expect(loadPersistedBlueprintBundle).toHaveBeenCalledWith('bundle');
+		expect(site?.metadata.originalBlueprint).toBe(bundle);
+	});
+});
+
+async function getSitesRoot(opfsRoot: MemoryDirectoryHandle) {
+	return opfsRoot.getDirectoryHandle('sites');
+}
+
+async function writeSiteMetadata(
+	sitesRoot: MemoryDirectoryHandle,
+	directoryName: string,
+	slug: string,
+	metadata: Partial<SiteMetadata> = {}
+) {
+	const siteDirectory = await sitesRoot.getDirectoryHandle(directoryName, {
+		create: true,
+	});
+	siteDirectory.setFile(
+		'wp-runtime.json',
+		JSON.stringify({
+			slug,
+			...createSiteMetadata(metadata),
+		})
+	);
+}
+
+function createSiteMetadata(
+	metadata: Partial<SiteMetadata> = {}
+): SiteMetadata {
+	return {
+		storage: 'opfs',
+		id: 'test-site-id',
+		name: 'Test Playground',
+		runtimeConfiguration: {
+			phpVersion: '8.3',
+			wpVersion: 'latest',
+			intl: false,
+			networking: true,
+			extraLibraries: [],
+			constants: {},
+		},
+		originalBlueprint: {},
+		originalBlueprintSource: {
+			type: 'none',
+		},
+		...metadata,
+	};
+}
+
+class MemoryDirectoryHandle {
+	kind = 'directory' as const;
+	name: string;
+	private children = new Map<
+		string,
+		MemoryDirectoryHandle | MemoryFileHandle
+	>();
+
+	constructor(name: string) {
+		this.name = name;
+	}
+
+	async getDirectoryHandle(
+		name: string,
+		options?: { create?: boolean }
+	): Promise<MemoryDirectoryHandle> {
+		const entry = this.children.get(name);
+		if (entry instanceof MemoryDirectoryHandle) {
+			return entry;
+		}
+		if (entry) {
+			throw createDomException('TypeMismatchError');
+		}
+		if (options?.create) {
+			const directory = new MemoryDirectoryHandle(name);
+			this.children.set(name, directory);
+			return directory;
+		}
+		throw createDomException('NotFoundError');
+	}
+
+	async getFileHandle(name: string): Promise<MemoryFileHandle> {
+		const entry = this.children.get(name);
+		if (entry instanceof MemoryFileHandle) {
+			return entry;
+		}
+		if (entry) {
+			throw createDomException('TypeMismatchError');
+		}
+		throw createDomException('NotFoundError');
+	}
+
+	async *values() {
+		yield* this.children.values();
+	}
+
+	async removeEntry(name: string) {
+		if (!this.children.delete(name)) {
+			throw createDomException('NotFoundError');
+		}
+	}
+
+	setFile(name: string, content: string) {
+		this.children.set(name, new MemoryFileHandle(name, content));
+	}
+}
+
+class MemoryFileHandle {
+	kind = 'file' as const;
+	name: string;
+	private content: string;
+
+	constructor(name: string, content: string) {
+		this.name = name;
+		this.content = content;
+	}
+
+	async getFile() {
+		return {
+			text: async () => this.content,
+		};
+	}
+}
+
+function createDomException(name: string) {
+	const error = new Error(name);
+	error.name = name;
+	return error;
+}

--- a/packages/playground/personal-wp/src/lib/state/opfs/opfs-site-storage.ts
+++ b/packages/playground/personal-wp/src/lib/state/opfs/opfs-site-storage.ts
@@ -11,6 +11,12 @@ import type { SiteInfo } from '../redux/slice-sites';
 import { joinPaths } from '@php-wasm/util';
 import { logger } from '@php-wasm/logger';
 import {
+	OPFS_SITE_METADATA_FILENAME,
+	OPFS_SITES_ROOT_PATH,
+	getCandidateDirectoryNamesForSlug,
+	getDirectoryNameForSlug,
+} from '@wp-playground/storage';
+import {
 	type ExtraLibrary,
 	type PHPConstants,
 	getBlueprintDeclaration,
@@ -18,10 +24,6 @@ import {
 import type { SupportedPHPVersion } from '@php-wasm/universal';
 import { RecommendedPHPVersion } from '@wp-playground/common';
 import { loadPersistedBlueprintBundle } from './opfs-blueprint-bundle-storage';
-
-const ROOT_PATH = '/sites';
-// TODO: Decide on metadata filename
-const SITE_METADATA_FILENAME = 'wp-runtime.json';
 
 // Use a symbol to mark legacy site metadata to avoid serializing it to JSON.
 // @TODO: Remove this backcompat code after 2024-12-01.
@@ -45,7 +47,7 @@ export interface StoredSiteMetadata extends SiteMetadata {
 let opfsSitesRoot: FileSystemDirectoryHandle | undefined = undefined;
 try {
 	opfsSitesRoot = await navigator.storage.getDirectory();
-	for (const path of ROOT_PATH.replace(/^\//, '').split('/')) {
+	for (const path of OPFS_SITES_ROOT_PATH.replace(/^\//, '').split('/')) {
 		opfsSitesRoot = await opfsSitesRoot.getDirectoryHandle(path, {
 			create: true,
 		});
@@ -62,30 +64,27 @@ class OpfsSiteStorage {
 
 	async create(slug: string, metadata: SiteMetadata): Promise<void> {
 		const newSiteDirName = getDirectoryNameForSlug(slug);
-		if (await opfsChildExists(this.root, newSiteDirName)) {
-			const dir = await this.root.getDirectoryHandle(newSiteDirName);
-			if (await opfsChildExists(dir, SITE_METADATA_FILENAME)) {
-				throw new Error(`Site with slug '${slug}' already exists.`);
-			}
+		if (await this.findExistingSiteDirName(slug)) {
+			throw new Error(`Site with slug '${slug}' already exists.`);
 		}
 
 		await this.root.getDirectoryHandle(newSiteDirName, {
 			create: true,
 		});
 		await opfsWriteFile(
-			joinPaths(ROOT_PATH, newSiteDirName, SITE_METADATA_FILENAME),
+			getSiteMetadataPath(newSiteDirName),
 			await metadataToStoredFormat(slug, metadata)
 		);
 	}
 
 	async update(slug: string, metadata: SiteMetadata): Promise<void> {
-		const newSiteDirName = getDirectoryNameForSlug(slug);
-		if (!(await opfsChildExists(this.root, newSiteDirName))) {
+		const siteDirName = await this.findExistingSiteDirName(slug);
+		if (!siteDirName) {
 			throw new Error(`Site with slug '${slug}' does not exist.`);
 		}
 
 		await opfsWriteFile(
-			joinPaths(ROOT_PATH, newSiteDirName, SITE_METADATA_FILENAME),
+			getSiteMetadataPath(siteDirName),
 			await metadataToStoredFormat(slug, metadata)
 		);
 	}
@@ -112,7 +111,11 @@ class OpfsSiteStorage {
 	}
 
 	async read(slug: string): Promise<SiteInfo | undefined> {
-		return await this.readSite(getDirectoryNameForSlug(slug));
+		const siteDirName = await this.findExistingSiteDirName(slug);
+		if (!siteDirName) {
+			return undefined;
+		}
+		return await this.readSite(siteDirName);
 	}
 
 	private async readSite(siteDirName: string) {
@@ -127,7 +130,7 @@ class OpfsSiteStorage {
 		siteDirectory: FileSystemDirectoryHandle
 	) {
 		const siteInfoFileHandle = await siteDirectory.getFileHandle(
-			SITE_METADATA_FILENAME
+			OPFS_SITE_METADATA_FILENAME
 		);
 		const file = await siteInfoFileHandle.getFile();
 		// TODO: Read metadata file and parse and validate via JSON schema
@@ -154,8 +157,25 @@ class OpfsSiteStorage {
 	}
 
 	async delete(slug: string): Promise<void> {
-		const siteDirName = getDirectoryNameForSlug(slug);
+		const siteDirName = await this.findExistingSiteDirName(slug);
+		if (!siteDirName) {
+			throw new Error(`Site with slug '${slug}' does not exist.`);
+		}
 		await this.root.removeEntry(siteDirName, { recursive: true });
+	}
+
+	private async findExistingSiteDirName(slug: string) {
+		for (const siteDirName of getCandidateDirectoryNamesForSlug(slug)) {
+			if (!(await opfsChildExists(this.root, siteDirName))) {
+				continue;
+			}
+			const dir = await this.root.getDirectoryHandle(siteDirName);
+			if (await opfsChildExists(dir, OPFS_SITE_METADATA_FILENAME)) {
+				return siteDirName;
+			}
+		}
+
+		return undefined;
 	}
 }
 
@@ -165,12 +185,12 @@ export const opfsSiteStorage: OpfsSiteStorage | undefined = opfsSitesRoot
 
 export const isOpfsAvailable = !!opfsSiteStorage;
 
-export function getDirectoryPathForSlug(slug: string) {
-	return joinPaths(ROOT_PATH, getDirectoryNameForSlug(slug));
-}
-
-export function getDirectoryNameForSlug(slug: string) {
-	return `site-${slug}`.replaceAll(/[^a-zA-Z0-9_-]/g, '-');
+function getSiteMetadataPath(siteDirName: string) {
+	return joinPaths(
+		OPFS_SITES_ROOT_PATH,
+		siteDirName,
+		OPFS_SITE_METADATA_FILENAME
+	);
 }
 
 async function metadataToStoredFormat(

--- a/packages/playground/personal-wp/src/lib/state/opfs/opfs-site-storage.ts
+++ b/packages/playground/personal-wp/src/lib/state/opfs/opfs-site-storage.ts
@@ -138,6 +138,13 @@ class OpfsSiteStorage {
 		//       ^ do not do it implicitly. Require user interaction. Maybe constrain this just
 		//         to the site files import flow.
 		const siteInfo = storedFormatToMetadata(await file.text());
+		if (siteDirectory.name !== getDirectoryNameForSlug(siteInfo.slug)) {
+			(siteInfo.metadata as any)[legacyOpfsPathSymbol] = joinPaths(
+				OPFS_SITES_ROOT_PATH,
+				siteDirectory.name
+			);
+		}
+
 		// If the blueprint source points to the bundle directory, load from there.
 		// This allows the site to access bundled resources, not just the JSON declaration.
 		if (siteInfo.metadata.originalBlueprintSource?.type === 'opfs-site') {

--- a/packages/playground/personal-wp/src/lib/state/redux/boot-site-client.ts
+++ b/packages/playground/personal-wp/src/lib/state/redux/boot-site-client.ts
@@ -1,9 +1,9 @@
-import { directoryHandleFromMountDevice } from '@wp-playground/storage';
-import { loadDirectoryHandle } from '../opfs/opfs-directory-handle-storage';
 import {
+	directoryHandleFromMountDevice,
 	getDirectoryPathForSlug,
-	legacyOpfsPathSymbol,
-} from '../opfs/opfs-site-storage';
+} from '@wp-playground/storage';
+import { loadDirectoryHandle } from '../opfs/opfs-directory-handle-storage';
+import { legacyOpfsPathSymbol } from '../opfs/opfs-site-storage';
 import {
 	addClientInfo,
 	removeClientInfo,

--- a/packages/playground/remote/bridge.html
+++ b/packages/playground/remote/bridge.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html>
+	<head>
+		<title>WordPress Playground OPFS Bridge</title>
+	</head>
+	<body>
+		<script type="module">
+			import { bootOpfsBridge } from './src/index';
+
+			window.opfsBridge = await bootOpfsBridge();
+		</script>
+	</body>
+</html>

--- a/packages/playground/remote/package.json
+++ b/packages/playground/remote/package.json
@@ -18,14 +18,10 @@
 	"license": "GPL-2.0-or-later",
 	"type": "module",
 	"files": [
-		"/.htaccess",
-		"/assets",
+		"/assets/bridge-*.js",
+		"/assets/index-*.css",
+		"/assets/index-*.js",
 		"/bridge.html",
-		"/remote.html",
-		"/sw.js",
-		"/sw.js.map",
-		"/*.js",
-		"/*.js.map",
 		"/lib",
 		"/index.d.ts"
 	],

--- a/packages/playground/remote/package.json
+++ b/packages/playground/remote/package.json
@@ -18,6 +18,14 @@
 	"license": "GPL-2.0-or-later",
 	"type": "module",
 	"files": [
+		"/.htaccess",
+		"/assets",
+		"/bridge.html",
+		"/remote.html",
+		"/sw.js",
+		"/sw.js.map",
+		"/*.js",
+		"/*.js.map",
 		"/lib",
 		"/index.d.ts"
 	],

--- a/packages/playground/remote/src/lib/boot-opfs-bridge.spec.ts
+++ b/packages/playground/remote/src/lib/boot-opfs-bridge.spec.ts
@@ -1,0 +1,186 @@
+import { TextWriter, Uint8ArrayReader, ZipReader } from '@zip.js/zip.js';
+import { zipSite } from './boot-opfs-bridge';
+
+describe('zipSite', () => {
+	let opfsRoot: MemoryDirectoryHandle;
+
+	beforeEach(() => {
+		opfsRoot = new MemoryDirectoryHandle('');
+		vi.stubGlobal('navigator', {
+			storage: {
+				getDirectory: vi.fn(async () => opfsRoot),
+			},
+		});
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('zips the entire saved OPFS site directory', async () => {
+		const site = await createSiteDirectory('demo-site');
+		site.setFile('wp-runtime.json', '{"slug":"demo-site"}');
+		const wpContent = await site.getDirectoryHandle('wp-content', {
+			create: true,
+		});
+		const plugins = await wpContent.getDirectoryHandle('plugins', {
+			create: true,
+		});
+		plugins.setFile('hello.php', '<?php echo "Hello";');
+
+		const zipBytes = await zipSite('demo-site');
+		const entries = await readZipEntries(zipBytes);
+
+		expect(entries.get('wp-runtime.json')).toBe('{"slug":"demo-site"}');
+		expect(entries.get('wp-content/plugins/hello.php')).toBe(
+			'<?php echo "Hello";'
+		);
+	});
+
+	it('uses the legacy slug directory when the canonical directory is incomplete', async () => {
+		const sitesRoot = await getSitesRoot();
+		await sitesRoot.getDirectoryHandle('site-a%2Fb', { create: true });
+		const legacySite = await sitesRoot.getDirectoryHandle('site-a-b', {
+			create: true,
+		});
+		legacySite.setFile('wp-runtime.json', '{"slug":"a/b"}');
+		legacySite.setFile('index.php', 'legacy');
+
+		const zipBytes = await zipSite('a/b');
+		const entries = await readZipEntries(zipBytes);
+
+		expect(entries.get('index.php')).toBe('legacy');
+	});
+
+	it('applies glob-style exclusions to zip paths', async () => {
+		const site = await createSiteDirectory('excluded-site');
+		site.setFile('wp-runtime.json', '{}');
+		const bundle = await site.getDirectoryHandle('blueprint-bundle', {
+			create: true,
+		});
+		bundle.setFile('blueprint.json', '{}');
+		const plugins = await (
+			await site.getDirectoryHandle('wp-content', { create: true })
+		).getDirectoryHandle('plugins', { create: true });
+		plugins.setFile('excluded.php', '<?php excluded();');
+		plugins.setFile('readme.txt', 'keep');
+
+		const zipBytes = await zipSite('excluded-site', {
+			exclude: ['blueprint-bundle/**', 'wp-content/plugins/*.php'],
+		});
+		const entries = await readZipEntries(zipBytes);
+
+		expect(entries.has('wp-runtime.json')).toBe(true);
+		expect(entries.has('blueprint-bundle/blueprint.json')).toBe(false);
+		expect(entries.has('wp-content/plugins/excluded.php')).toBe(false);
+		expect(entries.get('wp-content/plugins/readme.txt')).toBe('keep');
+	});
+
+	it('throws a NotFoundError when the saved site does not exist', async () => {
+		await expect(zipSite('missing-site')).rejects.toMatchObject({
+			name: 'NotFoundError',
+		});
+	});
+
+	async function createSiteDirectory(slug: string) {
+		const sitesRoot = await getSitesRoot();
+		return await sitesRoot.getDirectoryHandle(`site-${slug}`, {
+			create: true,
+		});
+	}
+
+	async function getSitesRoot() {
+		return await opfsRoot.getDirectoryHandle('sites', { create: true });
+	}
+});
+
+async function readZipEntries(zipBytes: Uint8Array) {
+	const reader = new ZipReader(new Uint8ArrayReader(zipBytes));
+	try {
+		const entries = await reader.getEntries();
+		const files = new Map<string, string>();
+		for (const entry of entries) {
+			if (!entry.directory) {
+				files.set(
+					entry.filename,
+					await entry.getData!(new TextWriter())
+				);
+			}
+		}
+		return files;
+	} finally {
+		await reader.close();
+	}
+}
+
+class MemoryDirectoryHandle {
+	kind = 'directory' as const;
+	name: string;
+	private children = new Map<
+		string,
+		MemoryDirectoryHandle | MemoryFileHandle
+	>();
+
+	constructor(name: string) {
+		this.name = name;
+	}
+
+	async getDirectoryHandle(
+		name: string,
+		options?: { create?: boolean }
+	): Promise<MemoryDirectoryHandle> {
+		const entry = this.children.get(name);
+		if (entry instanceof MemoryDirectoryHandle) {
+			return entry;
+		}
+		if (entry) {
+			throw createDomException('TypeMismatchError');
+		}
+		if (options?.create) {
+			const directory = new MemoryDirectoryHandle(name);
+			this.children.set(name, directory);
+			return directory;
+		}
+		throw createDomException('NotFoundError');
+	}
+
+	async getFileHandle(name: string): Promise<MemoryFileHandle> {
+		const entry = this.children.get(name);
+		if (entry instanceof MemoryFileHandle) {
+			return entry;
+		}
+		if (entry) {
+			throw createDomException('TypeMismatchError');
+		}
+		throw createDomException('NotFoundError');
+	}
+
+	async *entries() {
+		yield* this.children.entries();
+	}
+
+	setFile(name: string, content: string) {
+		this.children.set(name, new MemoryFileHandle(name, content));
+	}
+}
+
+class MemoryFileHandle {
+	kind = 'file' as const;
+	name: string;
+	private content: string;
+
+	constructor(name: string, content: string) {
+		this.name = name;
+		this.content = content;
+	}
+
+	async getFile() {
+		return new Blob([this.content]);
+	}
+}
+
+function createDomException(name: string) {
+	const error = new Error(name);
+	error.name = name;
+	return error;
+}

--- a/packages/playground/remote/src/lib/boot-opfs-bridge.spec.ts
+++ b/packages/playground/remote/src/lib/boot-opfs-bridge.spec.ts
@@ -29,10 +29,12 @@ describe('zipSite', () => {
 		plugins.setFile('hello.php', '<?php echo "Hello";');
 
 		const zipBytes = await zipSite('demo-site');
-		const entries = await readZipEntries(zipBytes);
+		const archive = await readZipEntries(zipBytes);
 
-		expect(entries.get('wp-runtime.json')).toBe('{"slug":"demo-site"}');
-		expect(entries.get('wp-content/plugins/hello.php')).toBe(
+		expect(archive.files.get('wp-runtime.json')).toBe(
+			'{"slug":"demo-site"}'
+		);
+		expect(archive.files.get('wp-content/plugins/hello.php')).toBe(
 			'<?php echo "Hello";'
 		);
 	});
@@ -47,33 +49,68 @@ describe('zipSite', () => {
 		legacySite.setFile('index.php', 'legacy');
 
 		const zipBytes = await zipSite('a/b');
-		const entries = await readZipEntries(zipBytes);
+		const archive = await readZipEntries(zipBytes);
 
-		expect(entries.get('index.php')).toBe('legacy');
+		expect(archive.files.get('index.php')).toBe('legacy');
 	});
 
 	it('applies glob-style exclusions to zip paths', async () => {
 		const site = await createSiteDirectory('excluded-site');
 		site.setFile('wp-runtime.json', '{}');
+		site.setFile('wp-config.php', 'secret');
+		site.setFile('debug.log', 'root log');
 		const bundle = await site.getDirectoryHandle('blueprint-bundle', {
 			create: true,
 		});
 		bundle.setFile('blueprint.json', '{}');
-		const plugins = await (
-			await site.getDirectoryHandle('wp-content', { create: true })
-		).getDirectoryHandle('plugins', { create: true });
+		const wpContent = await site.getDirectoryHandle('wp-content', {
+			create: true,
+		});
+		wpContent.setFile('debug.log', 'nested log');
+		const plugins = await wpContent.getDirectoryHandle('plugins', {
+			create: true,
+		});
 		plugins.setFile('excluded.php', '<?php excluded();');
 		plugins.setFile('readme.txt', 'keep');
 
 		const zipBytes = await zipSite('excluded-site', {
-			exclude: ['blueprint-bundle/**', 'wp-content/plugins/*.php'],
+			exclude: [
+				'/blueprint-bundle/**',
+				'/**/wp-config.php',
+				'**/*.log',
+				'/wp-content/plugins/*.php',
+			],
 		});
-		const entries = await readZipEntries(zipBytes);
+		const archive = await readZipEntries(zipBytes);
 
-		expect(entries.has('wp-runtime.json')).toBe(true);
-		expect(entries.has('blueprint-bundle/blueprint.json')).toBe(false);
-		expect(entries.has('wp-content/plugins/excluded.php')).toBe(false);
-		expect(entries.get('wp-content/plugins/readme.txt')).toBe('keep');
+		expect(archive.files.has('wp-runtime.json')).toBe(true);
+		expect(archive.directories.has('blueprint-bundle/')).toBe(false);
+		expect(archive.files.has('blueprint-bundle/blueprint.json')).toBe(
+			false
+		);
+		expect(archive.files.has('wp-config.php')).toBe(false);
+		expect(archive.files.has('debug.log')).toBe(false);
+		expect(archive.files.has('wp-content/debug.log')).toBe(false);
+		expect(archive.files.has('wp-content/plugins/excluded.php')).toBe(
+			false
+		);
+		expect(archive.files.get('wp-content/plugins/readme.txt')).toBe('keep');
+	});
+
+	it('preserves empty directories in the zip', async () => {
+		const site = await createSiteDirectory('empty-dir-site');
+		site.setFile('wp-runtime.json', '{}');
+		const uploads = await (
+			await site.getDirectoryHandle('wp-content', { create: true })
+		).getDirectoryHandle('uploads', { create: true });
+		await uploads.getDirectoryHandle('empty-cache', { create: true });
+
+		const zipBytes = await zipSite('empty-dir-site');
+		const archive = await readZipEntries(zipBytes);
+
+		expect(archive.directories.has('wp-content/uploads/empty-cache/')).toBe(
+			true
+		);
 	});
 
 	it('throws a NotFoundError when the saved site does not exist', async () => {
@@ -99,15 +136,21 @@ async function readZipEntries(zipBytes: Uint8Array) {
 	try {
 		const entries = await reader.getEntries();
 		const files = new Map<string, string>();
+		const directories = new Set<string>();
 		for (const entry of entries) {
-			if (!entry.directory) {
+			if (entry.directory) {
+				directories.add(entry.filename);
+			} else {
 				files.set(
 					entry.filename,
 					await entry.getData!(new TextWriter())
 				);
 			}
 		}
-		return files;
+		return {
+			files,
+			directories,
+		};
 	} finally {
 		await reader.close();
 	}

--- a/packages/playground/remote/src/lib/boot-opfs-bridge.ts
+++ b/packages/playground/remote/src/lib/boot-opfs-bridge.ts
@@ -1,0 +1,151 @@
+import { joinPaths } from '@php-wasm/util';
+import { exposeAPI } from '@php-wasm/web';
+import {
+	OPFS_SITE_METADATA_FILENAME,
+	OPFS_SITES_ROOT_PATH,
+	OpfsFilesystemBackend,
+	getCandidateDirectoryNamesForSlug,
+} from '@wp-playground/storage';
+import type { TraversableFilesystemBackend } from '@wp-playground/storage';
+import { BlobWriter, Uint8ArrayReader, ZipWriter } from '@zip.js/zip.js';
+
+export interface ZipOpfsSiteOptions {
+	exclude?: string[];
+}
+
+export interface OpfsBridgeClient {
+	zipSite(slug: string, options?: ZipOpfsSiteOptions): Promise<Uint8Array>;
+}
+
+export async function bootOpfsBridge() {
+	const [setAPIReady, , bridge] = exposeAPI<OpfsBridgeClient, undefined>({
+		zipSite,
+	});
+	setAPIReady();
+	return bridge;
+}
+
+export async function zipSite(slug: string, options: ZipOpfsSiteOptions = {}) {
+	const filesystem = await getOpfsSiteFilesystem(slug);
+	return await zipFilesystem(filesystem, options);
+}
+
+async function getOpfsSiteFilesystem(slug: string) {
+	for (const directoryName of getCandidateDirectoryNamesForSlug(slug)) {
+		const sitePath = joinPaths(OPFS_SITES_ROOT_PATH, directoryName);
+		try {
+			const filesystem = await OpfsFilesystemBackend.fromPath(sitePath);
+			if (
+				await filesystem.fileExists(`/${OPFS_SITE_METADATA_FILENAME}`)
+			) {
+				return filesystem;
+			}
+		} catch (error) {
+			if (!isMissingOpfsEntry(error)) {
+				throw error;
+			}
+		}
+	}
+
+	throw new DOMException(`Site not found: ${slug}`, 'NotFoundError');
+}
+
+async function zipFilesystem(
+	filesystem: TraversableFilesystemBackend,
+	options: ZipOpfsSiteOptions
+) {
+	const zipWriter = new ZipWriter(new BlobWriter('application/zip'));
+	const shouldExclude = createPathExcluder(options.exclude ?? []);
+	try {
+		await addDirectoryEntries(
+			zipWriter,
+			filesystem,
+			'/',
+			'',
+			shouldExclude
+		);
+		const blob = await zipWriter.close();
+		return new Uint8Array(await blob.arrayBuffer());
+	} catch (error) {
+		await zipWriter.close().catch(() => undefined);
+		throw error;
+	}
+}
+
+async function addDirectoryEntries(
+	zipWriter: ZipWriter<Blob>,
+	filesystem: TraversableFilesystemBackend,
+	dirPath: string,
+	relativeDirPath: string,
+	shouldExclude: (path: string) => boolean
+) {
+	const entries = await filesystem.listFiles(dirPath);
+	for (const name of entries) {
+		const absolutePath = joinPaths(dirPath, name);
+		const relativePath = relativeDirPath
+			? joinPaths(relativeDirPath, name)
+			: name;
+		if (shouldExclude(relativePath)) {
+			continue;
+		}
+
+		if (await filesystem.isDir(absolutePath)) {
+			await addDirectoryEntries(
+				zipWriter,
+				filesystem,
+				absolutePath,
+				relativePath,
+				shouldExclude
+			);
+		} else {
+			const file = await filesystem.read(absolutePath);
+			const buffer = new Uint8Array(await file.arrayBuffer());
+			await zipWriter.add(relativePath, new Uint8ArrayReader(buffer));
+		}
+	}
+}
+
+function createPathExcluder(patterns: string[]) {
+	const matchers = patterns
+		.map(normalizeGlobPattern)
+		.filter((pattern) => pattern.length > 0)
+		.map(globPatternToRegExp);
+
+	return (path: string) => {
+		const normalizedPath = path.replace(/^\/+/, '');
+		return matchers.some((matcher) => matcher.test(normalizedPath));
+	};
+}
+
+function normalizeGlobPattern(pattern: string) {
+	return pattern.replace(/^\/+/, '').replace(/\/+$/, '');
+}
+
+function globPatternToRegExp(pattern: string) {
+	let source = '^';
+	for (let i = 0; i < pattern.length; i++) {
+		const char = pattern[i];
+		const nextChar = pattern[i + 1];
+		if (char === '*' && nextChar === '*') {
+			source += '.*';
+			i++;
+		} else if (char === '*') {
+			source += '[^/]*';
+		} else if (char === '?') {
+			source += '[^/]';
+		} else {
+			source += escapeRegExp(char);
+		}
+	}
+	source += '$';
+	return new RegExp(source);
+}
+
+function escapeRegExp(char: string) {
+	return char.replace(/[\\^$.*+?()[\]{}|]/g, '\\$&');
+}
+
+function isMissingOpfsEntry(error: unknown) {
+	const name = (error as DOMException | undefined)?.name;
+	return name === 'NotFoundError' || name === 'TypeMismatchError';
+}

--- a/packages/playground/remote/src/lib/boot-opfs-bridge.ts
+++ b/packages/playground/remote/src/lib/boot-opfs-bridge.ts
@@ -85,11 +85,17 @@ async function addDirectoryEntries(
 		const relativePath = relativeDirPath
 			? joinPaths(relativeDirPath, name)
 			: name;
-		if (shouldExclude(relativePath)) {
-			continue;
-		}
 
 		if (await filesystem.isDir(absolutePath)) {
+			if (
+				shouldExclude(relativePath) ||
+				shouldExclude(`${relativePath}/`)
+			) {
+				continue;
+			}
+			await zipWriter.add(`${relativePath}/`, undefined, {
+				directory: true,
+			});
 			await addDirectoryEntries(
 				zipWriter,
 				filesystem,
@@ -98,6 +104,9 @@ async function addDirectoryEntries(
 				shouldExclude
 			);
 		} else {
+			if (shouldExclude(relativePath)) {
+				continue;
+			}
 			const file = await filesystem.read(absolutePath);
 			const buffer = new Uint8Array(await file.arrayBuffer());
 			await zipWriter.add(relativePath, new Uint8ArrayReader(buffer));
@@ -126,7 +135,11 @@ function globPatternToRegExp(pattern: string) {
 	for (let i = 0; i < pattern.length; i++) {
 		const char = pattern[i];
 		const nextChar = pattern[i + 1];
-		if (char === '*' && nextChar === '*') {
+		const afterNextChar = pattern[i + 2];
+		if (char === '*' && nextChar === '*' && afterNextChar === '/') {
+			source += '(?:.*/)?';
+			i += 2;
+		} else if (char === '*' && nextChar === '*') {
 			source += '.*';
 			i++;
 		} else if (char === '*') {

--- a/packages/playground/remote/src/lib/index.ts
+++ b/packages/playground/remote/src/lib/index.ts
@@ -1,4 +1,5 @@
 export * from './boot-playground-remote';
+export * from './boot-opfs-bridge';
 export * from './playground-client';
 export {
 	MinifiedWordPressVersions,

--- a/packages/playground/remote/vite.config.ts
+++ b/packages/playground/remote/vite.config.ts
@@ -191,6 +191,7 @@ export default defineConfig(({ mode }) => {
 			rollupOptions: {
 				input: {
 					wordpress: path('/remote.html'),
+					bridge: path('/bridge.html'),
 				},
 				output: {
 					assetFileNames: (chunkInfo) => {

--- a/packages/playground/storage/src/index.ts
+++ b/packages/playground/storage/src/index.ts
@@ -3,6 +3,7 @@ export * from './lib/changeset';
 export * from './lib/playground';
 export * from './lib/browser-fs';
 export * from './lib/paths';
+export * from './lib/opfs-site-path';
 export * from './lib/filesystems';
 export { GitAuthenticationError } from './lib/git-authentication-error';
 import type * as GitCreateDotGitDirectoryModule from './lib/git-create-dotgit-directory';

--- a/packages/playground/storage/src/lib/opfs-site-path.ts
+++ b/packages/playground/storage/src/lib/opfs-site-path.ts
@@ -1,13 +1,13 @@
 import { joinPaths } from '@php-wasm/util';
 
 export const OPFS_SITES_ROOT_PATH = '/sites';
+export const OPFS_SITE_METADATA_FILENAME = 'wp-runtime.json';
 
 /**
  * Computes the canonical OPFS path for writing a site slug.
  *
- * This does not perform legacy directory lookup. Use the site storage methods
- * when reading, updating, or deleting an existing site because those operations
- * need to check older directory names.
+ * This does not perform legacy directory lookup. Use
+ * getCandidateDirectoryNamesForSlug() when reading existing sites.
  */
 export function getDirectoryPathForSlug(slug: string) {
 	return joinPaths(OPFS_SITES_ROOT_PATH, getDirectoryNameForSlug(slug));
@@ -27,14 +27,11 @@ export function getDirectoryNameForSlug(slug: string) {
 /**
  * Returns the OPFS directory names that may contain the site data for a slug.
  *
- * Check the current reversible name first, then the legacy lossy name for sites
- * saved before slug path encoding was introduced.
+ * Check the current reversible name first, then the legacy lossy name for
+ * sites saved before slug path encoding was introduced.
  */
 export function getCandidateDirectoryNamesForSlug(slug: string) {
 	const directoryName = getDirectoryNameForSlug(slug);
-	// When the directory name is not the same as the slug, which happens
-	// for legacy sites stored using the older, unencoded slugs,
-	// return both the new and old directory names.
 	const legacyDirectoryName = `site-${slug}`.replaceAll(
 		/[^a-zA-Z0-9_-]/g,
 		'-'
@@ -43,6 +40,5 @@ export function getCandidateDirectoryNamesForSlug(slug: string) {
 		return [directoryName, legacyDirectoryName];
 	}
 
-	// Otherwise, return the single directory name.
 	return [directoryName];
 }

--- a/packages/playground/storage/src/test/opfs-site-path.spec.ts
+++ b/packages/playground/storage/src/test/opfs-site-path.spec.ts
@@ -1,7 +1,7 @@
 import {
 	getCandidateDirectoryNamesForSlug,
 	getDirectoryNameForSlug,
-} from './opfs-site-path';
+} from '../lib/opfs-site-path';
 
 describe('getDirectoryNameForSlug', () => {
 	it('keeps existing ASCII slug directory names stable', () => {

--- a/packages/playground/website/src/lib/state/opfs/opfs-blueprint-bundle-storage.ts
+++ b/packages/playground/website/src/lib/state/opfs/opfs-blueprint-bundle-storage.ts
@@ -12,7 +12,7 @@ import {
 	type TraversableFilesystemBackend,
 } from '@wp-playground/storage';
 import { joinPaths } from '@php-wasm/util';
-import { getDirectoryPathForSlug } from './opfs-site-path';
+import { getDirectoryPathForSlug } from '@wp-playground/storage';
 
 export const BUNDLE_DIR_NAME = 'blueprint-bundle';
 

--- a/packages/playground/website/src/lib/state/opfs/opfs-site-storage.ts
+++ b/packages/playground/website/src/lib/state/opfs/opfs-site-storage.ts
@@ -11,6 +11,12 @@ import type { SiteInfo } from '../redux/slice-sites';
 import { logger } from '@php-wasm/logger';
 import { joinPaths } from '@php-wasm/util';
 import {
+	OPFS_SITE_METADATA_FILENAME,
+	OPFS_SITES_ROOT_PATH,
+	getCandidateDirectoryNamesForSlug,
+	getDirectoryNameForSlug,
+} from '@wp-playground/storage';
+import {
 	type ExtraLibrary,
 	type PHPConstants,
 	getBlueprintDeclaration,
@@ -22,18 +28,10 @@ import {
 	loadPersistedBlueprintBundle,
 	loadPersistedBlueprintBundleFromPath,
 } from './opfs-blueprint-bundle-storage';
-import {
-	OPFS_SITES_ROOT_PATH,
-	getCandidateDirectoryNamesForSlug,
-	getDirectoryNameForSlug,
-} from './opfs-site-path';
 export {
 	getDirectoryNameForSlug,
 	getDirectoryPathForSlug,
-} from './opfs-site-path';
-
-// TODO: Decide on metadata filename
-const SITE_METADATA_FILENAME = 'wp-runtime.json';
+} from '@wp-playground/storage';
 
 // Use a symbol to mark legacy site metadata to avoid serializing it to JSON.
 // @TODO: Remove this backcompat code after 2024-12-01.
@@ -141,7 +139,7 @@ class OpfsSiteStorage {
 		siteDirectory: FileSystemDirectoryHandle
 	) {
 		const siteInfoFileHandle = await siteDirectory.getFileHandle(
-			SITE_METADATA_FILENAME
+			OPFS_SITE_METADATA_FILENAME
 		);
 		const file = await siteInfoFileHandle.getFile();
 		// TODO: Read metadata file and parse and validate via JSON schema
@@ -203,7 +201,10 @@ class OpfsSiteStorage {
 			// Recreating an autosaved Playground rebuilds WordPress in the same
 			// OPFS site directory. Keep the metadata and editable Blueprint
 			// bundle so the autosave keeps its slug and setup recipe.
-			if (name === SITE_METADATA_FILENAME || name === BUNDLE_DIR_NAME) {
+			if (
+				name === OPFS_SITE_METADATA_FILENAME ||
+				name === BUNDLE_DIR_NAME
+			) {
 				continue;
 			}
 			namesToDelete.push(name);
@@ -230,7 +231,10 @@ class OpfsSiteStorage {
 			);
 			if (
 				siteDirectory &&
-				(await opfsFileExists(siteDirectory, SITE_METADATA_FILENAME))
+				(await opfsFileExists(
+					siteDirectory,
+					OPFS_SITE_METADATA_FILENAME
+				))
 			) {
 				return siteDirName;
 			}
@@ -247,7 +251,11 @@ export const opfsSiteStorage: OpfsSiteStorage | undefined = opfsSitesRoot
 export const isOpfsAvailable = !!opfsSiteStorage;
 
 function getSiteMetadataPath(siteDirName: string) {
-	return joinPaths(OPFS_SITES_ROOT_PATH, siteDirName, SITE_METADATA_FILENAME);
+	return joinPaths(
+		OPFS_SITES_ROOT_PATH,
+		siteDirName,
+		OPFS_SITE_METADATA_FILENAME
+	);
 }
 
 async function metadataToStoredFormat(

--- a/packages/playground/website/src/lib/state/redux/boot-site-client.ts
+++ b/packages/playground/website/src/lib/state/redux/boot-site-client.ts
@@ -1,9 +1,7 @@
 import { directoryHandleFromMountDevice } from '@wp-playground/storage';
 import { loadDirectoryHandle } from '../opfs/opfs-directory-handle-storage';
-import {
-	getDirectoryPathForSlug,
-	legacyOpfsPathSymbol,
-} from '../opfs/opfs-site-storage';
+import { getDirectoryPathForSlug } from '@wp-playground/storage';
+import { legacyOpfsPathSymbol } from '../opfs/opfs-site-storage';
 import {
 	addClientInfo,
 	removeClientInfo,

--- a/packages/playground/website/src/lib/state/redux/persist-temporary-site.ts
+++ b/packages/playground/website/src/lib/state/redux/persist-temporary-site.ts
@@ -2,10 +2,8 @@ import { logger } from '@php-wasm/logger';
 import type { MountDescriptor, PlaygroundClient } from '@wp-playground/remote';
 import type { PHPConstants } from '@wp-playground/blueprints';
 import { saveDirectoryHandle } from '../opfs/opfs-directory-handle-storage';
-import {
-	opfsSiteStorage,
-	getDirectoryPathForSlug,
-} from '../opfs/opfs-site-storage';
+import { getDirectoryPathForSlug } from '@wp-playground/storage';
+import { opfsSiteStorage } from '../opfs/opfs-site-storage';
 import {
 	isTraversableFilesystemBackend,
 	persistBlueprintBundle,


### PR DESCRIPTION
## What this is

This is a reference PR for the original OPFS bridge export implementation that existed before #3959 was force-pushed and replaced with a smaller website-only implementation.

I do not intend to merge this PR as-is.

## Why this exists

The merged #3959 added an internal website API:

`opfsSiteStorage.exportSavedSiteAsZip(slug)`

That is useful for code already running inside the Playground website bundle, but it does not expose a way for an external consumer to load a lightweight iframe and retrieve saved OPFS files without booting Playground.

This reference PR preserves the broader implementation for discussion and comparison.

## Original direction

This implementation added:

- `bridge.html` as a lightweight remote entry point
- a remote OPFS bridge API for exporting a saved site ZIP by slug
- a client-side `startOpfsBridge()` API
- shared OPFS slug/path helpers
- ZIP export support without booting WordPress
- empty directory preservation
- optional exclude patterns for generated or sensitive files
- npm packaging changes needed for the bridge runtime

## Follow-up direction

I plan to open a separate focused PR based on current `trunk` that keeps the useful parts of #3959, but adds the missing public iframe/client access path needed by external consumers.

## Testing

This reference PR is not intended to be reviewed for merge.