### PR TITLE
[Website] Add reusable Playground export panel

### DIFF
--- a/packages/playground/website/src/components/site-manager/site-share-panel/index.tsx
+++ b/packages/playground/website/src/components/site-manager/site-share-panel/index.tsx
@@ -1,0 +1,248 @@
+import { logger } from '@php-wasm/logger';
+import { Button, Icon } from '@wordpress/components';
+import { chevronLeft, download, link } from '@wordpress/icons';
+import { lazy, Suspense, useEffect, useRef, useState } from 'react';
+import { GitHubIcon } from '../../../github/github';
+import { useGitHubExportSession } from '../../../github/github-export-session';
+import { getSetupUrlFromSite } from '../../../lib/state/playground-identity';
+import { setShareExportOpen } from '../../../lib/state/redux/slice-ui';
+import {
+	useActiveSite,
+	useAppDispatch,
+	useAppSelector,
+} from '../../../lib/state/redux/store';
+import { usePlaygroundClient } from '../../../lib/use-playground-client';
+import { PlaygroundBootNotice } from '../../pane-loading';
+import { Spinner } from '../../spinner';
+import { downloadPlaygroundAsZip } from '../../toolbar-buttons/download-as-zip';
+import css from './style.module.css';
+
+type CopyStatus = 'idle' | 'copied' | 'failed';
+
+// The export form pulls in the GitHub/storage stack, so load it only when the
+// user opens that option.
+const GitHubExportForm = lazy(
+	() => import('../../../github/github-export-form/form')
+);
+
+/**
+ * Offers the active Playground as a zip, a reproducible setup URL, or a GitHub
+ * export.
+ */
+export function SiteSharePanel() {
+	const activeSite = useActiveSite();
+	const playground = usePlaygroundClient();
+	const offline = useAppSelector((state) => state.ui.offline);
+	const dispatch = useAppDispatch();
+	const [isDownloading, setIsDownloading] = useState(false);
+	const [downloadError, setDownloadError] = useState('');
+	const [copyStatus, setCopyStatus] = useState<CopyStatus>('idle');
+	const showGitHubExport = useAppSelector(
+		(state) => state.ui.shareExportOpen
+	);
+	const githubExportSession = useGitHubExportSession();
+	const backButtonRef = useRef<HTMLButtonElement>(null);
+	const exportButtonRef = useRef<HTMLButtonElement>(null);
+	const exportWasOpenRef = useRef(false);
+
+	useEffect(() => {
+		return () => {
+			dispatch(setShareExportOpen(false));
+		};
+	}, [dispatch]);
+
+	useEffect(() => {
+		if (showGitHubExport) {
+			backButtonRef.current?.focus();
+		} else if (exportWasOpenRef.current) {
+			exportButtonRef.current?.focus();
+		}
+		exportWasOpenRef.current = showGitHubExport;
+	}, [showGitHubExport]);
+
+	/** Packages the running site's wp-content and database into a local zip. */
+	async function downloadZip() {
+		if (!playground) {
+			return;
+		}
+
+		setIsDownloading(true);
+		setDownloadError('');
+		try {
+			await downloadPlaygroundAsZip(playground);
+		} catch (error) {
+			logger.error('Failed to download Playground zip', error);
+			setDownloadError(
+				'Unable to prepare the .zip download. Please try again.'
+			);
+		} finally {
+			setIsDownloading(false);
+		}
+	}
+
+	/** Copies the site's original setup URL, falling back to the current URL. */
+	async function copySetupUrl() {
+		setCopyStatus('idle');
+		try {
+			const setupUrl = activeSite
+				? getSetupUrlFromSite(
+						activeSite,
+						window.location.href
+					).toString()
+				: window.location.href;
+			await navigator.clipboard.writeText(setupUrl);
+			setCopyStatus('copied');
+		} catch {
+			setCopyStatus('failed');
+		}
+	}
+
+	/** Warms the export form chunk before the user opens it. */
+	function preloadExportForm() {
+		void import('../../../github/github-export-form/form');
+	}
+
+	if (showGitHubExport) {
+		return (
+			<section className={css.sharePanel}>
+				<button
+					ref={backButtonRef}
+					type="button"
+					className={css.backButton}
+					onClick={() => dispatch(setShareExportOpen(false))}
+				>
+					<Icon icon={chevronLeft} size={24} />
+					Export to GitHub
+				</button>
+				{playground ? (
+					<Suspense
+						fallback={
+							<div className={css.exportLoading}>
+								<Spinner />
+							</div>
+						}
+					>
+						<GitHubExportForm
+							playground={playground}
+							onClose={() => dispatch(setShareExportOpen(false))}
+							onExported={(_prUrl, formValues) =>
+								githubExportSession.recordExport(formValues)
+							}
+							initialValues={githubExportSession.values}
+							initialFilesBeforeChanges={
+								githubExportSession.filesBeforeChanges
+							}
+							allowZipExport={githubExportSession.allowZipExport}
+						/>
+					</Suspense>
+				) : (
+					<PlaygroundBootNotice
+						show
+						message="The Playground is still loading — Export to GitHub will be ready in a moment."
+					/>
+				)}
+			</section>
+		);
+	}
+
+	return (
+		<section className={css.sharePanel} aria-label="Export options">
+			<PlaygroundBootNotice
+				show={!playground}
+				message="The Playground is still loading — Download and Export to GitHub will be ready in a moment."
+			/>
+			<div className={css.group}>
+				<span className={css.groupIcon} aria-hidden="true">
+					<Icon icon={download} size={22} />
+				</span>
+				<div className={css.groupBody}>
+					<h3 className={css.groupTitle}>Download a copy</h3>
+					<p className={css.hint}>
+						Saves everything as it is right now — files, database,
+						and your edits — to a .zip you can re-import later.
+					</p>
+					<div className={css.actions}>
+						<Button
+							variant="primary"
+							data-cy="download-as-zip"
+							disabled={!playground || isDownloading}
+							onClick={downloadZip}
+						>
+							{isDownloading
+								? 'Preparing .zip…'
+								: 'Download as .zip'}
+						</Button>
+						{downloadError && (
+							<p className={css.error} role="alert">
+								{downloadError}
+							</p>
+						)}
+					</div>
+				</div>
+			</div>
+
+			<div className={css.group}>
+				<span className={css.groupIcon} aria-hidden="true">
+					<Icon icon={link} size={22} />
+				</span>
+				<div className={css.groupBody}>
+					<h3 className={css.groupTitle}>Copy original setup link</h3>
+					<p className={css.hint}>
+						Copies a URL that rebuilds this Playground from its
+						original Blueprint on any device. It restores the
+						starting setup only — your edits to files and content
+						aren&apos;t included.
+					</p>
+					<div className={css.actions}>
+						<Button variant="secondary" onClick={copySetupUrl}>
+							{copyStatus === 'copied'
+								? 'Link copied'
+								: 'Copy link'}
+						</Button>
+						{copyStatus !== 'idle' && (
+							<p
+								className={
+									copyStatus === 'failed'
+										? css.error
+										: css.status
+								}
+								role={
+									copyStatus === 'failed' ? 'alert' : 'status'
+								}
+							>
+								{copyStatus === 'failed'
+									? 'Clipboard access was blocked. Please try again.'
+									: 'Setup URL copied to the clipboard.'}
+							</p>
+						)}
+					</div>
+				</div>
+			</div>
+
+			<div className={css.group}>
+				<span className={css.groupIcon} aria-hidden="true">
+					<Icon icon={GitHubIcon} size={22} />
+				</span>
+				<div className={css.groupBody}>
+					<h3 className={css.groupTitle}>Export to GitHub</h3>
+					<p className={css.hint}>
+						Pushes the current state — including your edits — to a
+						GitHub repository.
+					</p>
+					<div className={css.actions}>
+						<Button
+							ref={exportButtonRef}
+							variant="secondary"
+							disabled={offline || !playground}
+							onMouseEnter={preloadExportForm}
+							onFocus={preloadExportForm}
+							onClick={() => dispatch(setShareExportOpen(true))}
+						>
+							Export to GitHub
+						</Button>
+					</div>
+				</div>
+			</div>
+		</section>
+	);
+}

--- a/packages/playground/website/src/components/site-manager/site-share-panel/style.module.css
+++ b/packages/playground/website/src/components/site-manager/site-share-panel/style.module.css
@@ -1,0 +1,121 @@
+.share-panel {
+	display: flex;
+	flex-direction: column;
+	gap: var(--space-3);
+	padding: 0 var(--space-6) var(--space-6);
+}
+
+.back-button {
+	align-items: center;
+	align-self: flex-start;
+	background: transparent;
+	border: 0;
+	border-radius: var(--radius-control);
+	color: var(--ink);
+	cursor: pointer;
+	display: inline-flex;
+	font-size: 20px;
+	font-weight: 600;
+	gap: 4px;
+	letter-spacing: -0.01em;
+	line-height: 1.2;
+	/* This replaces the DockPane title when GitHub export is open, so give it
+	   the shared pane-title rhythm: 32px above the title and 24px below it. */
+	margin: 0 0 var(--space-6);
+	padding: var(--space-8) var(--space-2) 0 0;
+	transition: background 120ms ease;
+}
+
+.back-button:hover {
+	background: var(--paper-3);
+}
+
+.back-button :global(svg) {
+	fill: var(--ink-faint);
+	margin-left: -6px;
+}
+
+@media (max-width: 1024px) {
+	.back-button {
+		margin-bottom: var(--space-4);
+		padding-top: var(--space-6);
+	}
+}
+
+.export-loading {
+	display: flex;
+	justify-content: center;
+	padding: var(--space-8);
+}
+
+.group {
+	align-items: flex-start;
+	background: #ffffff;
+	border-radius: var(--radius-card);
+	box-shadow:
+		0 1px 2px rgba(40, 33, 23, 0.06),
+		0 4px 10px rgba(40, 33, 23, 0.05);
+	display: flex;
+	gap: var(--space-3);
+	padding: var(--space-4);
+}
+
+.group-icon {
+	align-items: center;
+	background: var(--paper-3);
+	border-radius: var(--radius-card);
+	color: var(--accent-link);
+	display: flex;
+	flex-shrink: 0;
+	height: 38px;
+	justify-content: center;
+	width: 38px;
+}
+
+.group-icon :global(svg) {
+	fill: currentColor;
+}
+
+.group-body {
+	display: flex;
+	flex: 1;
+	flex-direction: column;
+	gap: var(--space-2);
+	min-width: 0;
+}
+
+.group-title {
+	color: var(--ink);
+	font-size: 14px;
+	font-weight: 600;
+	line-height: 1.3;
+	margin: 0;
+}
+
+.actions {
+	display: flex;
+	flex-wrap: wrap;
+	gap: var(--space-3);
+	margin-top: var(--space-1);
+}
+
+.hint {
+	color: var(--ink-muted);
+	font-size: 13px;
+	line-height: 1.5;
+	margin: 0;
+}
+
+.actions p {
+	font-size: 13px;
+	line-height: 1.4;
+	margin: 0;
+}
+
+.status {
+	color: var(--ink-muted);
+}
+
+.error {
+	color: var(--color-alert-red, #cc1818);
+}

--- a/packages/playground/website/src/components/toolbar-buttons/download-as-zip.tsx
+++ b/packages/playground/website/src/components/toolbar-buttons/download-as-zip.tsx
@@ -15,7 +15,7 @@ export function DownloadAsZipMenuItem({ onClose, disabled }: Props) {
 			disabled={disabled}
 			onClick={() => {
 				if (!playground) return;
-				startDownload(playground);
+				void downloadPlaygroundAsZip(playground);
 				onClose();
 			}}
 		>
@@ -24,7 +24,8 @@ export function DownloadAsZipMenuItem({ onClose, disabled }: Props) {
 	);
 }
 
-async function startDownload(playground: PlaygroundClient) {
+/** Downloads a self-contained archive of the supplied Playground. */
+export async function downloadPlaygroundAsZip(playground: PlaygroundClient) {
 	const bytes = await zipWpContent(playground, {
 		selfContained: true,
 	});

--- a/packages/playground/website/src/components/toolbar-buttons/download-as-zip.tsx
+++ b/packages/playground/website/src/components/toolbar-buttons/download-as-zip.tsx
@@ -1,5 +1,6 @@
 import { MenuItem } from '@wordpress/components';
 
+import { logger } from '@php-wasm/logger';
 import type { PlaygroundClient } from '@wp-playground/client';
 import { zipWpContent } from '@wp-playground/client';
 import saveAs from 'file-saver';
@@ -15,7 +16,9 @@ export function DownloadAsZipMenuItem({ onClose, disabled }: Props) {
 			disabled={disabled}
 			onClick={() => {
 				if (!playground) return;
-				void downloadPlaygroundAsZip(playground);
+				void downloadPlaygroundAsZip(playground).catch((error) =>
+					logger.error('Failed to download Playground zip', error)
+				);
 				onClose();
 			}}
 		>

--- a/packages/playground/website/src/github/github-export-session.spec.tsx
+++ b/packages/playground/website/src/github/github-export-session.spec.tsx
@@ -85,16 +85,14 @@ describe('GitHubExportSessionProvider', () => {
 			});
 		});
 
-		expect(getSession()).toMatchObject({
-			filesBeforeChanges: ['before-change'],
-			values: {
-				repoUrl: 'https://github.com/new-owner/new-repo/pull/12',
-				prNumber: '12',
-				toPathInRepo: '/theme',
-				prAction: 'update',
-				contentType: 'theme',
-				theme: 'new-theme',
-			},
+		expect(getSession().filesBeforeChanges).toEqual(['before-change']);
+		expect(getSession().values).toEqual({
+			repoUrl: 'https://github.com/new-owner/new-repo/pull/12',
+			prNumber: '12',
+			toPathInRepo: '/theme',
+			prAction: 'update',
+			contentType: 'theme',
+			theme: 'new-theme',
 		});
 
 		act(() => {

--- a/packages/playground/website/src/github/github-export-session.spec.tsx
+++ b/packages/playground/website/src/github/github-export-session.spec.tsx
@@ -1,0 +1,129 @@
+// @vitest-environment jsdom
+
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import {
+	GitHubExportSessionProvider,
+	useGitHubExportSession,
+} from './github-export-session';
+
+type GitHubExportSession = ReturnType<typeof useGitHubExportSession>;
+
+describe('GitHubExportSessionProvider', () => {
+	let container: HTMLDivElement;
+	let root: Root;
+	let session: GitHubExportSession | undefined;
+
+	beforeAll(() => {
+		vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+	});
+
+	afterAll(() => {
+		vi.unstubAllGlobals();
+	});
+
+	beforeEach(() => {
+		window.history.replaceState(
+			null,
+			'',
+			'/?ghexport-repo-url=https%3A%2F%2Fgithub.com%2Fowner%2Frepo' +
+				'&ghexport-content-type=plugin&ghexport-pr-action=update' +
+				'&ghexport-pr-number=7&ghexport-playground-root=%2Fwordpress' +
+				'&ghexport-repo-root=%2Fplugin&ghexport-path=%2Fone' +
+				'&ghexport-path=%2Ftwo&ghexport-commit-message=Export' +
+				'&ghexport-plugin=example&ghexport-allow-include-zip=no'
+		);
+		container = document.createElement('div');
+		document.body.append(container);
+		root = createRoot(container);
+	});
+
+	afterEach(() => {
+		act(() => root.unmount());
+		container.remove();
+		session = undefined;
+	});
+
+	it('keeps query, import, and export state in one session', () => {
+		act(() => {
+			root.render(
+				<GitHubExportSessionProvider>
+					<SessionProbe />
+				</GitHubExportSessionProvider>
+			);
+		});
+
+		expect(getSession()).toMatchObject({
+			allowZipExport: false,
+			values: {
+				repoUrl: 'https://github.com/owner/repo',
+				contentType: 'plugin',
+				prAction: 'update',
+				prNumber: '7',
+				fromPlaygroundRoot: '/wordpress',
+				toPathInRepo: '/plugin',
+				relativeExportPaths: ['/one', '/two'],
+				commitMessage: 'Export',
+				plugin: 'example',
+			},
+		});
+
+		act(() => {
+			getSession().recordImport({
+				url: 'https://github.com/new-owner/new-repo/pull/12',
+				urlInformation: {
+					type: 'pr',
+					owner: 'new-owner',
+					repo: 'new-repo',
+					pr: 12,
+				},
+				branch: 'feature',
+				path: '/theme',
+				contentType: 'theme',
+				pluginOrThemeName: 'new-theme',
+				files: ['before-change'],
+			});
+		});
+
+		expect(getSession()).toMatchObject({
+			filesBeforeChanges: ['before-change'],
+			values: {
+				repoUrl: 'https://github.com/new-owner/new-repo/pull/12',
+				prNumber: '12',
+				toPathInRepo: '/theme',
+				prAction: 'update',
+				contentType: 'theme',
+				theme: 'new-theme',
+			},
+		});
+
+		act(() => {
+			getSession().recordExport({
+				repoUrl: 'https://github.com/new-owner/new-repo',
+				prAction: 'create',
+				prNumber: '',
+				contentType: 'wp-content',
+				toPathInRepo: '/wp-content',
+				fromPlaygroundRoot: '/wordpress/wp-content',
+				relativeExportPaths: ['/'],
+				commitMessage: 'Export wp-content',
+				includeZip: false,
+			});
+		});
+
+		expect(getSession().filesBeforeChanges).toBeUndefined();
+		expect(getSession().values.commitMessage).toBe('Export wp-content');
+	});
+
+	function SessionProbe() {
+		session = useGitHubExportSession();
+		return null;
+	}
+
+	function getSession() {
+		if (!session) {
+			throw new Error('The session probe has not rendered.');
+		}
+		return session;
+	}
+});

--- a/packages/playground/website/src/github/github-export-session.tsx
+++ b/packages/playground/website/src/github/github-export-session.tsx
@@ -47,8 +47,11 @@ export function GitHubExportSessionProvider({
 				toPathInRepo: details.path,
 				prAction: pr ? 'update' : 'create',
 				contentType: details.contentType,
-				plugin: details.pluginOrThemeName,
-				theme: details.pluginOrThemeName,
+				...(details.contentType === 'plugin'
+					? { plugin: details.pluginOrThemeName }
+					: details.contentType === 'theme'
+						? { theme: details.pluginOrThemeName }
+						: {}),
 			});
 			setFilesBeforeChanges(details.files);
 		},

--- a/packages/playground/website/src/github/github-export-session.tsx
+++ b/packages/playground/website/src/github/github-export-session.tsx
@@ -1,0 +1,108 @@
+import { createContext, useContext, useState, type ReactNode } from 'react';
+import type { ExportFormValues } from './github-export-form/form';
+import { asPullRequestAction } from './github-export-form/form';
+import type { GitHubImportFormProps } from './github-import-form/form';
+import { asContentType } from './import-from-github';
+
+type GitHubImportDetails = Parameters<GitHubImportFormProps['onImported']>[0];
+
+type GitHubExportSession = {
+	allowZipExport: boolean;
+	filesBeforeChanges?: unknown[];
+	values: Partial<ExportFormValues>;
+	recordExport: (values: ExportFormValues) => void;
+	recordImport: (details: GitHubImportDetails) => void;
+};
+
+const GitHubExportSessionContext = createContext<GitHubExportSession | null>(
+	null
+);
+
+/** Keeps GitHub import and export state shared by modal and Dock surfaces. */
+export function GitHubExportSessionProvider({
+	children,
+}: {
+	children: ReactNode;
+}) {
+	const query = new URL(window.location.href).searchParams;
+	const [filesBeforeChanges, setFilesBeforeChanges] = useState<unknown[]>();
+	const [values, setValues] = useState<Partial<ExportFormValues>>(() =>
+		readInitialValues(query)
+	);
+
+	const session: GitHubExportSession = {
+		allowZipExport:
+			(query.get('ghexport-allow-include-zip') ?? 'yes') === 'yes',
+		filesBeforeChanges,
+		values,
+		recordExport(nextValues) {
+			setValues(nextValues);
+			setFilesBeforeChanges(undefined);
+		},
+		recordImport(details) {
+			const { pr } = details.urlInformation;
+			setValues({
+				repoUrl: details.url,
+				prNumber: pr?.toString(),
+				toPathInRepo: details.path,
+				prAction: pr ? 'update' : 'create',
+				contentType: details.contentType,
+				plugin: details.pluginOrThemeName,
+				theme: details.pluginOrThemeName,
+			});
+			setFilesBeforeChanges(details.files);
+		},
+	};
+
+	return (
+		<GitHubExportSessionContext.Provider value={session}>
+			{children}
+		</GitHubExportSessionContext.Provider>
+	);
+}
+
+/** Returns the GitHub import/export session owned by the website layout. */
+export function useGitHubExportSession() {
+	const session = useContext(GitHubExportSessionContext);
+	if (!session) {
+		throw new Error(
+			'useGitHubExportSession must be used inside GitHubExportSessionProvider.'
+		);
+	}
+	return session;
+}
+
+function readInitialValues(query: URLSearchParams) {
+	const values: Partial<ExportFormValues> = {};
+	if (query.get('ghexport-repo-url')) {
+		values.repoUrl = query.get('ghexport-repo-url')!;
+	}
+	if (query.get('ghexport-content-type')) {
+		values.contentType = asContentType(query.get('ghexport-content-type'));
+	}
+	if (query.get('ghexport-pr-action')) {
+		values.prAction = asPullRequestAction(query.get('ghexport-pr-action'));
+	}
+	if (query.get('ghexport-pr-number')) {
+		values.prNumber = query.get('ghexport-pr-number')!;
+	}
+	if (query.get('ghexport-playground-root')) {
+		values.fromPlaygroundRoot = query.get('ghexport-playground-root')!;
+	}
+	if (query.get('ghexport-repo-root')) {
+		values.toPathInRepo = query.get('ghexport-repo-root')!;
+	}
+	if (query.get('ghexport-path')) {
+		values.relativeExportPaths = query.getAll('ghexport-path');
+	}
+	if (query.get('ghexport-commit-message')) {
+		values.commitMessage = query.get('ghexport-commit-message')!;
+	}
+	if (query.get('ghexport-plugin')) {
+		values.plugin = query.get('ghexport-plugin')!;
+	}
+	if (query.get('ghexport-theme')) {
+		values.theme = query.get('ghexport-theme')!;
+	}
+	return values;
+}

--- a/packages/playground/website/src/lib/state/redux/slice-ui.ts
+++ b/packages/playground/website/src/lib/state/redux/slice-ui.ts
@@ -161,6 +161,7 @@ export interface UIState {
 	siteSlugToSave?: string;
 	githubAuthRepoUrl?: string;
 	offline: boolean;
+	shareExportOpen: boolean;
 	siteManagerIsOpen: boolean;
 	siteManagerSection: SiteManagerSection;
 	/** Draft kept while the New Playground panel is closed or hidden. */
@@ -194,6 +195,7 @@ const initialState: UIState = {
 			? null
 			: query.get('modal') || null,
 	offline: !navigator.onLine,
+	shareExportOpen: false,
 	// NOTE: Please do not eliminate the cases in this siteManagerIsOpen expression,
 	// even if they seem redundant. We may experiment which toggling the manager
 	// to be open by default or closed by default, and we do not want to lose
@@ -273,6 +275,9 @@ const uiSlice = createSlice({
 		setSiteManagerOpen: (state, action: PayloadAction<boolean>) => {
 			state.siteManagerIsOpen = action.payload;
 		},
+		setShareExportOpen: (state, action: PayloadAction<boolean>) => {
+			state.shareExportOpen = action.payload;
+		},
 		setSiteManagerSection: (
 			state,
 			action: PayloadAction<SiteManagerSection>
@@ -351,6 +356,7 @@ export const {
 	clearActiveSiteError,
 	setGitHubAuthRepoUrl,
 	setOffline,
+	setShareExportOpen,
 	setSiteManagerOpen,
 	setSiteManagerSection,
 	setWriteOwnBlueprintDraft,


### PR DESCRIPTION
The bottom Dock needs a Share pane, but mounting it before the Dock exists would change the current website UI. This adds the export surface now and leaves it dormant until the Dock wiring lands.

The panel can download the active Playground, copy its original setup URL, or open the GitHub export form. A session provider keeps GitHub import and export state ready to share between modal and Dock surfaces. The existing ZIP menu now calls the same exported download helper.

This is an additive step toward #3965. Nothing mounts the new panel in the current layout.

Tested with:

- `npm exec nx test playground-website --testFile=github-export-session.spec.tsx`
- `npm exec -- nx run-many -t lint,typecheck -p playground-website`
