### PR TITLE
[Website] Let the Playground save form render inside a Dock pane

### DIFF
--- a/packages/playground/website/src/components/modal/modal-buttons.spec.tsx
+++ b/packages/playground/website/src/components/modal/modal-buttons.spec.tsx
@@ -1,0 +1,84 @@
+// @vitest-environment jsdom
+
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import ModalButtons from './modal-buttons';
+
+describe('ModalButtons', () => {
+	let container: HTMLDivElement;
+	let root: Root;
+
+	beforeAll(() => {
+		vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+		vi.stubGlobal(
+			'matchMedia',
+			vi.fn((query: string) => ({
+				matches: false,
+				media: query,
+				onchange: null,
+				addListener: vi.fn(),
+				removeListener: vi.fn(),
+				addEventListener: vi.fn(),
+				removeEventListener: vi.fn(),
+				dispatchEvent: vi.fn(),
+			}))
+		);
+	});
+
+	afterAll(() => {
+		vi.unstubAllGlobals();
+	});
+
+	beforeEach(() => {
+		container = document.createElement('div');
+		document.body.append(container);
+		root = createRoot(container);
+	});
+
+	afterEach(() => {
+		act(() => root.unmount());
+		container.remove();
+	});
+
+	it('keeps the existing behavior when no Cancel override is supplied', () => {
+		const [cancel, submit] = renderButtons(
+			<ModalButtons areDisabled onCancel={() => {}} />
+		);
+
+		expect(cancel.disabled).toBe(true);
+		expect(submit.disabled).toBe(true);
+	});
+
+	it('can keep Cancel enabled when only the submit action is invalid', () => {
+		const [cancel, submit] = renderButtons(
+			<ModalButtons
+				areDisabled
+				cancelDisabled={false}
+				onCancel={() => {}}
+			/>
+		);
+
+		expect(cancel.disabled).toBe(false);
+		expect(submit.disabled).toBe(true);
+	});
+
+	it('can disable Cancel independently for an in-flight operation', () => {
+		const [cancel, submit] = renderButtons(
+			<ModalButtons cancelDisabled onCancel={() => {}} />
+		);
+
+		expect(cancel.disabled).toBe(true);
+		expect(submit.disabled).toBe(false);
+	});
+
+	function renderButtons(element: JSX.Element) {
+		act(() => root.render(element));
+		const buttons = container.querySelectorAll('button');
+		if (buttons.length !== 2) {
+			throw new Error(
+				`Expected two modal buttons, received ${buttons.length}.`
+			);
+		}
+		return [buttons[0], buttons[1]] as const;
+	}
+});

--- a/packages/playground/website/src/components/modal/modal-buttons.tsx
+++ b/packages/playground/website/src/components/modal/modal-buttons.tsx
@@ -5,6 +5,11 @@ import css from './style.module.css';
 interface ModalButtonsProps {
 	submitText?: string;
 	areDisabled?: boolean;
+	/**
+	 * Overrides the legacy behavior where `areDisabled` disables both buttons.
+	 * Pane forms can keep Cancel available while only submission is invalid.
+	 */
+	cancelDisabled?: boolean;
 	areBusy?: boolean;
 	onCancel?: () => void;
 	onSubmit?: (e: any) => void;
@@ -13,17 +18,20 @@ interface ModalButtonsProps {
 export default function ModalButtons({
 	submitText = 'Submit',
 	areDisabled = false,
+	cancelDisabled,
 	areBusy,
 	onCancel,
 	onSubmit,
 	style,
 }: ModalButtonsProps) {
+	const isCancelDisabled = cancelDisabled ?? areDisabled;
+
 	return (
 		<Flex justify="end" className={css.modalButtons} style={style}>
 			<Button
 				type="button"
 				isBusy={areBusy}
-				disabled={areDisabled}
+				disabled={isCancelDisabled}
 				variant="link"
 				onClick={onCancel}
 			>

--- a/packages/playground/website/src/components/save-site-modal/index.tsx
+++ b/packages/playground/website/src/components/save-site-modal/index.tsx
@@ -4,6 +4,7 @@ import {
 	useState,
 	useRef,
 	type CSSProperties,
+	type ReactElement,
 } from 'react';
 import {
 	Button,
@@ -37,7 +38,16 @@ const helpTextStyle: CSSProperties = {
 	marginTop: 8,
 };
 
-export function SaveSiteModal() {
+export function SaveSiteModal({
+	asPane = false,
+	onClose,
+	onCloseBlockedChange,
+}: {
+	/** Render the form inside the Dock instead of a standalone modal. */
+	asPane?: boolean;
+	onClose?: () => void;
+	onCloseBlockedChange?: (isBlocked: boolean) => void;
+} = {}) {
 	const dispatch = useAppDispatch();
 	const sitesAPI = useSitesAPI();
 	const siteSlugToSave = useAppSelector((state) => state.ui.siteSlugToSave);
@@ -90,7 +100,7 @@ export function SaveSiteModal() {
 	}, [initialName, site?.slug]);
 
 	useEffect(() => {
-		// Select the text in the name input when the modal is shown
+		// Select the text in the name input when the save surface is shown
 		// Use a small delay to ensure the input is focused first by autoFocus
 		const timer = setTimeout(() => {
 			// Try using the ref first
@@ -135,18 +145,37 @@ export function SaveSiteModal() {
 	const isAutosaved = site && isAutosavedSite(site);
 	const canSaveSite =
 		site && (site.metadata.storage === 'none' || isAutosaved);
-	const closeModal = () => {
+	const closeSurface = () => {
+		if (asPane) {
+			onClose?.();
+			return;
+		}
 		dispatch(setActiveModal(null));
 		dispatch(setSiteSlugToSave(undefined));
 	};
 
 	useEffect(() => {
+		if (!asPane) {
+			return;
+		}
+		// A background autosave may already be running when this pane opens.
+		// Disable submission then, but only trap the pane while this form's own
+		// save is in flight.
+		onCloseBlockedChange?.(isSubmitting);
+		return () => onCloseBlockedChange?.(false);
+	}, [asPane, isSubmitting, onCloseBlockedChange]);
+
+	useEffect(() => {
 		if (site && canSaveSite) {
 			return;
 		}
-		dispatch(setActiveModal(null));
-		dispatch(setSiteSlugToSave(undefined));
-	}, [canSaveSite, dispatch, site]);
+		if (asPane) {
+			onClose?.();
+		} else {
+			dispatch(setActiveModal(null));
+			dispatch(setSiteSlugToSave(undefined));
+		}
+	}, [asPane, canSaveSite, dispatch, onClose, site]);
 
 	if (!site || !canSaveSite) {
 		return null;
@@ -280,7 +309,7 @@ export function SaveSiteModal() {
 				}
 			}
 
-			closeModal();
+			closeSurface();
 		} catch (error) {
 			logger.error(error);
 			setSubmitError(
@@ -315,31 +344,44 @@ export function SaveSiteModal() {
 				: 'Preparing to save...';
 
 	const handleRequestClose = () => {
-		if (!isSaving) {
-			closeModal();
+		const closeIsBlocked = asPane ? isSubmitting : isSaving;
+		if (!closeIsBlocked) {
+			closeSurface();
 		}
 	};
 
 	return (
-		<Modal
-			title="Save Playground"
-			contentLabel="Save Playground"
+		<SaveSurface
+			asPane={asPane}
+			isDismissible={asPane ? !isSubmitting : !isSaving}
 			onRequestClose={handleRequestClose}
-			isDismissible={!isSaving}
-			small
 		>
 			<form
 				onSubmit={(event) => {
 					event.preventDefault();
 					handleSubmit();
 				}}
-				style={{ display: 'flex', flexDirection: 'column', gap: 16 }}
+				style={{
+					display: 'flex',
+					flexDirection: 'column',
+					gap: 16,
+					...(asPane && {
+						padding: 'var(--space-2) var(--space-6) var(--space-6)',
+					}),
+				}}
 				autoComplete="off"
 			>
-				<p style={{ margin: 0, color: '#1e1e1e' }}>
+				<p
+					style={{
+						margin: 0,
+						color: asPane ? 'var(--ink, #21201d)' : '#1e1e1e',
+					}}
+				>
 					{isAutosaved
 						? 'This Playground is autosaved in this browser and may be removed after newer autosaves. Store it permanently in this browser or save it to a local directory.'
-						: 'This Playground is temporary and will be lost when you refresh or close this page. Save it to keep your work and find it later in Your Playgrounds.'}
+						: asPane
+							? 'This Playground is temporary and will be lost when you refresh or close this page. Store it permanently in this browser or save it to a local directory to keep your work and find it later in Your Playgrounds.'
+							: 'This Playground is temporary and will be lost when you refresh or close this page. Save it to keep your work and find it later in Your Playgrounds.'}
 				</p>
 				<TextControl
 					label="Playground name"
@@ -358,13 +400,17 @@ export function SaveSiteModal() {
 					options={[
 						{
 							label:
-								'Save in this browser' +
+								(asPane
+									? 'Save in browser storage'
+									: 'Save in this browser') +
 								(!isOpfsAvailable ? ' (not available)' : ''),
 							value: 'opfs',
 						},
 						{
 							label:
-								'Save to a local directory' +
+								(asPane
+									? 'Save in a local directory'
+									: 'Save to a local directory') +
 								(!localIsAvailable ? ' (not available)' : ''),
 							value: 'local-fs',
 						},
@@ -417,7 +463,13 @@ export function SaveSiteModal() {
 							id="save-progress"
 							max={savingProgress?.total || 100}
 							value={savingProgress?.files || 0}
-							style={{ width: '100%', height: 24 }}
+							style={{
+								width: '100%',
+								height: asPane ? 12 : 24,
+								...(asPane && {
+									accentColor: 'var(--accent, #3858e9)',
+								}),
+							}}
 						></progress>
 						<p style={{ ...helpTextStyle, marginTop: 4 }}>
 							{savingProgressLabel}
@@ -433,10 +485,39 @@ export function SaveSiteModal() {
 					submitText="Save"
 					onCancel={handleRequestClose}
 					areDisabled={saveDisabled}
+					cancelDisabled={asPane ? isSubmitting : undefined}
 					areBusy={false}
 					style={{ marginTop: 0 }}
 				/>
 			</form>
+		</SaveSurface>
+	);
+}
+
+/** Uses the Dock pane's chrome when embedded, or the standalone modal otherwise. */
+function SaveSurface({
+	asPane,
+	isDismissible,
+	onRequestClose,
+	children,
+}: {
+	asPane: boolean;
+	isDismissible: boolean;
+	onRequestClose: () => void;
+	children: ReactElement;
+}) {
+	if (asPane) {
+		return children;
+	}
+	return (
+		<Modal
+			title="Save Playground"
+			contentLabel="Save Playground"
+			onRequestClose={onRequestClose}
+			isDismissible={isDismissible}
+			small
+		>
+			{children}
 		</Modal>
 	);
 }

--- a/packages/playground/website/src/components/save-site-modal/index.tsx
+++ b/packages/playground/website/src/components/save-site-modal/index.tsx
@@ -1,10 +1,11 @@
 import {
+	useCallback,
 	useEffect,
 	useMemo,
 	useState,
 	useRef,
 	type CSSProperties,
-	type ReactElement,
+	type ReactNode,
 } from 'react';
 import {
 	Button,
@@ -32,22 +33,31 @@ import { isOpfsAvailable } from '../../lib/state/opfs/opfs-site-storage';
 
 type StorageOption = Extract<SiteStorageType, 'opfs' | 'local-fs'>;
 
+type SaveSiteModalProps =
+	| {
+			/** Render the form inside the Dock instead of a standalone modal. */
+			asPane: true;
+			onClose: () => void;
+			onCloseBlockedChange?: (isBlocked: boolean) => void;
+	  }
+	| {
+			asPane?: false;
+			onClose?: never;
+			onCloseBlockedChange?: never;
+	  };
+
 const helpTextStyle: CSSProperties = {
 	color: '#757575',
 	fontSize: 12,
 	marginTop: 8,
 };
 
-export function SaveSiteModal({
-	asPane = false,
-	onClose,
-	onCloseBlockedChange,
-}: {
-	/** Render the form inside the Dock instead of a standalone modal. */
-	asPane?: boolean;
-	onClose?: () => void;
-	onCloseBlockedChange?: (isBlocked: boolean) => void;
-} = {}) {
+export function SaveSiteModal(props: SaveSiteModalProps = {}) {
+	const { asPane = false } = props;
+	const onClose = props.asPane ? props.onClose : undefined;
+	const onCloseBlockedChange = props.asPane
+		? props.onCloseBlockedChange
+		: undefined;
 	const dispatch = useAppDispatch();
 	const sitesAPI = useSitesAPI();
 	const siteSlugToSave = useAppSelector((state) => state.ui.siteSlugToSave);
@@ -145,14 +155,14 @@ export function SaveSiteModal({
 	const isAutosaved = site && isAutosavedSite(site);
 	const canSaveSite =
 		site && (site.metadata.storage === 'none' || isAutosaved);
-	const closeSurface = () => {
-		if (asPane) {
-			onClose?.();
+	const closeSurface = useCallback(() => {
+		dispatch(setSiteSlugToSave(undefined));
+		if (onClose) {
+			onClose();
 			return;
 		}
 		dispatch(setActiveModal(null));
-		dispatch(setSiteSlugToSave(undefined));
-	};
+	}, [dispatch, onClose]);
 
 	useEffect(() => {
 		if (!asPane) {
@@ -169,13 +179,8 @@ export function SaveSiteModal({
 		if (site && canSaveSite) {
 			return;
 		}
-		if (asPane) {
-			onClose?.();
-		} else {
-			dispatch(setActiveModal(null));
-			dispatch(setSiteSlugToSave(undefined));
-		}
-	}, [asPane, canSaveSite, dispatch, onClose, site]);
+		closeSurface();
+	}, [canSaveSite, closeSurface, site]);
 
 	if (!site || !canSaveSite) {
 		return null;
@@ -504,7 +509,7 @@ function SaveSurface({
 	asPane: boolean;
 	isDismissible: boolean;
 	onRequestClose: () => void;
-	children: ReactElement;
+	children: ReactNode;
 }) {
 	if (asPane) {
 		return children;


### PR DESCRIPTION
The bottom Dock needs to run the Playground save flow inside its pane, but the current component always owns modal chrome. This adds an opt-in pane presentation and keeps the existing modal path as the default.

Pane callers supply their own close callback and receive close-blocking updates while this form's save is in flight. A background sync still disables submission, but it does not trap the user in the pane. `ModalButtons` can control Cancel independently; omitting that option preserves its current behavior.

This is an additive step toward #3965. No current call site passes `asPane`.

Tested with:

- `npm exec -- nx test playground-website --testFile=modal-buttons.spec.tsx`
- `npm exec -- nx run-many -t lint,typecheck -p playground-website`
