### PR TITLE
[Website] Reuse GitHub import details in the export form

### DIFF
--- a/packages/playground/website/src/components/layout/index.tsx
+++ b/packages/playground/website/src/components/layout/index.tsx
@@ -113,7 +113,6 @@ export function Layout() {
  * the "Show modal" button is rendered.
  */
 function Modals() {
-	const query = new URL(document.location.href).searchParams;
 	const githubExportSession = useGitHubExportSession();
 
 	const currentModal = useAppSelector(
@@ -181,7 +180,10 @@ function Modals() {
 		);
 	}
 
-	if (query.get('gh-ensure-auth') === 'yes') {
+	const shouldEnsureGitHubAuth =
+		new URL(document.location.href).searchParams.get('gh-ensure-auth') ===
+		'yes';
+	if (shouldEnsureGitHubAuth) {
 		return <GitHubOAuthGuardModal />;
 	}
 

--- a/packages/playground/website/src/components/layout/index.tsx
+++ b/packages/playground/website/src/components/layout/index.tsx
@@ -4,11 +4,12 @@ import { SiteManager } from '../site-manager';
 import { CSSTransition } from 'react-transition-group';
 import type { PlaygroundReduxState } from '../../lib/state/redux/store';
 import { useAppSelector } from '../../lib/state/redux/store';
-import { useState, useRef, lazy, Suspense } from 'react';
-import type { ExportFormValues } from '../../github/github-export-form/form';
-import { asPullRequestAction } from '../../github/github-export-form/form';
+import { useRef, lazy, Suspense } from 'react';
 import { GitHubOAuthGuardModal } from '../../github/github-oauth-guard';
-import { asContentType } from '../../github/import-from-github';
+import {
+	GitHubExportSessionProvider,
+	useGitHubExportSession,
+} from '../../github/github-export-session';
 import { LogModal } from '../log-modal';
 import { StartErrorModal } from '../start-error-modal';
 import type { DisplayMode } from '../playground-viewport';
@@ -66,33 +67,35 @@ export function Layout() {
 	const siteManagerWrapperRef = useRef<HTMLDivElement>(null);
 
 	return (
-		<div className={`${css.layout}`}>
-			<Modals />
-			<CSSTransition
-				nodeRef={siteManagerWrapperRef}
-				in={siteManagerIsOpen}
-				timeout={500}
-				classNames={{
-					enter: css.siteManagerWrapperEnter,
-					enterActive: css.siteManagerWrapperEnterActive,
-					exit: css.siteManagerWrapperExit,
-					exitActive: css.siteManagerWrapperExitActive,
-				}}
-				unmountOnExit
-			>
-				<div
-					ref={siteManagerWrapperRef}
-					className={css.siteManagerWrapper}
+		<GitHubExportSessionProvider>
+			<div className={`${css.layout}`}>
+				<Modals />
+				<CSSTransition
+					nodeRef={siteManagerWrapperRef}
+					in={siteManagerIsOpen}
+					timeout={500}
+					classNames={{
+						enter: css.siteManagerWrapperEnter,
+						enterActive: css.siteManagerWrapperEnterActive,
+						exit: css.siteManagerWrapperExit,
+						exitActive: css.siteManagerWrapperExitActive,
+					}}
+					unmountOnExit
 				>
-					<SiteManager />
-				</div>
-			</CSSTransition>
-			<div className={css.siteView}>
-				<div className={css.siteViewContent}>
-					<PlaygroundViewport displayMode={displayMode} />
+					<div
+						ref={siteManagerWrapperRef}
+						className={css.siteManagerWrapper}
+					>
+						<SiteManager />
+					</div>
+				</CSSTransition>
+				<div className={css.siteView}>
+					<div className={css.siteViewContent}>
+						<PlaygroundViewport displayMode={displayMode} />
+					</div>
 				</div>
 			</div>
-		</div>
+		</GitHubExportSessionProvider>
 	);
 }
 
@@ -111,48 +114,7 @@ export function Layout() {
  */
 function Modals() {
 	const query = new URL(document.location.href).searchParams;
-
-	const [githubExportFiles, setGithubExportFiles] = useState<any[]>();
-	const [githubExportValues, setGithubExportValues] = useState<
-		Partial<ExportFormValues>
-	>(() => {
-		const values: Partial<ExportFormValues> = {};
-		if (query.get('ghexport-repo-url')) {
-			values.repoUrl = query.get('ghexport-repo-url')!;
-		}
-		if (query.get('ghexport-content-type')) {
-			values.contentType = asContentType(
-				query.get('ghexport-content-type')
-			);
-		}
-		if (query.get('ghexport-pr-action')) {
-			values.prAction = asPullRequestAction(
-				query.get('ghexport-pr-action')
-			);
-		}
-		if (query.get('ghexport-pr-number')) {
-			values.prNumber = query.get('ghexport-pr-number')?.toString();
-		}
-		if (query.get('ghexport-playground-root')) {
-			values.fromPlaygroundRoot = query.get('ghexport-playground-root')!;
-		}
-		if (query.get('ghexport-repo-root')) {
-			values.toPathInRepo = query.get('ghexport-repo-root')!;
-		}
-		if (query.get('ghexport-path')) {
-			values.relativeExportPaths = query.getAll('ghexport-path');
-		}
-		if (query.get('ghexport-commit-message')) {
-			values.commitMessage = query.get('ghexport-commit-message')!;
-		}
-		if (query.get('ghexport-plugin')) {
-			values.plugin = query.get('ghexport-plugin')!;
-		}
-		if (query.get('ghexport-theme')) {
-			values.theme = query.get('ghexport-theme')!;
-		}
-		return values;
-	});
+	const githubExportSession = useGitHubExportSession();
 
 	const currentModal = useAppSelector(
 		(state: PlaygroundReduxState) => state.ui.activeModal
@@ -198,25 +160,7 @@ function Modals() {
 					createNewSiteBeforeImport={
 						currentModal === modalSlugs.GITHUB_IMPORT_NEW_SITE
 					}
-					onImported={({
-						url,
-						path,
-						files,
-						pluginOrThemeName,
-						contentType,
-						urlInformation: { owner, repo, type, pr },
-					}) => {
-						setGithubExportValues({
-							repoUrl: url,
-							prNumber: pr?.toString(),
-							toPathInRepo: path,
-							prAction: pr ? 'update' : 'create',
-							contentType,
-							plugin: pluginOrThemeName,
-							theme: pluginOrThemeName,
-						});
-						setGithubExportFiles(files);
-					}}
+					onImported={githubExportSession.recordImport}
 				/>
 			</LazyModal>
 		);
@@ -224,16 +168,14 @@ function Modals() {
 		return (
 			<LazyModal>
 				<GithubExportModal
-					allowZipExport={
-						(query.get('ghexport-allow-include-zip') ?? 'yes') ===
-						'yes'
+					allowZipExport={githubExportSession.allowZipExport}
+					initialValues={githubExportSession.values}
+					initialFilesBeforeChanges={
+						githubExportSession.filesBeforeChanges
 					}
-					initialValues={githubExportValues}
-					initialFilesBeforeChanges={githubExportFiles}
-					onExported={(prUrl, formValues) => {
-						setGithubExportValues(formValues);
-						setGithubExportFiles(undefined);
-					}}
+					onExported={(_prUrl, formValues) =>
+						githubExportSession.recordExport(formValues)
+					}
 				/>
 			</LazyModal>
 		);

--- a/packages/playground/website/src/components/saved-playgrounds-panel/index.tsx
+++ b/packages/playground/website/src/components/saved-playgrounds-panel/index.tsx
@@ -20,6 +20,7 @@ import { Icon } from '@wordpress/icons';
 import { GitHubIcon } from '../../github/github';
 import PreviewPRForm from '../../github/preview-pr/form';
 import GitHubImportForm from '../../github/github-import-form/form';
+import { useGitHubExportSession } from '../../github/github-export-session';
 import vanillaScreenshot from './vanilla-wordpress.jpeg';
 import { isValidBlueprintDraft } from './is-valid-blueprint-draft';
 import {
@@ -163,6 +164,7 @@ export function SavedPlaygroundsPanel({
 	const activeSiteSyncLabel = getActiveSiteSyncLabel(activeClientInfo);
 	const dispatch = useAppDispatch();
 	const sitesAPI = useSitesAPI();
+	const githubExportSession = useGitHubExportSession();
 	const playground = usePlaygroundClient();
 	const localFsAvailability = useLocalFsAvailability(playground ?? undefined);
 	const zipFileInputRef = useRef<HTMLInputElement>(null);
@@ -1436,7 +1438,8 @@ export function SavedPlaygroundsPanel({
 								createSiteForGitHubImport
 							}
 							onClose={() => setActiveCreationTab('gallery')}
-							onImported={() => {
+							onImported={(details) => {
+								githubExportSession.recordImport(details);
 								// eslint-disable-next-line no-alert
 								alert(
 									'Import finished! Your Playground has been updated.'

--- a/packages/playground/website/src/github/github-export-session.spec.tsx
+++ b/packages/playground/website/src/github/github-export-session.spec.tsx
@@ -44,15 +44,8 @@ describe('GitHubExportSessionProvider', () => {
 		session = undefined;
 	});
 
-	it('keeps query, import, and export state in one session', () => {
-		act(() => {
-			root.render(
-				<GitHubExportSessionProvider>
-					<SessionProbe />
-				</GitHubExportSessionProvider>
-			);
-		});
-
+	it('initializes export form state from URL query parameters', () => {
+		renderProvider();
 		expect(getSession()).toMatchObject({
 			allowZipExport: false,
 			values: {
@@ -67,7 +60,10 @@ describe('GitHubExportSessionProvider', () => {
 				plugin: 'example',
 			},
 		});
+	});
 
+	it('keeps import and export state in one session', () => {
+		renderProvider();
 		act(() => {
 			getSession().recordImport({
 				url: 'https://github.com/new-owner/new-repo/pull/12',
@@ -112,6 +108,16 @@ describe('GitHubExportSessionProvider', () => {
 		expect(getSession().filesBeforeChanges).toBeUndefined();
 		expect(getSession().values.commitMessage).toBe('Export wp-content');
 	});
+
+	function renderProvider() {
+		act(() => {
+			root.render(
+				<GitHubExportSessionProvider>
+					<SessionProbe />
+				</GitHubExportSessionProvider>
+			);
+		});
+	}
 
 	function SessionProbe() {
 		session = useGitHubExportSession();


### PR DESCRIPTION
This PR keeps GitHub import details and uses them to fill the export form.

After a GitHub import, the export form should open with the same repository, pull request, repository path, content type, and imported file list. This worked for the old import modal. Importing from Saved Playgrounds did not update the export form.

This PR moves these values to `GitHubExportSessionProvider`. Both import flows write to it. The export form reads from it and clears the imported file list after a successful export. The `ghexport-*` URL parameters still fill the form on first load.

This is needed so the GitHub import and export forms can move into the Dock in #3965 without changing how they pass data.

Verified with `npm exec nx test playground-website --output-style=static` and `npm exec nx typecheck playground-website --output-style=static`.
