### PR TITLE
[Website] Persist the Dock full-width preference

### DIFF
--- a/packages/playground/website/src/lib/dock-full-width.spec.ts
+++ b/packages/playground/website/src/lib/dock-full-width.spec.ts
@@ -1,0 +1,38 @@
+import { readDockFullWidth, writeDockFullWidth } from './dock-full-width';
+
+describe('Dock full-width preference', () => {
+	beforeEach(() => {
+		localStorage.clear();
+	});
+
+	it('persists and clears full-width mode', () => {
+		expect(readDockFullWidth()).toBe(false);
+
+		writeDockFullWidth(true);
+		expect(readDockFullWidth()).toBe(true);
+
+		writeDockFullWidth(false);
+		expect(readDockFullWidth()).toBe(false);
+		expect(localStorage.getItem('playground-dock-full-width')).toBeNull();
+	});
+
+	it('falls back when storage is unavailable', () => {
+		const getItem = vi
+			.spyOn(Storage.prototype, 'getItem')
+			.mockImplementation(() => {
+				throw new Error('Storage is unavailable');
+			});
+		const setItem = vi
+			.spyOn(Storage.prototype, 'setItem')
+			.mockImplementation(() => {
+				throw new Error('Storage is unavailable');
+			});
+
+		expect(readDockFullWidth()).toBe(false);
+		expect(() => writeDockFullWidth(true)).not.toThrow();
+
+		getItem.mockRestore();
+		setItem.mockRestore();
+	});
+});
+// @vitest-environment jsdom

--- a/packages/playground/website/src/lib/dock-full-width.spec.ts
+++ b/packages/playground/website/src/lib/dock-full-width.spec.ts
@@ -1,3 +1,5 @@
+// @vitest-environment jsdom
+
 import { readDockFullWidth, writeDockFullWidth } from './dock-full-width';
 
 describe('Dock full-width preference', () => {
@@ -35,4 +37,3 @@ describe('Dock full-width preference', () => {
 		setItem.mockRestore();
 	});
 });
-// @vitest-environment jsdom

--- a/packages/playground/website/src/lib/dock-full-width.ts
+++ b/packages/playground/website/src/lib/dock-full-width.ts
@@ -1,0 +1,25 @@
+/**
+ * Persists whether the user pinned the Dock to full width across sessions, so
+ * reopening Playground keeps the Dock the way they left it.
+ */
+const STORAGE_KEY = 'playground-dock-full-width';
+
+export function readDockFullWidth(): boolean {
+	try {
+		return localStorage.getItem(STORAGE_KEY) === 'true';
+	} catch {
+		return false;
+	}
+}
+
+export function writeDockFullWidth(fullWidth: boolean): void {
+	try {
+		if (fullWidth) {
+			localStorage.setItem(STORAGE_KEY, 'true');
+		} else {
+			localStorage.removeItem(STORAGE_KEY);
+		}
+	} catch {
+		// Best-effort: the Dock still works if the preference cannot be saved.
+	}
+}


### PR DESCRIPTION
This PR adds functions that save and load the Dock full-width setting.

The Dock full-width mode is a user preference. Without one storage boundary, the Dock wiring would need to know the storage key and repeat failure handling.

This adds read and write functions for that preference. The default state removes the key. Missing or blocked browser storage falls back to floating mode instead of breaking the Dock.

Nothing calls this yet. It is the persistence piece for #3965.

Verified with `npm exec nx test playground-website --output-style=static` and `npm exec nx typecheck playground-website --output-style=static`.
