### PR TITLE
[Website] Wrap YouHaveAutosaveNudge with RecentAutosaveNudge context for Dock

### DIFF
--- a/packages/playground/website/src/components/ensure-playground-site/ensure-playground-site-is-selected.tsx
+++ b/packages/playground/website/src/components/ensure-playground-site/ensure-playground-site-is-selected.tsx
@@ -30,7 +30,7 @@ import {
 } from '../../lib/state/playground-identity';
 import { getRelativeDate } from '../../lib/get-relative-date';
 import { listenForPointerDownAcrossIframes } from './listen-for-pointer-down-across-iframes';
-import { RecentAutosaveNudgeContext } from './recent-autosave-nudge-context';
+import { RecentAutosaveNudgeProvider } from './recent-autosave-nudge-context';
 
 /**
  * Ensures the redux store always has an activeSite value.
@@ -317,7 +317,7 @@ export function EnsurePlaygroundSiteIsSelected({
 	};
 
 	return (
-		<RecentAutosaveNudgeContext.Provider value={!!canShowAutosaveNudge}>
+		<RecentAutosaveNudgeProvider visible={!!canShowAutosaveNudge}>
 			{children}
 			{canShowAutosaveNudge && (
 				<YouHaveAutosaveNudge
@@ -363,7 +363,7 @@ export function EnsurePlaygroundSiteIsSelected({
 					}}
 				/>
 			)}
-		</RecentAutosaveNudgeContext.Provider>
+		</RecentAutosaveNudgeProvider>
 	);
 }
 

--- a/packages/playground/website/src/components/ensure-playground-site/ensure-playground-site-is-selected.tsx
+++ b/packages/playground/website/src/components/ensure-playground-site/ensure-playground-site-is-selected.tsx
@@ -30,6 +30,7 @@ import {
 } from '../../lib/state/playground-identity';
 import { getRelativeDate } from '../../lib/get-relative-date';
 import { listenForPointerDownAcrossIframes } from './listen-for-pointer-down-across-iframes';
+import { RecentAutosaveNudgeContext } from './recent-autosave-nudge-context';
 
 /**
  * Ensures the redux store always has an activeSite value.
@@ -316,7 +317,7 @@ export function EnsurePlaygroundSiteIsSelected({
 	};
 
 	return (
-		<>
+		<RecentAutosaveNudgeContext.Provider value={!!canShowAutosaveNudge}>
 			{children}
 			{canShowAutosaveNudge && (
 				<YouHaveAutosaveNudge
@@ -362,7 +363,7 @@ export function EnsurePlaygroundSiteIsSelected({
 					}}
 				/>
 			)}
-		</>
+		</RecentAutosaveNudgeContext.Provider>
 	);
 }
 

--- a/packages/playground/website/src/components/ensure-playground-site/recent-autosave-nudge-context.spec.tsx
+++ b/packages/playground/website/src/components/ensure-playground-site/recent-autosave-nudge-context.spec.tsx
@@ -1,6 +1,6 @@
 import { renderToStaticMarkup } from 'react-dom/server';
 import {
-	RecentAutosaveNudgeContext,
+	RecentAutosaveNudgeProvider,
 	useRecentAutosaveNudgeVisible,
 } from './recent-autosave-nudge-context';
 
@@ -12,9 +12,9 @@ describe('RecentAutosaveNudgeContext', () => {
 	it('exposes visible nudges to descendants', () => {
 		expect(
 			renderToStaticMarkup(
-				<RecentAutosaveNudgeContext.Provider value>
+				<RecentAutosaveNudgeProvider visible>
 					<Visibility />
-				</RecentAutosaveNudgeContext.Provider>
+				</RecentAutosaveNudgeProvider>
 			)
 		).toBe('visible');
 	});

--- a/packages/playground/website/src/components/ensure-playground-site/recent-autosave-nudge-context.spec.tsx
+++ b/packages/playground/website/src/components/ensure-playground-site/recent-autosave-nudge-context.spec.tsx
@@ -1,0 +1,25 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import {
+	RecentAutosaveNudgeContext,
+	useRecentAutosaveNudgeVisible,
+} from './recent-autosave-nudge-context';
+
+describe('RecentAutosaveNudgeContext', () => {
+	it('defaults to hidden', () => {
+		expect(renderToStaticMarkup(<Visibility />)).toBe('hidden');
+	});
+
+	it('exposes visible nudges to descendants', () => {
+		expect(
+			renderToStaticMarkup(
+				<RecentAutosaveNudgeContext.Provider value>
+					<Visibility />
+				</RecentAutosaveNudgeContext.Provider>
+			)
+		).toBe('visible');
+	});
+});
+
+function Visibility() {
+	return useRecentAutosaveNudgeVisible() ? 'visible' : 'hidden';
+}

--- a/packages/playground/website/src/components/ensure-playground-site/recent-autosave-nudge-context.ts
+++ b/packages/playground/website/src/components/ensure-playground-site/recent-autosave-nudge-context.ts
@@ -1,0 +1,7 @@
+import { createContext, useContext } from 'react';
+
+export const RecentAutosaveNudgeContext = createContext(false);
+
+export function useRecentAutosaveNudgeVisible(): boolean {
+	return useContext(RecentAutosaveNudgeContext);
+}

--- a/packages/playground/website/src/components/ensure-playground-site/recent-autosave-nudge-context.ts
+++ b/packages/playground/website/src/components/ensure-playground-site/recent-autosave-nudge-context.ts
@@ -1,7 +1,0 @@
-import { createContext, useContext } from 'react';
-
-export const RecentAutosaveNudgeContext = createContext(false);
-
-export function useRecentAutosaveNudgeVisible(): boolean {
-	return useContext(RecentAutosaveNudgeContext);
-}

--- a/packages/playground/website/src/components/ensure-playground-site/recent-autosave-nudge-context.tsx
+++ b/packages/playground/website/src/components/ensure-playground-site/recent-autosave-nudge-context.tsx
@@ -1,0 +1,22 @@
+import { createContext, useContext, type ReactNode } from 'react';
+
+const RecentAutosaveNudgeContext = createContext(false);
+RecentAutosaveNudgeContext.displayName = 'RecentAutosaveNudgeContext';
+
+export function RecentAutosaveNudgeProvider({
+	children,
+	visible,
+}: {
+	children: ReactNode;
+	visible: boolean;
+}) {
+	return (
+		<RecentAutosaveNudgeContext.Provider value={visible}>
+			{children}
+		</RecentAutosaveNudgeContext.Provider>
+	);
+}
+
+export function useRecentAutosaveNudgeVisible(): boolean {
+	return useContext(RecentAutosaveNudgeContext);
+}


### PR DESCRIPTION
This PR lets Dock code read whether the recent-autosave prompt is visible.

The recent-autosave prompt and the Dock can occupy the same part of the screen. The Dock needs to know when the prompt is visible, but it must not grow a second copy of autosave state.

The existing prompt remains the source of truth. A private context exposes its visibility through a provider and a read-only hook. Current prompt behavior and layout stay unchanged.

This gives #3965 the one signal it needs without coupling the Dock to autosave internals.

Verified with `npm exec nx test playground-website --output-style=static` and `npm exec nx typecheck playground-website --output-style=static`.
