### PR TITLE
[Website] Show export text in the GitHub login prompt

### DIFF
--- a/packages/playground/website/src/github/github-export-form/form.tsx
+++ b/packages/playground/website/src/github/github-export-form/form.tsx
@@ -495,7 +495,7 @@ export default function GitHubExportForm({
 	}
 
 	return (
-		<GitHubOAuthGuard>
+		<GitHubOAuthGuard intro="Export plugins, themes, or a wp-content directory to a GitHub repository.">
 			<form id="export-playground-form" onSubmit={handleSubmit}>
 				<p>
 					You may export WordPress plugins, themes, and entire

--- a/packages/playground/website/src/github/github-oauth-guard/index.spec.tsx
+++ b/packages/playground/website/src/github/github-oauth-guard/index.spec.tsx
@@ -1,9 +1,11 @@
+// @vitest-environment jsdom
+
 import { renderToStaticMarkup } from 'react-dom/server';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { oAuthState } from '../state';
 import GitHubOAuthGuard from '.';
 
-const originalOAuthState = oAuthState.value;
+const originalOAuthState = { ...oAuthState.value };
 
 describe('GitHubOAuthGuard', () => {
 	beforeEach(() => {
@@ -34,4 +36,3 @@ describe('GitHubOAuthGuard', () => {
 		expect(markup).not.toContain('Importing plugins');
 	});
 });
-// @vitest-environment jsdom

--- a/packages/playground/website/src/github/github-oauth-guard/index.spec.tsx
+++ b/packages/playground/website/src/github/github-oauth-guard/index.spec.tsx
@@ -1,0 +1,37 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { oAuthState } from '../state';
+import GitHubOAuthGuard from '.';
+
+const originalOAuthState = oAuthState.value;
+
+describe('GitHubOAuthGuard', () => {
+	beforeEach(() => {
+		oAuthState.value = {
+			isAuthorizing: false,
+			token: '',
+		};
+	});
+
+	afterEach(() => {
+		oAuthState.value = originalOAuthState;
+	});
+
+	it('describes importing by default', () => {
+		const markup = renderToStaticMarkup(<GitHubOAuthGuard />);
+
+		expect(markup).toContain(
+			'Importing plugins, themes, and wp-content directories directly from your public GitHub repositories.'
+		);
+	});
+
+	it('accepts copy for the active GitHub flow', () => {
+		const markup = renderToStaticMarkup(
+			<GitHubOAuthGuard intro="Export the active Playground to GitHub." />
+		);
+
+		expect(markup).toContain('Export the active Playground to GitHub.');
+		expect(markup).not.toContain('Importing plugins');
+	});
+});
+// @vitest-environment jsdom

--- a/packages/playground/website/src/github/github-oauth-guard/index.tsx
+++ b/packages/playground/website/src/github/github-oauth-guard/index.tsx
@@ -7,7 +7,10 @@ import classNames from 'classnames';
 import { Modal } from '../../components/modal';
 import { connectToGitHub } from '../connect-to-github';
 
-export function GitHubOAuthGuardModal({ children }: GitHubOAuthGuardProps) {
+export function GitHubOAuthGuardModal({
+	children,
+	intro,
+}: GitHubOAuthGuardProps) {
 	const [isModalOpen, setIsModalOpen] = useState(!oAuthState.value.token);
 
 	if (oAuthState.value.token && !children) {
@@ -25,7 +28,7 @@ export function GitHubOAuthGuardModal({ children }: GitHubOAuthGuardProps) {
 				setIsModalOpen(false);
 			}}
 		>
-			<GitHubOAuthGuard mayLoseProgress={false}>
+			<GitHubOAuthGuard mayLoseProgress={false} intro={intro}>
 				{children}
 			</GitHubOAuthGuard>
 		</Modal>
@@ -35,10 +38,12 @@ export function GitHubOAuthGuardModal({ children }: GitHubOAuthGuardProps) {
 interface GitHubOAuthGuardProps {
 	children?: React.ReactNode;
 	mayLoseProgress?: boolean;
+	intro?: React.ReactNode;
 }
 export default function GitHubOAuthGuard({
 	children,
 	mayLoseProgress,
+	intro,
 }: GitHubOAuthGuardProps) {
 	if (oAuthState.value.isAuthorizing) {
 		return (
@@ -56,14 +61,18 @@ export default function GitHubOAuthGuard({
 		return <div>{children}</div>;
 	}
 
-	return <Authenticate mayLoseProgress={mayLoseProgress} />;
+	return <Authenticate mayLoseProgress={mayLoseProgress} intro={intro} />;
 }
 
 interface AuthenticateProps {
 	mayLoseProgress?: boolean;
+	intro?: React.ReactNode;
 }
 
-function Authenticate({ mayLoseProgress = undefined }: AuthenticateProps) {
+function Authenticate({
+	mayLoseProgress = undefined,
+	intro,
+}: AuthenticateProps) {
 	const [exported, setExported] = useState(false);
 	const [error, setError] = useState<string>();
 	const buttonClass = classNames(css.githubButton, {
@@ -73,8 +82,8 @@ function Authenticate({ mayLoseProgress = undefined }: AuthenticateProps) {
 	return (
 		<div>
 			<p>
-				Importing plugins, themes, and wp-content directories directly
-				from your public GitHub repositories.
+				{intro ??
+					'Importing plugins, themes, and wp-content directories directly from your public GitHub repositories.'}
 			</p>
 			<p>
 				To enable this feature, connect your GitHub account with


### PR DESCRIPTION
This PR shows export-specific copy when the export form asks the user to log in to GitHub.

The GitHub login prompt says it is importing plugins, themes, or `wp-content`. It shows the same text when the export form asks the user to log in.

## Implementation

Add an optional `intro` prop to `GitHubOAuthGuard`. The export form now says what can be exported. Import callers omit the prop and keep the current import text. The login flow does not change.

This is needed when the GitHub forms move into the Dock in #3965.

## Testing

Verified with `npm exec nx test playground-website --output-style=static` and `npm exec nx typecheck playground-website --output-style=static`.
