### PR TITLE
[Website] Keep Adminer and phpMyAdmin checks on their related Playground and show download errors

### DIFF
--- a/packages/playground/website/src/components/site-manager/site-database-panel/adminer-button.tsx
+++ b/packages/playground/website/src/components/site-manager/site-database-panel/adminer-button.tsx
@@ -1,4 +1,5 @@
 import { Button, Icon, Flex, FlexItem } from '@wordpress/components';
+import { logger } from '@php-wasm/logger';
 import { external } from '@wordpress/icons';
 import { useEffect, useState } from 'react';
 import css from './style.module.css';
@@ -69,13 +70,19 @@ export function AdminerButton({
 		let cancelled = false;
 
 		async function detectAdminer() {
-			if (!playground) return;
-			const documentRoot = await playground.documentRoot;
-			if (cancelled) return;
-			const adminerPath = `${documentRoot}/adminer`;
-			const isDir = await playground.isDir(adminerPath);
-			if (cancelled) return;
-			setState(isDir ? 'ready' : 'idle');
+			try {
+				if (!playground) return;
+				const documentRoot = await playground.documentRoot;
+				if (cancelled) return;
+				const adminerPath = `${documentRoot}/adminer`;
+				const isDir = await playground.isDir(adminerPath);
+				if (cancelled) return;
+				setState(isDir ? 'ready' : 'idle');
+			} catch (error) {
+				if (cancelled) return;
+				logger.error('Failed to detect Adminer', error);
+				setState('idle');
+			}
 		}
 
 		void detectAdminer();

--- a/packages/playground/website/src/components/site-manager/site-database-panel/adminer-button.tsx
+++ b/packages/playground/website/src/components/site-manager/site-database-panel/adminer-button.tsx
@@ -61,21 +61,27 @@ export function AdminerButton({
 	const [error, setError] = useState<string | null>(null);
 
 	useEffect(() => {
-		async function detectAdminer() {
-			if (!playground) {
-				return;
-			}
-
-			const documentRoot = await playground.documentRoot;
-			const adminerPath = `${documentRoot}/adminer`;
-
-			if (await playground.isDir(adminerPath)) {
-				setState('ready');
-			} else {
-				setState('idle');
-			}
+		if (!playground) {
+			setState('idle');
+			setError(null);
+			return;
 		}
-		detectAdminer();
+		let cancelled = false;
+
+		async function detectAdminer() {
+			if (!playground) return;
+			const documentRoot = await playground.documentRoot;
+			if (cancelled) return;
+			const adminerPath = `${documentRoot}/adminer`;
+			const isDir = await playground.isDir(adminerPath);
+			if (cancelled) return;
+			setState(isDir ? 'ready' : 'idle');
+		}
+
+		void detectAdminer();
+		return () => {
+			cancelled = true;
+		};
 	}, [playground]);
 
 	const handleOpenAdminer = async () => {

--- a/packages/playground/website/src/components/site-manager/site-database-panel/download-button.spec.ts
+++ b/packages/playground/website/src/components/site-manager/site-database-panel/download-button.spec.ts
@@ -1,6 +1,11 @@
+// @vitest-environment jsdom
+
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { PlaygroundClient } from '@wp-playground/client';
-import { downloadDatabase } from './download-button';
+import {
+	downloadDatabase,
+	OBJECT_URL_REVOKE_DELAY_MS,
+} from './download-button';
 
 describe('downloadDatabase', () => {
 	const createObjectURL = vi.fn(() => 'blob:database');
@@ -53,8 +58,7 @@ describe('downloadDatabase', () => {
 		).toBeNull();
 		expect(revokeObjectURL).not.toHaveBeenCalled();
 
-		vi.advanceTimersByTime(60_000);
+		vi.advanceTimersByTime(OBJECT_URL_REVOKE_DELAY_MS);
 		expect(revokeObjectURL).toHaveBeenCalledWith('blob:database');
 	});
 });
-// @vitest-environment jsdom

--- a/packages/playground/website/src/components/site-manager/site-database-panel/download-button.spec.ts
+++ b/packages/playground/website/src/components/site-manager/site-database-panel/download-button.spec.ts
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { PlaygroundClient } from '@wp-playground/client';
+import { downloadDatabase } from './download-button';
+
+describe('downloadDatabase', () => {
+	const createObjectURL = vi.fn(() => 'blob:database');
+	const revokeObjectURL = vi.fn();
+	const click = vi
+		.spyOn(HTMLAnchorElement.prototype, 'click')
+		.mockImplementation(() => {});
+
+	beforeEach(() => {
+		vi.useFakeTimers();
+		Object.defineProperty(URL, 'createObjectURL', {
+			configurable: true,
+			value: createObjectURL,
+		});
+		Object.defineProperty(URL, 'revokeObjectURL', {
+			configurable: true,
+			value: revokeObjectURL,
+		});
+		createObjectURL.mockClear();
+		revokeObjectURL.mockClear();
+		click.mockClear();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('rejects missing database files', async () => {
+		const playground = {
+			fileExists: vi.fn().mockResolvedValue(false),
+		} as unknown as PlaygroundClient;
+
+		await expect(
+			downloadDatabase(playground, '/wordpress/database.sqlite')
+		).rejects.toThrow('Database file does not exist');
+		expect(createObjectURL).not.toHaveBeenCalled();
+	});
+
+	it('keeps the object URL alive long enough for the browser download', async () => {
+		const playground = {
+			fileExists: vi.fn().mockResolvedValue(true),
+			readFileAsBuffer: vi.fn().mockResolvedValue(new Uint8Array([1, 2])),
+		} as unknown as PlaygroundClient;
+
+		await downloadDatabase(playground, '/wordpress/database.sqlite');
+
+		expect(click).toHaveBeenCalledOnce();
+		expect(
+			document.querySelector('a[download="database.sqlite"]')
+		).toBeNull();
+		expect(revokeObjectURL).not.toHaveBeenCalled();
+
+		vi.advanceTimersByTime(60_000);
+		expect(revokeObjectURL).toHaveBeenCalledWith('blob:database');
+	});
+});
+// @vitest-environment jsdom

--- a/packages/playground/website/src/components/site-manager/site-database-panel/download-button.tsx
+++ b/packages/playground/website/src/components/site-manager/site-database-panel/download-button.tsx
@@ -5,6 +5,8 @@ import { download } from '@wordpress/icons';
 import type { PlaygroundClient } from '@wp-playground/client';
 import css from './style.module.css';
 
+export const OBJECT_URL_REVOKE_DELAY_MS = 60_000;
+
 export function DownloadButton({
 	playground,
 	databasePath,
@@ -46,7 +48,11 @@ export function DownloadButton({
 					</FlexItem>
 				</Flex>
 			</Button>
-			{error && <div className={css.error}>{error}</div>}
+			{error && (
+				<div className={css.error} role="alert">
+					{error}
+				</div>
+			)}
 		</>
 	);
 }
@@ -72,5 +78,5 @@ export async function downloadDatabase(
 	document.body.appendChild(link);
 	link.click();
 	document.body.removeChild(link);
-	setTimeout(() => URL.revokeObjectURL(url), 60_000);
+	setTimeout(() => URL.revokeObjectURL(url), OBJECT_URL_REVOKE_DELAY_MS);
 }

--- a/packages/playground/website/src/components/site-manager/site-database-panel/download-button.tsx
+++ b/packages/playground/website/src/components/site-manager/site-database-panel/download-button.tsx
@@ -1,8 +1,57 @@
+import { useState } from 'react';
+import { logger } from '@php-wasm/logger';
 import { Button, Icon, Flex, FlexItem } from '@wordpress/components';
 import { download } from '@wordpress/icons';
 import type { PlaygroundClient } from '@wp-playground/client';
+import css from './style.module.css';
 
-async function downloadDatabase(
+export function DownloadButton({
+	playground,
+	databasePath,
+}: {
+	playground: PlaygroundClient | undefined;
+	databasePath: string | null;
+}) {
+	const [isDownloading, setIsDownloading] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+
+	const handleDownload = async () => {
+		if (!playground || !databasePath) {
+			return;
+		}
+		setIsDownloading(true);
+		setError(null);
+		try {
+			await downloadDatabase(playground, databasePath);
+		} catch (downloadError) {
+			logger.error('Failed to download database', downloadError);
+			setError('Could not download the database. Please try again.');
+		} finally {
+			setIsDownloading(false);
+		}
+	};
+
+	return (
+		<>
+			<Button
+				variant="secondary"
+				disabled={!playground || !databasePath || isDownloading}
+				isBusy={isDownloading}
+				onClick={handleDownload}
+			>
+				<Flex justify="space-between" gap={2} expanded={true}>
+					<FlexItem>Download database.sqlite</FlexItem>
+					<FlexItem>
+						<Icon icon={download} size={16} />
+					</FlexItem>
+				</Flex>
+			</Button>
+			{error && <div className={css.error}>{error}</div>}
+		</>
+	);
+}
+
+export async function downloadDatabase(
 	playground: PlaygroundClient,
 	databasePath: string
 ): Promise<void> {
@@ -20,33 +69,8 @@ async function downloadDatabase(
 	const link = document.createElement('a');
 	link.href = url;
 	link.download = 'database.sqlite';
+	document.body.appendChild(link);
 	link.click();
-	URL.revokeObjectURL(url);
-}
-
-export function DownloadButton({
-	playground,
-	databasePath,
-}: {
-	playground: PlaygroundClient | undefined;
-	databasePath: string | null;
-}) {
-	return (
-		<Button
-			variant="secondary"
-			disabled={!playground || !databasePath}
-			onClick={
-				playground && databasePath
-					? () => downloadDatabase(playground, databasePath)
-					: undefined
-			}
-		>
-			<Flex justify="space-between" gap={2} expanded={true}>
-				<FlexItem>Download database.sqlite</FlexItem>
-				<FlexItem>
-					<Icon icon={download} size={16} />
-				</FlexItem>
-			</Flex>
-		</Button>
-	);
+	document.body.removeChild(link);
+	setTimeout(() => URL.revokeObjectURL(url), 60_000);
 }

--- a/packages/playground/website/src/components/site-manager/site-database-panel/phpmyadmin-button.tsx
+++ b/packages/playground/website/src/components/site-manager/site-database-panel/phpmyadmin-button.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { logger } from '@php-wasm/logger';
 import { Button, Icon, Flex, FlexItem } from '@wordpress/components';
 import { external } from '@wordpress/icons';
 import css from './style.module.css';
@@ -42,10 +43,16 @@ export function PhpMyAdminButton({
 		let cancelled = false;
 
 		async function detectPhpMyAdmin() {
-			if (!playground) return;
-			const isDir = await playground.isDir(PHPMYADMIN_INSTALL_PATH);
-			if (cancelled) return;
-			setState(isDir ? 'ready' : 'idle');
+			try {
+				if (!playground) return;
+				const isDir = await playground.isDir(PHPMYADMIN_INSTALL_PATH);
+				if (cancelled) return;
+				setState(isDir ? 'ready' : 'idle');
+			} catch (error) {
+				if (cancelled) return;
+				logger.error('Failed to detect phpMyAdmin', error);
+				setState('idle');
+			}
 		}
 
 		void detectPhpMyAdmin();

--- a/packages/playground/website/src/components/site-manager/site-database-panel/phpmyadmin-button.tsx
+++ b/packages/playground/website/src/components/site-manager/site-database-panel/phpmyadmin-button.tsx
@@ -34,18 +34,24 @@ export function PhpMyAdminButton({
 	const [error, setError] = useState<string | null>(null);
 
 	useEffect(() => {
-		async function detectPhpMyAdmin() {
-			if (!playground) {
-				return;
-			}
-
-			if (await playground.isDir(PHPMYADMIN_INSTALL_PATH)) {
-				setState('ready');
-			} else {
-				setState('idle');
-			}
+		if (!playground) {
+			setState('idle');
+			setError(null);
+			return;
 		}
-		detectPhpMyAdmin();
+		let cancelled = false;
+
+		async function detectPhpMyAdmin() {
+			if (!playground) return;
+			const isDir = await playground.isDir(PHPMYADMIN_INSTALL_PATH);
+			if (cancelled) return;
+			setState(isDir ? 'ready' : 'idle');
+		}
+
+		void detectPhpMyAdmin();
+		return () => {
+			cancelled = true;
+		};
 	}, [playground]);
 
 	const handleOpenPhpMyAdmin = async () => {


### PR DESCRIPTION
This PR keeps the Adminer and phpMyAdmin buttons tied to the current Playground and shows an error when `database.sqlite` cannot be downloaded.

The Database panel has two buttons: **Open Adminer** and **Open phpMyAdmin**. Before showing them, the panel asks the current Playground whether each tool is already installed. That answer is asynchronous. If the user switches to another Playground before it arrives, the answer belongs to the old Playground but can update the buttons for the new one. If the check fails, it also creates an unhandled promise rejection.

Each check now stops updating state after its Playground is replaced or the button is unmounted. Failed checks are logged and leave the button ready to try the install.

The database download button now shows a busy state while it reads `database.sqlite`. A missing file or failed read shows an error below the button instead of becoming an unhandled rejection. The temporary download link is removed after the click, and the blob URL is revoked after 60 seconds instead of immediately.

This is needed before these buttons move into the Dock in #3965.

Verified with `npm exec nx test playground-website --output-style=static` and `npm exec nx typecheck playground-website --output-style=static`.
