### PR TITLE
[Website] Center the modal loading spinner over the page

### DIFF
--- a/packages/playground/website/src/components/modal-loading-fallback/style.module.css
+++ b/packages/playground/website/src/components/modal-loading-fallback/style.module.css
@@ -11,6 +11,7 @@
 	justify-content: center;
 	padding: 24px;
 	position: fixed;
+	/* Match the @wordpress/components modal screen overlay. */
 	z-index: 100000;
 }
 

--- a/packages/playground/website/src/components/modal-loading-fallback/style.module.css
+++ b/packages/playground/website/src/components/modal-loading-fallback/style.module.css
@@ -1,11 +1,17 @@
+/* Fixed, centered overlay rather than an in-flow block: the modals mount as the
+   first child of the layout flex row, so an in-flow fallback briefly appeared as
+   a column on the left while the lazy modal chunk loaded ("a blink on the left").
+*/
 .fallback {
+	align-items: center;
 	display: flex;
 	flex-direction: column;
-	align-items: center;
-	justify-content: center;
-	min-height: 300px;
 	gap: 16px;
+	inset: 0;
+	justify-content: center;
 	padding: 24px;
+	position: fixed;
+	z-index: 100000;
 }
 
 .spinner {


### PR DESCRIPTION
This PR centers the modal loading spinner over the page instead of adding a column on the left.

The modal loading spinner mounts as the first child of the page flex row. While a modal file loads, the spinner appears in a new column on the left.

Make the spinner a fixed overlay that fills the page and centers its contents. Its `z-index` matches the WordPress modal that replaces it.

This removes the left-side blink found while working on the Dock in #3965.

Verified with `npm exec nx test playground-website --output-style=static` and `npm exec nx typecheck playground-website --output-style=static`.
