### PR TITLE
[Website] Keep the current WordPress version in the settings dropdown

### DIFF
--- a/packages/playground/website/src/components/site-manager/site-settings-form/unconnected-site-settings-form.tsx
+++ b/packages/playground/website/src/components/site-manager/site-settings-form/unconnected-site-settings-form.tsx
@@ -16,9 +16,8 @@ import { RecommendedPHPVersion } from '@wp-playground/common';
 import {
 	getForcedPhpVersionForWordPress,
 	isOlderWordPressVersion,
-	OlderWordPressVersions,
 } from './older-wordpress-versions';
-import { formatWordPressVersionLabel } from './wordpress-release-names';
+import { getWordPressVersionOptions } from './wordpress-version-options';
 
 type ConfigurableFields = Record<
 	keyof SiteFormData & ('wpVersion' | 'language' | 'multisite'),
@@ -144,42 +143,12 @@ export function UnconnectedSiteSettingsForm({
 	}, [forcedPhpVersion, setValue, getValues]);
 
 	const wpVersionOptions = useMemo(() => {
-		const modernOptions = Object.keys(supportedWPVersions || {}).map(
-			(version) => ({
-				label: formatWordPressVersionLabel(
-					`${supportedWPVersions[version]}`
-				),
-				value: version,
-			})
-		);
-		if (!includeOlderVersions) {
-			return [
-				// Without an empty option, React sometimes says the
-				// current selected version is "trunk" when `wp` is
-				// actually "6.4".
-				{ label: '-- Select a version --', value: '' },
-				...modernOptions,
-			];
-		}
-		return [
-			{ label: '-- Select a version --', value: '' },
-			{
-				label: '── Current versions ──',
-				value: '__modern_sep',
-				disabled: true,
-			},
-			...modernOptions,
-			{
-				label: '── Older versions ──',
-				value: '__older_sep',
-				disabled: true,
-			},
-			...OlderWordPressVersions.map((version) => ({
-				label: formatWordPressVersionLabel(version),
-				value: version,
-			})),
-		];
-	}, [supportedWPVersions, includeOlderVersions]);
+		return getWordPressVersionOptions({
+			supportedWPVersions,
+			includeOlderVersions,
+			selectedVersion: mergedDefaults.wpVersion,
+		});
+	}, [supportedWPVersions, includeOlderVersions, mergedDefaults.wpVersion]);
 
 	const phpVersionOptions = useMemo(() => {
 		if (forcedPhpVersion) {

--- a/packages/playground/website/src/components/site-manager/site-settings-form/wordpress-version-options.spec.ts
+++ b/packages/playground/website/src/components/site-manager/site-settings-form/wordpress-version-options.spec.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { getWordPressVersionOptions } from './wordpress-version-options';
+
+describe('getWordPressVersionOptions', () => {
+	it('keeps a selected version while the runtime index catches up', () => {
+		const options = getWordPressVersionOptions({
+			supportedWPVersions: {
+				latest: '6.9',
+				trunk: '7.0-beta1',
+			},
+			includeOlderVersions: false,
+			selectedVersion: '6.8',
+		});
+
+		expect(options.map(({ value }) => value)).toEqual([
+			'',
+			'6.8',
+			'latest',
+			'trunk',
+		]);
+	});
+
+	it('does not duplicate versions already in either list', () => {
+		const currentOptions = getWordPressVersionOptions({
+			supportedWPVersions: { '6.8': '6.8' },
+			includeOlderVersions: false,
+			selectedVersion: '6.8',
+		});
+		const olderOptions = getWordPressVersionOptions({
+			supportedWPVersions: { '6.8': '6.8' },
+			includeOlderVersions: true,
+			selectedVersion: '6.2',
+		});
+
+		expect(
+			currentOptions.filter(({ value }) => value === '6.8')
+		).toHaveLength(1);
+		expect(
+			olderOptions.filter(({ value }) => value === '6.2')
+		).toHaveLength(1);
+	});
+});

--- a/packages/playground/website/src/components/site-manager/site-settings-form/wordpress-version-options.spec.ts
+++ b/packages/playground/website/src/components/site-manager/site-settings-form/wordpress-version-options.spec.ts
@@ -39,4 +39,14 @@ describe('getWordPressVersionOptions', () => {
 			olderOptions.filter(({ value }) => value === '6.2')
 		).toHaveLength(1);
 	});
+
+	it('keeps a selected older version when the older list is hidden', () => {
+		const options = getWordPressVersionOptions({
+			supportedWPVersions: { '6.8': '6.8' },
+			includeOlderVersions: false,
+			selectedVersion: '6.2',
+		});
+
+		expect(options.map(({ value }) => value)).toContain('6.2');
+	});
 });

--- a/packages/playground/website/src/components/site-manager/site-settings-form/wordpress-version-options.ts
+++ b/packages/playground/website/src/components/site-manager/site-settings-form/wordpress-version-options.ts
@@ -27,7 +27,10 @@ export function getWordPressVersionOptions({
 	if (
 		selectedVersion &&
 		!modernOptions.some((option) => option.value === selectedVersion) &&
-		!(OlderWordPressVersions as readonly string[]).includes(selectedVersion)
+		(!includeOlderVersions ||
+			!(OlderWordPressVersions as readonly string[]).includes(
+				selectedVersion
+			))
 	) {
 		modernOptions.unshift({
 			label: formatWordPressVersionLabel(selectedVersion),

--- a/packages/playground/website/src/components/site-manager/site-settings-form/wordpress-version-options.ts
+++ b/packages/playground/website/src/components/site-manager/site-settings-form/wordpress-version-options.ts
@@ -1,0 +1,66 @@
+import { OlderWordPressVersions } from './older-wordpress-versions';
+import { formatWordPressVersionLabel } from './wordpress-release-names';
+
+type WordPressVersionOption = {
+	label: string;
+	value: string;
+	disabled?: boolean;
+};
+
+export function getWordPressVersionOptions({
+	supportedWPVersions,
+	includeOlderVersions,
+	selectedVersion,
+}: {
+	supportedWPVersions: Record<string, string>;
+	includeOlderVersions: boolean;
+	selectedVersion: string;
+}): WordPressVersionOption[] {
+	const modernOptions = Object.keys(supportedWPVersions).map((version) => ({
+		label: formatWordPressVersionLabel(`${supportedWPVersions[version]}`),
+		value: version,
+	}));
+
+	// The version index comes from the running client and can lag behind a
+	// settings-triggered reboot. Keep the site's selected value visible instead
+	// of letting the native select collapse to its empty placeholder meanwhile.
+	if (
+		selectedVersion &&
+		!modernOptions.some((option) => option.value === selectedVersion) &&
+		!(OlderWordPressVersions as readonly string[]).includes(selectedVersion)
+	) {
+		modernOptions.unshift({
+			label: formatWordPressVersionLabel(selectedVersion),
+			value: selectedVersion,
+		});
+	}
+
+	if (!includeOlderVersions) {
+		return [
+			// Without an empty option, React sometimes says the
+			// current selected version is "trunk" when `wp` is
+			// actually "6.4".
+			{ label: '-- Select a version --', value: '' },
+			...modernOptions,
+		];
+	}
+
+	return [
+		{ label: '-- Select a version --', value: '' },
+		{
+			label: '── Current versions ──',
+			value: '__modern_sep',
+			disabled: true,
+		},
+		...modernOptions,
+		{
+			label: '── Older versions ──',
+			value: '__older_sep',
+			disabled: true,
+		},
+		...OlderWordPressVersions.map((version) => ({
+			label: formatWordPressVersionLabel(version),
+			value: version,
+		})),
+	];
+}


### PR DESCRIPTION
This PR keeps the current WordPress version visible in the settings dropdown while the version list reloads.

The list of WordPress versions comes from the running Playground. After changing settings and restarting it, that list can arrive after the form. The form then has a selected version that is not in the dropdown, so the dropdown shows its empty option.

Add the selected version to the options until the list catches up. If it is an older version and the older list is hidden, keep it in the visible list. Do not add a second copy when the version is already present.

This keeps the settings form correct when it moves into the Dock in #3965.

Verified with `npm exec nx test playground-website --output-style=static` and `npm exec nx typecheck playground-website --output-style=static`.
