### PR TITLE
[Website] Create blueprint.json for editable Blueprints that have none

### DIFF
--- a/packages/playground/website/src/components/blueprint-editor/SiteBlueprintBundleEditor.spec.ts
+++ b/packages/playground/website/src/components/blueprint-editor/SiteBlueprintBundleEditor.spec.ts
@@ -1,3 +1,5 @@
+// @vitest-environment jsdom
+
 import { describe, expect, it, vi } from 'vitest';
 import { InMemoryFilesystemBackend } from '@wp-playground/storage';
 import { readSiteBlueprintJson } from './SiteBlueprintBundleEditor';
@@ -20,8 +22,9 @@ describe('readSiteBlueprintJson', () => {
 	it('does not modify a persisted bundle while reading it', async () => {
 		const backend = new InMemoryFilesystemBackend();
 
-		await expect(readSiteBlueprintJson(backend)).rejects.toThrow();
+		await expect(readSiteBlueprintJson(backend)).rejects.toThrow(
+			'File not found: /blueprint.json'
+		);
 		expect(await backend.fileExists('/blueprint.json')).toBe(false);
 	});
 });
-// @vitest-environment jsdom

--- a/packages/playground/website/src/components/blueprint-editor/SiteBlueprintBundleEditor.spec.ts
+++ b/packages/playground/website/src/components/blueprint-editor/SiteBlueprintBundleEditor.spec.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it, vi } from 'vitest';
+import { InMemoryFilesystemBackend } from '@wp-playground/storage';
+import { readSiteBlueprintJson } from './SiteBlueprintBundleEditor';
+
+vi.mock('../../lib/state/redux/store', () => ({
+	useAppDispatch: vi.fn(),
+	useAppSelector: vi.fn(),
+}));
+
+describe('readSiteBlueprintJson', () => {
+	it('seeds a minimal Blueprint when no declaration exists', async () => {
+		const blueprintJson = await readSiteBlueprintJson(undefined);
+
+		expect(JSON.parse(blueprintJson)).toEqual({
+			$schema: 'https://playground.wordpress.net/blueprint-schema.json',
+			steps: [],
+		});
+	});
+
+	it('does not modify a persisted bundle while reading it', async () => {
+		const backend = new InMemoryFilesystemBackend();
+
+		await expect(readSiteBlueprintJson(backend)).rejects.toThrow();
+		expect(await backend.fileExists('/blueprint.json')).toBe(false);
+	});
+});
+// @vitest-environment jsdom

--- a/packages/playground/website/src/components/blueprint-editor/SiteBlueprintBundleEditor.tsx
+++ b/packages/playground/website/src/components/blueprint-editor/SiteBlueprintBundleEditor.tsx
@@ -88,13 +88,29 @@ async function populateFilesystemFromBlueprint(
 }
 
 /**
+ * A minimal valid Blueprint. Every Playground starts from some Blueprint, so the
+ * editor should never open empty — when a site has no Blueprint on record we seed
+ * this stub so there is always a `blueprint.json` to view and edit.
+ */
+const STUB_BLUEPRINT_JSON = `${JSON.stringify(
+	{
+		$schema: 'https://playground.wordpress.net/blueprint-schema.json',
+		steps: [],
+	},
+	null,
+	2
+)}\n`;
+
+/**
  * Reads a site's `blueprint.json` as text without changing its stored bundle.
  * Used to seed compact Blueprint authoring surfaces.
  */
 export async function readSiteBlueprintJson(
 	originalBlueprint: SiteInfo['metadata']['originalBlueprint']
 ): Promise<string> {
-	const fs = await createFilesystemFromOriginalBlueprint(originalBlueprint);
+	const fs = await createFilesystemFromOriginalBlueprint(originalBlueprint, {
+		seedMissingBlueprintJson: !isFilesystemBackend(originalBlueprint),
+	});
 	return fs.readFileAsText('/blueprint.json');
 }
 
@@ -103,15 +119,29 @@ export async function readSiteBlueprintJson(
  *
  * Bundle backends can be used directly. Declaration-only Blueprints are copied
  * into a fresh in-memory filesystem so the editor always works with files.
+ * Editable filesystems get a stub `blueprint.json` when needed; read-only
+ * callers can leave a persisted bundle untouched instead.
  */
 async function createFilesystemFromOriginalBlueprint(
-	originalBlueprint: SiteInfo['metadata']['originalBlueprint']
+	originalBlueprint: SiteInfo['metadata']['originalBlueprint'],
+	options: {
+		/**
+		 * Whether a filesystem-backed bundle may be seeded with a missing
+		 * `blueprint.json`. Read-only callers leave persisted bundles untouched.
+		 */
+		seedMissingBlueprintJson?: boolean;
+	} = {}
 ): Promise<EventedFilesystem> {
+	const { seedMissingBlueprintJson = true } = options;
 	// If originalBlueprint is already a filesystem backend (e.g.,
 	// PersistedBlueprintBundle), use it directly instead of populating from
 	// Blueprint JSON.
 	if (isFilesystemBackend(originalBlueprint)) {
-		return new EventedFilesystem(originalBlueprint);
+		const fs = new EventedFilesystem(originalBlueprint);
+		if (seedMissingBlueprintJson) {
+			await ensureBlueprintJson(fs);
+		}
+		return fs;
 	}
 
 	// Otherwise, populate an in-memory filesystem with the Blueprint JSON.
@@ -122,7 +152,19 @@ async function createFilesystemFromOriginalBlueprint(
 			originalBlueprint as Blueprint
 		);
 	}
+	await ensureBlueprintJson(fs);
 	return fs;
+}
+
+/**
+ * Guarantees the editor always has a `blueprint.json` to show. A bundle (or a
+ * declaration-only Blueprint) that somehow carries none would otherwise render
+ * the editor empty.
+ */
+async function ensureBlueprintJson(fs: EventedFilesystem): Promise<void> {
+	if (!(await fs.fileExists('/blueprint.json'))) {
+		await fs.writeFile('/blueprint.json', STUB_BLUEPRINT_JSON);
+	}
 }
 
 function collectBundledResourcePaths(value: unknown): Set<string> {
@@ -234,7 +276,14 @@ export const SiteBlueprintBundleEditor = forwardRef<
 
 			setFilesystemIfMounted(
 				await createFilesystemFromOriginalBlueprint(
-					site.metadata.originalBlueprint
+					site.metadata.originalBlueprint,
+					{
+						seedMissingBlueprintJson:
+							!readOnly ||
+							!isFilesystemBackend(
+								site.metadata.originalBlueprint
+							),
+					}
 				)
 			);
 		};


### PR DESCRIPTION
This PR creates a minimal `blueprint.json` when an editable Blueprint has none.

The Blueprint editor always reads `/blueprint.json`. An editable Blueprint with no declaration or a bundle with no file leaves the editor with nothing to open.

Create a minimal `blueprint.json` when an editable filesystem does not have one. Do not write the file when reading a stored, read-only bundle.

This gives the Blueprint editor a file to open when it moves into the Dock in #3965.

Verified with `npm exec nx test playground-website --output-style=static` and `npm exec nx typecheck playground-website --output-style=static`.
