### PR TITLE
[Website] Let the Blueprint editor show Dock controls

### DIFF
--- a/packages/playground/components/src/FilePickerTree/style.module.css
+++ b/packages/playground/components/src/FilePickerTree/style.module.css
@@ -2,7 +2,7 @@
 	width: 100%;
 
 	tr:nth-child(even) {
-		background-color: #f7f7f7;
+		background-color: var(--file-tree-row-background, #f7f7f7);
 	}
 
 	&:active {
@@ -26,20 +26,23 @@
 	-webkit-appearance: none;
 	background: none;
 	transition: box-shadow 0.1s linear;
-	height: 30px;
+	height: var(--file-tree-row-height, 30px);
 	align-items: center;
 	box-sizing: border-box;
-	padding: 6px 12px;
+	padding: var(--file-tree-row-padding, 6px);
 	border-radius: 2px;
 
 	width: 100%;
 	white-space: nowrap;
-	color: var(--wp-components-color-foreground, #1e1e1e);
+	color: var(
+		--file-tree-row-color,
+		var(--wp-components-color-foreground, #1e1e1e)
+	);
 	background: transparent;
-	padding: 6px;
 
-	font-family: -apple-system, 'system-ui', 'Segoe UI', Roboto, Oxygen-Sans,
-		Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
+	font-family:
+		-apple-system, 'system-ui', 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu,
+		Cantarell, 'Helvetica Neue', sans-serif;
 	font-size: 13px;
 	font-weight: 400;
 
@@ -51,24 +54,37 @@
 }
 
 .selected {
-	background-color: var(--wp-admin-theme-color);
-	color: #fff;
+	background-color: var(
+		--file-tree-selected-background,
+		var(--wp-admin-theme-color)
+	);
+	color: var(--file-tree-selected-color, #fff);
+	box-shadow: var(--file-tree-selected-shadow, none);
 
 	&:hover,
 	&:active,
 	&:focus {
-		color: #fff !important;
-		background-color: var(--wp-admin-theme-color);
+		color: var(--file-tree-selected-color, #fff) !important;
+		background-color: var(
+			--file-tree-selected-background,
+			var(--wp-admin-theme-color)
+		);
 	}
 }
 
 .focused {
-	box-shadow: 0 0 0 1px var(--wp-admin-theme-color) inset;
+	box-shadow: var(
+		--file-tree-focus-shadow,
+		0 0 0 1px var(--wp-admin-theme-color) inset
+	);
 	border-radius: 2px;
 }
 
 .dropTarget {
-	box-shadow: inset 0 0 0 2px var(--wp-admin-theme-color);
+	box-shadow: var(
+		--file-tree-drop-shadow,
+		inset 0 0 0 2px var(--wp-admin-theme-color)
+	);
 }
 
 .dropTarget:not(.selected) {

--- a/packages/playground/components/src/PlaygroundFileEditor/file-explorer-sidebar.spec.tsx
+++ b/packages/playground/components/src/PlaygroundFileEditor/file-explorer-sidebar.spec.tsx
@@ -1,0 +1,109 @@
+// @vitest-environment jsdom
+
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import type { AsyncWritableFilesystem } from '@wp-playground/storage';
+import {
+	afterAll,
+	afterEach,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	vi,
+} from 'vitest';
+import { FileExplorerSidebar } from './file-explorer-sidebar';
+import { MAX_INLINE_FILE_BYTES } from './file-utils';
+
+const filePickerTree = vi.hoisted(() => ({
+	props: undefined as
+		| { onDoubleClickFile: (path: string) => Promise<void> }
+		| undefined,
+}));
+
+vi.mock('@wp-playground/components', async () => {
+	const React = await import('react');
+	return {
+		BinaryFilePreview: () => null,
+		FilePickerTree: React.forwardRef(function MockFilePickerTree(
+			props: { onDoubleClickFile: (path: string) => Promise<void> },
+			_ref
+		) {
+			filePickerTree.props = props;
+			return null;
+		}),
+	};
+});
+
+describe('FileExplorerSidebar Dock presentation', () => {
+	let container: HTMLDivElement;
+	let root: Root;
+
+	beforeAll(() => {
+		vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+	});
+
+	afterAll(() => {
+		vi.unstubAllGlobals();
+	});
+
+	beforeEach(() => {
+		container = document.createElement('div');
+		document.body.append(container);
+		root = createRoot(container);
+	});
+
+	afterEach(() => {
+		act(() => root.unmount());
+		container.remove();
+		filePickerTree.props = undefined;
+	});
+
+	it('offers a button when a file is too large for inline editing', async () => {
+		const arrayBuffer = vi.fn<() => Promise<ArrayBuffer>>();
+		const filesystem = Object.assign(new EventTarget(), {
+			read: vi.fn().mockResolvedValue({
+				size: MAX_INLINE_FILE_BYTES + 1,
+				arrayBuffer,
+			}),
+		}) as unknown as AsyncWritableFilesystem;
+		const onShowMessage = vi.fn();
+
+		act(() => {
+			root.render(
+				<FileExplorerSidebar
+					filesystem={filesystem}
+					currentPath={null}
+					selectedDirPath="/wordpress"
+					setSelectedDirPath={() => {}}
+					onFileOpened={() => {}}
+					onSelectionCleared={() => {}}
+					onShowMessage={onShowMessage}
+					documentRoot="/wordpress"
+					readOnly
+					dockPresentation
+				/>
+			);
+		});
+		if (!filePickerTree.props) {
+			throw new Error('The file picker did not render.');
+		}
+
+		await act(async () => {
+			await filePickerTree.props!.onDoubleClickFile(
+				'/wordpress/large.zip'
+			);
+		});
+
+		expect(arrayBuffer).not.toHaveBeenCalled();
+		expect(onShowMessage).toHaveBeenCalledOnce();
+		const message = onShowMessage.mock.calls[0][1];
+		act(() => root.render(message));
+		const button = Array.from(container.querySelectorAll('button')).find(
+			(candidate) => candidate.textContent === 'Download large.zip'
+		);
+		expect(button?.type).toBe('button');
+		expect(container.querySelector('a')).toBeNull();
+	});
+});

--- a/packages/playground/components/src/PlaygroundFileEditor/file-explorer-sidebar.tsx
+++ b/packages/playground/components/src/PlaygroundFileEditor/file-explorer-sidebar.tsx
@@ -6,7 +6,7 @@ import React, {
 	type Dispatch,
 	type SetStateAction,
 } from 'react';
-import { Icon } from '@wordpress/components';
+import { Icon, Tooltip } from '@wordpress/components';
 import { file as folderIcon, page as fileIcon, upload } from '@wordpress/icons';
 import classNames from 'classnames';
 import styles from './file-explorer.module.css';
@@ -44,6 +44,10 @@ export type FileExplorerSidebarProps = {
 	) => Promise<void> | void;
 	documentRoot: string;
 	readOnly?: boolean;
+	title?: string;
+	showBinaryPreviewHeader?: boolean;
+	dockPresentation?: boolean;
+	useWordPressTooltips?: boolean;
 };
 
 /**
@@ -59,6 +63,10 @@ export function FileExplorerSidebar({
 	onShowMessage,
 	documentRoot,
 	readOnly = false,
+	title = 'Files',
+	showBinaryPreviewHeader = true,
+	dockPresentation = false,
+	useWordPressTooltips = false,
 }: FileExplorerSidebarProps) {
 	const treeRef = useRef<FilePickerTreeHandle | null>(null);
 	const uploadInputRef = useRef<HTMLInputElement | null>(null);
@@ -98,12 +106,35 @@ export function FileExplorerSidebar({
 
 			if (previewRead.type === 'too-large') {
 				const maxInlineMegabytes = MAX_INLINE_FILE_BYTES / 1024 / 1024;
+				if (!dockPresentation) {
+					await onShowMessage(
+						path,
+						<>
+							<p>{`File too large to open (>${maxInlineMegabytes}MB).`}</p>
+							<p>
+								Open or download it outside the in-browser
+								editor.
+							</p>
+						</>
+					);
+					return;
+				}
+				const filename = basename(path) || 'download';
 				await onShowMessage(
 					path,
 					<>
 						<p>{`File too large to open (>${maxInlineMegabytes}MB).`}</p>
 						<p>
-							Open or download it outside the in-browser editor.
+							<a
+								href="#"
+								download={filename}
+								onClick={(event) => {
+									event.preventDefault();
+									void downloadFile(path, filename);
+								}}
+							>
+								Download {filename}
+							</a>
 						</p>
 					</>
 				);
@@ -132,6 +163,7 @@ export function FileExplorerSidebar({
 							mimeType={mimeType}
 							dataUrl={dataUrl}
 							downloadUrl={downloadUrl}
+							showHeader={showBinaryPreviewHeader}
 						/>
 					);
 					return;
@@ -157,6 +189,24 @@ export function FileExplorerSidebar({
 		} catch (error) {
 			logger.error('Could not open file', error);
 			await onShowMessage(null, 'Could not open file.');
+		}
+	};
+
+	/** Reads a rejected large file only after the user asks to download it. */
+	const downloadFile = async (path: string, filename: string) => {
+		try {
+			const file = await filesystem.read(path);
+			const data = new Uint8Array(await file.arrayBuffer());
+			const { url } = createDownloadUrl(data, filename);
+			const anchor = document.createElement('a');
+			anchor.href = url;
+			anchor.download = filename;
+			document.body.appendChild(anchor);
+			anchor.click();
+			document.body.removeChild(anchor);
+		} catch (error) {
+			logger.error('Could not download file', error);
+			await onShowMessage(path, 'Could not download file.');
 		}
 	};
 
@@ -201,6 +251,7 @@ export function FileExplorerSidebar({
 		<div
 			className={classNames(styles['fileExplorerContainer'], {
 				[styles['dropActive']]: isDraggingSidebar,
+				[styles['dockPresentation']]: dockPresentation,
 			})}
 			onDragEnter={(event) => {
 				if (
@@ -236,55 +287,94 @@ export function FileExplorerSidebar({
 			onDrop={handleSidebarDrop}
 		>
 			<div className={styles['fileExplorerHeader']}>
-				<span className={styles['fileExplorerTitle']}>Files</span>
+				<span className={styles['fileExplorerTitle']}>{title}</span>
 				{!readOnly ? (
 					<div className={styles['fileExplorerActions']}>
-						<button
-							className={classNames(
-								styles['fileExplorerButton'],
-								styles['fileExplorerIconButton']
-							)}
-							type="button"
-							onClick={() => {
-								if (!treeRef.current) {
-									return;
+						<FileActionTooltip
+							label="Create new file"
+							useWordPressTooltip={useWordPressTooltips}
+						>
+							<button
+								className={classNames(
+									styles['fileExplorerButton'],
+									styles['fileExplorerIconButton']
+								)}
+								type="button"
+								onClick={() => {
+									if (!treeRef.current) {
+										return;
+									}
+									void treeRef.current.createFile();
+								}}
+								aria-label="Create new file"
+								title={
+									useWordPressTooltips
+										? undefined
+										: 'Create new file'
 								}
-								void treeRef.current.createFile();
-							}}
-							aria-label="Create new file"
-							title="Create new file"
+							>
+								{dockPresentation ? (
+									<FilePlusIcon />
+								) : (
+									<Icon icon={fileIcon} size={20} />
+								)}
+							</button>
+						</FileActionTooltip>
+						<FileActionTooltip
+							label="Create new folder"
+							useWordPressTooltip={useWordPressTooltips}
 						>
-							<Icon icon={fileIcon} size={20} />
-						</button>
-						<button
-							className={classNames(
-								styles['fileExplorerButton'],
-								styles['fileExplorerIconButton']
-							)}
-							type="button"
-							onClick={() => {
-								if (!treeRef.current) {
-									return;
+							<button
+								className={classNames(
+									styles['fileExplorerButton'],
+									styles['fileExplorerIconButton']
+								)}
+								type="button"
+								onClick={() => {
+									if (!treeRef.current) {
+										return;
+									}
+									void treeRef.current.createFolder();
+								}}
+								aria-label="Create new folder"
+								title={
+									useWordPressTooltips
+										? undefined
+										: 'Create new folder'
 								}
-								void treeRef.current.createFolder();
-							}}
-							aria-label="Create new folder"
-							title="Create new folder"
+							>
+								{dockPresentation ? (
+									<FolderPlusIcon />
+								) : (
+									<Icon icon={folderIcon} size={20} />
+								)}
+							</button>
+						</FileActionTooltip>
+						<FileActionTooltip
+							label="Upload files"
+							useWordPressTooltip={useWordPressTooltips}
 						>
-							<Icon icon={folderIcon} size={20} />
-						</button>
-						<button
-							className={classNames(
-								styles['fileExplorerButton'],
-								styles['fileExplorerIconButton']
-							)}
-							type="button"
-							onClick={() => uploadInputRef.current?.click()}
-							aria-label="Upload files"
-							title="Upload files"
-						>
-							<Icon icon={upload} size={20} />
-						</button>
+							<button
+								className={classNames(
+									styles['fileExplorerButton'],
+									styles['fileExplorerIconButton'],
+									styles['fileExplorerUploadButton']
+								)}
+								type="button"
+								onClick={() => uploadInputRef.current?.click()}
+								aria-label="Upload files"
+								title={
+									useWordPressTooltips
+										? undefined
+										: 'Upload files'
+								}
+							>
+								<Icon
+									icon={upload}
+									size={dockPresentation ? 16 : 20}
+								/>
+							</button>
+						</FileActionTooltip>
 						<input
 							ref={uploadInputRef}
 							type="file"
@@ -329,3 +419,80 @@ export function FileExplorerSidebar({
 		</div>
 	);
 }
+
+function FileActionTooltip({
+	label,
+	useWordPressTooltip,
+	children,
+}: {
+	label: string;
+	useWordPressTooltip: boolean;
+	children: JSX.Element;
+}) {
+	if (!useWordPressTooltip) {
+		return children;
+	}
+	return (
+		<Tooltip text={label} delay={0} placement="top">
+			{children}
+		</Tooltip>
+	);
+}
+
+const FilePlusIcon = () => (
+	<svg viewBox="0 0 32 32" width="24" height="24" aria-hidden="true">
+		<path
+			d="M11 6h7l5 5v12a2 2 0 0 1-2 2H11a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2z"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="2"
+			strokeLinejoin="round"
+		/>
+		<path
+			d="M18 6v5h5"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="2"
+			strokeLinejoin="round"
+		/>
+		<g transform="translate(19 19)">
+			<circle cx="5" cy="5" r="8" fill="var(--paper-2, #fff)" />
+			<path
+				d="M5 1.5v7M1.5 5h7"
+				fill="none"
+				stroke="currentColor"
+				strokeWidth="2"
+				strokeLinecap="round"
+			/>
+		</g>
+	</svg>
+);
+
+const FolderPlusIcon = () => (
+	<svg viewBox="0 0 32 32" width="24" height="24" aria-hidden="true">
+		<path
+			d="M6 9h7l3 3h10v11a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2V9z"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="2"
+			strokeLinejoin="round"
+		/>
+		<path
+			d="M6 9V8a2 2 0 0 1 2-2h5l3 3"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="2"
+			strokeLinejoin="round"
+		/>
+		<g transform="translate(19 19)">
+			<circle cx="5" cy="5" r="8" fill="var(--paper-2, #fff)" />
+			<path
+				d="M5 1.5v7M1.5 5h7"
+				fill="none"
+				stroke="currentColor"
+				strokeWidth="2"
+				strokeLinecap="round"
+			/>
+		</g>
+	</svg>
+);

--- a/packages/playground/components/src/PlaygroundFileEditor/file-explorer-sidebar.tsx
+++ b/packages/playground/components/src/PlaygroundFileEditor/file-explorer-sidebar.tsx
@@ -6,7 +6,7 @@ import React, {
 	type Dispatch,
 	type SetStateAction,
 } from 'react';
-import { Icon, Tooltip } from '@wordpress/components';
+import { Button, Icon, Tooltip } from '@wordpress/components';
 import { file as folderIcon, page as fileIcon, upload } from '@wordpress/icons';
 import classNames from 'classnames';
 import styles from './file-explorer.module.css';
@@ -125,16 +125,15 @@ export function FileExplorerSidebar({
 					<>
 						<p>{`File too large to open (>${maxInlineMegabytes}MB).`}</p>
 						<p>
-							<a
-								href="#"
-								download={filename}
-								onClick={(event) => {
-									event.preventDefault();
+							<Button
+								type="button"
+								variant="link"
+								onClick={() => {
 									void downloadFile(path, filename);
 								}}
 							>
 								Download {filename}
-							</a>
+							</Button>
 						</p>
 					</>
 				);

--- a/packages/playground/components/src/PlaygroundFileEditor/file-explorer.module.css
+++ b/packages/playground/components/src/PlaygroundFileEditor/file-explorer.module.css
@@ -82,3 +82,70 @@
 	overflow: auto;
 	padding: 6px 0;
 }
+
+/* Quiet Paper and the larger Dock header are explicit so shared consumers keep
+   the original compact file explorer by default. */
+.fileExplorerContainer.dockPresentation {
+	background: var(--paper-1, #ffffff);
+	--file-tree-row-background: var(--paper-2, #f7f7f7);
+	--file-tree-row-padding: 6px 12px;
+	--file-tree-row-color: var(
+		--ink,
+		var(--wp-components-color-foreground, #1e1e1e)
+	);
+	--file-tree-selected-background: var(
+		--paper-5,
+		var(--wp-admin-theme-color)
+	);
+	--file-tree-selected-color: var(--ink, #fff);
+	--file-tree-selected-shadow: inset 2px 0 0 var(--accent, transparent);
+	--file-tree-focus-shadow: 0 0 0 1px
+		var(--accent, var(--wp-admin-theme-color)) inset;
+	--file-tree-drop-shadow: inset 0 0 0 2px
+		var(--accent, var(--wp-admin-theme-color));
+}
+
+.fileExplorerContainer.dockPresentation.dropActive {
+	border-color: var(--accent, #3858e9);
+	background: rgba(56, 88, 233, 0.06);
+}
+
+.dockPresentation .fileExplorerHeader {
+	gap: 8px;
+	min-height: 56px;
+	padding: 8px 16px 8px 24px;
+	background: var(--paper-2, #ffffff);
+	border-bottom-color: var(--line-subtle, #ddd);
+}
+
+.dockPresentation .fileExplorerTitle {
+	text-transform: none;
+	font-size: 20px;
+	letter-spacing: -0.01em;
+	color: var(--ink, #1e1e1e);
+}
+
+.dockPresentation .fileExplorerActions {
+	gap: 6px;
+}
+
+.dockPresentation .fileExplorerButton {
+	border-radius: var(--radius-control, 4px);
+	color: var(--ink, #1e1e1e);
+}
+
+.dockPresentation .fileExplorerButton:hover {
+	background: var(--paper-4, rgba(0, 0, 0, 0.04));
+	color: var(--ink, #1e1e1e);
+	border-color: transparent;
+}
+
+.dockPresentation .fileExplorerIconButton svg {
+	width: 24px;
+	height: 24px;
+}
+
+.dockPresentation .fileExplorerUploadButton svg {
+	width: 16px;
+	height: 16px;
+}

--- a/packages/playground/components/src/PlaygroundFileEditor/playground-file-editor.module.css
+++ b/packages/playground/components/src/PlaygroundFileEditor/playground-file-editor.module.css
@@ -85,6 +85,22 @@
 	font-weight: 500;
 }
 
+.saveButton {
+	/* Fixed width so the label swapping between Save / Saving… / Saved / Retry
+	   save doesn't jog the dock header layout. */
+	min-width: 96px;
+	justify-content: center;
+	white-space: nowrap;
+}
+
+/* In sync: a calm, confirmed "✓ Saved" (secondary button + green check/label),
+   distinct from the solid blue "Save" that appears with pending edits. */
+.saveButton.saveButtonSaved,
+.saveButton.saveButtonSaved svg {
+	color: var(--color-success, #007017);
+	fill: var(--color-success, #007017);
+}
+
 .editor {
 	flex: 1;
 	min-height: 0;
@@ -157,6 +173,71 @@
 	display: none;
 }
 
+/* Quiet Paper is opt-in because these components also render in DevTools,
+   Personal WP, FilePickerControl, and standalone harnesses. */
+.dockPresentation .content {
+	background: var(--paper-1, #ffffff);
+}
+
+.dockPresentation .sidebarWrapper {
+	border-right-color: var(--line-subtle, #ddd);
+	background: var(--paper-1, #ffffff);
+}
+
+.dockPresentation .editorHeader {
+	min-height: 56px;
+	padding: 8px 16px 8px 24px;
+	border-bottom-color: var(--line-subtle, #ddd);
+	background: var(--paper-2, #ffffff);
+}
+
+.dockPresentation .editorPath {
+	color: var(--ink-muted, #50575e);
+}
+
+.dockPresentation .editorPathPlaceholder {
+	color: var(--ink-faint, #787c82);
+}
+
+.dockPresentation .editor,
+.dockPresentation .editor :global(.cm-editor) {
+	background: var(--paper-1, #ffffff);
+}
+
+.dockPresentation .editor :global(.cm-gutters) {
+	background: var(--paper-2, #ffffff);
+	color: var(--ink-faint, #787c82);
+	border-right: 1px solid var(--line-subtle, #ddd);
+}
+
+.dockPresentation .editor :global(.cm-activeLine),
+.dockPresentation .editor :global(.cm-activeLineGutter) {
+	background: var(--paper-3, #f0f0f1);
+}
+
+.dockPresentation .placeholder {
+	color: var(--ink-muted, #50575e);
+	background: var(--paper-1, #ffffff);
+}
+
+.dockPresentation .messageArea {
+	background: var(--paper-1, #ffffff);
+}
+
+.dockPresentation .messageArea a {
+	color: var(--accent-link, #2271b1);
+}
+
+.dockPresentation .messageArea a:hover {
+	color: var(--accent-hover, #135e96);
+}
+
+/* This specificity outranks WordPress' `.components-button { display }`
+   regardless of stylesheet load order. */
+.dockPresentation .editorHeader .mobileToggle {
+	display: none;
+}
+
 @media (max-width: 960px) {
 	.sidebarWrapper {
 		position: absolute;
@@ -205,6 +286,62 @@
 	}
 
 	.content {
+		flex-direction: column;
+	}
+}
+
+/* The website Dock switches at 1024px; only its explicit presentation follows
+   that breakpoint. Default consumers retain the original 960px behavior. */
+@media (max-width: 1024px) {
+	.dockPresentation .sidebarWrapper {
+		position: absolute;
+		top: 0;
+		bottom: 0;
+		left: 0;
+		width: min(85%, 340px);
+		box-shadow: 0 18px 40px rgba(0, 0, 0, 0.2);
+		display: none;
+	}
+
+	.dockPresentation .sidebarOpen .sidebarWrapper {
+		display: flex;
+	}
+
+	.dockPresentation .mobileOverlay {
+		position: absolute;
+		inset: 0;
+		background: rgba(0, 0, 0, 0.3);
+		z-index: 2;
+		display: none;
+	}
+
+	.dockPresentation .sidebarOpen .mobileOverlay {
+		display: block;
+	}
+
+	.dockPresentation .editorHeader {
+		flex-wrap: wrap;
+		gap: 8px;
+		background: var(--paper-2, #ffffff);
+	}
+
+	.dockPresentation .editorPath {
+		width: 100%;
+		order: 2;
+		/* Keep long paths clear of the dock pane's close button. */
+		margin-right: 48px;
+	}
+
+	.dockPresentation .editorHeader .mobileToggle {
+		display: inline-flex;
+		order: 1;
+	}
+
+	.dockPresentation .saveButton {
+		order: 3;
+	}
+
+	.dockPresentation .content {
 		flex-direction: column;
 	}
 }

--- a/packages/playground/components/src/PlaygroundFileEditor/playground-file-editor.spec.tsx
+++ b/packages/playground/components/src/PlaygroundFileEditor/playground-file-editor.spec.tsx
@@ -1,0 +1,70 @@
+// @vitest-environment jsdom
+
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import {
+	afterAll,
+	afterEach,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	vi,
+} from 'vitest';
+import { PlaygroundFileEditor } from './playground-file-editor';
+import styles from './playground-file-editor.module.css';
+
+describe('PlaygroundFileEditor presentation', () => {
+	let container: HTMLDivElement;
+	let root: Root;
+
+	beforeAll(() => {
+		vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+	});
+
+	afterAll(() => {
+		vi.unstubAllGlobals();
+	});
+
+	beforeEach(() => {
+		container = document.createElement('div');
+		document.body.append(container);
+		root = createRoot(container);
+	});
+
+	afterEach(() => {
+		act(() => root.unmount());
+		container.remove();
+	});
+
+	it('keeps the existing presentation unless Dock presentation is requested', () => {
+		act(() => {
+			root.render(
+				<PlaygroundFileEditor filesystem={null} documentRoot="/" />
+			);
+		});
+
+		expect(
+			container.firstElementChild?.classList.contains(
+				styles['dockPresentation']
+			)
+		).toBe(false);
+
+		act(() => {
+			root.render(
+				<PlaygroundFileEditor
+					filesystem={null}
+					documentRoot="/"
+					dockPresentation
+				/>
+			);
+		});
+
+		expect(
+			container.firstElementChild?.classList.contains(
+				styles['dockPresentation']
+			)
+		).toBe(true);
+	});
+});

--- a/packages/playground/components/src/PlaygroundFileEditor/playground-file-editor.spec.tsx
+++ b/packages/playground/components/src/PlaygroundFileEditor/playground-file-editor.spec.tsx
@@ -12,8 +12,52 @@ import {
 	it,
 	vi,
 } from 'vitest';
+import type { AsyncWritableFilesystem } from '@wp-playground/storage';
 import { PlaygroundFileEditor } from './playground-file-editor';
 import styles from './playground-file-editor.module.css';
+
+vi.mock('./file-explorer-sidebar', () => ({
+	FileExplorerSidebar: ({
+		onFileOpened,
+	}: {
+		onFileOpened: (path: string, content: string) => void;
+	}) => (
+		<button
+			type="button"
+			onClick={() => onFileOpened('/wordpress/test.php', 'initial')}
+		>
+			Open test file
+		</button>
+	),
+}));
+
+vi.mock('./code-editor', async () => {
+	const React = await import('react');
+	return {
+		CodeEditor: React.forwardRef(function MockCodeEditor(
+			{
+				code,
+				onChange,
+			}: {
+				code: string;
+				onChange: (code: string) => void;
+			},
+			ref
+		) {
+			React.useImperativeHandle(ref, () => ({
+				blur() {},
+				focus() {},
+				getCursorPosition: () => 0,
+				setCursorPosition() {},
+			}));
+			return (
+				<button type="button" onClick={() => onChange(`${code}!`)}>
+					Edit test file
+				</button>
+			);
+		}),
+	};
+});
 
 describe('PlaygroundFileEditor presentation', () => {
 	let container: HTMLDivElement;
@@ -67,4 +111,57 @@ describe('PlaygroundFileEditor presentation', () => {
 			)
 		).toBe(true);
 	});
+
+	it('enables Dock save for a pending edit and disables it while saving', async () => {
+		let finishWrite: () => void = () => {};
+		const writePromise = new Promise<void>((resolve) => {
+			finishWrite = resolve;
+		});
+		const filesystem = Object.assign(new EventTarget(), {
+			writeFile: vi.fn(() => writePromise),
+		}) as unknown as AsyncWritableFilesystem;
+
+		await act(async () => {
+			root.render(
+				<PlaygroundFileEditor
+					filesystem={filesystem}
+					documentRoot="/wordpress"
+					dockPresentation
+				/>
+			);
+		});
+
+		await clickButton('Open test file');
+		expect(findButton('File saved').disabled).toBe(true);
+
+		await clickButton('Edit test file');
+		expect(findButton('Save file').disabled).toBe(false);
+
+		await clickButton('Save file');
+		expect(filesystem.writeFile).toHaveBeenCalledWith(
+			'/wordpress/test.php',
+			'initial!'
+		);
+		expect(findButton('Saving…').disabled).toBe(true);
+
+		await act(async () => {
+			finishWrite();
+			await writePromise;
+		});
+		expect(findButton('File saved').disabled).toBe(true);
+	});
+
+	async function clickButton(label: string) {
+		await act(async () => findButton(label).click());
+	}
+
+	function findButton(label: string) {
+		const button = Array.from(container.querySelectorAll('button')).find(
+			(candidate) => candidate.textContent === label
+		);
+		if (!button) {
+			throw new Error(`Could not find button “${label}”.`);
+		}
+		return button;
+	}
 });

--- a/packages/playground/components/src/PlaygroundFileEditor/playground-file-editor.tsx
+++ b/packages/playground/components/src/PlaygroundFileEditor/playground-file-editor.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import classNames from 'classnames';
 import { Button, Notice } from '@wordpress/components';
+import { check } from '@wordpress/icons';
 import type { AsyncWritableFilesystem } from '@wp-playground/storage';
 import { FileExplorerSidebar } from './file-explorer-sidebar';
 import { CodeEditor, type CodeEditorHandle } from './code-editor';
@@ -25,6 +26,7 @@ export type PlaygroundFileEditorProps = {
 	documentRoot: string;
 	initialPath?: string | null;
 	placeholderText?: string;
+	dockPresentation?: boolean;
 };
 
 type PendingSave = {
@@ -44,6 +46,7 @@ export function PlaygroundFileEditor({
 	documentRoot,
 	initialPath = null,
 	placeholderText = 'Select a file to view or edit its contents.',
+	dockPresentation = false,
 }: PlaygroundFileEditorProps) {
 	const [selectedDirPath, setSelectedDirPath] = useState<string | null>(
 		documentRoot
@@ -411,19 +414,52 @@ export function PlaygroundFileEditor({
 		flushPendingSave();
 	}, [flushPendingSave]);
 
+	const handleDockManualSave = useCallback(() => {
+		if (
+			!pendingSaveRef.current &&
+			saveState === SaveState.ERROR &&
+			filesystem &&
+			currentPath
+		) {
+			pendingSaveRef.current = {
+				filesystem,
+				path: currentPath,
+				content: code,
+			};
+		}
+		if (!pendingSaveRef.current) {
+			return;
+		}
+		setSaveError(null);
+		handleManualSave();
+	}, [code, currentPath, filesystem, handleManualSave, saveState]);
+
 	const saveStatusLabel = getSaveStatusLabel(saveState, saveError);
 	const saveStatusClassName = getSaveStatusClassName(saveState, styles);
+	const saveButtonLabel = getSaveButtonLabel(saveState);
+	const saveButtonStateClassName = getSaveButtonStateClassName(
+		saveState,
+		styles
+	);
 
 	if (!filesystem) {
 		return (
-			<div className={styles['container']}>
+			<div
+				className={classNames(styles['container'], {
+					[styles['dockPresentation']]: dockPresentation,
+				})}
+			>
 				<div className={styles['placeholder']}>{placeholderText}</div>
 			</div>
 		);
 	}
 
 	return (
-		<div className={styles['container']}>
+		<div
+			className={classNames(styles['container'], {
+				[styles['dockPresentation']]: dockPresentation,
+			})}
+		>
 			<div
 				className={classNames(styles['content'], {
 					[styles['sidebarOpen']]: showExplorerOnMobile,
@@ -443,6 +479,8 @@ export function PlaygroundFileEditor({
 						onSelectionCleared={handleClearSelection}
 						onShowMessage={handleShowMessage}
 						documentRoot={documentRoot}
+						dockPresentation={dockPresentation}
+						useWordPressTooltips={dockPresentation}
 					/>
 				</aside>
 				<section className={styles['editorWrapper']}>
@@ -468,14 +506,42 @@ export function PlaygroundFileEditor({
 								? currentPath
 								: `Browse files under ${documentRoot}`}
 						</div>
-						<div
-							className={classNames(
-								styles['saveStatus'],
-								saveStatusClassName
-							)}
-						>
-							{saveStatusLabel}
-						</div>
+						{dockPresentation && !readOnly && currentPath ? (
+							<Button
+								variant={
+									saveState === SaveState.IDLE ||
+									saveState === SaveState.SAVED
+										? 'secondary'
+										: 'primary'
+								}
+								isDestructive={saveState === SaveState.ERROR}
+								icon={
+									saveState === SaveState.IDLE ||
+									saveState === SaveState.SAVED
+										? check
+										: undefined
+								}
+								className={classNames(
+									styles['saveButton'],
+									saveButtonStateClassName
+								)}
+								isBusy={saveState === SaveState.SAVING}
+								disabled={saveState === SaveState.SAVING}
+								onClick={handleDockManualSave}
+								title="Save this file"
+							>
+								{saveButtonLabel}
+							</Button>
+						) : !dockPresentation ? (
+							<div
+								className={classNames(
+									styles['saveStatus'],
+									saveStatusClassName
+								)}
+							>
+								{saveStatusLabel}
+							</div>
+						) : null}
 					</div>
 					{saveError ? (
 						<div style={{ padding: '8px 16px' }}>
@@ -536,6 +602,32 @@ function getSaveStatusClassName(
 			return styleSheet['saveStatusSaving'];
 		case SaveState.ERROR:
 			return styleSheet['saveStatusError'];
+		default:
+			return undefined;
+	}
+}
+
+function getSaveButtonLabel(saveState: SaveState) {
+	switch (saveState) {
+		case SaveState.PENDING:
+			return 'Save file';
+		case SaveState.SAVING:
+			return 'Saving…';
+		case SaveState.ERROR:
+			return 'Retry save';
+		default:
+			return 'File saved';
+	}
+}
+
+function getSaveButtonStateClassName(
+	saveState: SaveState,
+	styleSheet: typeof styles
+) {
+	switch (saveState) {
+		case SaveState.IDLE:
+		case SaveState.SAVED:
+			return styleSheet['saveButtonSaved'];
 		default:
 			return undefined;
 	}

--- a/packages/playground/components/src/PlaygroundFileEditor/playground-file-editor.tsx
+++ b/packages/playground/components/src/PlaygroundFileEditor/playground-file-editor.tsx
@@ -526,9 +526,12 @@ export function PlaygroundFileEditor({
 									saveButtonStateClassName
 								)}
 								isBusy={saveState === SaveState.SAVING}
-								disabled={saveState === SaveState.SAVING}
+								disabled={
+									saveState !== SaveState.PENDING &&
+									saveState !== SaveState.ERROR
+								}
 								onClick={handleDockManualSave}
-								title="Save this file"
+								title={saveButtonLabel}
 							>
 								{saveButtonLabel}
 							</Button>

--- a/packages/playground/website/src/components/blueprint-editor/BlueprintBundleEditor.spec.tsx
+++ b/packages/playground/website/src/components/blueprint-editor/BlueprintBundleEditor.spec.tsx
@@ -14,6 +14,7 @@ const EDITED_BLUEPRINT = '{"steps":[{"step":"login"}]}';
 const mocks = vi.hoisted(() => ({
 	changeCode: undefined as ((code: string) => void) | undefined,
 	dispatch: vi.fn(),
+	fileExplorerProps: undefined as Record<string, unknown> | undefined,
 	resolveRuntimeConfiguration: vi.fn(),
 }));
 
@@ -34,7 +35,10 @@ vi.mock('@wp-playground/components', async () => {
 				return null;
 			}
 		),
-		FileExplorerSidebar: () => null,
+		FileExplorerSidebar: (props: Record<string, unknown>) => {
+			mocks.fileExplorerProps = props;
+			return null;
+		},
 	};
 });
 
@@ -79,6 +83,7 @@ describe('BlueprintBundleEditor Run barrier', () => {
 			writeFile,
 		} as unknown as AsyncWritableFilesystem;
 		mocks.changeCode = undefined;
+		mocks.fileExplorerProps = undefined;
 		mocks.dispatch.mockReset();
 		mocks.resolveRuntimeConfiguration.mockReset();
 	});
@@ -123,9 +128,38 @@ describe('BlueprintBundleEditor Run barrier', () => {
 		);
 	});
 
-	async function renderEditor(): Promise<
-		React.RefObject<BlueprintBundleEditorHandle>
-	> {
+	it('keeps the existing presentation by default', async () => {
+		await renderEditor();
+
+		expect(container.textContent).not.toContain('Export');
+		expect(
+			container.querySelector(
+				'a[aria-label="See Blueprints documentation"]'
+			)
+		).toBeNull();
+		expect(mocks.fileExplorerProps).not.toHaveProperty('dockPresentation');
+	});
+
+	it('can render the Blueprint editor as Dock content', async () => {
+		await renderEditor(true);
+
+		expect(container.textContent).toContain('Export');
+		expect(
+			container.querySelector(
+				'a[aria-label="See Blueprints documentation"]'
+			)
+		).not.toBeNull();
+		expect(mocks.fileExplorerProps).toMatchObject({
+			title: 'Blueprint',
+			showBinaryPreviewHeader: false,
+			dockPresentation: true,
+			useWordPressTooltips: true,
+		});
+	});
+
+	async function renderEditor(
+		dockPresentation = false
+	): Promise<React.RefObject<BlueprintBundleEditorHandle>> {
 		const editorRef = createRef<BlueprintBundleEditorHandle>();
 		await act(async () => {
 			root.render(
@@ -133,6 +167,7 @@ describe('BlueprintBundleEditor Run barrier', () => {
 					ref={editorRef}
 					filesystem={filesystem}
 					site={site}
+					dockPresentation={dockPresentation}
 				/>
 			);
 			await Promise.resolve();

--- a/packages/playground/website/src/components/blueprint-editor/BlueprintBundleEditor.tsx
+++ b/packages/playground/website/src/components/blueprint-editor/BlueprintBundleEditor.tsx
@@ -7,8 +7,16 @@ import {
 	type Tooltip,
 } from '@codemirror/view';
 import { logger } from '@php-wasm/logger';
-import { Button, Icon, Notice } from '@wordpress/components';
-import { download, link } from '@wordpress/icons';
+import {
+	Button,
+	Dropdown,
+	Icon,
+	MenuGroup,
+	MenuItem,
+	Notice,
+	Tooltip as WpTooltip,
+} from '@wordpress/components';
+import { chevronDown, download, help, link } from '@wordpress/icons';
 import {
 	resolveRuntimeConfiguration,
 	type BlueprintValidationResult,
@@ -265,6 +273,7 @@ export type BlueprintBundleEditorProps = {
 	site?: SiteInfo;
 	autoRunToken?: number;
 	readOnly?: boolean;
+	dockPresentation?: boolean;
 };
 
 export interface BlueprintBundleEditorHandle {
@@ -277,7 +286,14 @@ export const BlueprintBundleEditor = forwardRef<
 	BlueprintBundleEditorHandle,
 	BlueprintBundleEditorProps
 >(function BlueprintFilesystemEditor(
-	{ filesystem, className, site, autoRunToken, readOnly },
+	{
+		filesystem,
+		className,
+		site,
+		autoRunToken,
+		readOnly,
+		dockPresentation = false,
+	},
 	ref
 ) {
 	const [selectedDirPath, setSelectedDirPath] = useState<string | null>('/');
@@ -719,7 +735,11 @@ export const BlueprintBundleEditor = forwardRef<
 	const disableRunButton = isRecreating || !site || hasValidationErrors;
 	return (
 		<>
-			<div className={classNames(styles.container, className)}>
+			<div
+				className={classNames(styles.container, className, {
+					[styles.dockPresentation]: dockPresentation,
+				})}
+			>
 				<div
 					className={classNames(styles.content, {
 						[styles.sidebarOpen]: showExplorerOnMobile,
@@ -745,6 +765,14 @@ export const BlueprintBundleEditor = forwardRef<
 							onShowMessage={handleShowMessage}
 							documentRoot="/"
 							readOnly={readOnly || isRecreating}
+							{...(dockPresentation
+								? {
+										title: 'Blueprint',
+										showBinaryPreviewHeader: false,
+										dockPresentation: true,
+										useWordPressTooltips: true,
+									}
+								: {})}
 						/>
 					</aside>
 					<section className={styles.editorWrapper}>
@@ -762,36 +790,133 @@ export const BlueprintBundleEditor = forwardRef<
 									? 'Hide files'
 									: 'Browse files'}
 							</Button>
-							<div
-								className={classNames(styles.editorPath, {
-									[styles.editorPathPlaceholder]:
-										!currentPath?.length,
-								})}
-							>
-								{displayPath ||
-									selectedDirPath ||
-									'Browse files under /'}
-							</div>
+							{!dockPresentation && (
+								<div
+									className={classNames(styles.editorPath, {
+										[styles.editorPathPlaceholder]:
+											!currentPath?.length,
+									})}
+								>
+									{displayPath ||
+										selectedDirPath ||
+										'Browse files under /'}
+								</div>
+							)}
 
 							<div className={styles.editorHeaderActions}>
-								<Button
-									variant="tertiary"
-									className={styles.editorToolbarButton}
-									onClick={handleShareBlueprint}
-									title="Copy link to blueprint"
-									aria-label="Copy link to blueprint"
-									disabled={!isBundleShareable}
-								>
-									<Icon icon={link} />
-								</Button>
-								<Button
-									variant="tertiary"
-									className={styles.editorToolbarButton}
-									onClick={handleDownloadBundle}
-									title="Download bundle"
-								>
-									<Icon icon={download} />
-								</Button>
+								{dockPresentation ? (
+									<>
+										<WpTooltip
+											text="See Blueprints documentation"
+											delay={0}
+											placement="top"
+										>
+											<a
+												className={
+													styles.editorDocsLink
+												}
+												href="https://wordpress.github.io/wordpress-playground/blueprints"
+												target="_blank"
+												rel="noreferrer"
+												aria-label="See Blueprints documentation"
+											>
+												<Icon icon={help} size={24} />
+											</a>
+										</WpTooltip>
+										<Dropdown
+											className={styles.editorExport}
+											popoverProps={{
+												placement: 'bottom-end',
+											}}
+											renderToggle={({
+												isOpen,
+												onToggle,
+											}) => (
+												<Button
+													variant="secondary"
+													className={classNames(
+														styles.editorToolbarButton,
+														styles.editorExportToggle
+													)}
+													onClick={onToggle}
+													aria-expanded={isOpen}
+													aria-haspopup="menu"
+												>
+													Export
+													<Icon
+														icon={chevronDown}
+														size={20}
+													/>
+												</Button>
+											)}
+											renderContent={({ onClose }) => (
+												<>
+													<MenuGroup>
+														<MenuItem
+															icon={link}
+															disabled={
+																!isBundleShareable
+															}
+															onClick={() => {
+																handleShareBlueprint();
+																onClose();
+															}}
+														>
+															Copy Blueprint URL
+														</MenuItem>
+														<MenuItem
+															icon={download}
+															onClick={() => {
+																handleDownloadBundle();
+																onClose();
+															}}
+														>
+															Download Zip
+														</MenuItem>
+													</MenuGroup>
+													{!isBundleShareable && (
+														<p
+															className={
+																styles.exportHint
+															}
+														>
+															Multi-file
+															Blueprints can’t be
+															shared as a URL —
+															download a zip
+															instead.
+														</p>
+													)}
+												</>
+											)}
+										/>
+									</>
+								) : (
+									<>
+										<Button
+											variant="tertiary"
+											className={
+												styles.editorToolbarButton
+											}
+											onClick={handleShareBlueprint}
+											title="Copy link to blueprint"
+											aria-label="Copy link to blueprint"
+											disabled={!isBundleShareable}
+										>
+											<Icon icon={link} />
+										</Button>
+										<Button
+											variant="tertiary"
+											className={
+												styles.editorToolbarButton
+											}
+											onClick={handleDownloadBundle}
+											title="Download bundle"
+										>
+											<Icon icon={download} />
+										</Button>
+									</>
+								)}
 								{!readOnly && (
 									<Button
 										variant="primary"
@@ -837,7 +962,9 @@ export const BlueprintBundleEditor = forwardRef<
 								</Notice>
 							</div>
 						) : null}
-						{!readOnly && !isBundleShareable ? (
+						{!dockPresentation &&
+						!readOnly &&
+						!isBundleShareable ? (
 							<div style={{ padding: '8px 16px' }}>
 								<Notice status="warning" isDismissible={false}>
 									This Blueprint bundle contains multiple

--- a/packages/playground/website/src/components/blueprint-editor/SiteBlueprintBundleEditor.tsx
+++ b/packages/playground/website/src/components/blueprint-editor/SiteBlueprintBundleEditor.tsx
@@ -165,6 +165,7 @@ export interface SiteBlueprintBundleEditorHandle {
 type SiteBlueprintBundleEditorProps = {
 	className?: string;
 	site: SiteInfo;
+	dockPresentation?: boolean;
 };
 
 /**
@@ -174,7 +175,10 @@ type SiteBlueprintBundleEditorProps = {
 export const SiteBlueprintBundleEditor = forwardRef<
 	SiteBlueprintBundleEditorHandle,
 	SiteBlueprintBundleEditorProps
->(function SiteBlueprintBundleEditor({ className, site }, ref) {
+>(function SiteBlueprintBundleEditor(
+	{ className, site, dockPresentation = false },
+	ref
+) {
 	const dispatch = useAppDispatch();
 	const [filesystem, setFilesystem] = useState<EventedFilesystem | null>(
 		null
@@ -278,6 +282,7 @@ export const SiteBlueprintBundleEditor = forwardRef<
 					site={site}
 					className={className}
 					readOnly={readOnly}
+					dockPresentation={dockPresentation}
 				/>
 			)}
 		</div>

--- a/packages/playground/website/src/components/blueprint-editor/blueprint-bundle-editor.module.css
+++ b/packages/playground/website/src/components/blueprint-editor/blueprint-bundle-editor.module.css
@@ -143,6 +143,82 @@
 	height: 18px;
 }
 
+.dockPresentation .content {
+	background: var(--paper-1, #ffffff);
+}
+
+.dockPresentation .sidebarWrapper {
+	background: var(--paper-1, #ffffff);
+	border-right-color: var(--line-subtle, #ddd);
+}
+
+.dockPresentation .editorHeader {
+	background: var(--paper-2, #ffffff);
+	border-bottom-color: var(--line-subtle, #ddd);
+	min-height: 56px;
+	padding: 8px 16px;
+}
+
+.dockPresentation .editorHeaderActions {
+	flex-wrap: wrap;
+	justify-content: flex-end;
+	margin-left: auto;
+	min-width: 0;
+}
+
+.editorExport {
+	display: inline-flex;
+}
+
+.editorExportToggle svg {
+	margin-left: 4px;
+	margin-right: -2px;
+}
+
+.exportHint {
+	border-top: 1px solid var(--line-subtle, #e0e0e0);
+	color: var(--ink-muted, #50575e);
+	font-size: 12px;
+	line-height: 1.4;
+	margin: 4px 0 0;
+	max-width: 240px;
+	padding: 8px 12px 4px;
+}
+
+.editorDocsLink {
+	align-items: center;
+	border-radius: 6px;
+	color: var(--ink-muted, #50575e);
+	display: inline-flex;
+	height: 32px;
+	justify-content: center;
+	margin-right: 2px;
+	width: 32px;
+}
+
+.editorDocsLink:hover {
+	background: rgba(20, 18, 15, 0.06);
+	color: var(--accent, #3858e9);
+}
+
+.dockPresentation .editor,
+.dockPresentation .editor :global(.cm-editor),
+.dockPresentation .placeholder,
+.dockPresentation .messageArea {
+	background: var(--paper-1, #ffffff);
+}
+
+.dockPresentation .editor :global(.cm-gutters) {
+	background: var(--paper-2, #ffffff);
+	border-right: 1px solid var(--line-subtle, #ddd);
+	color: var(--ink-faint, #787c82);
+}
+
+.dockPresentation .editor :global(.cm-activeLine),
+.dockPresentation .editor :global(.cm-activeLineGutter) {
+	background: var(--paper-3, #f0f0f1);
+}
+
 .mobileToggle {
 	display: none;
 }
@@ -196,5 +272,60 @@
 
 	.content {
 		flex-direction: column;
+	}
+}
+
+@media (min-width: 961px) and (max-width: 1024px) {
+	.dockPresentation .sidebarWrapper {
+		bottom: 0;
+		box-shadow: 0 18px 40px rgba(40, 33, 23, 0.18);
+		display: none;
+		left: 0;
+		position: absolute;
+		top: 0;
+		width: min(85%, 340px);
+	}
+
+	.dockPresentation .sidebarOpen .sidebarWrapper {
+		display: flex;
+	}
+
+	.dockPresentation .mobileOverlay {
+		background: rgba(40, 33, 23, 0.3);
+		display: none;
+		inset: 0;
+		position: absolute;
+		z-index: 2;
+	}
+
+	.dockPresentation .sidebarOpen .mobileOverlay {
+		display: block;
+	}
+
+	.dockPresentation .editorHeader .mobileToggle {
+		display: inline-flex;
+		order: 1;
+	}
+
+	.dockPresentation .content {
+		flex-direction: column;
+	}
+}
+
+@media (max-width: 1024px) {
+	.dockPresentation .editorHeaderActions {
+		gap: 8px;
+		justify-content: flex-start;
+		order: 3;
+		width: 100%;
+	}
+
+	.dockPresentation .editorDocsLink {
+		margin-right: 0;
+	}
+
+	.dockPresentation .editorHeaderActions .editorToolbarButton:last-child {
+		flex: 1 0 100%;
+		justify-content: center;
 	}
 }


### PR DESCRIPTION
This PR lets the Blueprint editor show Dock file and export controls when `dockPresentation` is enabled.

The Blueprint editor currently shows a file path and separate icon buttons for copying a link and downloading a zip. The Dock version needs a file list title, a documentation link, and one Export menu.

Add a `dockPresentation` prop that enables those controls and the Dock colors and spacing. The prop is off by default, so the current Site Manager does not change.

This PR is based on #4042 because it uses the File Explorer Dock props. The controls will be enabled by #3965.

Verified with `npm exec nx test playground-website --output-style=static` and `npm exec nx typecheck playground-website --output-style=static`.
