### PR TITLE
[Website] Let Dock buttons be disabled and pane subtitles contain links

### DIFF
--- a/packages/playground/website/src/components/dock/dock-item-button.spec.tsx
+++ b/packages/playground/website/src/components/dock/dock-item-button.spec.tsx
@@ -37,6 +37,19 @@ describe('DockItemButton', () => {
 		);
 		expect(hiddenMarkerCount).toBe(2);
 	});
+
+	it('can disable unavailable actions', () => {
+		const markup = renderToStaticMarkup(
+			<DockItemButton
+				label="Database"
+				ariaLabel="Database"
+				icon={<DockDatabaseIcon />}
+				disabled
+			/>
+		);
+
+		expect(markup).toContain('disabled=""');
+	});
 });
 
 function countMatches(value: string, substring: string) {

--- a/packages/playground/website/src/components/dock/dock-item-button.spec.tsx
+++ b/packages/playground/website/src/components/dock/dock-item-button.spec.tsx
@@ -48,7 +48,7 @@ describe('DockItemButton', () => {
 			/>
 		);
 
-		expect(markup).toContain('disabled=""');
+		expect(markup).toMatch(/<button\b[^>]*\sdisabled(?:="")?(?=\s|>)/);
 	});
 });
 

--- a/packages/playground/website/src/components/dock/dock-item-button.tsx
+++ b/packages/playground/website/src/components/dock/dock-item-button.tsx
@@ -12,6 +12,7 @@ export type DockItemButtonProps = {
 	hasSeparator?: boolean;
 	hasNotification?: boolean;
 	notificationAriaSuffix?: string;
+	disabled?: boolean;
 	dataCy?: string;
 	onClick?: MouseEventHandler<HTMLButtonElement>;
 };
@@ -33,6 +34,7 @@ export const DockItemButton = forwardRef<
 		hasSeparator = false,
 		hasNotification = false,
 		notificationAriaSuffix = 'notification available',
+		disabled = false,
 		dataCy,
 		onClick,
 	},
@@ -57,6 +59,7 @@ export const DockItemButton = forwardRef<
 				})}
 				aria-label={buttonAriaLabel}
 				aria-pressed={isActive}
+				disabled={disabled}
 				onClick={onClick}
 				data-cy={dataCy}
 			>

--- a/packages/playground/website/src/components/dock/dock-pane.spec.tsx
+++ b/packages/playground/website/src/components/dock/dock-pane.spec.tsx
@@ -32,6 +32,21 @@ describe('DockPane', () => {
 		expect(markup).toContain('Editor content');
 	});
 
+	it('can replace the description with richer header content', () => {
+		const markup = renderToStaticMarkup(
+			<DockPane
+				title="Blueprint"
+				description="Plain description"
+				headerSubtitle={<a href="/docs">Blueprint documentation</a>}
+			>
+				<p>Editor content</p>
+			</DockPane>
+		);
+
+		expect(markup).toContain('Blueprint documentation');
+		expect(markup).not.toContain('Plain description');
+	});
+
 	it('renders a disabled close button when pane closing is blocked', () => {
 		const markup = renderToStaticMarkup(
 			<DockPane

--- a/packages/playground/website/src/components/dock/dock-pane.tsx
+++ b/packages/playground/website/src/components/dock/dock-pane.tsx
@@ -99,12 +99,17 @@ export const DockPane = forwardRef<HTMLElement, DockPaneProps>(
 					<div className={css.paneHeader}>
 						<div className={css.paneHeaderMain}>
 							<h2>{title}</h2>
-							{headerSubtitle ??
-								(description && (
+							{headerSubtitle !== undefined ? (
+								<div className={css.paneDescription}>
+									{headerSubtitle}
+								</div>
+							) : (
+								description && (
 									<p className={css.paneDescription}>
 										{description}
 									</p>
-								))}
+								)
+							)}
 						</div>
 						{headerAction}
 					</div>

--- a/packages/playground/website/src/components/dock/dock-pane.tsx
+++ b/packages/playground/website/src/components/dock/dock-pane.tsx
@@ -8,6 +8,7 @@ export type DockPaneProps = {
 	title: string;
 	children: ReactNode;
 	description?: string;
+	headerSubtitle?: ReactNode;
 	className?: string;
 	style?: CSSProperties;
 	isEditor?: boolean;
@@ -30,6 +31,7 @@ export const DockPane = forwardRef<HTMLElement, DockPaneProps>(
 		{
 			title,
 			description,
+			headerSubtitle,
 			children,
 			className,
 			style,
@@ -97,11 +99,12 @@ export const DockPane = forwardRef<HTMLElement, DockPaneProps>(
 					<div className={css.paneHeader}>
 						<div className={css.paneHeaderMain}>
 							<h2>{title}</h2>
-							{description && (
-								<p className={css.paneDescription}>
-									{description}
-								</p>
-							)}
+							{headerSubtitle ??
+								(description && (
+									<p className={css.paneDescription}>
+										{description}
+									</p>
+								))}
 						</div>
 						{headerAction}
 					</div>

--- a/packages/playground/website/src/components/dock/dock-toggle-pill.spec.tsx
+++ b/packages/playground/website/src/components/dock/dock-toggle-pill.spec.tsx
@@ -35,4 +35,23 @@ describe('DockTogglePill', () => {
 		expect(markup).toContain('aria-label="Full width"');
 		expect(markup).toContain('aria-pressed="false"');
 	});
+
+	it('can disable collapsing without disabling full-width mode', () => {
+		const markup = renderToStaticMarkup(
+			<DockTogglePill
+				isCollapsed={false}
+				isFullWidth={false}
+				collapseDisabled
+				onToggleCollapsed={() => {}}
+				onToggleFullWidth={() => {}}
+			/>
+		);
+
+		expect(markup).toContain('title="Tools cannot be hidden right now"');
+		expect(countMatches(markup, 'disabled=""')).toBe(1);
+	});
 });
+
+function countMatches(value: string, substring: string) {
+	return value.split(substring).length - 1;
+}

--- a/packages/playground/website/src/components/dock/dock-toggle-pill.spec.tsx
+++ b/packages/playground/website/src/components/dock/dock-toggle-pill.spec.tsx
@@ -48,10 +48,12 @@ describe('DockTogglePill', () => {
 		);
 
 		expect(markup).toContain('title="Tools cannot be hidden right now"');
-		expect(countMatches(markup, 'disabled=""')).toBe(1);
+		expect(markup).toContain(
+			'aria-label="Tools cannot be hidden right now"'
+		);
+		const buttons = markup.match(/<button\b[^>]*>/g);
+		expect(buttons).toHaveLength(2);
+		expect(buttons?.[0]).toMatch(/\sdisabled(?:="")?(?=\s|>)/);
+		expect(buttons?.[1]).not.toMatch(/\sdisabled(?:="")?(?=\s|>)/);
 	});
 });
-
-function countMatches(value: string, substring: string) {
-	return value.split(substring).length - 1;
-}

--- a/packages/playground/website/src/components/dock/dock-toggle-pill.tsx
+++ b/packages/playground/website/src/components/dock/dock-toggle-pill.tsx
@@ -10,6 +10,7 @@ import css from './style.module.css';
 export type DockTogglePillProps = {
 	isCollapsed: boolean;
 	isFullWidth: boolean;
+	collapseDisabled?: boolean;
 	collapseButtonRef?: Ref<HTMLButtonElement>;
 	onToggleCollapsed: MouseEventHandler<HTMLButtonElement>;
 	onToggleFullWidth: MouseEventHandler<HTMLButtonElement>;
@@ -22,6 +23,7 @@ export type DockTogglePillProps = {
 export function DockTogglePill({
 	isCollapsed,
 	isFullWidth,
+	collapseDisabled = false,
 	collapseButtonRef,
 	onToggleCollapsed,
 	onToggleFullWidth,
@@ -36,7 +38,14 @@ export function DockTogglePill({
 				})}
 				aria-label={isCollapsed ? 'Show tools' : 'Hide tools'}
 				aria-expanded={!isCollapsed}
-				title={isCollapsed ? 'Show tools' : 'Hide tools'}
+				title={
+					collapseDisabled
+						? 'Tools cannot be hidden right now'
+						: isCollapsed
+							? 'Show tools'
+							: 'Hide tools'
+				}
+				disabled={collapseDisabled}
 				onClick={onToggleCollapsed}
 			>
 				<DockCollapseChevronIcon />

--- a/packages/playground/website/src/components/dock/dock-toggle-pill.tsx
+++ b/packages/playground/website/src/components/dock/dock-toggle-pill.tsx
@@ -28,6 +28,12 @@ export function DockTogglePill({
 	onToggleCollapsed,
 	onToggleFullWidth,
 }: DockTogglePillProps) {
+	const collapseButtonLabel = collapseDisabled
+		? 'Tools cannot be hidden right now'
+		: isCollapsed
+			? 'Show tools'
+			: 'Hide tools';
+
 	return (
 		<div className={css.dockTogglePill}>
 			<button
@@ -36,15 +42,9 @@ export function DockTogglePill({
 				className={classNames(css.dockPillBtn, css.dockPillCollapse, {
 					[css.dockPillCollapseClosed]: isCollapsed,
 				})}
-				aria-label={isCollapsed ? 'Show tools' : 'Hide tools'}
+				aria-label={collapseButtonLabel}
 				aria-expanded={!isCollapsed}
-				title={
-					collapseDisabled
-						? 'Tools cannot be hidden right now'
-						: isCollapsed
-							? 'Show tools'
-							: 'Hide tools'
-				}
+				title={collapseButtonLabel}
 				disabled={collapseDisabled}
 				onClick={onToggleCollapsed}
 			>

--- a/packages/playground/website/src/components/dock/style.module.css
+++ b/packages/playground/website/src/components/dock/style.module.css
@@ -40,6 +40,16 @@
 	color: #f7f5f2;
 }
 
+.dock-item:disabled {
+	color: rgba(247, 245, 242, 0.4);
+	cursor: default;
+}
+
+.dock-item:disabled:hover {
+	background: transparent;
+	color: rgba(247, 245, 242, 0.4);
+}
+
 .dock-item-active {
 	background: rgba(247, 245, 242, 0.22);
 	color: #ffffff;
@@ -117,6 +127,16 @@
 .dock-pill-btn:hover {
 	background: rgba(247, 245, 242, 0.14);
 	color: #ffffff;
+}
+
+.dock-pill-btn:disabled {
+	color: rgba(247, 245, 242, 0.4);
+	cursor: default;
+}
+
+.dock-pill-btn:disabled:hover {
+	background: transparent;
+	color: rgba(247, 245, 242, 0.4);
 }
 
 .dock-pill-btn:focus-visible {


### PR DESCRIPTION
This PR lets Dock buttons be disabled and lets pane subtitles contain React content.

The Dock needs to disable tool buttons and its collapse button while some actions are running. Those buttons did not accept a disabled state. Pane subtitles also accepted only plain text, so they could not contain a documentation link.

Add disabled props and disabled styles to the Dock buttons. Add a `headerSubtitle` prop that accepts React content and keeps the normal subtitle spacing and text style. No current caller uses the new props.

These props are needed by the Dock work in #3965.

Verified with `npm exec nx test playground-website --output-style=static` and `npm exec nx typecheck playground-website --output-style=static`.
