### PR TITLE
[PHP-WASM] Close child stdin when proc_open omits descriptor 0

### DIFF
--- a/packages/php-wasm/compile/php/phpwasm-emscripten-library.js
+++ b/packages/php-wasm/compile/php/phpwasm-emscripten-library.js
@@ -945,6 +945,13 @@ const LibraryExample = {
 				// callbacks.
 				const interval = setInterval(pump, 20);
 				pump();
+			} else {
+				/**
+				 * Descriptor 0 was not provided, so the child process must observe EOF.
+				 * Closing stdin explicitly lets spawn handlers distinguish that case from
+				 * a valid pipe whose first bytes have not arrived yet.
+				 */
+				cp.stdin.end();
 			}
 
 			return ProcInfo.pid;

--- a/packages/php-wasm/node-builds/5-2/asyncify/php_5_2.js
+++ b/packages/php-wasm/node-builds/5-2/asyncify/php_5_2.js
@@ -6145,7 +6145,7 @@ export function init(RuntimeName, PHPLoader) {
 		O_NONBLOCK: 2048,
 		POLLHUP: 16,
 		SETFL_MASK: 3072,
-		socketTimeouts: new Map(),
+		socketTimeouts: new Map,
 		init: function () {
 			// TODO: Move this to a library function that is made an onInit callback by the `__postset` suffix.
 			if (PHPLoader.bindUserSpace) {

--- a/packages/php-wasm/node-builds/5-2/asyncify/php_5_2.js
+++ b/packages/php-wasm/node-builds/5-2/asyncify/php_5_2.js
@@ -6145,7 +6145,7 @@ export function init(RuntimeName, PHPLoader) {
 		O_NONBLOCK: 2048,
 		POLLHUP: 16,
 		SETFL_MASK: 3072,
-		socketTimeouts: new Map,
+		socketTimeouts: new Map(),
 		init: function () {
 			// TODO: Move this to a library function that is made an onInit callback by the `__postset` suffix.
 			if (PHPLoader.bindUserSpace) {
@@ -9185,6 +9185,13 @@ export function init(RuntimeName, PHPLoader) {
 				// callbacks.
 				const interval = setInterval(pump, 20);
 				pump();
+			} else {
+				/**
+				 * Descriptor 0 was not provided, so the child process must observe EOF.
+				 * Closing stdin explicitly lets spawn handlers distinguish that case from
+				 * a valid pipe whose first bytes have not arrived yet.
+				 */
+				cp.stdin.end();
 			}
 			return ProcInfo.pid;
 		});

--- a/packages/php-wasm/node-builds/5-2/jspi/php_5_2.js
+++ b/packages/php-wasm/node-builds/5-2/jspi/php_5_2.js
@@ -6086,7 +6086,7 @@ export function init(RuntimeName, PHPLoader) {
 		O_NONBLOCK: 2048,
 		POLLHUP: 16,
 		SETFL_MASK: 3072,
-		socketTimeouts: new Map,
+		socketTimeouts: new Map(),
 		init: function () {
 			// TODO: Move this to a library function that is made an onInit callback by the `__postset` suffix.
 			if (PHPLoader.bindUserSpace) {
@@ -9120,6 +9120,13 @@ export function init(RuntimeName, PHPLoader) {
 				// callbacks.
 				const interval = setInterval(pump, 20);
 				pump();
+			} else {
+				/**
+				 * Descriptor 0 was not provided, so the child process must observe EOF.
+				 * Closing stdin explicitly lets spawn handlers distinguish that case from
+				 * a valid pipe whose first bytes have not arrived yet.
+				 */
+				cp.stdin.end();
 			}
 			return ProcInfo.pid;
 		});

--- a/packages/php-wasm/node-builds/5-2/jspi/php_5_2.js
+++ b/packages/php-wasm/node-builds/5-2/jspi/php_5_2.js
@@ -6086,7 +6086,7 @@ export function init(RuntimeName, PHPLoader) {
 		O_NONBLOCK: 2048,
 		POLLHUP: 16,
 		SETFL_MASK: 3072,
-		socketTimeouts: new Map(),
+		socketTimeouts: new Map,
 		init: function () {
 			// TODO: Move this to a library function that is made an onInit callback by the `__postset` suffix.
 			if (PHPLoader.bindUserSpace) {

--- a/packages/php-wasm/node-builds/7-4/asyncify/php_7_4.js
+++ b/packages/php-wasm/node-builds/7-4/asyncify/php_7_4.js
@@ -9416,6 +9416,13 @@ export function init(RuntimeName, PHPLoader) {
 				// callbacks.
 				const interval = setInterval(pump, 20);
 				pump();
+			} else {
+				/**
+				 * Descriptor 0 was not provided, so the child process must observe EOF.
+				 * Closing stdin explicitly lets spawn handlers distinguish that case from
+				 * a valid pipe whose first bytes have not arrived yet.
+				 */
+				cp.stdin.end();
 			}
 			return ProcInfo.pid;
 		});

--- a/packages/php-wasm/node-builds/7-4/jspi/php_7_4.js
+++ b/packages/php-wasm/node-builds/7-4/jspi/php_7_4.js
@@ -9291,6 +9291,13 @@ export function init(RuntimeName, PHPLoader) {
 				// callbacks.
 				const interval = setInterval(pump, 20);
 				pump();
+			} else {
+				/**
+				 * Descriptor 0 was not provided, so the child process must observe EOF.
+				 * Closing stdin explicitly lets spawn handlers distinguish that case from
+				 * a valid pipe whose first bytes have not arrived yet.
+				 */
+				cp.stdin.end();
 			}
 			return ProcInfo.pid;
 		});

--- a/packages/php-wasm/node-builds/8-0/asyncify/php_8_0.js
+++ b/packages/php-wasm/node-builds/8-0/asyncify/php_8_0.js
@@ -9416,6 +9416,13 @@ export function init(RuntimeName, PHPLoader) {
 				// callbacks.
 				const interval = setInterval(pump, 20);
 				pump();
+			} else {
+				/**
+				 * Descriptor 0 was not provided, so the child process must observe EOF.
+				 * Closing stdin explicitly lets spawn handlers distinguish that case from
+				 * a valid pipe whose first bytes have not arrived yet.
+				 */
+				cp.stdin.end();
 			}
 			return ProcInfo.pid;
 		});

--- a/packages/php-wasm/node-builds/8-0/jspi/php_8_0.js
+++ b/packages/php-wasm/node-builds/8-0/jspi/php_8_0.js
@@ -9291,6 +9291,13 @@ export function init(RuntimeName, PHPLoader) {
 				// callbacks.
 				const interval = setInterval(pump, 20);
 				pump();
+			} else {
+				/**
+				 * Descriptor 0 was not provided, so the child process must observe EOF.
+				 * Closing stdin explicitly lets spawn handlers distinguish that case from
+				 * a valid pipe whose first bytes have not arrived yet.
+				 */
+				cp.stdin.end();
 			}
 			return ProcInfo.pid;
 		});

--- a/packages/php-wasm/node-builds/8-1/asyncify/php_8_1.js
+++ b/packages/php-wasm/node-builds/8-1/asyncify/php_8_1.js
@@ -9430,6 +9430,13 @@ export function init(RuntimeName, PHPLoader) {
 				// callbacks.
 				const interval = setInterval(pump, 20);
 				pump();
+			} else {
+				/**
+				 * Descriptor 0 was not provided, so the child process must observe EOF.
+				 * Closing stdin explicitly lets spawn handlers distinguish that case from
+				 * a valid pipe whose first bytes have not arrived yet.
+				 */
+				cp.stdin.end();
 			}
 			return ProcInfo.pid;
 		});

--- a/packages/php-wasm/node-builds/8-1/jspi/php_8_1.js
+++ b/packages/php-wasm/node-builds/8-1/jspi/php_8_1.js
@@ -9305,6 +9305,13 @@ export function init(RuntimeName, PHPLoader) {
 				// callbacks.
 				const interval = setInterval(pump, 20);
 				pump();
+			} else {
+				/**
+				 * Descriptor 0 was not provided, so the child process must observe EOF.
+				 * Closing stdin explicitly lets spawn handlers distinguish that case from
+				 * a valid pipe whose first bytes have not arrived yet.
+				 */
+				cp.stdin.end();
 			}
 			return ProcInfo.pid;
 		});

--- a/packages/php-wasm/node-builds/8-2/asyncify/php_8_2.js
+++ b/packages/php-wasm/node-builds/8-2/asyncify/php_8_2.js
@@ -9432,6 +9432,13 @@ export function init(RuntimeName, PHPLoader) {
 				// callbacks.
 				const interval = setInterval(pump, 20);
 				pump();
+			} else {
+				/**
+				 * Descriptor 0 was not provided, so the child process must observe EOF.
+				 * Closing stdin explicitly lets spawn handlers distinguish that case from
+				 * a valid pipe whose first bytes have not arrived yet.
+				 */
+				cp.stdin.end();
 			}
 			return ProcInfo.pid;
 		});

--- a/packages/php-wasm/node-builds/8-2/jspi/php_8_2.js
+++ b/packages/php-wasm/node-builds/8-2/jspi/php_8_2.js
@@ -9307,6 +9307,13 @@ export function init(RuntimeName, PHPLoader) {
 				// callbacks.
 				const interval = setInterval(pump, 20);
 				pump();
+			} else {
+				/**
+				 * Descriptor 0 was not provided, so the child process must observe EOF.
+				 * Closing stdin explicitly lets spawn handlers distinguish that case from
+				 * a valid pipe whose first bytes have not arrived yet.
+				 */
+				cp.stdin.end();
 			}
 			return ProcInfo.pid;
 		});

--- a/packages/php-wasm/node-builds/8-3/asyncify/php_8_3.js
+++ b/packages/php-wasm/node-builds/8-3/asyncify/php_8_3.js
@@ -9432,6 +9432,13 @@ export function init(RuntimeName, PHPLoader) {
 				// callbacks.
 				const interval = setInterval(pump, 20);
 				pump();
+			} else {
+				/**
+				 * Descriptor 0 was not provided, so the child process must observe EOF.
+				 * Closing stdin explicitly lets spawn handlers distinguish that case from
+				 * a valid pipe whose first bytes have not arrived yet.
+				 */
+				cp.stdin.end();
 			}
 			return ProcInfo.pid;
 		});

--- a/packages/php-wasm/node-builds/8-3/jspi/php_8_3.js
+++ b/packages/php-wasm/node-builds/8-3/jspi/php_8_3.js
@@ -9307,6 +9307,13 @@ export function init(RuntimeName, PHPLoader) {
 				// callbacks.
 				const interval = setInterval(pump, 20);
 				pump();
+			} else {
+				/**
+				 * Descriptor 0 was not provided, so the child process must observe EOF.
+				 * Closing stdin explicitly lets spawn handlers distinguish that case from
+				 * a valid pipe whose first bytes have not arrived yet.
+				 */
+				cp.stdin.end();
 			}
 			return ProcInfo.pid;
 		});

--- a/packages/php-wasm/node-builds/8-4/asyncify/php_8_4.js
+++ b/packages/php-wasm/node-builds/8-4/asyncify/php_8_4.js
@@ -9432,6 +9432,13 @@ export function init(RuntimeName, PHPLoader) {
 				// callbacks.
 				const interval = setInterval(pump, 20);
 				pump();
+			} else {
+				/**
+				 * Descriptor 0 was not provided, so the child process must observe EOF.
+				 * Closing stdin explicitly lets spawn handlers distinguish that case from
+				 * a valid pipe whose first bytes have not arrived yet.
+				 */
+				cp.stdin.end();
 			}
 			return ProcInfo.pid;
 		});

--- a/packages/php-wasm/node-builds/8-4/jspi/php_8_4.js
+++ b/packages/php-wasm/node-builds/8-4/jspi/php_8_4.js
@@ -9307,6 +9307,13 @@ export function init(RuntimeName, PHPLoader) {
 				// callbacks.
 				const interval = setInterval(pump, 20);
 				pump();
+			} else {
+				/**
+				 * Descriptor 0 was not provided, so the child process must observe EOF.
+				 * Closing stdin explicitly lets spawn handlers distinguish that case from
+				 * a valid pipe whose first bytes have not arrived yet.
+				 */
+				cp.stdin.end();
 			}
 			return ProcInfo.pid;
 		});

--- a/packages/php-wasm/node-builds/8-5/asyncify/php_8_5.js
+++ b/packages/php-wasm/node-builds/8-5/asyncify/php_8_5.js
@@ -9432,6 +9432,13 @@ export function init(RuntimeName, PHPLoader) {
 				// callbacks.
 				const interval = setInterval(pump, 20);
 				pump();
+			} else {
+				/**
+				 * Descriptor 0 was not provided, so the child process must observe EOF.
+				 * Closing stdin explicitly lets spawn handlers distinguish that case from
+				 * a valid pipe whose first bytes have not arrived yet.
+				 */
+				cp.stdin.end();
 			}
 			return ProcInfo.pid;
 		});

--- a/packages/php-wasm/node-builds/8-5/jspi/php_8_5.js
+++ b/packages/php-wasm/node-builds/8-5/jspi/php_8_5.js
@@ -9307,6 +9307,13 @@ export function init(RuntimeName, PHPLoader) {
 				// callbacks.
 				const interval = setInterval(pump, 20);
 				pump();
+			} else {
+				/**
+				 * Descriptor 0 was not provided, so the child process must observe EOF.
+				 * Closing stdin explicitly lets spawn handlers distinguish that case from
+				 * a valid pipe whose first bytes have not arrived yet.
+				 */
+				cp.stdin.end();
 			}
 			return ProcInfo.pid;
 		});

--- a/packages/php-wasm/node/src/test/php-part-1.spec.ts
+++ b/packages/php-wasm/node/src/test/php-part-1.spec.ts
@@ -728,6 +728,46 @@ phpLoaderOptions.forEach((options) => {
 		});
 
 		describe('proc_open()', () => {
+			it('closes child stdin when descriptor 0 is omitted', async () => {
+				let stdinFinished = false;
+				const handler = createSpawnHandler(
+					async (command: string[], processApi: any) => {
+						const stdin = processApi.childProcess.stdin;
+						stdinFinished =
+							stdin.ended ||
+							(await new Promise<boolean>((resolve) => {
+								const timeout = setTimeout(
+									() => resolve(false),
+									1000
+								);
+								stdin.once('finish', () => {
+									clearTimeout(timeout);
+									resolve(true);
+								});
+							}));
+						processApi.exit(stdinFinished ? 0 : 1);
+					}
+				);
+				php.setSpawnHandler(handler);
+
+				const result = await php.run({
+					code: `<?php
+						$proc = proc_open(
+							"wait-for-stdin-eof",
+							array(
+								1 => array("pipe", "w"),
+								2 => array("pipe", "w"),
+							),
+							$pipes
+						);
+						echo proc_close($proc);
+					`,
+				});
+
+				expect(result.text).toBe('0');
+				expect(stdinFinished).toBe(true);
+			});
+
 			it('resolves without crashing with unknown function signature mismatch', async () => {
 				const promise = php.runStream({
 					code: `<?php

--- a/packages/php-wasm/web-builds/5-2/asyncify/php_5_2.js
+++ b/packages/php-wasm/web-builds/5-2/asyncify/php_5_2.js
@@ -4716,7 +4716,7 @@ export function init(RuntimeName, PHPLoader) {
 		O_NONBLOCK: 2048,
 		POLLHUP: 16,
 		SETFL_MASK: 3072,
-		socketTimeouts: new Map(),
+		socketTimeouts: new Map,
 		init: function () {
 			if (PHPLoader.bindUserSpace) {
 				addOnInit(() => {

--- a/packages/php-wasm/web-builds/5-2/asyncify/php_5_2.js
+++ b/packages/php-wasm/web-builds/5-2/asyncify/php_5_2.js
@@ -4716,7 +4716,7 @@ export function init(RuntimeName, PHPLoader) {
 		O_NONBLOCK: 2048,
 		POLLHUP: 16,
 		SETFL_MASK: 3072,
-		socketTimeouts: new Map,
+		socketTimeouts: new Map(),
 		init: function () {
 			if (PHPLoader.bindUserSpace) {
 				addOnInit(() => {
@@ -7192,6 +7192,13 @@ export function init(RuntimeName, PHPLoader) {
 				}
 				const interval = setInterval(pump, 20);
 				pump();
+			} else {
+				/**
+				 * Descriptor 0 was not provided, so the child process must observe EOF.
+				 * Closing stdin explicitly lets spawn handlers distinguish that case from
+				 * a valid pipe whose first bytes have not arrived yet.
+				 */
+				cp.stdin.end();
 			}
 			return ProcInfo.pid;
 		});

--- a/packages/php-wasm/web-builds/5-2/jspi/php_5_2.js
+++ b/packages/php-wasm/web-builds/5-2/jspi/php_5_2.js
@@ -4673,7 +4673,7 @@ export function init(RuntimeName, PHPLoader) {
 		O_NONBLOCK: 2048,
 		POLLHUP: 16,
 		SETFL_MASK: 3072,
-		socketTimeouts: new Map(),
+		socketTimeouts: new Map,
 		init: function () {
 			if (PHPLoader.bindUserSpace) {
 				addOnInit(() => {

--- a/packages/php-wasm/web-builds/5-2/jspi/php_5_2.js
+++ b/packages/php-wasm/web-builds/5-2/jspi/php_5_2.js
@@ -4673,7 +4673,7 @@ export function init(RuntimeName, PHPLoader) {
 		O_NONBLOCK: 2048,
 		POLLHUP: 16,
 		SETFL_MASK: 3072,
-		socketTimeouts: new Map,
+		socketTimeouts: new Map(),
 		init: function () {
 			if (PHPLoader.bindUserSpace) {
 				addOnInit(() => {
@@ -7145,6 +7145,13 @@ export function init(RuntimeName, PHPLoader) {
 				}
 				const interval = setInterval(pump, 20);
 				pump();
+			} else {
+				/**
+				 * Descriptor 0 was not provided, so the child process must observe EOF.
+				 * Closing stdin explicitly lets spawn handlers distinguish that case from
+				 * a valid pipe whose first bytes have not arrived yet.
+				 */
+				cp.stdin.end();
 			}
 			return ProcInfo.pid;
 		});

--- a/packages/php-wasm/web-builds/7-4/asyncify/php_7_4.js
+++ b/packages/php-wasm/web-builds/7-4/asyncify/php_7_4.js
@@ -7207,6 +7207,13 @@ export function init(RuntimeName, PHPLoader) {
 				}
 				const interval = setInterval(pump, 20);
 				pump();
+			} else {
+				/**
+				 * Descriptor 0 was not provided, so the child process must observe EOF.
+				 * Closing stdin explicitly lets spawn handlers distinguish that case from
+				 * a valid pipe whose first bytes have not arrived yet.
+				 */
+				cp.stdin.end();
 			}
 			return ProcInfo.pid;
 		});

--- a/packages/php-wasm/web-builds/7-4/jspi/php_7_4.js
+++ b/packages/php-wasm/web-builds/7-4/jspi/php_7_4.js
@@ -7160,6 +7160,13 @@ export function init(RuntimeName, PHPLoader) {
 				}
 				const interval = setInterval(pump, 20);
 				pump();
+			} else {
+				/**
+				 * Descriptor 0 was not provided, so the child process must observe EOF.
+				 * Closing stdin explicitly lets spawn handlers distinguish that case from
+				 * a valid pipe whose first bytes have not arrived yet.
+				 */
+				cp.stdin.end();
 			}
 			return ProcInfo.pid;
 		});

--- a/packages/php-wasm/web-builds/8-0/asyncify/php_8_0.js
+++ b/packages/php-wasm/web-builds/8-0/asyncify/php_8_0.js
@@ -7207,6 +7207,13 @@ export function init(RuntimeName, PHPLoader) {
 				}
 				const interval = setInterval(pump, 20);
 				pump();
+			} else {
+				/**
+				 * Descriptor 0 was not provided, so the child process must observe EOF.
+				 * Closing stdin explicitly lets spawn handlers distinguish that case from
+				 * a valid pipe whose first bytes have not arrived yet.
+				 */
+				cp.stdin.end();
 			}
 			return ProcInfo.pid;
 		});

--- a/packages/php-wasm/web-builds/8-0/jspi/php_8_0.js
+++ b/packages/php-wasm/web-builds/8-0/jspi/php_8_0.js
@@ -7160,6 +7160,13 @@ export function init(RuntimeName, PHPLoader) {
 				}
 				const interval = setInterval(pump, 20);
 				pump();
+			} else {
+				/**
+				 * Descriptor 0 was not provided, so the child process must observe EOF.
+				 * Closing stdin explicitly lets spawn handlers distinguish that case from
+				 * a valid pipe whose first bytes have not arrived yet.
+				 */
+				cp.stdin.end();
 			}
 			return ProcInfo.pid;
 		});

--- a/packages/php-wasm/web-builds/8-1/asyncify/php_8_1.js
+++ b/packages/php-wasm/web-builds/8-1/asyncify/php_8_1.js
@@ -7218,6 +7218,13 @@ export function init(RuntimeName, PHPLoader) {
 				}
 				const interval = setInterval(pump, 20);
 				pump();
+			} else {
+				/**
+				 * Descriptor 0 was not provided, so the child process must observe EOF.
+				 * Closing stdin explicitly lets spawn handlers distinguish that case from
+				 * a valid pipe whose first bytes have not arrived yet.
+				 */
+				cp.stdin.end();
 			}
 			return ProcInfo.pid;
 		});

--- a/packages/php-wasm/web-builds/8-1/jspi/php_8_1.js
+++ b/packages/php-wasm/web-builds/8-1/jspi/php_8_1.js
@@ -7171,6 +7171,13 @@ export function init(RuntimeName, PHPLoader) {
 				}
 				const interval = setInterval(pump, 20);
 				pump();
+			} else {
+				/**
+				 * Descriptor 0 was not provided, so the child process must observe EOF.
+				 * Closing stdin explicitly lets spawn handlers distinguish that case from
+				 * a valid pipe whose first bytes have not arrived yet.
+				 */
+				cp.stdin.end();
 			}
 			return ProcInfo.pid;
 		});

--- a/packages/php-wasm/web-builds/8-2/asyncify/php_8_2.js
+++ b/packages/php-wasm/web-builds/8-2/asyncify/php_8_2.js
@@ -7219,6 +7219,13 @@ export function init(RuntimeName, PHPLoader) {
 				}
 				const interval = setInterval(pump, 20);
 				pump();
+			} else {
+				/**
+				 * Descriptor 0 was not provided, so the child process must observe EOF.
+				 * Closing stdin explicitly lets spawn handlers distinguish that case from
+				 * a valid pipe whose first bytes have not arrived yet.
+				 */
+				cp.stdin.end();
 			}
 			return ProcInfo.pid;
 		});

--- a/packages/php-wasm/web-builds/8-2/jspi/php_8_2.js
+++ b/packages/php-wasm/web-builds/8-2/jspi/php_8_2.js
@@ -7172,6 +7172,13 @@ export function init(RuntimeName, PHPLoader) {
 				}
 				const interval = setInterval(pump, 20);
 				pump();
+			} else {
+				/**
+				 * Descriptor 0 was not provided, so the child process must observe EOF.
+				 * Closing stdin explicitly lets spawn handlers distinguish that case from
+				 * a valid pipe whose first bytes have not arrived yet.
+				 */
+				cp.stdin.end();
 			}
 			return ProcInfo.pid;
 		});

--- a/packages/php-wasm/web-builds/8-3/asyncify/php_8_3.js
+++ b/packages/php-wasm/web-builds/8-3/asyncify/php_8_3.js
@@ -7219,6 +7219,13 @@ export function init(RuntimeName, PHPLoader) {
 				}
 				const interval = setInterval(pump, 20);
 				pump();
+			} else {
+				/**
+				 * Descriptor 0 was not provided, so the child process must observe EOF.
+				 * Closing stdin explicitly lets spawn handlers distinguish that case from
+				 * a valid pipe whose first bytes have not arrived yet.
+				 */
+				cp.stdin.end();
 			}
 			return ProcInfo.pid;
 		});

--- a/packages/php-wasm/web-builds/8-3/jspi/php_8_3.js
+++ b/packages/php-wasm/web-builds/8-3/jspi/php_8_3.js
@@ -7172,6 +7172,13 @@ export function init(RuntimeName, PHPLoader) {
 				}
 				const interval = setInterval(pump, 20);
 				pump();
+			} else {
+				/**
+				 * Descriptor 0 was not provided, so the child process must observe EOF.
+				 * Closing stdin explicitly lets spawn handlers distinguish that case from
+				 * a valid pipe whose first bytes have not arrived yet.
+				 */
+				cp.stdin.end();
 			}
 			return ProcInfo.pid;
 		});

--- a/packages/php-wasm/web-builds/8-4/asyncify/php_8_4.js
+++ b/packages/php-wasm/web-builds/8-4/asyncify/php_8_4.js
@@ -7219,6 +7219,13 @@ export function init(RuntimeName, PHPLoader) {
 				}
 				const interval = setInterval(pump, 20);
 				pump();
+			} else {
+				/**
+				 * Descriptor 0 was not provided, so the child process must observe EOF.
+				 * Closing stdin explicitly lets spawn handlers distinguish that case from
+				 * a valid pipe whose first bytes have not arrived yet.
+				 */
+				cp.stdin.end();
 			}
 			return ProcInfo.pid;
 		});

--- a/packages/php-wasm/web-builds/8-4/jspi/php_8_4.js
+++ b/packages/php-wasm/web-builds/8-4/jspi/php_8_4.js
@@ -7172,6 +7172,13 @@ export function init(RuntimeName, PHPLoader) {
 				}
 				const interval = setInterval(pump, 20);
 				pump();
+			} else {
+				/**
+				 * Descriptor 0 was not provided, so the child process must observe EOF.
+				 * Closing stdin explicitly lets spawn handlers distinguish that case from
+				 * a valid pipe whose first bytes have not arrived yet.
+				 */
+				cp.stdin.end();
 			}
 			return ProcInfo.pid;
 		});

--- a/packages/php-wasm/web-builds/8-5/asyncify/php_8_5.js
+++ b/packages/php-wasm/web-builds/8-5/asyncify/php_8_5.js
@@ -7219,6 +7219,13 @@ export function init(RuntimeName, PHPLoader) {
 				}
 				const interval = setInterval(pump, 20);
 				pump();
+			} else {
+				/**
+				 * Descriptor 0 was not provided, so the child process must observe EOF.
+				 * Closing stdin explicitly lets spawn handlers distinguish that case from
+				 * a valid pipe whose first bytes have not arrived yet.
+				 */
+				cp.stdin.end();
 			}
 			return ProcInfo.pid;
 		});

--- a/packages/php-wasm/web-builds/8-5/jspi/php_8_5.js
+++ b/packages/php-wasm/web-builds/8-5/jspi/php_8_5.js
@@ -7172,6 +7172,13 @@ export function init(RuntimeName, PHPLoader) {
 				}
 				const interval = setInterval(pump, 20);
 				pump();
+			} else {
+				/**
+				 * Descriptor 0 was not provided, so the child process must observe EOF.
+				 * Closing stdin explicitly lets spawn handlers distinguish that case from
+				 * a valid pipe whose first bytes have not arrived yet.
+				 */
+				cp.stdin.end();
 			}
 			return ProcInfo.pid;
 		});


### PR DESCRIPTION
`proc_open()` may omit descriptor 0. The PHP spawn bridge currently leaves the JavaScript child process's stdin open in that case. A spawn handler waiting for EOF cannot distinguish the missing descriptor from a valid pipe whose first bytes have not arrived, so it either hangs or invents a timeout.

Close child stdin when descriptor 0 is absent. The source change lives in the Emscripten library; the committed Node and web `php.js` artifacts are regenerated for every Asyncify and JSPI build.

The regression test runs `proc_open()` with only stdout and stderr descriptors and requires the spawn handler to observe stdin completion. It failed before this change and passes across PHP 7.4–8.5 with both Asyncify and JSPI.
