### PR TITLE
[Website] Define Dock pane and notice positioning

### DIFF
--- a/packages/playground/website/src/components/dock/dock-positioning.spec.ts
+++ b/packages/playground/website/src/components/dock/dock-positioning.spec.ts
@@ -1,0 +1,136 @@
+import {
+	DOCK_PANE_GAP,
+	DOCK_PANE_MIN_HEIGHT,
+	getDockOperationToastStyle,
+	getDockPaneCenter,
+	getDockPaneStyle,
+} from './dock-positioning';
+
+describe('Dock positioning', () => {
+	it('waits for the Dock height before positioning a pane or toast', () => {
+		expect(
+			getDockPaneStyle({
+				isMobile: false,
+				dockSize: { width: 800, height: 0 },
+				dockCenter: null,
+				viewportSize: { width: 1200, height: 800 },
+				isEditorSection: false,
+				isFixedHeightSection: false,
+				isPlaygroundsSection: false,
+			})
+		).toBeUndefined();
+		expect(
+			getDockOperationToastStyle({
+				isMobile: false,
+				dockSize: { width: 800, height: 0 },
+				toolsHeight: 60,
+				isCollapsed: false,
+				dockCenter: null,
+				viewportSize: { width: 1200, height: 800 },
+				paneHeight: 400,
+				toastHeight: 62,
+				paneOpen: false,
+				isEditorSection: false,
+			})
+		).toBeUndefined();
+	});
+
+	it('uses the minimum desktop pane height when the viewport is too short', () => {
+		expect(
+			getDockPaneStyle({
+				isMobile: false,
+				dockSize: { width: 800, height: 80 },
+				dockCenter: null,
+				viewportSize: { width: 1200, height: 100 },
+				isEditorSection: false,
+				isFixedHeightSection: false,
+				isPlaygroundsSection: false,
+			})
+		).toMatchObject({ maxHeight: `${DOCK_PANE_MIN_HEIGHT}px` });
+	});
+
+	it('passes the measured Dock height to the mobile pane', () => {
+		expect(
+			getDockPaneStyle({
+				isMobile: true,
+				dockSize: { width: 390, height: 72 },
+				dockCenter: null,
+				viewportSize: { width: 390, height: 844 },
+				isEditorSection: false,
+				isFixedHeightSection: false,
+				isPlaygroundsSection: false,
+			})
+		).toEqual({ '--dock-height': '72px' });
+	});
+
+	it('keeps desktop panes above the Dock and inside the viewport', () => {
+		expect(
+			getDockPaneStyle({
+				isMobile: false,
+				dockSize: { width: 800, height: 80 },
+				dockCenter: 100,
+				viewportSize: { width: 1200, height: 800 },
+				isEditorSection: false,
+				isFixedHeightSection: true,
+				isPlaygroundsSection: true,
+			})
+		).toEqual({
+			left: '308px',
+			bottom: `${80 + DOCK_PANE_GAP}px`,
+			top: 'auto',
+			maxHeight: '560px',
+			height: '560px',
+		});
+	});
+
+	it('keeps operation notices visible above an open pane', () => {
+		expect(
+			getDockOperationToastStyle({
+				isMobile: false,
+				dockSize: { width: 800, height: 80 },
+				toolsHeight: 60,
+				isCollapsed: false,
+				dockCenter: 100,
+				viewportSize: { width: 1200, height: 800 },
+				paneHeight: 400,
+				toastHeight: 62,
+				paneOpen: true,
+				isEditorSection: false,
+			})
+		).toEqual({ bottom: '504px', left: '308px' });
+	});
+
+	it('centers operation notices when the viewport is narrower than its gaps', () => {
+		expect(
+			getDockOperationToastStyle({
+				isMobile: false,
+				dockSize: { width: 10, height: 80 },
+				toolsHeight: 60,
+				isCollapsed: false,
+				dockCenter: 0,
+				viewportSize: { width: 10, height: 800 },
+				paneHeight: 0,
+				toastHeight: 62,
+				paneOpen: false,
+				isEditorSection: false,
+			})
+		).toEqual({ bottom: '92px', left: '5px' });
+	});
+
+	it('clamps pane centers at both viewport edges', () => {
+		expect(
+			getDockPaneCenter({
+				dockCenter: 0,
+				viewportWidth: 1200,
+				isEditorSection: false,
+			})
+		).toBe(308);
+		expect(
+			getDockPaneCenter({
+				dockCenter: 1200,
+				viewportWidth: 1200,
+				isEditorSection: false,
+			})
+		).toBe(892);
+	});
+});

--- a/packages/playground/website/src/components/dock/dock-positioning.ts
+++ b/packages/playground/website/src/components/dock/dock-positioning.ts
@@ -1,0 +1,147 @@
+import type { CSSProperties } from 'react';
+
+export const DOCK_DRAG_EDGE = 8;
+export const DOCK_PANE_GAP = 12;
+export const DOCK_PANE_MIN_HEIGHT = 160;
+export const DOCK_OPERATION_TOAST_MIN_HEIGHT = 62;
+
+const LIST_PANE_HEIGHT = 560;
+const OPERATION_TOAST_WIDTH = 520;
+
+type Size = { width: number; height: number };
+
+/** Positions one pane above its Dock, or full-screen above the mobile bar. */
+export function getDockPaneStyle({
+	isMobile,
+	dockSize,
+	dockCenter,
+	viewportSize,
+	isEditorSection,
+	isFixedHeightSection,
+	isPlaygroundsSection,
+}: {
+	isMobile: boolean;
+	dockSize: Size;
+	dockCenter: number | null;
+	viewportSize: Size;
+	isEditorSection: boolean;
+	isFixedHeightSection: boolean;
+	isPlaygroundsSection: boolean;
+}): CSSProperties | undefined {
+	if (!dockSize.height) {
+		return undefined;
+	}
+	if (isMobile) {
+		return {
+			'--dock-height': `${dockSize.height}px`,
+		} as CSSProperties;
+	}
+
+	const dockTop = viewportSize.height - dockSize.height;
+	const center = getDockPaneCenter({
+		dockCenter,
+		viewportWidth: viewportSize.width,
+		isEditorSection,
+	});
+	const availableHeight = Math.max(
+		DOCK_PANE_MIN_HEIGHT,
+		dockTop - DOCK_PANE_GAP - DOCK_DRAG_EDGE
+	);
+	const stableHeight = Math.min(LIST_PANE_HEIGHT, availableHeight);
+	const maxHeight = isPlaygroundsSection ? stableHeight : availableHeight;
+
+	return {
+		left: `${center}px`,
+		bottom: `${dockSize.height + DOCK_PANE_GAP}px`,
+		top: 'auto',
+		maxHeight: `${maxHeight}px`,
+		...(isFixedHeightSection ? { height: `${stableHeight}px` } : {}),
+	};
+}
+
+/** Keeps a global operation failure with the visible Dock surface. */
+export function getDockOperationToastStyle({
+	isMobile,
+	dockSize,
+	toolsHeight,
+	isCollapsed,
+	dockCenter,
+	viewportSize,
+	paneHeight,
+	toastHeight,
+	paneOpen,
+	isEditorSection,
+}: {
+	isMobile: boolean;
+	dockSize: Size;
+	toolsHeight: number;
+	isCollapsed: boolean;
+	dockCenter: number | null;
+	viewportSize: Size;
+	paneHeight: number;
+	toastHeight: number;
+	paneOpen: boolean;
+	isEditorSection: boolean;
+}): CSSProperties | undefined {
+	if (!dockSize.height) {
+		return undefined;
+	}
+
+	const visibleDockHeight = isCollapsed
+		? Math.max(0, dockSize.height - toolsHeight)
+		: dockSize.height;
+	const desiredBottom =
+		visibleDockHeight +
+		DOCK_PANE_GAP +
+		(!isMobile && paneOpen ? paneHeight + DOCK_PANE_GAP : 0);
+	// Editor panes and mobile panes can consume all available space. Keep the
+	// toast reachable at the viewport edge instead of placing it off-screen.
+	const maxBottom = Math.max(
+		DOCK_PANE_GAP,
+		viewportSize.height - DOCK_PANE_GAP - toastHeight
+	);
+	const toastWidth = Math.min(
+		OPERATION_TOAST_WIDTH,
+		Math.max(0, viewportSize.width - 2 * DOCK_PANE_GAP)
+	);
+	const halfToastWidth = toastWidth / 2;
+	const desiredCenter = isMobile
+		? viewportSize.width / 2
+		: getDockPaneCenter({
+				dockCenter,
+				viewportWidth: viewportSize.width,
+				isEditorSection,
+			});
+	const minCenter = halfToastWidth + DOCK_PANE_GAP;
+	const maxCenter = viewportSize.width - halfToastWidth - DOCK_PANE_GAP;
+	const center =
+		maxCenter < minCenter
+			? viewportSize.width / 2
+			: Math.min(Math.max(desiredCenter, minCenter), maxCenter);
+
+	return {
+		bottom: `${Math.min(desiredBottom, maxBottom)}px`,
+		left: `${center}px`,
+	};
+}
+
+/** Centers a pane over a moved Dock without letting it cross the viewport. */
+export function getDockPaneCenter({
+	dockCenter,
+	viewportWidth,
+	isEditorSection,
+}: {
+	dockCenter: number | null;
+	viewportWidth: number;
+	isEditorSection: boolean;
+}) {
+	const desiredCenter = dockCenter ?? viewportWidth / 2;
+	const halfPaneWidth = Math.min(
+		isEditorSection ? 560 : 300,
+		(viewportWidth - 2 * DOCK_DRAG_EDGE) / 2
+	);
+	return Math.min(
+		Math.max(desiredCenter, halfPaneWidth + DOCK_DRAG_EDGE),
+		viewportWidth - halfPaneWidth - DOCK_DRAG_EDGE
+	);
+}


### PR DESCRIPTION
This PR adds the calculations that keep bottom Dock panes and operation notices inside the viewport.

The Dock in #4009 currently performs these calculations inside its main component. That mixes rendering and pointer state with desktop, mobile, narrow-viewport, and open-pane geometry.

The new module calculates pane height and position, clamps panes at both viewport edges, places notices above an open pane, and keeps notices on-screen when a pane consumes most of the viewport. Focused tests lock those boundaries down.

Nothing imports the module yet, so this PR does not change the website UI. #4009 will use it when the rest of the Dock stack lands for #3965.

Tested with:

- `npm exec nx test playground-website -- --testFile=dock-positioning.spec.ts --output-style=static`
- `npm exec nx typecheck playground-website -- --output-style=static`
- `npm exec nx lint playground-website -- --output-style=static`
