### PR TITLE
[Website] Add an inert state and listbox navigation to the address bar

### DIFF
--- a/packages/playground/website/src/components/address-bar/index.spec.tsx
+++ b/packages/playground/website/src/components/address-bar/index.spec.tsx
@@ -1,0 +1,128 @@
+// @vitest-environment jsdom
+
+import { act, type ComponentProps } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import AddressBar from './index';
+
+vi.mock('@wordpress/components', () => ({
+	Icon: () => <svg aria-hidden="true" />,
+	Popover: ({ children }: { children: JSX.Element }) => (
+		<div data-testid="popover">{children}</div>
+	),
+}));
+
+vi.mock('@wordpress/icons', () => ({
+	home: {},
+	layout: {},
+	pin: {},
+	wordpress: {},
+}));
+
+describe('AddressBar', () => {
+	let container: HTMLDivElement;
+	let root: Root;
+
+	beforeAll(() => {
+		vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+	});
+
+	afterAll(() => {
+		vi.unstubAllGlobals();
+	});
+
+	beforeEach(() => {
+		vi.useFakeTimers();
+		container = document.createElement('div');
+		document.body.append(container);
+		root = createRoot(container);
+	});
+
+	afterEach(() => {
+		act(() => {
+			vi.runOnlyPendingTimers();
+			root.unmount();
+		});
+		vi.useRealTimers();
+		container.remove();
+	});
+
+	it('keeps focus on the combobox while arrow keys select an option', () => {
+		const onUpdate = vi.fn();
+		renderAddressBar({ url: '/', onUpdate });
+		const input = getInput();
+
+		act(() => input.focus());
+		expect(input.getAttribute('role')).toBe('combobox');
+		expect(input.getAttribute('aria-expanded')).toBe('true');
+		expect(container.querySelector('[role="listbox"]')).not.toBeNull();
+
+		pressKey(input, 'ArrowDown');
+		expect(document.activeElement).toBe(input);
+		expect(input.getAttribute('aria-activedescendant')).toBe(
+			getOption('Homepage').id
+		);
+		expect(getOption('Homepage').getAttribute('aria-selected')).toBe(
+			'true'
+		);
+
+		pressKey(input, 'ArrowDown');
+		pressKey(input, 'Enter');
+		expect(onUpdate).toHaveBeenCalledWith('/wp-admin/');
+		expect(container.querySelector('[role="listbox"]')).toBeNull();
+	});
+
+	it('wraps ArrowUp from the input to the last option', () => {
+		renderAddressBar({ url: '/' });
+		const input = getInput();
+
+		act(() => input.focus());
+		pressKey(input, 'ArrowUp');
+
+		expect(input.getAttribute('aria-activedescendant')).toBe(
+			getOption('Themes').id
+		);
+		expect(getOption('Themes').getAttribute('aria-selected')).toBe('true');
+	});
+
+	it('closes the listbox and disables navigation controls while inert', () => {
+		renderAddressBar({ url: '/wp-admin/' });
+		act(() => getInput().focus());
+		expect(container.querySelector('[role="listbox"]')).not.toBeNull();
+
+		renderAddressBar({ url: '/new-path', disabled: true });
+		const input = getInput();
+		const refresh = container.querySelector<HTMLButtonElement>(
+			'button[aria-label="Refresh page"]'
+		)!;
+
+		expect(input.disabled).toBe(true);
+		expect(input.value).toBe('/new-path');
+		expect(input.getAttribute('aria-expanded')).toBe('false');
+		expect(refresh.disabled).toBe(true);
+		expect(container.querySelector('[role="listbox"]')).toBeNull();
+	});
+
+	function renderAddressBar(props: ComponentProps<typeof AddressBar>) {
+		act(() => root.render(<AddressBar {...props} />));
+	}
+
+	function getInput() {
+		return container.querySelector<HTMLInputElement>(
+			'input[role="combobox"]'
+		)!;
+	}
+
+	function getOption(label: string) {
+		return Array.from(
+			container.querySelectorAll<HTMLElement>('[role="option"]')
+		).find((option) => option.textContent?.includes(label))!;
+	}
+
+	function pressKey(input: HTMLInputElement, key: string) {
+		act(() => {
+			input.dispatchEvent(
+				new KeyboardEvent('keydown', { key, bubbles: true })
+			);
+		});
+	}
+});

--- a/packages/playground/website/src/components/address-bar/index.tsx
+++ b/packages/playground/website/src/components/address-bar/index.tsx
@@ -1,6 +1,7 @@
-import React, { useState, useRef, useEffect } from 'react';
-import { Icon, MenuItem, NavigableMenu, Popover } from '@wordpress/components';
+import React, { useEffect, useId, useRef, useState } from 'react';
+import { Icon, Popover } from '@wordpress/components';
 import { home, wordpress, layout, pin } from '@wordpress/icons';
+import classNames from 'classnames';
 import css from './style.module.css';
 
 /**
@@ -69,30 +70,57 @@ const quickNavItems: QuickNavItem[] = [
 interface AddressBarProps {
 	url?: string;
 	onUpdate?: (url: string) => void;
+	/**
+	 * Renders the bar inert (e.g. while the Playground is still booting and
+	 * there is no client to navigate yet) instead of hiding it, so the Dock
+	 * layout stays stable through loading.
+	 */
+	disabled?: boolean;
 }
 
-export default function AddressBar({ url, onUpdate }: AddressBarProps) {
+export default function AddressBar({
+	url,
+	onUpdate,
+	disabled = false,
+}: AddressBarProps) {
 	const inputRef = useRef<HTMLInputElement>(null);
 	const containerRef = useRef<HTMLDivElement>(null);
-	const menuRef = useRef<HTMLDivElement>(null);
 	const [value, setValue] = useState(url || '');
 	const [isFocused, setIsFocused] = useState(false);
 	const [isOpen, setIsOpen] = useState(false);
-	const [focusMenu, setFocusMenu] = useState(false);
+	// -1 means no option is active; focus stays on the input and the active
+	// option is exposed via aria-activedescendant (WAI-ARIA combobox pattern).
+	const [activeIndex, setActiveIndex] = useState(-1);
 	const [menuWidth, setMenuWidth] = useState(0);
 
+	const idPrefix = useId();
+	const listboxId = `${idPrefix}-suggestions`;
+	const optionId = (index: number) => `${idPrefix}-suggestion-${index}`;
+
 	useEffect(() => {
-		if (!isFocused && url) {
-			setValue(url);
+		if (!isFocused) {
+			setValue(url ?? '');
 		}
 	}, [isFocused, url]);
 
-	// Update menu width when popover opens and track resize
+	useEffect(() => {
+		if (disabled) {
+			setIsOpen(false);
+			setActiveIndex(-1);
+			setIsFocused(false);
+			setValue(url ?? '');
+		}
+	}, [disabled, url]);
+
+	// Update listbox width when it opens and track resize.
 	useEffect(() => {
 		if (!isOpen || !inputRef.current) {
 			return;
 		}
 		setMenuWidth(inputRef.current.offsetWidth);
+		if (typeof ResizeObserver === 'undefined') {
+			return;
+		}
 
 		const resizeObserver = new ResizeObserver((entries) => {
 			for (const entry of entries) {
@@ -103,25 +131,17 @@ export default function AddressBar({ url, onUpdate }: AddressBarProps) {
 		return () => resizeObserver.disconnect();
 	}, [isOpen]);
 
-	// Focus the first menu item when focusMenu is set
-	useEffect(() => {
-		if (focusMenu && menuRef.current) {
-			const firstItem = menuRef.current.querySelector(
-				'button, [role="menuitem"]'
-			) as HTMLElement;
-			if (firstItem) {
-				firstItem.focus();
-			}
-			setFocusMenu(false);
-		}
-	}, [focusMenu]);
+	function closeSuggestions() {
+		setIsOpen(false);
+		setActiveIndex(-1);
+	}
 
 	function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
 		e.preventDefault();
 		const requestedPath = inputRef.current!.value;
 		onUpdate?.(requestedPath);
 		inputRef.current!.blur();
-		setIsOpen(false);
+		closeSuggestions();
 	}
 
 	function handleRefresh(e: React.MouseEvent<HTMLButtonElement>) {
@@ -133,61 +153,62 @@ export default function AddressBar({ url, onUpdate }: AddressBarProps) {
 
 	function handleNavigation(path: string) {
 		onUpdate?.(path);
-		setIsOpen(false);
+		closeSuggestions();
 		inputRef.current?.blur();
 	}
 
 	function handleInputKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+		// Combobox keyboard model: focus stays on the input; arrow keys move the
+		// active option (Down lands on the first, Up wraps to the last), Enter
+		// chooses the active option (or, if none, submits the typed path).
+		const count = quickNavItems.length;
 		if (e.key === 'ArrowDown') {
 			e.preventDefault();
-			if (!isOpen) {
-				setIsOpen(true);
+			if (disabled) {
+				return;
 			}
-			setFocusMenu(true);
+			setIsOpen(true);
+			setActiveIndex((index) => (index + 1) % count);
+		} else if (e.key === 'ArrowUp') {
+			e.preventDefault();
+			if (disabled) {
+				return;
+			}
+			setIsOpen(true);
+			setActiveIndex((index) => (index <= 0 ? count - 1 : index - 1));
+		} else if (e.key === 'Enter') {
+			if (isOpen && activeIndex >= 0) {
+				e.preventDefault();
+				handleNavigation(quickNavItems[activeIndex].path);
+			}
 		} else if (e.key === 'Escape') {
-			setIsOpen(false);
+			closeSuggestions();
 		}
 	}
 
 	function handleFocus() {
+		if (disabled) {
+			return;
+		}
 		setIsFocused(true);
 		setIsOpen(true);
 	}
 
 	function handleBlur() {
 		setIsFocused(false);
-		// Close popover if focus moves outside the component
-		// Use setTimeout to allow focus to move to menu items first
+		// Close once focus leaves the whole control. Options are chosen via a
+		// mousedown that keeps focus on the input, so leaving the input means
+		// leaving the control.
 		setTimeout(() => {
-			const isInInput = inputRef.current?.contains(
-				document.activeElement
-			);
-			const isInMenu = menuRef.current?.contains(document.activeElement);
-			if (!isInInput && !isInMenu) {
-				setIsOpen(false);
+			if (!containerRef.current?.contains(document.activeElement)) {
+				closeSuggestions();
 			}
 		}, 0);
 	}
 
 	function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
 		setValue(e.target.value);
-	}
-
-	function handleMenuKeyDown(e: React.KeyboardEvent<HTMLDivElement>) {
-		if (e.key === 'Escape') {
-			e.preventDefault();
-			setIsOpen(false);
-			inputRef.current?.focus();
-		} else if (e.key === 'ArrowUp') {
-			const firstItem = menuRef.current?.querySelector(
-				'button, [role="menuitem"]'
-			);
-			if (document.activeElement === firstItem) {
-				e.preventDefault();
-				e.stopPropagation();
-				inputRef.current?.focus();
-			}
-		}
+		setActiveIndex(-1);
 	}
 
 	return (
@@ -196,6 +217,7 @@ export default function AddressBar({ url, onUpdate }: AddressBarProps) {
 				type="button"
 				className={css.refreshButton}
 				onClick={handleRefresh}
+				disabled={disabled}
 				aria-label="Refresh page"
 				title="Refresh page"
 			>
@@ -221,32 +243,55 @@ export default function AddressBar({ url, onUpdate }: AddressBarProps) {
 					onFocus={handleFocus}
 					onBlur={handleBlur}
 					onKeyDown={handleInputKeyDown}
+					disabled={disabled}
 					name="url"
 					type="text"
 					aria-label='URL to visit in the WordPress site, like "/wp-admin"'
 					autoComplete="off"
+					role="combobox"
+					aria-autocomplete="list"
+					aria-haspopup="listbox"
+					aria-expanded={isOpen}
+					aria-controls={isOpen ? listboxId : undefined}
+					aria-activedescendant={
+						isOpen && activeIndex >= 0
+							? optionId(activeIndex)
+							: undefined
+					}
 				/>
 				{isOpen && (
 					<Popover
 						placement="bottom-start"
-						onClose={() => setIsOpen(false)}
+						onClose={closeSuggestions}
 						anchor={inputRef.current}
 						noArrow={true}
 						focusOnMount={false}
 						className={css.popover}
 					>
-						<NavigableMenu
-							ref={menuRef}
+						<ul
+							id={listboxId}
+							role="listbox"
 							className={css.suggestions}
-							onKeyDownCapture={handleMenuKeyDown}
-							onBlur={handleBlur}
 							style={{ width: menuWidth }}
 						>
-							{quickNavItems.map((item) => (
-								<MenuItem
+							{quickNavItems.map((item, index) => (
+								<li
 									key={item.path}
-									className={css.suggestionItem}
+									id={optionId(index)}
+									role="option"
+									aria-selected={index === activeIndex}
+									className={classNames(css.suggestionItem, {
+										[css.suggestionItemActive]:
+											index === activeIndex,
+									})}
+									// Keep focus in the combobox until click activates
+									// the option. Assistive technology also synthesizes
+									// click without a preceding mouse event.
+									onMouseDown={(event) => {
+										event.preventDefault();
+									}}
 									onClick={() => handleNavigation(item.path)}
+									onMouseEnter={() => setActiveIndex(index)}
 								>
 									<span className={css.suggestionIcon}>
 										{item.icon}
@@ -257,13 +302,22 @@ export default function AddressBar({ url, onUpdate }: AddressBarProps) {
 									<span className={css.suggestionPath}>
 										{item.path}
 									</span>
-								</MenuItem>
+								</li>
 							))}
-						</NavigableMenu>
+						</ul>
 					</Popover>
 				)}
 			</div>
-			<input className={css.submit} type="submit" tabIndex={-1} />
+			{/* Off-screen submit so Enter in the input navigates. Hidden from AT
+			    and given an explicit value so it never surfaces the browser's
+			    localized default ("Submit"/"Prześlij"). */}
+			<input
+				className={css.submit}
+				type="submit"
+				value="Go"
+				tabIndex={-1}
+				aria-hidden="true"
+			/>
 		</form>
 	);
 }

--- a/packages/playground/website/src/components/address-bar/style.module.css
+++ b/packages/playground/website/src/components/address-bar/style.module.css
@@ -28,6 +28,12 @@
 	transform: scale(0.95);
 }
 
+.refresh-button:disabled,
+.refresh-button:disabled:hover {
+	color: rgba(180, 190, 203, 0.4);
+	cursor: default;
+}
+
 .input-container {
 	position: relative;
 	display: flex;
@@ -65,6 +71,11 @@
 
 .input:focus {
 	outline: none;
+}
+
+.input:disabled {
+	color: rgba(180, 190, 203, 0.4);
+	cursor: default;
 }
 
 /* Popover container */
@@ -106,7 +117,8 @@
 }
 
 .suggestion-item:hover,
-.suggestion-item:focus {
+.suggestion-item:focus,
+.suggestion-item-active {
 	background: #4f5861;
 	color: #e0e6eb;
 	outline: none;

--- a/packages/playground/website/src/components/dock/dock-positioning.spec.ts
+++ b/packages/playground/website/src/components/dock/dock-positioning.spec.ts
@@ -1,0 +1,136 @@
+import {
+	DOCK_PANE_GAP,
+	DOCK_PANE_MIN_HEIGHT,
+	getDockOperationToastStyle,
+	getDockPaneCenter,
+	getDockPaneStyle,
+} from './dock-positioning';
+
+describe('Dock positioning', () => {
+	it('waits for the Dock height before positioning a pane or toast', () => {
+		expect(
+			getDockPaneStyle({
+				isMobile: false,
+				dockSize: { width: 800, height: 0 },
+				dockCenter: null,
+				viewportSize: { width: 1200, height: 800 },
+				isEditorSection: false,
+				isFixedHeightSection: false,
+				isPlaygroundsSection: false,
+			})
+		).toBeUndefined();
+		expect(
+			getDockOperationToastStyle({
+				isMobile: false,
+				dockSize: { width: 800, height: 0 },
+				toolsHeight: 60,
+				isCollapsed: false,
+				dockCenter: null,
+				viewportSize: { width: 1200, height: 800 },
+				paneHeight: 400,
+				toastHeight: 62,
+				paneOpen: false,
+				isEditorSection: false,
+			})
+		).toBeUndefined();
+	});
+
+	it('uses the minimum desktop pane height when the viewport is too short', () => {
+		expect(
+			getDockPaneStyle({
+				isMobile: false,
+				dockSize: { width: 800, height: 80 },
+				dockCenter: null,
+				viewportSize: { width: 1200, height: 100 },
+				isEditorSection: false,
+				isFixedHeightSection: false,
+				isPlaygroundsSection: false,
+			})
+		).toMatchObject({ maxHeight: `${DOCK_PANE_MIN_HEIGHT}px` });
+	});
+
+	it('passes the measured Dock height to the mobile pane', () => {
+		expect(
+			getDockPaneStyle({
+				isMobile: true,
+				dockSize: { width: 390, height: 72 },
+				dockCenter: null,
+				viewportSize: { width: 390, height: 844 },
+				isEditorSection: false,
+				isFixedHeightSection: false,
+				isPlaygroundsSection: false,
+			})
+		).toEqual({ '--dock-height': '72px' });
+	});
+
+	it('keeps desktop panes above the Dock and inside the viewport', () => {
+		expect(
+			getDockPaneStyle({
+				isMobile: false,
+				dockSize: { width: 800, height: 80 },
+				dockCenter: 100,
+				viewportSize: { width: 1200, height: 800 },
+				isEditorSection: false,
+				isFixedHeightSection: true,
+				isPlaygroundsSection: true,
+			})
+		).toEqual({
+			left: '308px',
+			bottom: `${80 + DOCK_PANE_GAP}px`,
+			top: 'auto',
+			maxHeight: '560px',
+			height: '560px',
+		});
+	});
+
+	it('keeps operation notices visible above an open pane', () => {
+		expect(
+			getDockOperationToastStyle({
+				isMobile: false,
+				dockSize: { width: 800, height: 80 },
+				toolsHeight: 60,
+				isCollapsed: false,
+				dockCenter: 100,
+				viewportSize: { width: 1200, height: 800 },
+				paneHeight: 400,
+				toastHeight: 62,
+				paneOpen: true,
+				isEditorSection: false,
+			})
+		).toEqual({ bottom: '504px', left: '308px' });
+	});
+
+	it('centers operation notices when the viewport is narrower than its gaps', () => {
+		expect(
+			getDockOperationToastStyle({
+				isMobile: false,
+				dockSize: { width: 10, height: 80 },
+				toolsHeight: 60,
+				isCollapsed: false,
+				dockCenter: 0,
+				viewportSize: { width: 10, height: 800 },
+				paneHeight: 0,
+				toastHeight: 62,
+				paneOpen: false,
+				isEditorSection: false,
+			})
+		).toEqual({ bottom: '92px', left: '5px' });
+	});
+
+	it('clamps pane centers at both viewport edges', () => {
+		expect(
+			getDockPaneCenter({
+				dockCenter: 0,
+				viewportWidth: 1200,
+				isEditorSection: false,
+			})
+		).toBe(308);
+		expect(
+			getDockPaneCenter({
+				dockCenter: 1200,
+				viewportWidth: 1200,
+				isEditorSection: false,
+			})
+		).toBe(892);
+	});
+});

--- a/packages/playground/website/src/components/dock/dock-positioning.ts
+++ b/packages/playground/website/src/components/dock/dock-positioning.ts
@@ -1,0 +1,147 @@
+import type { CSSProperties } from 'react';
+
+export const DOCK_DRAG_EDGE = 8;
+export const DOCK_PANE_GAP = 12;
+export const DOCK_PANE_MIN_HEIGHT = 160;
+export const DOCK_OPERATION_TOAST_MIN_HEIGHT = 62;
+
+const LIST_PANE_HEIGHT = 560;
+const OPERATION_TOAST_WIDTH = 520;
+
+type Size = { width: number; height: number };
+
+/** Positions one pane above its Dock, or full-screen above the mobile bar. */
+export function getDockPaneStyle({
+	isMobile,
+	dockSize,
+	dockCenter,
+	viewportSize,
+	isEditorSection,
+	isFixedHeightSection,
+	isPlaygroundsSection,
+}: {
+	isMobile: boolean;
+	dockSize: Size;
+	dockCenter: number | null;
+	viewportSize: Size;
+	isEditorSection: boolean;
+	isFixedHeightSection: boolean;
+	isPlaygroundsSection: boolean;
+}): CSSProperties | undefined {
+	if (!dockSize.height) {
+		return undefined;
+	}
+	if (isMobile) {
+		return {
+			'--dock-height': `${dockSize.height}px`,
+		} as CSSProperties;
+	}
+
+	const dockTop = viewportSize.height - dockSize.height;
+	const center = getDockPaneCenter({
+		dockCenter,
+		viewportWidth: viewportSize.width,
+		isEditorSection,
+	});
+	const availableHeight = Math.max(
+		DOCK_PANE_MIN_HEIGHT,
+		dockTop - DOCK_PANE_GAP - DOCK_DRAG_EDGE
+	);
+	const stableHeight = Math.min(LIST_PANE_HEIGHT, availableHeight);
+	const maxHeight = isPlaygroundsSection ? stableHeight : availableHeight;
+
+	return {
+		left: `${center}px`,
+		bottom: `${dockSize.height + DOCK_PANE_GAP}px`,
+		top: 'auto',
+		maxHeight: `${maxHeight}px`,
+		...(isFixedHeightSection ? { height: `${stableHeight}px` } : {}),
+	};
+}
+
+/** Keeps a global operation failure with the visible Dock surface. */
+export function getDockOperationToastStyle({
+	isMobile,
+	dockSize,
+	toolsHeight,
+	isCollapsed,
+	dockCenter,
+	viewportSize,
+	paneHeight,
+	toastHeight,
+	paneOpen,
+	isEditorSection,
+}: {
+	isMobile: boolean;
+	dockSize: Size;
+	toolsHeight: number;
+	isCollapsed: boolean;
+	dockCenter: number | null;
+	viewportSize: Size;
+	paneHeight: number;
+	toastHeight: number;
+	paneOpen: boolean;
+	isEditorSection: boolean;
+}): CSSProperties | undefined {
+	if (!dockSize.height) {
+		return undefined;
+	}
+
+	const visibleDockHeight = isCollapsed
+		? Math.max(0, dockSize.height - toolsHeight)
+		: dockSize.height;
+	const desiredBottom =
+		visibleDockHeight +
+		DOCK_PANE_GAP +
+		(!isMobile && paneOpen ? paneHeight + DOCK_PANE_GAP : 0);
+	// Editor panes and mobile panes can consume all available space. Keep the
+	// toast reachable at the viewport edge instead of placing it off-screen.
+	const maxBottom = Math.max(
+		DOCK_PANE_GAP,
+		viewportSize.height - DOCK_PANE_GAP - toastHeight
+	);
+	const toastWidth = Math.min(
+		OPERATION_TOAST_WIDTH,
+		Math.max(0, viewportSize.width - 2 * DOCK_PANE_GAP)
+	);
+	const halfToastWidth = toastWidth / 2;
+	const desiredCenter = isMobile
+		? viewportSize.width / 2
+		: getDockPaneCenter({
+				dockCenter,
+				viewportWidth: viewportSize.width,
+				isEditorSection,
+			});
+	const minCenter = halfToastWidth + DOCK_PANE_GAP;
+	const maxCenter = viewportSize.width - halfToastWidth - DOCK_PANE_GAP;
+	const center =
+		maxCenter < minCenter
+			? viewportSize.width / 2
+			: Math.min(Math.max(desiredCenter, minCenter), maxCenter);
+
+	return {
+		bottom: `${Math.min(desiredBottom, maxBottom)}px`,
+		left: `${center}px`,
+	};
+}
+
+/** Centers a pane over a moved Dock without letting it cross the viewport. */
+export function getDockPaneCenter({
+	dockCenter,
+	viewportWidth,
+	isEditorSection,
+}: {
+	dockCenter: number | null;
+	viewportWidth: number;
+	isEditorSection: boolean;
+}) {
+	const desiredCenter = dockCenter ?? viewportWidth / 2;
+	const halfPaneWidth = Math.min(
+		isEditorSection ? 560 : 300,
+		(viewportWidth - 2 * DOCK_DRAG_EDGE) / 2
+	);
+	return Math.min(
+		Math.max(desiredCenter, halfPaneWidth + DOCK_DRAG_EDGE),
+		viewportWidth - halfPaneWidth - DOCK_DRAG_EDGE
+	);
+}

--- a/packages/playground/website/src/components/site-manager/site-info-panel/index.tsx
+++ b/packages/playground/website/src/components/site-manager/site-info-panel/index.tsx
@@ -11,13 +11,12 @@ import {
 import { chevronLeft, edit, moreVertical } from '@wordpress/icons';
 import { getLogoDataURL, WordPressIcon } from '@wp-playground/components';
 import classNames from 'classnames';
-import { lazy, Suspense, useEffect, useState } from 'react';
+import { useState } from 'react';
 import { getRelativeDate } from '../../../lib/get-relative-date';
 import { selectClientInfoBySiteSlug } from '../../../lib/state/redux/slice-clients';
 import type { SiteInfo } from '../../../lib/state/redux/slice-sites';
 import {
 	isAutosavedSite,
-	isExplicitlySavedSite,
 	MAX_AUTOSAVED_SITES,
 } from '../../../lib/state/redux/slice-sites';
 import {
@@ -30,24 +29,12 @@ import {
 } from '../../../lib/state/redux/slice-ui';
 import { useAppDispatch, useAppSelector } from '../../../lib/state/redux/store';
 import { usePlaygroundClientInfo } from '../../../lib/use-playground-client';
-import { SiteLogs } from '../../log-modal';
-import { OfflineNotice } from '../../offline-notice';
 import { DownloadAsZipMenuItem } from '../../toolbar-buttons/download-as-zip';
 import { GithubExportMenuItem } from '../../toolbar-buttons/github-export-menu-item';
-import { SiteDatabasePanel } from '../site-database-panel';
-import { ActiveSiteSettingsForm } from '../site-settings-form/active-site-settings-form';
-import { TemporarySiteNotice } from '../temporary-site-notice';
+import { SiteToolPanels, type SiteInfoTabName } from './site-tool-panels';
 import css from './style.module.css';
 
-const SiteFileBrowser = lazy(() =>
-	import('../site-file-browser').then((m) => ({ default: m.SiteFileBrowser }))
-);
-
-const SiteBlueprintBundleEditor = lazy(() =>
-	import('../../blueprint-editor/SiteBlueprintBundleEditor').then((m) => ({
-		default: m.SiteBlueprintBundleEditor,
-	}))
-);
+export type { SiteInfoTabName } from './site-tool-panels';
 
 const LAST_TAB_STORAGE_KEY = 'playground-site-last-tabs';
 
@@ -94,9 +81,6 @@ export function SiteInfoPanel({
 		return lastTab || 'settings';
 	});
 
-	// Resolve documentRoot from playground client
-	const [documentRoot, setDocumentRoot] = useState<string | null>(null);
-
 	// Save the tab when it changes
 	const handleTabSelect = (tabName: string) => {
 		setSiteLastTab(site.slug, tabName);
@@ -104,7 +88,6 @@ export function SiteInfoPanel({
 
 	const isTemporary = site.metadata.storage === 'none';
 	const isAutosaved = isAutosavedSite(site);
-	const isBlueprintReadOnly = isExplicitlySavedSite(site);
 
 	const removeSiteAndCloseMenu = (onClose: () => void) => {
 		dispatch(setSiteSlugToDelete(site.slug));
@@ -119,18 +102,6 @@ export function SiteInfoPanel({
 		selectClientInfoBySiteSlug(state, site.slug)
 	);
 	const playground = clientInfo?.client;
-
-	// Resolve documentRoot from playground
-	useEffect(() => {
-		if (!playground) {
-			setDocumentRoot(null);
-			return;
-		}
-
-		void playground.documentRoot.then((root) => {
-			setDocumentRoot(root);
-		});
-	}, [playground]);
 
 	function navigateTo(path: string) {
 		if (siteViewHidden) {
@@ -416,125 +387,11 @@ export function SiteInfoPanel({
 						]}
 					>
 						{(tab) => (
-							<>
-								<div
-									className={classNames(css.tabContents, {
-										[css.tabHidden]:
-											tab.name !== 'settings',
-									})}
-									hidden={tab.name !== 'settings'}
-								>
-									{offline ? (
-										<div className={css.padded}>
-											<OfflineNotice />
-										</div>
-									) : null}
-
-									{isTemporary ? (
-										<div data-testid="temporary-site-notice">
-											<TemporarySiteNotice
-												className={css.siteNotice}
-											/>
-										</div>
-									) : null}
-
-									<ActiveSiteSettingsForm />
-								</div>
-								<div
-									className={classNames(
-										css.tabContents,
-										css.fileBrowserTab,
-										{
-											[css.tabHidden]:
-												tab.name !== 'files',
-										}
-									)}
-									hidden={tab.name !== 'files'}
-								>
-									<Suspense
-										fallback={
-											<div className={css.padded}>
-												Loading file browser...
-											</div>
-										}
-									>
-										{documentRoot && (
-											<SiteFileBrowser
-												key={site.slug}
-												site={site}
-												isVisible={tab.name === 'files'}
-												documentRoot={documentRoot}
-											/>
-										)}
-									</Suspense>
-								</div>
-								<div
-									className={classNames(
-										css.blueprintWrapper,
-										{
-											[css.tabHidden]:
-												tab.name !== 'blueprint',
-										}
-									)}
-									hidden={tab.name !== 'blueprint'}
-								>
-									{isBlueprintReadOnly && (
-										<div className={css.blueprintNotice}>
-											This Blueprint is read-only for
-											saved Playgrounds. Create an Unsaved
-											Playground to edit and test
-											Blueprint changes.
-										</div>
-									)}
-									<Suspense
-										fallback={
-											<div>
-												Loading Blueprint editor...
-											</div>
-										}
-									>
-										<SiteBlueprintBundleEditor
-											key={site.slug}
-											site={site}
-											className={classNames(
-												css.blueprintEditor
-											)}
-										/>
-									</Suspense>
-								</div>
-								<div
-									className={classNames(
-										css.tabContents,
-										css.padded,
-										{
-											[css.tabHidden]:
-												tab.name !== 'database',
-										}
-									)}
-									hidden={tab.name !== 'database'}
-								>
-									<SiteDatabasePanel
-										playground={playground}
-									/>
-								</div>
-								<div
-									className={classNames(
-										css.tabContents,
-										css.padded,
-										{
-											[css.tabHidden]:
-												tab.name !== 'logs',
-										}
-									)}
-									hidden={tab.name !== 'logs'}
-								>
-									<div
-										className={classNames(css.logsWrapper)}
-									>
-										<SiteLogs className={css.logsSection} />
-									</div>
-								</div>
-							</>
+							<SiteToolPanels
+								site={site}
+								playground={playground}
+								activeTabName={tab.name as SiteInfoTabName}
+							/>
 						)}
 					</TabPanel>
 				</FlexItem>

--- a/packages/playground/website/src/components/site-manager/site-info-panel/site-tool-panels.spec.tsx
+++ b/packages/playground/website/src/components/site-manager/site-info-panel/site-tool-panels.spec.tsx
@@ -1,0 +1,127 @@
+// @vitest-environment jsdom
+
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import type { PlaygroundClient } from '@wp-playground/client';
+import type { SiteInfo } from '../../../lib/state/redux/slice-sites';
+import { SiteToolPanels } from './site-tool-panels';
+
+vi.mock('../../../lib/state/redux/store', () => ({
+	useAppSelector: () => false,
+}));
+
+vi.mock('../site-file-browser', () => ({
+	SiteFileBrowser: ({ isVisible }: { isVisible: boolean }) => (
+		<div data-testid="files" data-visible={isVisible}>
+			File browser
+		</div>
+	),
+}));
+
+vi.mock('../../blueprint-editor/SiteBlueprintBundleEditor', () => ({
+	SiteBlueprintBundleEditor: () => (
+		<div data-testid="blueprint">Blueprint editor</div>
+	),
+}));
+
+vi.mock('../site-settings-form/active-site-settings-form', () => ({
+	ActiveSiteSettingsForm: () => (
+		<div data-testid="settings">Site settings</div>
+	),
+}));
+
+vi.mock('../site-database-panel', () => ({
+	SiteDatabasePanel: () => <div data-testid="database">Database tools</div>,
+}));
+
+vi.mock('../../log-modal', () => ({
+	SiteLogs: () => <div data-testid="logs">Site logs</div>,
+}));
+
+vi.mock('../../offline-notice', () => ({
+	OfflineNotice: () => <div>Offline</div>,
+}));
+
+vi.mock('../temporary-site-notice', () => ({
+	TemporarySiteNotice: () => <div>Temporary Playground</div>,
+}));
+
+const site = {
+	slug: 'test-site',
+	metadata: {
+		storage: 'opfs',
+		id: 'test-site',
+		name: 'Test site',
+		persistence: 'explicit',
+		runtimeConfiguration: {},
+		originalBlueprint: {},
+		originalBlueprintSource: {},
+	},
+} as SiteInfo;
+
+const playground = {
+	documentRoot: Promise.resolve('/wordpress'),
+} as PlaygroundClient;
+
+describe('SiteToolPanels', () => {
+	let container: HTMLDivElement;
+	let root: Root;
+
+	beforeAll(() => {
+		vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+	});
+
+	afterAll(() => {
+		vi.unstubAllGlobals();
+	});
+
+	beforeEach(() => {
+		container = document.createElement('div');
+		document.body.append(container);
+		root = createRoot(container);
+	});
+
+	afterEach(() => {
+		act(() => root.unmount());
+		container.remove();
+	});
+
+	it('keeps every tool mounted and shows only the active tab', async () => {
+		await renderPanels('database');
+
+		const database = findTool('database');
+		expect(database.closest('[hidden]')).toBeNull();
+		for (const name of ['settings', 'files', 'blueprint', 'logs']) {
+			expect(findTool(name).closest('[hidden]')).not.toBeNull();
+		}
+
+		await renderPanels('logs');
+		expect(findTool('database')).toBe(database);
+		expect(database.closest('[hidden]')).not.toBeNull();
+		expect(findTool('logs').closest('[hidden]')).toBeNull();
+	});
+
+	async function renderPanels(
+		activeTabName: React.ComponentProps<
+			typeof SiteToolPanels
+		>['activeTabName']
+	) {
+		await act(async () => {
+			root.render(
+				<SiteToolPanels
+					site={site}
+					playground={playground}
+					activeTabName={activeTabName}
+				/>
+			);
+		});
+	}
+
+	function findTool(name: string) {
+		const tool = container.querySelector(`[data-testid="${name}"]`);
+		if (!tool) {
+			throw new Error(`Could not find ${name} tool.`);
+		}
+		return tool;
+	}
+});

--- a/packages/playground/website/src/components/site-manager/site-info-panel/site-tool-panels.tsx
+++ b/packages/playground/website/src/components/site-manager/site-info-panel/site-tool-panels.tsx
@@ -1,0 +1,144 @@
+import classNames from 'classnames';
+import { lazy, Suspense, useEffect, useState } from 'react';
+import type { PlaygroundClient } from '@wp-playground/client';
+import type { SiteInfo } from '../../../lib/state/redux/slice-sites';
+import { isExplicitlySavedSite } from '../../../lib/state/redux/slice-sites';
+import { useAppSelector } from '../../../lib/state/redux/store';
+import { SiteLogs } from '../../log-modal';
+import { OfflineNotice } from '../../offline-notice';
+import { SiteDatabasePanel } from '../site-database-panel';
+import { ActiveSiteSettingsForm } from '../site-settings-form/active-site-settings-form';
+import { TemporarySiteNotice } from '../temporary-site-notice';
+import css from './style.module.css';
+
+const SiteFileBrowser = lazy(() =>
+	import('../site-file-browser').then((m) => ({ default: m.SiteFileBrowser }))
+);
+
+const SiteBlueprintBundleEditor = lazy(() =>
+	import('../../blueprint-editor/SiteBlueprintBundleEditor').then((m) => ({
+		default: m.SiteBlueprintBundleEditor,
+	}))
+);
+
+export type SiteInfoTabName =
+	| 'settings'
+	| 'files'
+	| 'blueprint'
+	| 'database'
+	| 'logs';
+
+/** Renders the tool surfaces selected by the site information tabs. */
+export function SiteToolPanels({
+	site,
+	playground,
+	activeTabName,
+}: {
+	site: SiteInfo;
+	playground: PlaygroundClient | undefined;
+	activeTabName: SiteInfoTabName;
+}) {
+	const offline = useAppSelector((state) => state.ui.offline);
+	const [documentRoot, setDocumentRoot] = useState<string | null>(null);
+	const isTemporary = site.metadata.storage === 'none';
+	const isBlueprintReadOnly = isExplicitlySavedSite(site);
+
+	// Resolve documentRoot from playground client
+	useEffect(() => {
+		if (!playground) {
+			setDocumentRoot(null);
+			return;
+		}
+
+		void playground.documentRoot.then((root) => {
+			setDocumentRoot(root);
+		});
+	}, [playground]);
+
+	return (
+		<>
+			<div
+				className={classNames(css.tabContents, {
+					[css.tabHidden]: activeTabName !== 'settings',
+				})}
+				hidden={activeTabName !== 'settings'}
+			>
+				{offline ? (
+					<div className={css.padded}>
+						<OfflineNotice />
+					</div>
+				) : null}
+
+				{isTemporary ? (
+					<div data-testid="temporary-site-notice">
+						<TemporarySiteNotice className={css.siteNotice} />
+					</div>
+				) : null}
+
+				<ActiveSiteSettingsForm />
+			</div>
+			<div
+				className={classNames(css.tabContents, css.fileBrowserTab, {
+					[css.tabHidden]: activeTabName !== 'files',
+				})}
+				hidden={activeTabName !== 'files'}
+			>
+				<Suspense
+					fallback={
+						<div className={css.padded}>
+							Loading file browser...
+						</div>
+					}
+				>
+					{documentRoot && (
+						<SiteFileBrowser
+							key={site.slug}
+							site={site}
+							isVisible={activeTabName === 'files'}
+							documentRoot={documentRoot}
+						/>
+					)}
+				</Suspense>
+			</div>
+			<div
+				className={classNames(css.blueprintWrapper, {
+					[css.tabHidden]: activeTabName !== 'blueprint',
+				})}
+				hidden={activeTabName !== 'blueprint'}
+			>
+				{isBlueprintReadOnly && (
+					<div className={css.blueprintNotice}>
+						This Blueprint is read-only for saved Playgrounds.
+						Create an Unsaved Playground to edit and test Blueprint
+						changes.
+					</div>
+				)}
+				<Suspense fallback={<div>Loading Blueprint editor...</div>}>
+					<SiteBlueprintBundleEditor
+						key={site.slug}
+						site={site}
+						className={classNames(css.blueprintEditor)}
+					/>
+				</Suspense>
+			</div>
+			<div
+				className={classNames(css.tabContents, css.padded, {
+					[css.tabHidden]: activeTabName !== 'database',
+				})}
+				hidden={activeTabName !== 'database'}
+			>
+				<SiteDatabasePanel playground={playground} />
+			</div>
+			<div
+				className={classNames(css.tabContents, css.padded, {
+					[css.tabHidden]: activeTabName !== 'logs',
+				})}
+				hidden={activeTabName !== 'logs'}
+			>
+				<div className={classNames(css.logsWrapper)}>
+					<SiteLogs className={css.logsSection} />
+				</div>
+			</div>
+		</>
+	);
+}


### PR DESCRIPTION
This PR lets the address bar stay visible but disabled while a Playground loads and makes its quick links work as an accessible keyboard listbox.

The current quick-link menu moves keyboard focus out of the address field. The address field now remains the focused combobox. Up and Down select an option through `aria-activedescendant`, Enter opens it, and Escape closes the list. Pointer selection uses the same options without moving focus before the click.

The new `disabled` property disables both the address field and refresh button, closes an open list, and keeps the displayed URL in sync. This lets #4009 keep the bottom Dock layout stable while there is no Playground client to navigate yet. The current address bar still opens its list below the field; #4009 will move it above the field when the bar moves to the bottom Dock.

This is the third PR in the #4009 stack for #3965. It is based on #4057.

Tested with:

- `npm exec nx test playground-website -- --output-style=static`
- `npm exec nx typecheck playground-website -- --output-style=static`
- `npm exec nx lint playground-website -- --output-style=static`
