### PR TITLE
[Website] Keep the Dock corner launcher clickable after dragging

### DIFF
--- a/packages/playground/website/playwright/e2e/website-ui.spec.ts
+++ b/packages/playground/website/playwright/e2e/website-ui.spec.ts
@@ -447,6 +447,76 @@ test('should switch the desktop Dock between full width and collapsed states', a
 	).toBeVisible();
 });
 
+test('should fold and restore the desktop Dock without hiding an open pane', async ({
+	website,
+}) => {
+	await website.page.emulateMedia({ reducedMotion: 'reduce' });
+	await website.goto('./?storage=temp');
+	const dock = website.page.getByRole('navigation', {
+		name: 'Playground tools',
+	});
+	const initialBounds = await dock.boundingBox();
+	expect(initialBounds).not.toBeNull();
+
+	await dragDockPastLeftEdge();
+	const launcher = website.page.getByRole('button', {
+		name: 'Show Playground tools',
+	});
+	await expect(launcher).toBeVisible();
+	await expect(dock).not.toBeVisible();
+
+	await launcher.click();
+	await expect(dock).toBeVisible();
+	await expect(launcher).toHaveCount(0);
+	const restoredBounds = await dock.boundingBox();
+	expect(restoredBounds).not.toBeNull();
+	expect(restoredBounds!.x).toBeCloseTo(initialBounds!.x, 0);
+
+	await website.openDockPane('Files');
+	await dragDockPastLeftEdge();
+	await expect(
+		website.page.getByRole('dialog', { name: 'Files pane' })
+	).toBeVisible();
+	await expect(dock).toBeVisible();
+	await expect(launcher).toHaveCount(0);
+
+	async function dragDockPastLeftEdge() {
+		const bounds = await dock.boundingBox();
+		expect(bounds).not.toBeNull();
+		const startX = bounds!.x + bounds!.width / 2;
+		const endX = -bounds!.width;
+		await dock.dispatchEvent('pointerdown', {
+			bubbles: true,
+			button: 0,
+			buttons: 1,
+			clientX: startX,
+			isPrimary: true,
+			pointerId: 1,
+		});
+		await website.page.evaluate((clientX) => {
+			window.dispatchEvent(
+				new PointerEvent('pointermove', {
+					bubbles: true,
+					button: 0,
+					buttons: 1,
+					clientX,
+					isPrimary: true,
+					pointerId: 1,
+				})
+			);
+			window.dispatchEvent(
+				new PointerEvent('pointerup', {
+					bubbles: true,
+					button: 0,
+					clientX,
+					isPrimary: true,
+					pointerId: 1,
+				})
+			);
+		}, endX);
+	}
+});
+
 SupportedPHPVersions.forEach(async (version) => {
 	test(`should switch PHP version to ${version}`, async ({ website }) => {
 		await website.goto('./?storage=temp');
@@ -830,6 +900,15 @@ test('should make every Dock tool reachable on mobile', async ({ website }) => {
 	await expect(
 		website.page.getByRole('dialog', { name: 'Export pane' })
 	).toBeFocused();
+	const exportPane = website.page.getByRole('dialog', {
+		name: 'Export pane',
+	});
+	const preview = website.page.locator('[class*="site-view-content"]');
+	await exportPane.getByRole('button', { name: 'Close' }).click();
+	await expect(exportPane).not.toBeVisible();
+	await expect(preview).not.toHaveAttribute('inert', '');
+	await expect(dock.getByRole('button', { name: 'Export' })).toBeFocused();
+
 	await website.page.setViewportSize({ width: 320, height: 700 });
 	await website.openDockPane('Site details');
 	const siteDetailsPane = website.page.getByRole('dialog', {
@@ -840,9 +919,7 @@ test('should make every Dock tool reachable on mobile', async ({ website }) => {
 		.boundingBox();
 	expect(closeBounds).not.toBeNull();
 
-	const previewBounds = await website.page
-		.locator('[class*="site-view-content"]')
-		.boundingBox();
+	const previewBounds = await preview.boundingBox();
 	const dockBounds = await dock.boundingBox();
 	expect(previewBounds).not.toBeNull();
 	expect(dockBounds).not.toBeNull();

--- a/packages/playground/website/playwright/e2e/website-ui.spec.ts
+++ b/packages/playground/website/playwright/e2e/website-ui.spec.ts
@@ -470,7 +470,7 @@ test('should fold and restore the desktop Dock without hiding an open pane', asy
 	await expect(launcher).toHaveCount(0);
 	const restoredBounds = await dock.boundingBox();
 	expect(restoredBounds).not.toBeNull();
-	expect(restoredBounds!.x).toBeCloseTo(initialBounds!.x, 0);
+	expect(Math.abs(restoredBounds!.x - initialBounds!.x)).toBeLessThan(3);
 
 	await website.openDockPane('Files');
 	await dragDockPastLeftEdge();
@@ -906,7 +906,7 @@ test('should make every Dock tool reachable on mobile', async ({ website }) => {
 	const preview = website.page.locator('[class*="site-view-content"]');
 	await exportPane.getByRole('button', { name: 'Close' }).click();
 	await expect(exportPane).not.toBeVisible();
-	await expect(preview).not.toHaveAttribute('inert', '');
+	await expect(preview).not.toHaveAttribute('inert', /.*/);
 	await expect(dock.getByRole('button', { name: 'Export' })).toBeFocused();
 
 	await website.page.setViewportSize({ width: 320, height: 700 });

--- a/packages/playground/website/src/components/dock/dock.tsx
+++ b/packages/playground/website/src/components/dock/dock.tsx
@@ -664,6 +664,12 @@ export function Dock({
 			draggedRef.current = false;
 
 			const eatClick = (clickEvent: MouseEvent) => {
+				if (
+					!(clickEvent.target instanceof Node) ||
+					!dockRef.current?.contains(clickEvent.target)
+				) {
+					return;
+				}
 				clickEvent.stopPropagation();
 				clickEvent.preventDefault();
 			};

--- a/packages/playground/website/src/components/dock/dock.tsx
+++ b/packages/playground/website/src/components/dock/dock.tsx
@@ -657,6 +657,8 @@ export function Dock({
 		const finishDockDrag = () => {
 			dragCleanupRef.current?.();
 			dragCleanupRef.current = null;
+			// Let the next click target the restored corner launcher instead of
+			// staying captured by the Dock that just finished folding.
 			try {
 				dock.releasePointerCapture(pointerId);
 			} catch {

--- a/packages/playground/website/src/components/dock/dock.tsx
+++ b/packages/playground/website/src/components/dock/dock.tsx
@@ -657,6 +657,11 @@ export function Dock({
 		const finishDockDrag = () => {
 			dragCleanupRef.current?.();
 			dragCleanupRef.current = null;
+			try {
+				dock.releasePointerCapture(pointerId);
+			} catch {
+				// Synthetic pointer events may not support capture.
+			}
 			dragArmedRef.current = false;
 			if (!draggedRef.current) {
 				return;


### PR DESCRIPTION
This keeps the Dock corner launcher clickable immediately after a drag and adds coverage for the missing desktop-corner and mobile-close flows.

#4009 suppresses the click synthesized after dragging so a drag cannot activate a Dock control. That listener was global. With reduced motion enabled, the corner launcher appears immediately, and its first click was swallowed even though the launcher is outside the Dock. This limits suppression to click targets inside the dragged Dock.

The Playwright tests now fold and reopen the desktop Dock, confirm an open pane prevents folding, close a mobile pane, and verify that closing returns focus to its Dock button and makes the preview interactive again. The flows pass in Chromium, Firefox, and WebKit.

This PR is stacked on #4009 so the production change and added coverage do not enlarge that PR.

## Testing

- Selected corner and mobile Playwright tests: 6/6 across Chromium, Firefox, and WebKit
- `npx nx run-many -t lint,typecheck,test -p playground-website`: 57 test files, 303 tests
