### PR TITLE
[PHP-WASM] Transfer event stdin streams across workers

### DIFF
--- a/packages/php-wasm/universal/src/lib/api.ts
+++ b/packages/php-wasm/universal/src/lib/api.ts
@@ -252,6 +252,10 @@ function setupTransferHandlers() {
 		stream?: ReadableStream<Uint8Array>;
 		port?: MessagePort;
 	};
+	/**
+	 * Keeps the stream live while it crosses the Comlink boundary. Safari cannot
+	 * transfer ReadableStreams, so the handler uses the existing MessagePort bridge.
+	 */
 	const readableStreamTransferHandler: Comlink.TransferHandler<
 		ReadableStream<Uint8Array>,
 		SerializedReadableStream
@@ -287,6 +291,11 @@ function setupTransferHandlers() {
 		type: string;
 		stdin: SerializedReadableStream;
 	};
+	/**
+	 * Transfers an event whose stdin contains a ReadableStream. Comlink applies a
+	 * transfer handler to the top-level value only, so it will not discover the
+	 * nested stream on its own.
+	 */
 	const eventWithReadableStreamTransferHandler: Comlink.TransferHandler<
 		EventWithReadableStream,
 		SerializedEventWithReadableStream

--- a/packages/php-wasm/universal/src/lib/api.ts
+++ b/packages/php-wasm/universal/src/lib/api.ts
@@ -470,11 +470,21 @@ function supportsTransferableStreams(): boolean {
  *   { t: 'chunk', b: ArrayBuffer } – next binary chunk
  *   { t: 'close' }                 – end of stream
  *   { t: 'error', m: string }      – terminal error
+ *   { t: 'cancel' }                – consumer cancelled the stream
  */
 export function streamToPort(stream: ReadableStream<Uint8Array>): MessagePort {
 	const { port1, port2 } = new MessageChannel();
+	const reader = stream.getReader();
+	const onMessage = (event: MessageEvent) => {
+		if (event.data?.t === 'cancel') {
+			reader.cancel().catch(() => {
+				// The consumer has already cancelled and cannot observe source errors.
+			});
+		}
+	};
+	port1.addEventListener('message', onMessage);
+	port1.start();
 	(async () => {
-		const reader = stream.getReader();
 		try {
 			while (true) {
 				const { done, value } = await reader.read();
@@ -518,6 +528,7 @@ export function streamToPort(stream: ReadableStream<Uint8Array>): MessagePort {
 				// Ignore error
 			}
 		} finally {
+			port1.removeEventListener('message', onMessage);
 			try {
 				port1.close();
 			} catch {
@@ -599,6 +610,11 @@ export function portToStream(port: MessagePort): ReadableStream<Uint8Array> {
 			}
 		},
 		cancel() {
+			try {
+				port.postMessage({ t: 'cancel' });
+			} catch {
+				// The producer has already closed its port.
+			}
 			try {
 				port.close();
 			} catch {

--- a/packages/php-wasm/universal/src/lib/api.ts
+++ b/packages/php-wasm/universal/src/lib/api.ts
@@ -248,6 +248,72 @@ function setupTransferHandlers() {
 			return port;
 		},
 	});
+	type SerializedReadableStream = {
+		stream?: ReadableStream<Uint8Array>;
+		port?: MessagePort;
+	};
+	const readableStreamTransferHandler: Comlink.TransferHandler<
+		ReadableStream<Uint8Array>,
+		SerializedReadableStream
+	> = {
+		canHandle: (obj: unknown): obj is ReadableStream<Uint8Array> =>
+			typeof ReadableStream !== 'undefined' &&
+			obj instanceof ReadableStream,
+		serialize(
+			stream: ReadableStream<Uint8Array>
+		): [SerializedReadableStream, Transferable[]] {
+			if (supportsTransferableStreams()) {
+				return [{ stream }, [stream as unknown as Transferable]];
+			}
+
+			const port = streamToPort(stream);
+			return [{ port }, [port]];
+		},
+		deserialize(
+			data: SerializedReadableStream
+		): ReadableStream<Uint8Array> {
+			return data.stream || portToStream(data.port!);
+		},
+	};
+	Comlink.transferHandlers.set(
+		'READABLE_STREAM',
+		readableStreamTransferHandler
+	);
+	type EventWithReadableStream = {
+		type: string;
+		stdin: ReadableStream<Uint8Array>;
+	};
+	type SerializedEventWithReadableStream = {
+		type: string;
+		stdin: SerializedReadableStream;
+	};
+	const eventWithReadableStreamTransferHandler: Comlink.TransferHandler<
+		EventWithReadableStream,
+		SerializedEventWithReadableStream
+	> = {
+		canHandle: (obj: unknown): obj is EventWithReadableStream =>
+			typeof obj === 'object' &&
+			obj !== null &&
+			'type' in obj &&
+			typeof obj.type === 'string' &&
+			'stdin' in obj &&
+			readableStreamTransferHandler.canHandle(obj.stdin),
+		serialize(event): [SerializedEventWithReadableStream, Transferable[]] {
+			const [stdin, transferables] =
+				readableStreamTransferHandler.serialize(event.stdin);
+			return [{ ...event, stdin }, transferables];
+		},
+		deserialize(event): EventWithReadableStream {
+			return {
+				...event,
+				stdin: readableStreamTransferHandler.deserialize(event.stdin),
+			};
+		},
+	};
+	Comlink.transferHandlers.set(
+		'EVENT_WITH_READABLE_STREAM',
+		eventWithReadableStreamTransferHandler
+	);
 	Comlink.transferHandlers.set('PHPResponse', {
 		canHandle: (obj: unknown): obj is PHPResponseData =>
 			typeof obj === 'object' &&

--- a/packages/php-wasm/universal/src/lib/api.ts
+++ b/packages/php-wasm/universal/src/lib/api.ts
@@ -253,8 +253,8 @@ function setupTransferHandlers() {
 		port?: MessagePort;
 	};
 	/**
-	 * Keeps the stream live while it crosses the Comlink boundary. Safari cannot
-	 * transfer ReadableStreams, so the handler uses the existing MessagePort bridge.
+	 * Keeps the stream live while it crosses the Comlink boundary. Runtimes without
+	 * transferable stream support use the existing MessagePort bridge.
 	 */
 	const readableStreamTransferHandler: Comlink.TransferHandler<
 		ReadableStream<Uint8Array>,
@@ -283,36 +283,36 @@ function setupTransferHandlers() {
 		'READABLE_STREAM',
 		readableStreamTransferHandler
 	);
-	type EventWithReadableStream = {
+	type EventWithReadableStdin = {
 		type: string;
 		stdin: ReadableStream<Uint8Array>;
 	};
-	type SerializedEventWithReadableStream = {
+	type SerializedEventWithReadableStdin = {
 		type: string;
 		stdin: SerializedReadableStream;
 	};
 	/**
-	 * Transfers an event whose stdin contains a ReadableStream. Comlink applies a
-	 * transfer handler to the top-level value only, so it will not discover the
-	 * nested stream on its own.
+	 * Transfers a worker event whose `stdin` property is a ReadableStream. Comlink
+	 * applies a transfer handler to the top-level value only, so it will not discover
+	 * the `stdin` stream on its own.
 	 */
-	const eventWithReadableStreamTransferHandler: Comlink.TransferHandler<
-		EventWithReadableStream,
-		SerializedEventWithReadableStream
+	const eventWithReadableStdinTransferHandler: Comlink.TransferHandler<
+		EventWithReadableStdin,
+		SerializedEventWithReadableStdin
 	> = {
-		canHandle: (obj: unknown): obj is EventWithReadableStream =>
+		canHandle: (obj: unknown): obj is EventWithReadableStdin =>
 			typeof obj === 'object' &&
 			obj !== null &&
 			'type' in obj &&
 			typeof obj.type === 'string' &&
 			'stdin' in obj &&
 			readableStreamTransferHandler.canHandle(obj.stdin),
-		serialize(event): [SerializedEventWithReadableStream, Transferable[]] {
+		serialize(event): [SerializedEventWithReadableStdin, Transferable[]] {
 			const [stdin, transferables] =
 				readableStreamTransferHandler.serialize(event.stdin);
 			return [{ ...event, stdin }, transferables];
 		},
-		deserialize(event): EventWithReadableStream {
+		deserialize(event): EventWithReadableStdin {
 			return {
 				...event,
 				stdin: readableStreamTransferHandler.deserialize(event.stdin),
@@ -320,8 +320,8 @@ function setupTransferHandlers() {
 		},
 	};
 	Comlink.transferHandlers.set(
-		'EVENT_WITH_READABLE_STREAM',
-		eventWithReadableStreamTransferHandler
+		'EVENT_WITH_READABLE_STDIN',
+		eventWithReadableStdinTransferHandler
 	);
 	Comlink.transferHandlers.set('PHPResponse', {
 		canHandle: (obj: unknown): obj is PHPResponseData =>
@@ -492,12 +492,12 @@ export function streamToPort(stream: ReadableStream<Uint8Array>): MessagePort {
 					break;
 				}
 				if (value) {
-					// Ensure we transfer an owned buffer
-					const owned =
-						value.byteOffset === 0 &&
-						value.byteLength === value.buffer.byteLength
-							? value
-							: value.slice();
+					/**
+					 * ReadableStream.tee() gives each branch the same chunk object. Transfer
+					 * an owned copy so detaching this buffer does not invalidate another
+					 * listener's branch.
+					 */
+					const owned = value.slice();
 					const buf = owned.buffer;
 					try {
 						port1.postMessage({ t: 'chunk', b: buf }, [

--- a/packages/php-wasm/universal/src/lib/php-worker.ts
+++ b/packages/php-wasm/universal/src/lib/php-worker.ts
@@ -362,7 +362,9 @@ export class PHPWorker implements LimitedPHPApi, AsyncDisposable {
 		this.#eventListeners.get(eventType)?.delete(listener);
 	}
 
-	protected dispatchEvent<Event extends PHPWorkerEvent>(event: Event) {
+	protected dispatchEvent<EventType extends PHPWorkerEvent>(
+		event: EventType
+	) {
 		const listeners = this.#eventListeners.get(event.type);
 		if (!listeners) {
 			return;
@@ -383,7 +385,7 @@ export class PHPWorker implements LimitedPHPApi, AsyncDisposable {
 				listener({
 					...event,
 					stdin: streams[streamIndex++],
-				} as Event);
+				} as EventType);
 			}
 			return;
 		}
@@ -449,9 +451,13 @@ function teeReadableStream(
 	stream: ReadableStream<Uint8Array>,
 	branches: number
 ): ReadableStream<Uint8Array>[] {
-	if (branches === 1) {
-		return [stream];
+	const streams: ReadableStream<Uint8Array>[] = [];
+	let remaining = stream;
+	while (streams.length < branches - 1) {
+		const [branch, next] = remaining.tee();
+		streams.push(branch);
+		remaining = next;
 	}
-	const [first, remaining] = stream.tee();
-	return [first, ...teeReadableStream(remaining, branches - 1)];
+	streams.push(remaining);
+	return streams;
 }

--- a/packages/php-wasm/universal/src/lib/php-worker.ts
+++ b/packages/php-wasm/universal/src/lib/php-worker.ts
@@ -367,7 +367,27 @@ export class PHPWorker implements LimitedPHPApi, AsyncDisposable {
 		if (!listeners) {
 			return;
 		}
-		for (const listener of listeners) {
+		const eventListeners = [...listeners];
+		if (eventListeners.length > 1 && hasReadableStdin(event)) {
+			/**
+			 * A ReadableStream can only be transferred through Comlink once. Give each
+			 * listener its own branch so one listener cannot lock the stream before the
+			 * remaining listeners receive the event.
+			 */
+			const streams = teeReadableStream(
+				event.stdin,
+				eventListeners.length
+			);
+			let streamIndex = 0;
+			for (const listener of eventListeners) {
+				listener({
+					...event,
+					stdin: streams[streamIndex++],
+				} as Event);
+			}
+			return;
+		}
+		for (const listener of eventListeners) {
 			listener(event);
 		}
 	}
@@ -407,4 +427,25 @@ export class PHPWorker implements LimitedPHPApi, AsyncDisposable {
 		}
 		throw new Error('PHPWorker is not connected to a request handler.');
 	}
+}
+
+function hasReadableStdin(
+	event: PHPWorkerEvent
+): event is PHPWorkerEvent & { stdin: ReadableStream<Uint8Array> } {
+	return (
+		'stdin' in event &&
+		typeof ReadableStream !== 'undefined' &&
+		event.stdin instanceof ReadableStream
+	);
+}
+
+function teeReadableStream(
+	stream: ReadableStream<Uint8Array>,
+	branches: number
+): ReadableStream<Uint8Array>[] {
+	if (branches === 1) {
+		return [stream];
+	}
+	const [first, remaining] = stream.tee();
+	return [first, ...teeReadableStream(remaining, branches - 1)];
 }

--- a/packages/php-wasm/universal/src/lib/php-worker.ts
+++ b/packages/php-wasm/universal/src/lib/php-worker.ts
@@ -439,6 +439,12 @@ function hasReadableStdin(
 	);
 }
 
+/**
+ * Creates one independently transferable stream branch per event listener.
+ *
+ * ReadableStream.tee() may buffer unread chunks for a slow branch. PHPWorker
+ * does not coordinate backpressure between listeners.
+ */
 function teeReadableStream(
 	stream: ReadableStream<Uint8Array>,
 	branches: number

--- a/packages/php-wasm/web/playwright.config.ts
+++ b/packages/php-wasm/web/playwright.config.ts
@@ -3,7 +3,11 @@ import { defineConfig, devices } from '@playwright/test';
 export default defineConfig({
 	outputDir: './src/test/test-results',
 	testDir: './src/test',
-	testMatch: ['php-dynamic-loading.spec.ts', 'php-networking.spec.ts'],
+	testMatch: [
+		'php-dynamic-loading.spec.ts',
+		'php-networking.spec.ts',
+		'readable-stream-transfer.spec.ts',
+	],
 	fullyParallel: false,
 	forbidOnly: !!process.env['CI'],
 	workers: 1,

--- a/packages/php-wasm/web/src/test/playwright/browser-globals.ts
+++ b/packages/php-wasm/web/src/test/playwright/browser-globals.ts
@@ -1,4 +1,5 @@
 import {
+	consumeAPI,
 	PHP,
 	PHPRequestHandler,
 	proxyFileSystem,
@@ -8,7 +9,10 @@ import {
 	certificateToPEM,
 	generateCertificate,
 	loadWebRuntime,
+	spawnPHPWorkerThread,
 } from '../../lib';
+// @ts-ignore
+import readableStreamWorkerUrl from './readable-stream-worker.ts?worker&url';
 
 declare global {
 	interface Window {
@@ -17,6 +21,9 @@ declare global {
 		loadWebRuntime: typeof loadWebRuntime;
 		proxyFileSystem: typeof proxyFileSystem;
 		setPhpIniEntries: typeof setPhpIniEntries;
+		consumeAPI: typeof consumeAPI;
+		spawnPHPWorkerThread: typeof spawnPHPWorkerThread;
+		readableStreamWorkerUrl: string;
 		generateCertificate: typeof generateCertificate;
 		certificateToPEM: typeof certificateToPEM;
 	}
@@ -27,5 +34,8 @@ window.PHPRequestHandler = PHPRequestHandler;
 window.loadWebRuntime = loadWebRuntime;
 window.proxyFileSystem = proxyFileSystem;
 window.setPhpIniEntries = setPhpIniEntries;
+window.consumeAPI = consumeAPI;
+window.spawnPHPWorkerThread = spawnPHPWorkerThread;
+window.readableStreamWorkerUrl = readableStreamWorkerUrl;
 window.generateCertificate = generateCertificate;
 window.certificateToPEM = certificateToPEM;

--- a/packages/php-wasm/web/src/test/playwright/browser-globals.ts
+++ b/packages/php-wasm/web/src/test/playwright/browser-globals.ts
@@ -11,7 +11,6 @@ import {
 	loadWebRuntime,
 	spawnPHPWorkerThread,
 } from '../../lib';
-// @ts-ignore
 import readableStreamWorkerUrl from './readable-stream-worker.ts?worker&url';
 
 declare global {

--- a/packages/php-wasm/web/src/test/playwright/readable-stream-worker.ts
+++ b/packages/php-wasm/web/src/test/playwright/readable-stream-worker.ts
@@ -1,0 +1,31 @@
+import { exposeAPI, PHPWorker } from '@php-wasm/universal';
+
+self.postMessage('worker-script-started');
+
+class ReadableStreamWorker extends PHPWorker {
+	#streamFinished = true;
+
+	emitStream() {
+		this.#streamFinished = false;
+		const encoder = new TextEncoder();
+		const stream = new ReadableStream<Uint8Array>({
+			start: (controller) => {
+				controller.enqueue(encoder.encode('first chunk'));
+				setTimeout(() => {
+					controller.enqueue(encoder.encode('second chunk'));
+					controller.close();
+					this.#streamFinished = true;
+				}, 500);
+			},
+		});
+		this.dispatchEvent({ type: 'test.stream', stdin: stream });
+	}
+
+	isStreamFinished() {
+		return this.#streamFinished;
+	}
+}
+
+const endpoint = new ReadableStreamWorker();
+const [setApiReady] = exposeAPI(endpoint);
+setApiReady();

--- a/packages/php-wasm/web/src/test/playwright/readable-stream-worker.ts
+++ b/packages/php-wasm/web/src/test/playwright/readable-stream-worker.ts
@@ -4,8 +4,9 @@ self.postMessage('worker-script-started');
 
 class ReadableStreamWorker extends PHPWorker {
 	#streamFinished = true;
+	#transferableStreamProbeRejected = false;
 
-	emitStream() {
+	emitStream(forceMessagePortFallback = false) {
 		this.#streamFinished = false;
 		const encoder = new TextEncoder();
 		const stream = new ReadableStream<Uint8Array>({
@@ -18,11 +19,47 @@ class ReadableStreamWorker extends PHPWorker {
 				}, 500);
 			},
 		});
-		this.dispatchEvent({ type: 'test.stream', stdin: stream });
+		const originalPostMessage = MessagePort.prototype.postMessage;
+		let transferableStreamProbeRejected = false;
+		if (forceMessagePortFallback) {
+			/**
+			 * Emulates a runtime without transferable streams. The production feature
+			 * detection must reject the probe and select the MessagePort bridge.
+			 */
+			MessagePort.prototype.postMessage = function (
+				this: MessagePort,
+				message: unknown,
+				optionsOrTransfer: StructuredSerializeOptions | Transferable[]
+			) {
+				if (message instanceof ReadableStream) {
+					transferableStreamProbeRejected = true;
+					throw new DOMException(
+						'Transferable streams disabled by test',
+						'DataCloneError'
+					);
+				}
+				const options = Array.isArray(optionsOrTransfer)
+					? { transfer: optionsOrTransfer }
+					: optionsOrTransfer;
+				return originalPostMessage.call(this, message, options);
+			} as MessagePort['postMessage'];
+		}
+
+		try {
+			this.dispatchEvent({ type: 'test.stream', stdin: stream });
+		} finally {
+			MessagePort.prototype.postMessage = originalPostMessage;
+			this.#transferableStreamProbeRejected =
+				transferableStreamProbeRejected;
+		}
 	}
 
 	isStreamFinished() {
 		return this.#streamFinished;
+	}
+
+	wasTransferableStreamProbeRejected() {
+		return this.#transferableStreamProbeRejected;
 	}
 }
 

--- a/packages/php-wasm/web/src/test/playwright/readable-stream-worker.ts
+++ b/packages/php-wasm/web/src/test/playwright/readable-stream-worker.ts
@@ -4,19 +4,26 @@ self.postMessage('worker-script-started');
 
 class ReadableStreamWorker extends PHPWorker {
 	#streamFinished = true;
+	#streamCancelled = false;
 	#transferableStreamProbeRejected = false;
 
-	emitStream(forceMessagePortFallback = false) {
+	emitStream(forceMessagePortFallback = false, secondChunkDelay = 500) {
 		this.#streamFinished = false;
+		this.#streamCancelled = false;
 		const encoder = new TextEncoder();
+		let secondChunkTimeout: ReturnType<typeof setTimeout>;
 		const stream = new ReadableStream<Uint8Array>({
 			start: (controller) => {
 				controller.enqueue(encoder.encode('first chunk'));
-				setTimeout(() => {
+				secondChunkTimeout = setTimeout(() => {
 					controller.enqueue(encoder.encode('second chunk'));
 					controller.close();
 					this.#streamFinished = true;
-				}, 500);
+				}, secondChunkDelay);
+			},
+			cancel: () => {
+				clearTimeout(secondChunkTimeout);
+				this.#streamCancelled = true;
 			},
 		});
 		const originalPostMessage = MessagePort.prototype.postMessage;
@@ -56,6 +63,10 @@ class ReadableStreamWorker extends PHPWorker {
 
 	isStreamFinished() {
 		return this.#streamFinished;
+	}
+
+	wasStreamCancelled() {
+		return this.#streamCancelled;
 	}
 
 	wasTransferableStreamProbeRejected() {

--- a/packages/php-wasm/web/src/test/readable-stream-transfer.spec.ts
+++ b/packages/php-wasm/web/src/test/readable-stream-transfer.spec.ts
@@ -1,6 +1,6 @@
 import test from '@playwright/test';
 
-test.describe('ReadableStream worker transfer', () => {
+test.describe('worker event stdin stream transfer', () => {
 	test.beforeEach(async ({ page }) => {
 		await page.goto('/');
 		await page.addScriptTag({
@@ -9,105 +9,126 @@ test.describe('ReadableStream worker transfer', () => {
 		});
 	});
 
-	test('streams an event payload to every listener before the source closes', async ({
-		page,
-	}) => {
-		const result = await page.evaluate(async () => {
-			type StreamEvent = {
-				type: string;
-				stdin: ReadableStream<Uint8Array>;
-			};
-			type WorkerAPI = {
-				isReady(): Promise<void>;
-				addEventListener(
-					eventType: string,
-					listener: (event: StreamEvent) => void
-				): Promise<void>;
-				emitStream(): Promise<void>;
-				isStreamFinished(): Promise<boolean>;
-			};
+	for (const forceMessagePortFallback of [false, true]) {
+		const transport = forceMessagePortFallback
+			? 'the MessagePort fallback'
+			: 'transferable streams';
+		test(`streams stdin to every listener through ${transport}`, async ({
+			page,
+		}) => {
+			const result = await page.evaluate(
+				async (forceMessagePortFallback) => {
+					type StreamEvent = {
+						type: string;
+						stdin: ReadableStream<Uint8Array>;
+					};
+					type WorkerAPI = {
+						isReady(): Promise<void>;
+						addEventListener(
+							eventType: string,
+							listener: (event: StreamEvent) => void
+						): Promise<void>;
+						emitStream(
+							forceMessagePortFallback: boolean
+						): Promise<void>;
+						isStreamFinished(): Promise<boolean>;
+						wasTransferableStreamProbeRejected(): Promise<boolean>;
+					};
 
-			const worker = await window.spawnPHPWorkerThread(
-				window.readableStreamWorkerUrl
-			);
-			const api = window.consumeAPI<WorkerAPI>(worker);
-			await api.isReady();
+					const worker = await window.spawnPHPWorkerThread(
+						window.readableStreamWorkerUrl
+					);
+					const api = window.consumeAPI<WorkerAPI>(worker);
+					await api.isReady();
 
-			let resolveFirstStream!: (
-				stream: ReadableStream<Uint8Array>
-			) => void;
-			let resolveSecondStream!: (
-				stream: ReadableStream<Uint8Array>
-			) => void;
-			const firstStream = new Promise<ReadableStream<Uint8Array>>(
-				(resolve) => (resolveFirstStream = resolve)
-			);
-			const secondStream = new Promise<ReadableStream<Uint8Array>>(
-				(resolve) => (resolveSecondStream = resolve)
-			);
+					let resolveFirstStream!: (
+						stream: ReadableStream<Uint8Array>
+					) => void;
+					let resolveSecondStream!: (
+						stream: ReadableStream<Uint8Array>
+					) => void;
+					const firstStream = new Promise<ReadableStream<Uint8Array>>(
+						(resolve) => (resolveFirstStream = resolve)
+					);
+					const secondStream = new Promise<
+						ReadableStream<Uint8Array>
+					>((resolve) => (resolveSecondStream = resolve));
 
-			await api.addEventListener('test.stream', (event) => {
-				resolveFirstStream(event.stdin);
-			});
-			await api.addEventListener('test.stream', (event) => {
-				resolveSecondStream(event.stdin);
-			});
+					await api.addEventListener('test.stream', (event) => {
+						resolveFirstStream(event.stdin);
+					});
+					await api.addEventListener('test.stream', (event) => {
+						resolveSecondStream(event.stdin);
+					});
 
-			try {
-				await api.emitStream();
-				const [streamA, streamB] = await Promise.race([
-					Promise.all([firstStream, secondStream]),
-					new Promise<never>((_, reject) =>
-						setTimeout(
-							() =>
-								reject(
-									new Error(
-										'Stream event was not transferred'
-									)
-								),
-							2000
-						)
-					),
-				]);
+					try {
+						await api.emitStream(forceMessagePortFallback);
+						const [streamA, streamB] = await Promise.race([
+							Promise.all([firstStream, secondStream]),
+							new Promise<never>((_, reject) =>
+								setTimeout(
+									() =>
+										reject(
+											new Error(
+												'Stream event was not transferred'
+											)
+										),
+									2000
+								)
+							),
+						]);
 
-				const readerA = streamA.getReader();
-				const firstRead = await readerA.read();
-				const sourceFinishedAfterFirstRead =
-					await api.isStreamFinished();
+						const readerA = streamA.getReader();
+						const firstRead = await readerA.read();
+						const sourceFinishedAfterFirstRead =
+							await api.isStreamFinished();
 
-				const readRemaining = async (
-					reader: ReadableStreamDefaultReader<Uint8Array>
-				) => {
-					const chunks: Uint8Array[] = [];
-					while (true) {
-						const { done, value } = await reader.read();
-						if (done) {
-							return chunks;
-						}
-						chunks.push(value);
+						const readRemaining = async (
+							reader: ReadableStreamDefaultReader<Uint8Array>
+						) => {
+							const chunks: Uint8Array[] = [];
+							while (true) {
+								const { done, value } = await reader.read();
+								if (done) {
+									return chunks;
+								}
+								chunks.push(value);
+							}
+						};
+						const [remainingA, chunksB] = await Promise.all([
+							readRemaining(readerA),
+							readRemaining(streamB.getReader()),
+						]);
+						const decoder = new TextDecoder();
+						return {
+							firstChunk: decoder.decode(firstRead.value),
+							remainingA: remainingA.map((chunk) =>
+								decoder.decode(chunk)
+							),
+							chunksB: chunksB.map((chunk) =>
+								decoder.decode(chunk)
+							),
+							sourceFinishedAfterFirstRead,
+							transferableStreamProbeRejected:
+								await api.wasTransferableStreamProbeRejected(),
+						};
+					} finally {
+						worker.terminate();
 					}
-				};
-				const [remainingA, chunksB] = await Promise.all([
-					readRemaining(readerA),
-					readRemaining(streamB.getReader()),
-				]);
-				const decoder = new TextDecoder();
-				return {
-					firstChunk: decoder.decode(firstRead.value),
-					remainingA: remainingA.map((chunk) =>
-						decoder.decode(chunk)
-					),
-					chunksB: chunksB.map((chunk) => decoder.decode(chunk)),
-					sourceFinishedAfterFirstRead,
-				};
-			} finally {
-				worker.terminate();
-			}
-		});
+				},
+				forceMessagePortFallback
+			);
 
-		test.expect(result.firstChunk).toBe('first chunk');
-		test.expect(result.remainingA).toEqual(['second chunk']);
-		test.expect(result.chunksB).toEqual(['first chunk', 'second chunk']);
-		test.expect(result.sourceFinishedAfterFirstRead).toBe(false);
-	});
+			test.expect(result.firstChunk).toBe('first chunk');
+			test.expect(result.remainingA).toEqual(['second chunk']);
+			test.expect(result.chunksB).toEqual([
+				'first chunk',
+				'second chunk',
+			]);
+			test.expect(result.sourceFinishedAfterFirstRead).toBe(false);
+			test.expect(result.transferableStreamProbeRejected).toBe(
+				forceMessagePortFallback
+			);
+		});
+	}
 });

--- a/packages/php-wasm/web/src/test/readable-stream-transfer.spec.ts
+++ b/packages/php-wasm/web/src/test/readable-stream-transfer.spec.ts
@@ -1,0 +1,113 @@
+import test from '@playwright/test';
+
+test.describe('ReadableStream worker transfer', () => {
+	test.beforeEach(async ({ page }) => {
+		await page.goto('/');
+		await page.addScriptTag({
+			type: 'module',
+			url: '/src/test/playwright/browser-globals.ts',
+		});
+	});
+
+	test('streams an event payload to every listener before the source closes', async ({
+		page,
+	}) => {
+		const result = await page.evaluate(async () => {
+			type StreamEvent = {
+				type: string;
+				stdin: ReadableStream<Uint8Array>;
+			};
+			type WorkerAPI = {
+				isReady(): Promise<void>;
+				addEventListener(
+					eventType: string,
+					listener: (event: StreamEvent) => void
+				): Promise<void>;
+				emitStream(): Promise<void>;
+				isStreamFinished(): Promise<boolean>;
+			};
+
+			const worker = await window.spawnPHPWorkerThread(
+				window.readableStreamWorkerUrl
+			);
+			const api = window.consumeAPI<WorkerAPI>(worker);
+			await api.isReady();
+
+			let resolveFirstStream!: (
+				stream: ReadableStream<Uint8Array>
+			) => void;
+			let resolveSecondStream!: (
+				stream: ReadableStream<Uint8Array>
+			) => void;
+			const firstStream = new Promise<ReadableStream<Uint8Array>>(
+				(resolve) => (resolveFirstStream = resolve)
+			);
+			const secondStream = new Promise<ReadableStream<Uint8Array>>(
+				(resolve) => (resolveSecondStream = resolve)
+			);
+
+			await api.addEventListener('test.stream', (event) => {
+				resolveFirstStream(event.stdin);
+			});
+			await api.addEventListener('test.stream', (event) => {
+				resolveSecondStream(event.stdin);
+			});
+
+			try {
+				await api.emitStream();
+				const [streamA, streamB] = await Promise.race([
+					Promise.all([firstStream, secondStream]),
+					new Promise<never>((_, reject) =>
+						setTimeout(
+							() =>
+								reject(
+									new Error(
+										'Stream event was not transferred'
+									)
+								),
+							2000
+						)
+					),
+				]);
+
+				const readerA = streamA.getReader();
+				const firstRead = await readerA.read();
+				const sourceFinishedAfterFirstRead =
+					await api.isStreamFinished();
+
+				const readRemaining = async (
+					reader: ReadableStreamDefaultReader<Uint8Array>
+				) => {
+					const chunks: Uint8Array[] = [];
+					while (true) {
+						const { done, value } = await reader.read();
+						if (done) {
+							return chunks;
+						}
+						chunks.push(value);
+					}
+				};
+				const [remainingA, chunksB] = await Promise.all([
+					readRemaining(readerA),
+					readRemaining(streamB.getReader()),
+				]);
+				const decoder = new TextDecoder();
+				return {
+					firstChunk: decoder.decode(firstRead.value),
+					remainingA: remainingA.map((chunk) =>
+						decoder.decode(chunk)
+					),
+					chunksB: chunksB.map((chunk) => decoder.decode(chunk)),
+					sourceFinishedAfterFirstRead,
+				};
+			} finally {
+				worker.terminate();
+			}
+		});
+
+		test.expect(result.firstChunk).toBe('first chunk');
+		test.expect(result.remainingA).toEqual(['second chunk']);
+		test.expect(result.chunksB).toEqual(['first chunk', 'second chunk']);
+		test.expect(result.sourceFinishedAfterFirstRead).toBe(false);
+	});
+});

--- a/packages/php-wasm/web/src/test/readable-stream-transfer.spec.ts
+++ b/packages/php-wasm/web/src/test/readable-stream-transfer.spec.ts
@@ -131,4 +131,96 @@ test.describe('worker event stdin stream transfer', () => {
 			);
 		});
 	}
+
+	for (const forceMessagePortFallback of [false, true]) {
+		const transport = forceMessagePortFallback
+			? 'the MessagePort fallback'
+			: 'transferable streams';
+		test(`cancels the source through ${transport}`, async ({ page }) => {
+			const result = await page.evaluate(
+				async (forceMessagePortFallback) => {
+					type StreamEvent = {
+						type: string;
+						stdin: ReadableStream<Uint8Array>;
+					};
+					type WorkerAPI = {
+						isReady(): Promise<void>;
+						addEventListener(
+							eventType: string,
+							listener: (event: StreamEvent) => void
+						): Promise<void>;
+						emitStream(
+							forceMessagePortFallback: boolean,
+							secondChunkDelay: number
+						): Promise<void>;
+						wasStreamCancelled(): Promise<boolean>;
+						wasTransferableStreamProbeRejected(): Promise<boolean>;
+					};
+
+					const worker = await window.spawnPHPWorkerThread(
+						window.readableStreamWorkerUrl
+					);
+					const api = window.consumeAPI<WorkerAPI>(worker);
+					await api.isReady();
+
+					let resolveFirstStream!: (
+						stream: ReadableStream<Uint8Array>
+					) => void;
+					let resolveSecondStream!: (
+						stream: ReadableStream<Uint8Array>
+					) => void;
+					const firstStream = new Promise<ReadableStream<Uint8Array>>(
+						(resolve) => (resolveFirstStream = resolve)
+					);
+					const secondStream = new Promise<
+						ReadableStream<Uint8Array>
+					>((resolve) => (resolveSecondStream = resolve));
+					await api.addEventListener('test.stream', (event) => {
+						resolveFirstStream(event.stdin);
+					});
+					await api.addEventListener('test.stream', (event) => {
+						resolveSecondStream(event.stdin);
+					});
+
+					try {
+						await api.emitStream(forceMessagePortFallback, 5000);
+						const streams = await Promise.all([
+							firstStream,
+							secondStream,
+						]);
+						await Promise.all(
+							streams.map((stream) => stream.cancel())
+						);
+
+						const deadline = Date.now() + 2000;
+						while (Date.now() < deadline) {
+							if (await api.wasStreamCancelled()) {
+								return {
+									sourceCancelled: true,
+									transferableStreamProbeRejected:
+										await api.wasTransferableStreamProbeRejected(),
+								};
+							}
+							await new Promise((resolve) =>
+								setTimeout(resolve, 10)
+							);
+						}
+						return {
+							sourceCancelled: false,
+							transferableStreamProbeRejected:
+								await api.wasTransferableStreamProbeRejected(),
+						};
+					} finally {
+						worker.terminate();
+					}
+				},
+				forceMessagePortFallback
+			);
+
+			test.expect(result.transferableStreamProbeRejected).toBe(
+				forceMessagePortFallback
+			);
+			test.expect(result.sourceCancelled).toBe(true);
+		});
+	}
 });

--- a/packages/php-wasm/web/src/typings.d.ts
+++ b/packages/php-wasm/web/src/typings.d.ts
@@ -22,3 +22,8 @@ declare module '*.module.styl' {
 	const classes: { readonly [key: string]: string };
 	export default classes;
 }
+
+declare module '*?worker&url' {
+	const workerUrl: string;
+	export default workerUrl;
+}


### PR DESCRIPTION
`PHPWorker` can now deliver an event whose `stdin` remains a live `ReadableStream` across the browser worker boundary. Comlink applies transfer handlers only to the top-level value, so a stream stored in an event's `stdin` property otherwise reaches `postMessage()` without a transfer list and structured cloning fails.

The event handler serializes `stdin` through a dedicated stream handler. It transfers the stream directly when the runtime supports that operation and uses the existing `MessagePort` bridge otherwise. The bridge transfers owned chunk copies because `ReadableStream.tee()` branches share chunk objects and detaching one branch's buffer must not invalidate the others. Consumer cancellation travels back over the port and cancels the source reader.

A stream can only be transferred once, so `PHPWorker` gives each listener its own tee branch. Slow listeners may queue unread chunks because this transport does not coordinate backpressure between branches.

Browser-worker tests cover native stream transfer and the forced `MessagePort` fallback, including incremental delivery to two listeners and source cancellation after both tee branches cancel.

This is the worker transport required by #3996. It adds no sendmail behavior.
