### PR TITLE
[Website] Show the current boot stage in startup progress

### DIFF
--- a/packages/playground/client/src/index.spec.ts
+++ b/packages/playground/client/src/index.spec.ts
@@ -52,7 +52,6 @@ describe('startPlaygroundWeb', () => {
 				remoteUrl:
 					'http://localhost/remote.html?blueprints-runner=v2&existing=1',
 				progressTracker: createProgressTracker(),
-				siteName: 'Curious Harbor',
 				blueprint: {
 					steps: [],
 				},
@@ -63,9 +62,6 @@ describe('startPlaygroundWeb', () => {
 		expect(mocks.BlueprintsV2Handler).not.toHaveBeenCalled();
 		expect(iframe.src).not.toContain('blueprints-runner');
 		expect(iframe.src).toContain('existing=1');
-		expect(new URL(iframe.src).searchParams.get('progressbarTitle')).toBe(
-			'Curious Harbor'
-		);
 	});
 
 	it('routes Blueprint v2 declarations through the v2 handler', async () => {

--- a/packages/playground/client/src/index.spec.ts
+++ b/packages/playground/client/src/index.spec.ts
@@ -52,7 +52,6 @@ describe('startPlaygroundWeb', () => {
 				remoteUrl:
 					'http://localhost/remote.html?blueprints-runner=v2&existing=1',
 				progressTracker: createProgressTracker(),
-				siteName: 'Curious Harbor',
 				blueprint: {
 					steps: [],
 				},
@@ -63,9 +62,6 @@ describe('startPlaygroundWeb', () => {
 		expect(mocks.BlueprintsV2Handler).not.toHaveBeenCalled();
 		expect(iframe.src).not.toContain('blueprints-runner');
 		expect(iframe.src).toContain('existing=1');
-		expect(new URL(iframe.src).searchParams.has('progressbarTitle')).toBe(
-			false
-		);
 	});
 
 	it('routes Blueprint v2 declarations through the v2 handler', async () => {

--- a/packages/playground/client/src/index.spec.ts
+++ b/packages/playground/client/src/index.spec.ts
@@ -52,6 +52,7 @@ describe('startPlaygroundWeb', () => {
 				remoteUrl:
 					'http://localhost/remote.html?blueprints-runner=v2&existing=1',
 				progressTracker: createProgressTracker(),
+				siteName: 'Curious Harbor',
 				blueprint: {
 					steps: [],
 				},
@@ -62,6 +63,9 @@ describe('startPlaygroundWeb', () => {
 		expect(mocks.BlueprintsV2Handler).not.toHaveBeenCalled();
 		expect(iframe.src).not.toContain('blueprints-runner');
 		expect(iframe.src).toContain('existing=1');
+		expect(new URL(iframe.src).searchParams.has('progressbarTitle')).toBe(
+			false
+		);
 	});
 
 	it('routes Blueprint v2 declarations through the v2 handler', async () => {

--- a/packages/playground/client/src/index.spec.ts
+++ b/packages/playground/client/src/index.spec.ts
@@ -63,8 +63,8 @@ describe('startPlaygroundWeb', () => {
 		expect(mocks.BlueprintsV2Handler).not.toHaveBeenCalled();
 		expect(iframe.src).not.toContain('blueprints-runner');
 		expect(iframe.src).toContain('existing=1');
-		expect(new URL(iframe.src).searchParams.get('progressbarTitle')).toBe(
-			'Curious Harbor'
+		expect(new URL(iframe.src).searchParams.has('progressbarTitle')).toBe(
+			false
 		);
 	});
 

--- a/packages/playground/client/src/index.spec.ts
+++ b/packages/playground/client/src/index.spec.ts
@@ -63,8 +63,8 @@ describe('startPlaygroundWeb', () => {
 		expect(mocks.BlueprintsV2Handler).not.toHaveBeenCalled();
 		expect(iframe.src).not.toContain('blueprints-runner');
 		expect(iframe.src).toContain('existing=1');
-		expect(new URL(iframe.src).searchParams.has('progressbarTitle')).toBe(
-			false
+		expect(new URL(iframe.src).searchParams.get('progressbarTitle')).toBe(
+			'Curious Harbor'
 		);
 	});
 

--- a/packages/playground/client/src/index.ts
+++ b/packages/playground/client/src/index.ts
@@ -57,11 +57,6 @@ export interface StartPlaygroundOptions {
 	remoteUrl: string;
 	progressTracker?: ProgressTracker;
 	disableProgressBar?: boolean;
-	/**
-	 * A stable label for the loading progress bar, typically the name of the
-	 * Playground being started. It stays visible while boot captions change.
-	 */
-	siteName?: string;
 	blueprint?: BlueprintV1;
 	/**
 	 * PHP extensions to install before the runtime starts.
@@ -174,7 +169,6 @@ export async function startPlaygroundWeb(
 	remoteUrlWithoutLegacyRunner.searchParams.delete('blueprints-runner');
 	remoteUrl = setQueryParams(remoteUrlWithoutLegacyRunner.toString(), {
 		progressbar: !disableProgressBar,
-		progressbarTitle: options.siteName || undefined,
 		[WITH_ADMIN_TRANSITIONS_PARAM]: new URL(
 			globalThis.location.href
 		).searchParams.has(WITH_ADMIN_TRANSITIONS_PARAM)

--- a/packages/playground/client/src/index.ts
+++ b/packages/playground/client/src/index.ts
@@ -173,7 +173,6 @@ export async function startPlaygroundWeb(
 	remoteUrlWithoutLegacyRunner.searchParams.delete('blueprints-runner');
 	remoteUrl = setQueryParams(remoteUrlWithoutLegacyRunner.toString(), {
 		progressbar: !disableProgressBar,
-		progressbarTitle: options.siteName || undefined,
 		[WITH_ADMIN_TRANSITIONS_PARAM]: new URL(
 			globalThis.location.href
 		).searchParams.has(WITH_ADMIN_TRANSITIONS_PARAM)

--- a/packages/playground/client/src/index.ts
+++ b/packages/playground/client/src/index.ts
@@ -57,10 +57,6 @@ export interface StartPlaygroundOptions {
 	remoteUrl: string;
 	progressTracker?: ProgressTracker;
 	disableProgressBar?: boolean;
-	/**
-	 * @deprecated This option no longer appears in the loading progress bar.
-	 */
-	siteName?: string;
 	blueprint?: BlueprintV1;
 	/**
 	 * PHP extensions to install before the runtime starts.

--- a/packages/playground/client/src/index.ts
+++ b/packages/playground/client/src/index.ts
@@ -173,6 +173,7 @@ export async function startPlaygroundWeb(
 	remoteUrlWithoutLegacyRunner.searchParams.delete('blueprints-runner');
 	remoteUrl = setQueryParams(remoteUrlWithoutLegacyRunner.toString(), {
 		progressbar: !disableProgressBar,
+		progressbarTitle: options.siteName || undefined,
 		[WITH_ADMIN_TRANSITIONS_PARAM]: new URL(
 			globalThis.location.href
 		).searchParams.has(WITH_ADMIN_TRANSITIONS_PARAM)

--- a/packages/playground/client/src/index.ts
+++ b/packages/playground/client/src/index.ts
@@ -57,6 +57,10 @@ export interface StartPlaygroundOptions {
 	remoteUrl: string;
 	progressTracker?: ProgressTracker;
 	disableProgressBar?: boolean;
+	/**
+	 * @deprecated This option no longer appears in the loading progress bar.
+	 */
+	siteName?: string;
 	blueprint?: BlueprintV1;
 	/**
 	 * PHP extensions to install before the runtime starts.

--- a/packages/playground/remote/src/lib/boot-playground-remote.ts
+++ b/packages/playground/remote/src/lib/boot-playground-remote.ts
@@ -66,9 +66,7 @@ export async function bootPlaygroundRemote() {
 	const hasProgressBar = query.has('progressbar');
 	let bar: ProgressBar | undefined;
 	if (hasProgressBar) {
-		bar = new ProgressBar({
-			title: query.get('progressbarTitle') || undefined,
-		});
+		bar = new ProgressBar();
 		document.body.prepend(bar.element);
 	}
 	const sw = navigator.serviceWorker;

--- a/packages/playground/remote/src/lib/boot-playground-remote.ts
+++ b/packages/playground/remote/src/lib/boot-playground-remote.ts
@@ -66,7 +66,9 @@ export async function bootPlaygroundRemote() {
 	const hasProgressBar = query.has('progressbar');
 	let bar: ProgressBar | undefined;
 	if (hasProgressBar) {
-		bar = new ProgressBar();
+		bar = new ProgressBar({
+			title: query.get('progressbarTitle') || undefined,
+		});
 		document.body.prepend(bar.element);
 	}
 	const sw = navigator.serviceWorker;

--- a/packages/playground/remote/src/lib/progress-bar/index.spec.ts
+++ b/packages/playground/remote/src/lib/progress-bar/index.spec.ts
@@ -10,9 +10,11 @@ describe('ProgressBar', () => {
 
 	it('shows the boot caption as a heading and announces updates', () => {
 		const progressBar = new ProgressBar({
+			title: 'Curious Harbor',
 			caption: 'Preparing WordPress',
 		});
 
+		expect(progressBar.element.textContent).not.toContain('Curious Harbor');
 		expect(progressBar.captionElement.textContent).toBe(
 			'Preparing WordPress'
 		);

--- a/packages/playground/remote/src/lib/progress-bar/index.spec.ts
+++ b/packages/playground/remote/src/lib/progress-bar/index.spec.ts
@@ -8,16 +8,11 @@ describe('ProgressBar', () => {
 		document.body.innerHTML = '';
 	});
 
-	it('keeps the Playground name stable while its boot caption changes', () => {
+	it('updates the boot caption', () => {
 		const progressBar = new ProgressBar({
-			title: 'Curious Harbor',
 			caption: 'Preparing WordPress',
 		});
 
-		expect(progressBar.labelElement.textContent).toBe(
-			'Starting Your Playground:'
-		);
-		expect(progressBar.titleElement.textContent).toBe('Curious Harbor');
 		expect(progressBar.captionElement.textContent).toBe(
 			'Preparing WordPress'
 		);
@@ -34,24 +29,18 @@ describe('ProgressBar', () => {
 
 		progressBar.setOptions({ caption: 'Installing WordPress' });
 
-		expect(progressBar.titleElement.textContent).toBe('Curious Harbor');
 		expect(progressBar.captionElement.textContent).toBe(
 			'Installing WordPress'
 		);
 	});
 
-	it('can clear the Playground name and caption', () => {
+	it('can clear the boot caption', () => {
 		const progressBar = new ProgressBar({
-			title: 'Curious Harbor',
 			caption: 'Preparing WordPress',
 		});
 
-		progressBar.setOptions({ title: undefined, caption: '' });
+		progressBar.setOptions({ caption: '' });
 
-		expect(progressBar.title).toBe('');
-		expect(progressBar.titleElement.textContent).toBe('');
-		expect(progressBar.titleElement.hidden).toBe(true);
-		expect(progressBar.labelElement.hidden).toBe(true);
 		expect(progressBar.caption).toBe('');
 		expect(progressBar.captionElement.textContent).toBe('');
 	});

--- a/packages/playground/remote/src/lib/progress-bar/index.spec.ts
+++ b/packages/playground/remote/src/lib/progress-bar/index.spec.ts
@@ -8,7 +8,7 @@ describe('ProgressBar', () => {
 		document.body.innerHTML = '';
 	});
 
-	it('updates the boot caption', () => {
+	it('shows the boot caption as a heading and announces updates', () => {
 		const progressBar = new ProgressBar({
 			caption: 'Preparing WordPress',
 		});
@@ -18,18 +18,21 @@ describe('ProgressBar', () => {
 		);
 		expect(
 			progressBar.element.querySelectorAll('h1, h2, h3, h4, h5, h6')
-		).toHaveLength(0);
-		expect(progressBar.captionElement.getAttribute('role')).toBe('status');
-		expect(progressBar.captionElement.getAttribute('aria-live')).toBe(
+		).toHaveLength(1);
+		expect(progressBar.statusElement.getAttribute('role')).toBe('status');
+		expect(progressBar.statusElement.getAttribute('aria-live')).toBe(
 			'polite'
 		);
-		expect(progressBar.captionElement.getAttribute('aria-atomic')).toBe(
+		expect(progressBar.statusElement.getAttribute('aria-atomic')).toBe(
 			'true'
 		);
 
 		progressBar.setOptions({ caption: 'Installing WordPress' });
 
 		expect(progressBar.captionElement.textContent).toBe(
+			'Installing WordPress'
+		);
+		expect(progressBar.statusElement.textContent).toBe(
 			'Installing WordPress'
 		);
 	});

--- a/packages/playground/remote/src/lib/progress-bar/index.spec.ts
+++ b/packages/playground/remote/src/lib/progress-bar/index.spec.ts
@@ -10,11 +10,9 @@ describe('ProgressBar', () => {
 
 	it('shows the boot caption as a heading and announces updates', () => {
 		const progressBar = new ProgressBar({
-			title: 'Curious Harbor',
 			caption: 'Preparing WordPress',
 		});
 
-		expect(progressBar.element.textContent).not.toContain('Curious Harbor');
 		expect(progressBar.captionElement.textContent).toBe(
 			'Preparing WordPress'
 		);

--- a/packages/playground/remote/src/lib/progress-bar/index.ts
+++ b/packages/playground/remote/src/lib/progress-bar/index.ts
@@ -2,6 +2,10 @@
 import css from './style.module.css';
 
 export interface ProgressBarOptions {
+	/**
+	 * @deprecated The startup loader no longer displays site titles.
+	 */
+	title?: string;
 	caption?: string;
 	progress?: number;
 	isIndefinite?: boolean;

--- a/packages/playground/remote/src/lib/progress-bar/index.ts
+++ b/packages/playground/remote/src/lib/progress-bar/index.ts
@@ -2,11 +2,6 @@
 import css from './style.module.css';
 
 export interface ProgressBarOptions {
-	/**
-	 * A stable heading for the Playground being started. Unlike the caption, it
-	 * is not overwritten as boot stages advance.
-	 */
-	title?: string;
 	caption?: string;
 	progress?: number;
 	isIndefinite?: boolean;
@@ -15,10 +10,7 @@ export interface ProgressBarOptions {
 
 class ProgressBar {
 	element: HTMLDivElement;
-	labelElement: HTMLParagraphElement;
-	titleElement: HTMLDivElement;
 	captionElement: HTMLDivElement;
-	title = '';
 	caption = 'Preparing WordPress';
 	progress = 0;
 	isIndefinite = false;
@@ -26,22 +18,15 @@ class ProgressBar {
 
 	constructor(options: ProgressBarOptions = {}) {
 		this.element = document.createElement('div');
-		this.labelElement = document.createElement('p');
-		this.titleElement = document.createElement('div');
 		this.captionElement = document.createElement('div');
 		this.captionElement.setAttribute('role', 'status');
 		this.captionElement.setAttribute('aria-live', 'polite');
 		this.captionElement.setAttribute('aria-atomic', 'true');
-		this.element.appendChild(this.labelElement);
-		this.element.appendChild(this.titleElement);
 		this.element.appendChild(this.captionElement);
 		this.setOptions(options);
 	}
 
 	setOptions(options: ProgressBarOptions) {
-		if ('title' in options) {
-			this.title = options.title ?? '';
-		}
 		if ('caption' in options) {
 			this.caption = options.caption ?? '';
 		}
@@ -74,18 +59,6 @@ class ProgressBar {
 		if (!this.visible) {
 			this.element.classList.add(css['isHidden']);
 		}
-
-		// Frame the stable site name as the Playground being started. Hide both
-		// elements when an embedding client does not provide a name.
-		this.labelElement.className = '';
-		this.labelElement.classList.add(css['label']);
-		this.labelElement.textContent = 'Starting Your Playground:';
-		this.labelElement.hidden = !this.title;
-
-		this.titleElement.className = '';
-		this.titleElement.classList.add(css['title']);
-		this.titleElement.textContent = this.title;
-		this.titleElement.hidden = !this.title;
 
 		this.captionElement.className = '';
 		this.captionElement.classList.add(css['caption']);

--- a/packages/playground/remote/src/lib/progress-bar/index.ts
+++ b/packages/playground/remote/src/lib/progress-bar/index.ts
@@ -2,10 +2,6 @@
 import css from './style.module.css';
 
 export interface ProgressBarOptions {
-	/**
-	 * @deprecated The startup loader no longer displays site titles.
-	 */
-	title?: string;
 	caption?: string;
 	progress?: number;
 	isIndefinite?: boolean;

--- a/packages/playground/remote/src/lib/progress-bar/index.ts
+++ b/packages/playground/remote/src/lib/progress-bar/index.ts
@@ -10,7 +10,8 @@ export interface ProgressBarOptions {
 
 class ProgressBar {
 	element: HTMLDivElement;
-	captionElement: HTMLDivElement;
+	captionElement: HTMLHeadingElement;
+	statusElement: HTMLDivElement;
 	caption = 'Preparing WordPress';
 	progress = 0;
 	isIndefinite = false;
@@ -18,11 +19,13 @@ class ProgressBar {
 
 	constructor(options: ProgressBarOptions = {}) {
 		this.element = document.createElement('div');
-		this.captionElement = document.createElement('div');
-		this.captionElement.setAttribute('role', 'status');
-		this.captionElement.setAttribute('aria-live', 'polite');
-		this.captionElement.setAttribute('aria-atomic', 'true');
+		this.captionElement = document.createElement('h1');
+		this.statusElement = document.createElement('div');
+		this.statusElement.setAttribute('role', 'status');
+		this.statusElement.setAttribute('aria-live', 'polite');
+		this.statusElement.setAttribute('aria-atomic', 'true');
 		this.element.appendChild(this.captionElement);
+		this.element.appendChild(this.statusElement);
 		this.setOptions(options);
 	}
 
@@ -63,6 +66,9 @@ class ProgressBar {
 		this.captionElement.className = '';
 		this.captionElement.classList.add(css['caption']);
 		this.captionElement.textContent = this.caption;
+		this.statusElement.className = '';
+		this.statusElement.classList.add(css['visuallyHidden']);
+		this.statusElement.textContent = this.caption;
 
 		const progressBarWrapper = this.element.querySelector(
 			`.${css['wrapper']}`

--- a/packages/playground/remote/src/lib/progress-bar/style.module.css
+++ b/packages/playground/remote/src/lib/progress-bar/style.module.css
@@ -111,7 +111,7 @@
 .caption {
 	font-weight: 300;
 	font-family: -apple-system, BlinkMacSystemFont, sans-serif;
-	font-size: 14px;
+	font-size: 20px;
 	line-height: 1.12;
 	margin: 0;
 	width: calc(100% - 48px);

--- a/packages/playground/remote/src/lib/progress-bar/style.module.css
+++ b/packages/playground/remote/src/lib/progress-bar/style.module.css
@@ -109,7 +109,7 @@
 }
 
 .caption {
-	font-weight: 400;
+	font-weight: 300;
 	font-family: -apple-system, BlinkMacSystemFont, sans-serif;
 	font-size: clamp(1.55rem, 3.4vw, 2.35rem);
 	line-height: 1.12;

--- a/packages/playground/remote/src/lib/progress-bar/style.module.css
+++ b/packages/playground/remote/src/lib/progress-bar/style.module.css
@@ -27,7 +27,7 @@
 	width: calc(100% - 48px);
 	max-width: 420px;
 	height: 9px;
-	margin: 1.45rem auto 0;
+	margin: 19px auto 0;
 	overflow: hidden;
 	border-radius: 999px;
 	background: #d8dce2;
@@ -111,7 +111,7 @@
 .caption {
 	font-weight: 300;
 	font-family: -apple-system, BlinkMacSystemFont, sans-serif;
-	font-size: clamp(1.55rem, 3.4vw, 2.35rem);
+	font-size: 14px;
 	line-height: 1.12;
 	margin: 0;
 	width: calc(100% - 48px);

--- a/packages/playground/remote/src/lib/progress-bar/style.module.css
+++ b/packages/playground/remote/src/lib/progress-bar/style.module.css
@@ -109,7 +109,7 @@
 }
 
 .caption {
-	font-weight: 600;
+	font-weight: 400;
 	font-family: -apple-system, BlinkMacSystemFont, sans-serif;
 	font-size: clamp(1.55rem, 3.4vw, 2.35rem);
 	line-height: 1.12;
@@ -123,6 +123,16 @@
 .caption,
 .wrapper {
 	z-index: 1;
+}
+
+.visually-hidden {
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	margin: -1px;
+	overflow: hidden;
+	clip: rect(0, 0, 0, 0);
+	white-space: nowrap;
 }
 
 @media (prefers-color-scheme: dark) {

--- a/packages/playground/remote/src/lib/progress-bar/style.module.css
+++ b/packages/playground/remote/src/lib/progress-bar/style.module.css
@@ -2,13 +2,7 @@
 	position: absolute;
 	top: 0;
 	left: 0;
-	background:
-		radial-gradient(
-			circle at 50% calc(50% - 140px),
-			rgb(56 88 233 / 0.13),
-			transparent 34%
-		),
-		linear-gradient(180deg, #f7f9fc 0%, #fff 100%);
+	background: #fff;
 	z-index: 5;
 	display: flex;
 	flex-direction: column;
@@ -114,47 +108,18 @@
 	}
 }
 
-/* A quiet prefix above the name, so the big text below reads as the Playground
-   being started, not a page title. */
-.label {
-	color: #757575;
-	font-family: -apple-system, BlinkMacSystemFont, sans-serif;
-	font-size: clamp(0.9rem, 1.45vw, 1rem);
-	font-weight: 500;
-	letter-spacing: 0.01em;
-	line-height: 1.3;
-	margin: 0 0 0.45rem;
-	text-align: center;
-}
-
-/* The stable Playground name — larger and bolder than the caption, sitting just
-   above it. It wraps in full and never changes as boot stages advance. */
-.title {
+.caption {
 	font-weight: 600;
 	font-family: -apple-system, BlinkMacSystemFont, sans-serif;
 	font-size: clamp(1.55rem, 3.4vw, 2.35rem);
 	line-height: 1.12;
-	margin: 0 0 0.45rem;
+	margin: 0;
 	width: calc(100% - 48px);
 	max-width: 720px;
 	overflow-wrap: anywhere;
 	text-align: center;
 }
 
-.caption {
-	font-weight: 400;
-	font-family: -apple-system, BlinkMacSystemFont, sans-serif;
-	font-size: clamp(0.95rem, 1.75vw, 1.12rem);
-	/* With the name carrying identity above, the changing stage caption reads as
-	   secondary status. */
-	color: #757575;
-	line-height: 1.3;
-	margin: 0;
-	text-align: center;
-}
-
-.label,
-.title,
 .caption,
 .wrapper {
 	z-index: 1;
@@ -162,13 +127,7 @@
 
 @media (prefers-color-scheme: dark) {
 	.overlay {
-		background:
-			radial-gradient(
-				circle at 50% calc(50% - 140px),
-				rgb(56 88 233 / 0.2),
-				transparent 34%
-			),
-			linear-gradient(180deg, #191a1d 0%, #1e1e1e 100%);
+		background: #1e1e1e;
 		color: #fff;
 	}
 

--- a/packages/playground/website/src/components/browser-chrome/style.module.css
+++ b/packages/playground/website/src/components/browser-chrome/style.module.css
@@ -34,6 +34,7 @@ body.is-embedded .fake-window-wrapper {
 }
 
 .content {
+	position: relative;
 	display: flex;
 	flex-grow: 1;
 	background: #ffffff;

--- a/packages/playground/website/src/components/playground-viewport/index.tsx
+++ b/packages/playground/website/src/components/playground-viewport/index.tsx
@@ -135,14 +135,7 @@ export const KeepAliveTemporarySitesViewport = () => {
 
 	const sitesFinishedLoading = useAppSelector(selectSitesLoaded);
 	if (!sitesFinishedLoading) {
-		return (
-			<div className={css.loadingViewport}>
-				<h3 className={css.loadingCaption}>&nbsp;</h3>
-				<div className={css.progressWrapper}>
-					<div className={css.progressBar} />
-				</div>
-			</div>
-		);
+		return <LoadingViewport caption="Loading Playgrounds" />;
 	}
 
 	return (
@@ -166,12 +159,7 @@ export const KeepAliveTemporarySitesViewport = () => {
 				</div>
 			)}
 			{!hasVisibleSite && (
-				<div className={css.loadingViewport}>
-					<h3 className={css.loadingCaption}>&nbsp;</h3>
-					<div className={css.progressWrapper}>
-						<div className={css.progressBar} />
-					</div>
-				</div>
+				<LoadingViewport caption="Preparing WordPress" />
 			)}
 			{slugsSeenSoFar.map((slug) => {
 				const site = sitesBySlug.get(slug);
@@ -194,6 +182,17 @@ export const KeepAliveTemporarySitesViewport = () => {
 		</>
 	);
 };
+
+function LoadingViewport({ caption }: { caption: string }) {
+	return (
+		<div className={css.loadingViewport}>
+			<h1 className={css.loadingCaption}>{caption}</h1>
+			<div className={css.progressWrapper}>
+				<div className={css.progressBar} />
+			</div>
+		</div>
+	);
+}
 
 export const JustViewport = function JustViewport({
 	siteSlug,

--- a/packages/playground/website/src/components/playground-viewport/index.tsx
+++ b/packages/playground/website/src/components/playground-viewport/index.tsx
@@ -135,7 +135,14 @@ export const KeepAliveTemporarySitesViewport = () => {
 
 	const sitesFinishedLoading = useAppSelector(selectSitesLoaded);
 	if (!sitesFinishedLoading) {
-		return <LoadingViewport caption="Loading Playgrounds" />;
+		return (
+			<div className={css.loadingViewport}>
+				<h1 className={css.loadingCaption}>Loading Playgrounds</h1>
+				<div className={css.progressWrapper}>
+					<div className={css.progressBar} />
+				</div>
+			</div>
+		);
 	}
 
 	return (
@@ -159,7 +166,12 @@ export const KeepAliveTemporarySitesViewport = () => {
 				</div>
 			)}
 			{!hasVisibleSite && (
-				<LoadingViewport caption="Preparing WordPress" />
+				<div className={css.loadingViewport}>
+					<h1 className={css.loadingCaption}>Preparing WordPress</h1>
+					<div className={css.progressWrapper}>
+						<div className={css.progressBar} />
+					</div>
+				</div>
 			)}
 			{slugsSeenSoFar.map((slug) => {
 				const site = sitesBySlug.get(slug);
@@ -182,17 +194,6 @@ export const KeepAliveTemporarySitesViewport = () => {
 		</>
 	);
 };
-
-function LoadingViewport({ caption }: { caption: string }) {
-	return (
-		<div className={css.loadingViewport}>
-			<h1 className={css.loadingCaption}>{caption}</h1>
-			<div className={css.progressWrapper}>
-				<div className={css.progressBar} />
-			</div>
-		</div>
-	);
-}
 
 export const JustViewport = function JustViewport({
 	siteSlug,

--- a/packages/playground/website/src/components/playground-viewport/style.module.css
+++ b/packages/playground/website/src/components/playground-viewport/style.module.css
@@ -24,25 +24,51 @@
 	flex-direction: column;
 	justify-content: center;
 	align-items: center;
+	box-sizing: border-box;
+	overflow: hidden;
+	padding: 24px;
 	background: #fff;
 }
 
 .loading-caption {
-	font-weight: 400;
+	font-weight: 300;
 	font-family: -apple-system, BlinkMacSystemFont, sans-serif;
-	font-size: 1.1rem;
+	font-size: clamp(1.55rem, 3.4vw, 2.35rem);
 	color: #000;
-	margin: 0 0 4px 0;
+	line-height: 1.12;
+	margin: 0;
+	width: calc(100% - 48px);
+	max-width: 720px;
+	overflow-wrap: anywhere;
+	text-align: center;
 }
 
 .progress-wrapper {
 	position: relative;
-	width: 512px;
-	max-width: 60vw;
-	height: 4px;
-	margin: 4px auto;
-	border-radius: 10px;
-	background: #e0e0e0;
+	width: calc(100% - 48px);
+	max-width: 420px;
+	height: 9px;
+	margin: 1.45rem auto 0;
+	overflow: hidden;
+	border-radius: 999px;
+	background: #d8dce2;
+	box-shadow:
+		0 1px 0 rgb(255 255 255 / 0.72) inset,
+		0 10px 24px rgb(0 0 0 / 0.08);
+}
+
+.progress-wrapper::after {
+	position: absolute;
+	inset: 0;
+	background: linear-gradient(
+		90deg,
+		transparent 0%,
+		rgb(255 255 255 / 0.58) 50%,
+		transparent 100%
+	);
+	animation: track-shimmer 2.2s ease-in-out infinite;
+	content: '';
+	transform: translateX(-100%);
 }
 
 @media (prefers-color-scheme: dark) {
@@ -55,7 +81,14 @@
 	}
 
 	.progress-wrapper {
-		background: #1e1e1e;
+		background: #2f3338;
+		box-shadow:
+			inset 0 0 0 1px rgb(255 255 255 / 0.04),
+			0 10px 28px rgb(0 0 0 / 0.22);
+	}
+
+	.progress-bar {
+		box-shadow: 0 0 18px rgb(72 103 255 / 0.45);
 	}
 }
 
@@ -65,10 +98,17 @@
 	left: 0;
 	bottom: 0;
 	right: 100%;
+	z-index: 1;
 	width: 0;
-	background: #3858e9;
-	border-radius: 2px;
+	background: linear-gradient(90deg, #3858e9 0%, #6f7dff 100%);
+	border-radius: inherit;
 	animation: indefinite-loading 2s linear infinite;
+}
+
+@keyframes track-shimmer {
+	100% {
+		transform: translateX(100%);
+	}
 }
 
 @keyframes indefinite-loading {
@@ -91,5 +131,12 @@
 		left: 100%;
 		right: 0%;
 		width: 0%;
+	}
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.progress-wrapper::after,
+	.progress-bar {
+		animation: none;
 	}
 }

--- a/packages/playground/website/src/components/playground-viewport/style.module.css
+++ b/packages/playground/website/src/components/playground-viewport/style.module.css
@@ -33,7 +33,7 @@
 .loading-caption {
 	font-weight: 300;
 	font-family: -apple-system, BlinkMacSystemFont, sans-serif;
-	font-size: clamp(1.55rem, 3.4vw, 2.35rem);
+	font-size: 14px;
 	color: #000;
 	line-height: 1.12;
 	margin: 0;
@@ -48,7 +48,7 @@
 	width: calc(100% - 48px);
 	max-width: 420px;
 	height: 9px;
-	margin: 1.45rem auto 0;
+	margin: 19px auto 0;
 	overflow: hidden;
 	border-radius: 999px;
 	background: #d8dce2;

--- a/packages/playground/website/src/components/playground-viewport/style.module.css
+++ b/packages/playground/website/src/components/playground-viewport/style.module.css
@@ -33,7 +33,7 @@
 .loading-caption {
 	font-weight: 300;
 	font-family: -apple-system, BlinkMacSystemFont, sans-serif;
-	font-size: 14px;
+	font-size: 20px;
 	color: #000;
 	line-height: 1.12;
 	margin: 0;

--- a/packages/playground/website/src/lib/state/redux/boot-site-client.ts
+++ b/packages/playground/website/src/lib/state/redux/boot-site-client.ts
@@ -232,8 +232,6 @@ export function bootSiteClient(
 				iframe: iframe!,
 				remoteUrl: getRemoteUrl().toString(),
 				scope: site.slug,
-				// Keep the Playground identified while its boot-stage caption changes.
-				siteName: site.metadata.name,
 				blueprint,
 				extensions: phpExtensions,
 				// Intercept the Playground client even if the


### PR DESCRIPTION
The startup progress screen now makes the changing boot stage the headline, so it tells people what is happening instead of emphasizing a generated Playground name.

The previous screen passed the name through the client and URL query, then rendered it above the live status as the largest text. This removes the unused `siteName` client option and title query, and gives the live caption that visual weight. The startup surface also uses plain light and dark backgrounds without the blue radial backdrop.

**Breaking change:** `siteName` has been removed from `StartPlaygroundOptions`.

The website-level loader now names its initial storage phase and uses the same 300-weight heading, 20px type size, 19px title-to-track gap, indeterminate track, shimmer, and light/dark styling as the remote loader. The outer loading overlay is positioned relative to the content viewport, so both stages keep the heading and progress track at the same position. The visible status is a semantic heading. A separate, visually hidden live region announces boot-stage changes.

![The startup loader shows “Preparing WordPress” above its progress bar.](https://raw.githubusercontent.com/WordPress/wordpress-playground/dock-ui-product-wiring-media/pr-media/4062/startup-progress-current-stage.png)

<video src="https://raw.githubusercontent.com/WordPress/wordpress-playground/dock-ui-product-wiring-media/pr-media/4062/site-loading.mp4" controls muted></video>

[MP4 recording of a full Playground startup](https://raw.githubusercontent.com/WordPress/wordpress-playground/dock-ui-product-wiring-media/pr-media/4062/site-loading.mp4)

Tested:
- `npm exec nx test playground-remote --testFile=progress-bar/index.spec.ts`
- `npm exec nx test playground-client --testFile=index.spec.ts`
- `npm exec nx run playground-website:lint`
- `npm exec nx run playground-website:typecheck`
- `npm exec nx run playground-remote:lint`
- `npm exec nx run playground-remote:typecheck`
- `npm exec nx run playground-client:lint`
- `npm exec nx run playground-client:typecheck`
