### PR TITLE
[Web] Capture sendmail stdin in remote Playground instances

### DIFF
--- a/packages/playground/remote/src/lib/playground-worker-endpoint.ts
+++ b/packages/playground/remote/src/lib/playground-worker-endpoint.ts
@@ -2,7 +2,7 @@ import type { FilesystemOperation } from '@php-wasm/fs-journal';
 import { journalFSEvents, replayFSJournal } from '@php-wasm/fs-journal';
 import type { EmscriptenDownloadMonitor } from '@php-wasm/progress';
 import { setURLScope } from '@php-wasm/scopes';
-import { joinPaths } from '@php-wasm/util';
+import { joinPaths, sendmailSpawnHandler } from '@php-wasm/util';
 import type {
 	DirectoryHandleMount,
 	PHPWebExtension,
@@ -235,6 +235,16 @@ export abstract class PlaygroundWorkerEndpoint extends PHPWorker {
 				});
 			},
 			onPHPInstanceCreated: async (php: PHP, { isPrimary }) => {
+				/**
+				 * The remote runtime has no mail server. Capture sendmail stdin as an
+				 * event through a null transport; consumers must relay the message if
+				 * they want it delivered.
+				 */
+				php.setCommandSpawnHandler(
+					'sendmail',
+					sendmailSpawnHandler(php)
+				);
+
 				if (!isPrimary) {
 					const pathsToShareBetweenPhpInstances = [
 						'/tmp',

--- a/packages/playground/remote/src/lib/sendmail-transport.spec.ts
+++ b/packages/playground/remote/src/lib/sendmail-transport.spec.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { EmscriptenDownloadMonitor } from '@php-wasm/progress';
+
+const bootRequestHandlerMock = vi.hoisted(() => vi.fn());
+
+vi.mock('@wp-playground/wordpress', async (importOriginal) => ({
+	...(await importOriginal<Record<string, unknown>>()),
+	bootRequestHandler: bootRequestHandlerMock,
+}));
+
+describe('remote sendmail transport', () => {
+	afterEach(() => {
+		bootRequestHandlerMock.mockReset();
+		vi.unstubAllGlobals();
+	});
+
+	it('registers sendmail capture when a PHP instance is created', async () => {
+		vi.stubGlobal('caches', { open: vi.fn(async () => ({})) });
+		vi.stubGlobal('location', { href: 'http://playground.test/' });
+		const setCommandSpawnHandler = vi.fn();
+		const php = {
+			requestHandler: undefined,
+			setCommandSpawnHandler,
+		};
+		const requestHandler = {
+			documentRoot: '/wordpress',
+			getPrimaryPhp: vi.fn(async () => php),
+		};
+		bootRequestHandlerMock.mockImplementationOnce(async (options) => {
+			await options.onPHPInstanceCreated(php, { isPrimary: true });
+			return requestHandler;
+		});
+
+		const { PlaygroundWorkerEndpoint } =
+			await import('./playground-worker-endpoint');
+		class TestEndpoint extends PlaygroundWorkerEndpoint {
+			async boot() {}
+
+			createRequestHandlerForTest() {
+				return this.createRequestHandler({
+					siteUrl: 'http://playground.test/',
+					sapiName: 'cli',
+					knownRemoteAssetPaths: new Set<string>(),
+					withNetworking: false,
+					phpVersion: '8.4',
+				});
+			}
+		}
+		const endpoint = new TestEndpoint({} as EmscriptenDownloadMonitor);
+
+		await endpoint.createRequestHandlerForTest();
+
+		expect(setCommandSpawnHandler).toHaveBeenCalledOnce();
+		expect(setCommandSpawnHandler).toHaveBeenCalledWith(
+			'sendmail',
+			expect.any(Function)
+		);
+	});
+});


### PR DESCRIPTION
Adds `sendmailSpawnHandler()` (introduced in #3996) to PHP.wasm objects instantiated in the `remote.html` web worker. The handler catches any emails sent by WordPress and re-exposes it through an event listener as follows:

```ts
php.setCommandSpawnHandler('sendmail', sendmailSpawnHandler(php));

// In the website package:
php.addEventListener('sendmail.spawned', async (event) => {
	if (event.type !== 'sendmail.spawned') {
		return;
	}
	const rawMessage = await new Response(event.stdin).arrayBuffer();
	// Parse or relay rawMessage.
});
```

The goal is to expose these emails in the UI in a follow-up PR.

