### PR TITLE
[PHP-WASM] Transfer marked event stdin streams to every listener

### DIFF
--- a/packages/php-wasm/universal/src/lib/api.ts
+++ b/packages/php-wasm/universal/src/lib/api.ts
@@ -1,3 +1,7 @@
+import {
+	phpEventStdinTransfer,
+	type PHPEventWithStdinTransfer,
+} from '@php-wasm/util';
 import type { PHPResponseData } from './php-response';
 import { PHPResponse, StreamedPHPResponse } from './php-response';
 import * as Comlink from './comlink-sync';
@@ -283,26 +287,24 @@ function setupTransferHandlers() {
 		'READABLE_STREAM',
 		readableStreamTransferHandler
 	);
-	type EventWithReadableStdin = {
-		type: string;
-		stdin: ReadableStream<Uint8Array>;
-	};
 	type SerializedEventWithReadableStdin = {
 		type: string;
 		stdin: SerializedReadableStream;
 	};
 	/**
-	 * Transfers a worker event whose `stdin` property is a ReadableStream. Comlink
-	 * applies a transfer handler to the top-level value only, so it will not discover
-	 * the `stdin` stream on its own.
+	 * Transfers a worker event explicitly branded with `phpEventStdinTransfer`.
+	 * Comlink applies a transfer handler to the top-level value only, so it will not
+	 * discover the nested `stdin` stream on its own.
 	 */
 	const eventWithReadableStdinTransferHandler: Comlink.TransferHandler<
-		EventWithReadableStdin,
+		PHPEventWithStdinTransfer,
 		SerializedEventWithReadableStdin
 	> = {
-		canHandle: (obj: unknown): obj is EventWithReadableStdin =>
+		canHandle: (obj: unknown): obj is PHPEventWithStdinTransfer =>
 			typeof obj === 'object' &&
 			obj !== null &&
+			phpEventStdinTransfer in obj &&
+			obj[phpEventStdinTransfer] === true &&
 			'type' in obj &&
 			typeof obj.type === 'string' &&
 			'stdin' in obj &&
@@ -312,10 +314,12 @@ function setupTransferHandlers() {
 				readableStreamTransferHandler.serialize(event.stdin);
 			return [{ ...event, stdin }, transferables];
 		},
-		deserialize(event): EventWithReadableStdin {
+		deserialize(event): PHPEventWithStdinTransfer {
+			// Symbol properties are not structured-cloned. Restore the brand locally.
 			return {
 				...event,
 				stdin: readableStreamTransferHandler.deserialize(event.stdin),
+				[phpEventStdinTransfer]: true,
 			};
 		},
 	};

--- a/packages/php-wasm/universal/src/lib/index.ts
+++ b/packages/php-wasm/universal/src/lib/index.ts
@@ -74,6 +74,8 @@ export {
 } from './php';
 export type { MountHandler, UnmountFunction } from './php';
 export { loadPHPRuntime, popLoadedRuntime } from './load-php-runtime';
+export { phpEventStdinTransfer } from '@php-wasm/util';
+export type { PHPEventWithStdinTransfer } from '@php-wasm/util';
 export type { Emscripten } from './emscripten-types';
 export type {
 	DataModule,

--- a/packages/php-wasm/universal/src/lib/php-worker.ts
+++ b/packages/php-wasm/universal/src/lib/php-worker.ts
@@ -1,4 +1,5 @@
 import type { EmscriptenDownloadMonitor } from '@php-wasm/progress';
+import { phpEventStdinTransfer } from '@php-wasm/util';
 import type { ListFilesOptions, RmDirOptions } from './fs-helpers';
 import type { PHP } from './php';
 import type { PHPRequestHandler } from './php-request-handler';
@@ -369,24 +370,30 @@ export class PHPWorker implements LimitedPHPApi, AsyncDisposable {
 		if (!listeners) {
 			return;
 		}
+		// Callbacks may mutate the Set. Dispatch the listeners that matched at entry.
 		const eventListeners = [...listeners];
-		if (eventListeners.length > 1 && hasReadableStdin(event)) {
+		const transfersStdin =
+			phpEventStdinTransfer in event &&
+			event[phpEventStdinTransfer] === true &&
+			'stdin' in event &&
+			typeof ReadableStream !== 'undefined' &&
+			event.stdin instanceof ReadableStream;
+		if (eventListeners.length > 1 && transfersStdin) {
 			/**
-			 * A ReadableStream can only be transferred through Comlink once. Give each
-			 * listener its own branch so one listener cannot lock the stream before the
-			 * remaining listeners receive the event.
+			 * Split the unassigned stream branch before each transfer, then give the
+			 * final listener what remains. Unread branches may buffer the full input
+			 * because tee() does not coordinate backpressure.
 			 */
-			const streams = teeReadableStream(
-				event.stdin,
-				eventListeners.length
-			);
-			let streamIndex = 0;
-			for (const listener of eventListeners) {
-				listener({
-					...event,
-					stdin: streams[streamIndex++],
-				} as EventType);
+			let remainingStdin = event.stdin as ReadableStream<Uint8Array>;
+			for (let index = 0; index < eventListeners.length - 1; index++) {
+				const [stdin, nextStdin] = remainingStdin.tee();
+				remainingStdin = nextStdin;
+				eventListeners[index]({ ...event, stdin } as EventType);
 			}
+			eventListeners[eventListeners.length - 1]({
+				...event,
+				stdin: remainingStdin,
+			} as EventType);
 			return;
 		}
 		for (const listener of eventListeners) {
@@ -429,35 +436,4 @@ export class PHPWorker implements LimitedPHPApi, AsyncDisposable {
 		}
 		throw new Error('PHPWorker is not connected to a request handler.');
 	}
-}
-
-function hasReadableStdin(
-	event: PHPWorkerEvent
-): event is PHPWorkerEvent & { stdin: ReadableStream<Uint8Array> } {
-	return (
-		'stdin' in event &&
-		typeof ReadableStream !== 'undefined' &&
-		event.stdin instanceof ReadableStream
-	);
-}
-
-/**
- * Creates one independently transferable stream branch per event listener.
- *
- * ReadableStream.tee() may buffer unread chunks for a slow branch. PHPWorker
- * does not coordinate backpressure between listeners.
- */
-function teeReadableStream(
-	stream: ReadableStream<Uint8Array>,
-	branches: number
-): ReadableStream<Uint8Array>[] {
-	const streams: ReadableStream<Uint8Array>[] = [];
-	let remaining = stream;
-	while (streams.length < branches - 1) {
-		const [branch, next] = remaining.tee();
-		streams.push(branch);
-		remaining = next;
-	}
-	streams.push(remaining);
-	return streams;
 }

--- a/packages/php-wasm/universal/src/lib/php.spec.ts
+++ b/packages/php-wasm/universal/src/lib/php.spec.ts
@@ -1,6 +1,70 @@
 import { describe, expect, it, vi } from 'vitest';
-import { createSpawnHandler } from '@php-wasm/util';
+import {
+	createSpawnHandler,
+	phpEventStdinTransfer,
+	type PHPEventWithStdinTransfer,
+} from '@php-wasm/util';
 import { __private__dont__use, MountStillActiveError, PHP } from './php';
+
+type RuntimeInitializedWithStdin = PHPEventWithStdinTransfer & {
+	type: 'runtime.initialized';
+};
+
+describe('PHP events', () => {
+	it('gives every matching listener its own branded stdin stream', async () => {
+		const php = new PHP();
+		const streamContents: Promise<number[]>[] = [];
+		const collectStdin = (event: RuntimeInitializedWithStdin) => {
+			// Lock each stream immediately, before dispatch advances to the next listener.
+			streamContents.push(readStream(event.stdin));
+		};
+		php.addEventListener('runtime.initialized', (event) => {
+			if (event.type === 'runtime.initialized') {
+				collectStdin(event as RuntimeInitializedWithStdin);
+			}
+		});
+		php.addEventListener('runtime.initialized', (event) => {
+			if (event.type === 'runtime.initialized') {
+				collectStdin(event as RuntimeInitializedWithStdin);
+			}
+		});
+		php.addEventListener('*', (event) => {
+			if (event.type === 'runtime.initialized') {
+				collectStdin(event as RuntimeInitializedWithStdin);
+			}
+		});
+
+		php.dispatchEvent({
+			type: 'runtime.initialized',
+			stdin: new ReadableStream<Uint8Array>({
+				start(controller) {
+					controller.enqueue(new Uint8Array([1, 2, 3]));
+					controller.close();
+				},
+			}),
+			[phpEventStdinTransfer]: true,
+		} satisfies RuntimeInitializedWithStdin);
+
+		expect(streamContents).toHaveLength(3);
+		expect(await Promise.all(streamContents)).toEqual([
+			[1, 2, 3],
+			[1, 2, 3],
+			[1, 2, 3],
+		]);
+	});
+});
+
+async function readStream(stream: ReadableStream<Uint8Array>) {
+	const bytes: number[] = [];
+	const reader = stream.getReader();
+	while (true) {
+		const { done, value } = await reader.read();
+		if (done) {
+			return bytes;
+		}
+		bytes.push(...value);
+	}
+}
 
 describe('PHP mounts', () => {
 	it('forgets mount tracking even when the unmount callback fails', async () => {

--- a/packages/php-wasm/universal/src/lib/php.ts
+++ b/packages/php-wasm/universal/src/lib/php.ts
@@ -5,6 +5,7 @@ import {
 	createSpawnHandler,
 	dirname,
 	joinPaths,
+	phpEventStdinTransfer,
 	splitShellCommand,
 } from '@php-wasm/util';
 import type { Emscripten } from './emscripten-types';
@@ -198,7 +199,33 @@ export class PHP implements Disposable {
 			...(this.#eventListeners.get(event.type) || []),
 			...(this.#eventListeners.get('*') || []),
 		];
-		if (!listeners) {
+		if (listeners.length === 0) {
+			return;
+		}
+		const transfersStdin =
+			phpEventStdinTransfer in event &&
+			event[phpEventStdinTransfer] === true &&
+			'stdin' in event &&
+			typeof ReadableStream !== 'undefined' &&
+			event.stdin instanceof ReadableStream;
+		if (listeners.length > 1 && transfersStdin) {
+			/**
+			 * A stream permits only one active reader, and a transferred stream cannot
+			 * be transferred again. Split the unassigned branch before calling each
+			 * listener, then give the final branch to the final listener. PHPWorker may
+			 * split its wildcard branch again for remote listeners. Unread branches may
+			 * buffer the full input because tee() does not coordinate backpressure.
+			 */
+			let remainingStdin = event.stdin as ReadableStream<Uint8Array>;
+			for (let index = 0; index < listeners.length - 1; index++) {
+				const [stdin, nextStdin] = remainingStdin.tee();
+				remainingStdin = nextStdin;
+				listeners[index]({ ...event, stdin } as Event);
+			}
+			listeners[listeners.length - 1]({
+				...event,
+				stdin: remainingStdin,
+			} as Event);
 			return;
 		}
 		for (const listener of listeners) {

--- a/packages/php-wasm/universal/src/test/php-worker.spec.ts
+++ b/packages/php-wasm/universal/src/test/php-worker.spec.ts
@@ -48,6 +48,10 @@ class TestEndpoint extends PHPWorker {
 		this.registerWorkerListeners(php);
 	}
 
+	emitEvent(event: PhpEvent) {
+		this.dispatchEvent(event);
+	}
+
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	async boot(_: unknown = undefined) {}
 }
@@ -68,6 +72,48 @@ class EndpointWithoutRequestHandler extends TestEndpoint {
 }
 
 describe('PlaygroundWorkerEndpoint', () => {
+	test('does not infer stream fan-out from an stdin property', () => {
+		const endpoint = new TestEndpoint();
+		const received: PhpEvent[] = [];
+		endpoint.addEventListener('unbranded.stream', (event) =>
+			received.push(event as PhpEvent)
+		);
+		endpoint.addEventListener('unbranded.stream', (event) =>
+			received.push(event as PhpEvent)
+		);
+
+		const unbrandedStream = new ReadableStream<Uint8Array>();
+		endpoint.emitEvent({
+			type: 'unbranded.stream',
+			stdin: unbrandedStream,
+		});
+
+		expect(received).toHaveLength(2);
+		expect(received[0]['stdin']).toBe(unbrandedStream);
+		expect(received[1]['stdin']).toBe(unbrandedStream);
+	});
+
+	test('uses a stable listener snapshot during dispatch', () => {
+		const endpoint = new TestEndpoint();
+		const addedDuringDispatch = vi.fn();
+		const removedDuringDispatch = vi.fn();
+		const mutatesListeners = vi.fn(() => {
+			endpoint.removeEventListener(
+				'snapshot.test',
+				removedDuringDispatch
+			);
+			endpoint.addEventListener('snapshot.test', addedDuringDispatch);
+		});
+		endpoint.addEventListener('snapshot.test', mutatesListeners);
+		endpoint.addEventListener('snapshot.test', removedDuringDispatch);
+
+		endpoint.emitEvent({ type: 'snapshot.test' });
+
+		expect(mutatesListeners).toHaveBeenCalledOnce();
+		expect(removedDuringDispatch).toHaveBeenCalledOnce();
+		expect(addedDuringDispatch).not.toHaveBeenCalled();
+	});
+
 	test('listeners receive events from each PHP instance', async () => {
 		const endpoint = new TestEndpoint();
 		const phpA = createMockPHP();

--- a/packages/php-wasm/util/src/lib/index.ts
+++ b/packages/php-wasm/util/src/lib/index.ts
@@ -13,6 +13,8 @@ export {
 	toPosixPath,
 } from './paths';
 export { createSpawnHandler } from './create-spawn-handler';
+export { phpEventStdinTransfer } from './php-event';
+export type { PHPEventWithStdinTransfer } from './php-event';
 export { randomString } from './random-string';
 export { randomFilename } from './random-filename';
 export { splitShellCommand } from './split-shell-command';

--- a/packages/php-wasm/util/src/lib/php-event.ts
+++ b/packages/php-wasm/util/src/lib/php-event.ts
@@ -1,0 +1,15 @@
+/**
+ * Explicitly marks an event whose `stdin` ReadableStream needs an independent
+ * branch per listener and must be transferred across worker boundaries. The
+ * global symbol registry keeps the marker stable if this package is loaded
+ * more than once in the same realm.
+ */
+export const phpEventStdinTransfer = Symbol.for(
+	'@php-wasm/php-event-stdin-transfer'
+);
+
+export type PHPEventWithStdinTransfer = {
+	type: string;
+	stdin: ReadableStream<Uint8Array>;
+	[phpEventStdinTransfer]: true;
+};

--- a/packages/php-wasm/web/src/test/playwright/readable-stream-worker.ts
+++ b/packages/php-wasm/web/src/test/playwright/readable-stream-worker.ts
@@ -1,4 +1,8 @@
-import { exposeAPI, PHPWorker } from '@php-wasm/universal';
+import {
+	exposeAPI,
+	PHPWorker,
+	phpEventStdinTransfer,
+} from '@php-wasm/universal';
 
 self.postMessage('worker-script-started');
 
@@ -53,7 +57,11 @@ class ReadableStreamWorker extends PHPWorker {
 		}
 
 		try {
-			this.dispatchEvent({ type: 'test.stream', stdin: stream });
+			this.dispatchEvent({
+				type: 'test.stream',
+				stdin: stream,
+				[phpEventStdinTransfer]: true,
+			});
 		} finally {
 			MessagePort.prototype.postMessage = originalPostMessage;
 			this.#transferableStreamProbeRejected =


### PR DESCRIPTION
Events can now opt their `stdin` stream into worker transfer and listener fan-out. A `ReadableStream` has one active reader and can be transferred only once. Passing the same stream to direct, wildcard, or remote listeners lets the first listener lock it and leaves the rest with an unusable event.

Event types that carry transferable stdin extend `PHPEventWithStdinTransfer`. Producers set the `phpEventStdinTransfer` symbol when they dispatch the event:

```ts
interface PHPProcessStdinEvent extends PHPEventWithStdinTransfer {
	type: 'process.stdin';
}

// Add PHPProcessStdinEvent to the PHPEvent union.
php.dispatchEvent({
	type: 'process.stdin',
	stdin,
	[phpEventStdinTransfer]: true,
} satisfies PHPProcessStdinEvent);
```

Listeners use the stream normally. Each matching direct, wildcard, or remote listener receives its own stream:

```ts
php.addEventListener('process.stdin', async (event) => {
	if (event.type !== 'process.stdin') {
		return;
	}
	const bytes = await new Response(event.stdin).arrayBuffer();
});
```

The marker is explicit. An unrelated event does not acquire new dispatch semantics merely because it has a property named `stdin`. Comlink cannot discover a nested stream, so its event transfer handler serializes marked stdin and restores the symbol after deserialization. Dispatch splits marked streams with `tee()` before a listener can lock or transfer them. An unread branch may buffer the full stream; this PR does not add coordinated backpressure.

The browser tests exercise native transferable streams and the MessagePort fallback used by Safari. They also verify that cancellation reaches the source after every listener cancels its branch.

Verified with:

```
npm exec nx run-many -- --targets=lint,typecheck,test --projects=php-wasm-util,php-wasm-universal --outputStyle=static
npm exec nx run php-wasm-web:e2e -- --outputStyle=static
```
