### PR TITLE
[CI] Schedule asset refreshes before weekly deploy

### DIFF
--- a/.github/workflows/refresh-php-next.yml
+++ b/.github/workflows/refresh-php-next.yml
@@ -6,9 +6,9 @@ on:
             php_ref:
                 description: 'php-src ref to build (defaults to php-src development branch)'
                 required: false
-    # Refresh PHP next binaries every 4 days at 6am UTC.
+    # Refresh PHP next binaries before the weekly website deploy.
     schedule:
-        - cron: '0 6 */4 * *'
+        - cron: '0 6 * * 2'
 
 concurrency:
     group: refresh-php-next
@@ -18,7 +18,7 @@ concurrency:
 permissions: {}
 
 jobs:
-    build_publish_and_deploy:
+    build_and_publish:
         # Only run this workflow on the playground repo, from the trunk branch,
         # and when triggered by a Playground maintainer.
         if: >
@@ -38,7 +38,6 @@ jobs:
         timeout-minutes: 240
         permissions:
             contents: write # Required to push the refreshed PHP next branch.
-            actions: write # Required to trigger the deploy-website workflow.
         environment:
             name: wordpress-assets
         steps:
@@ -79,8 +78,3 @@ jobs:
                   git config --global user.email "deployment_bot@users.noreply.github.com"
                   git -C "$publish_worktree" commit -m "Refresh PHP next builds"
                   git -C "$publish_worktree" push --force origin HEAD:"$branch"
-            - name: Deploy website
-              uses: benc-uk/workflow-dispatch@v1
-              with:
-                  workflow: deploy-website.yml
-                  token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/refresh-sqlite-integration.yml
+++ b/.github/workflows/refresh-sqlite-integration.yml
@@ -2,15 +2,16 @@ name: 'Refresh SQLite plugin'
 
 on:
     workflow_dispatch:
+    # Refresh SQLite before the weekly website deploy.
     schedule:
-        - cron: '0 10 * * *'
+        - cron: '0 10 * * 2'
 
 # Disable permissions for all available scopes by default.
 # Any needed permissions should be configured at the job level.
 permissions: {}
 
 jobs:
-    build_and_deploy:
+    build_and_push:
         # Only run this workflow on the playground repo, from the trunk branch, and when triggered by a Playground maintainer
         if: >
             github.repository == 'WordPress/wordpress-playground' &&
@@ -29,7 +30,6 @@ jobs:
         timeout-minutes: 60
         permissions:
             contents: write # Required to clone the repo and push the updated SQLite bundle commit.
-            actions: write  # Required to trigger the deploy-website workflow via workflow_dispatch.
         environment:
             name: wordpress-assets
         concurrency:
@@ -70,9 +70,3 @@ jobs:
                   if [ $? -eq 0 ]; then
                       git push origin HEAD:trunk
                   fi;
-            - name: Deploy website
-              if: steps.changes.outputs.CHANGES == '1'
-              uses: benc-uk/workflow-dispatch@v1
-              with:
-                  workflow: deploy-website.yml
-                  token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/refresh-sqlite-integration.yml
+++ b/.github/workflows/refresh-sqlite-integration.yml
@@ -4,7 +4,7 @@ on:
     workflow_dispatch:
     # Refresh SQLite before the weekly website deploy.
     schedule:
-        - cron: '0 10 * * 2'
+        - cron: '0 9 * * 2'
 
 # Disable permissions for all available scopes by default.
 # Any needed permissions should be configured at the job level.


### PR DESCRIPTION
The website deploy cadence is weekly on purpose. Deploying the public app more often invalidates caches and makes Playground reload code that did not need to move.

`refresh-sqlite-integration.yml` was bypassing that rule. A daily SQLite refresh could commit a new ZIP and immediately dispatch `deploy-website.yml`. Some of those ZIP changes are just archive metadata churn, but they still produced real website deploys. `refresh-php-next.yml` did the same every four days.

This keeps the asset refreshes, but stops them from being deploy triggers. PHP Next now runs Tuesday at 06:00 UTC. SQLite now runs Tuesday at 09:00 UTC, which leaves two hours before the 11:00 UTC website deploy instead of racing its own 60-minute timeout. The existing website deploy picks up whatever those workflows published. Manual dispatch still works for both refresh workflows, but it refreshes assets only; it no longer deploys the website as a side effect.

Validated with:

```bash
git diff --check
ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "parsed #{f}" }' .github/workflows/refresh-php-next.yml .github/workflows/refresh-sqlite-integration.yml
```
