### PR TITLE
[Website] Run edited Blueprints in fresh Playgrounds

### DIFF
--- a/packages/playground/website/playwright/e2e/website-ui.spec.ts
+++ b/packages/playground/website/playwright/e2e/website-ui.spec.ts
@@ -1251,7 +1251,7 @@ test.describe('Default Playground storage', () => {
 		).toBe(false);
 	});
 
-	test('should edit a Blueprint for an autosaved Playground and recreate the same autosave', async ({
+	test('should edit a Blueprint for an autosaved Playground and run it in a new Playground', async ({
 		website,
 		wordpress,
 		browserName,
@@ -1266,13 +1266,17 @@ test.describe('Default Playground storage', () => {
 			website.page.getByRole('button', { name: 'Autosaved' })
 		).toBeVisible({ timeout: 120000 });
 		const originalSite = await getActivePlaygroundSite(website.page);
+		await runPHPAndFlushOpfs(
+			website.page,
+			"<?php file_put_contents('/wordpress/index.php', 'Original autosaved Playground');"
+		);
 
 		await website.openDockPane('Current Blueprint', 'Blueprint pane');
 		await expect(
 			website.page
 				.getByLabel('WordPress Playground')
 				.getByText(
-					'Running this Blueprint will recreate this autosaved Playground under the same name and replace all its files.'
+					`Running this Blueprint creates a fresh autosaved Playground. “${originalSite.name}” stays in Recent autosaves.`
 				)
 		).toBeVisible();
 
@@ -1296,36 +1300,48 @@ test.describe('Default Playground storage', () => {
 			website.page.locator('[class*="blueprint-editor"] .cm-content')
 		).toContainText('Autosaved Blueprint test');
 
-		const runBlueprintButton = website.page.getByRole('button', {
-			name: 'Run Blueprint and reset site',
-		});
-		// Recreate failures are shown inline and leave the Run button available,
-		// so retry the action instead of waiting on an unchanged iframe.
-		await expect(async () => {
-			await expect(runBlueprintButton).toBeEnabled({
-				timeout: 5000,
-			});
-			await runBlueprintButton.click();
-			await expect(
-				website.page.getByText(
-					'Could not recreate Playground. Try again.'
-				)
-			).toHaveCount(0, { timeout: 5000 });
-			await website.waitForNestedIframes();
-			await expect(wordpress.locator('body')).toContainText(
-				'Autosaved Blueprint test',
-				{ timeout: 30000 }
-			);
-		}).toPass({ timeout: 180000 });
+		await website.page
+			.getByRole('button', { name: 'Run in a new Playground' })
+			.click();
+
+		await expect(
+			website.page.getByRole('dialog', { name: 'Blueprint pane' })
+		).not.toBeVisible({ timeout: 120000 });
+		await website.waitForNestedIframes();
+		await expect(wordpress.locator('body')).toContainText(
+			'Autosaved Blueprint test',
+			{ timeout: 120000 }
+		);
+		const newSite = await getActivePlaygroundSite(website.page);
+		expect(newSite).toMatchObject({ persistence: 'autosave' });
+		expect(newSite.slug).not.toBe(originalSite.slug);
 		await expect
-			.poll(() => getActivePlaygroundSite(website.page), {
-				timeout: 120000,
-			})
-			.toMatchObject({
-				slug: originalSite.slug,
-				name: originalSite.name,
-				persistence: 'autosave',
-			});
+			.poll(() =>
+				website.page.evaluate(
+					(slug) =>
+						(window as any).playgroundSites
+							.list()
+							.some((site: any) => site.slug === slug),
+					originalSite.slug
+				)
+			)
+			.toBe(true);
+
+		await website.page.evaluate((slug) => {
+			return (window as any).playgroundSites.setActiveSite(slug);
+		}, originalSite.slug);
+		await website.waitForNestedIframes();
+		await expect(wordpress.locator('body')).toContainText(
+			'Original autosaved Playground',
+			{ timeout: 120000 }
+		);
+		await expect(wordpress.locator('body')).not.toContainText(
+			'Autosaved Blueprint test'
+		);
+		await website.openDockPane('Current Blueprint', 'Blueprint pane');
+		await expect(
+			website.page.locator('[class*="blueprint-editor"] .cm-content')
+		).toContainText('Autosaved Blueprint test');
 	});
 
 	test('should edit a Blueprint for a saved Playground and run it in a new Playground', async ({

--- a/packages/playground/website/playwright/e2e/website-ui.spec.ts
+++ b/packages/playground/website/playwright/e2e/website-ui.spec.ts
@@ -1316,14 +1316,16 @@ test.describe('Default Playground storage', () => {
 		expect(newSite).toMatchObject({ persistence: 'autosave' });
 		expect(newSite.slug).not.toBe(originalSite.slug);
 		await expect
-			.poll(() =>
-				website.page.evaluate(
-					(slug) =>
-						(window as any).playgroundSites
-							.list()
-							.some((site: any) => site.slug === slug),
-					originalSite.slug
-				)
+			.poll(
+				() =>
+					website.page.evaluate(
+						(slug) =>
+							(window as any).playgroundSites
+								.list()
+								.some((site: any) => site.slug === slug),
+						originalSite.slug
+					),
+				{ timeout: 120000 }
 			)
 			.toBe(true);
 

--- a/packages/playground/website/src/components/blueprint-editor/BlueprintBundleEditor.spec.tsx
+++ b/packages/playground/website/src/components/blueprint-editor/BlueprintBundleEditor.spec.tsx
@@ -353,7 +353,9 @@ describe('BlueprintBundleEditor Run barrier', () => {
 	it('keeps the existing presentation by default', async () => {
 		await renderEditor();
 
-		expect(container.textContent).toContain('Run Blueprint');
+		expect(container.textContent).toContain(
+			'Discard current Playground & run Blueprint'
+		);
 		expect(container.textContent).not.toContain('Run in a new Playground');
 		expect(container.textContent).not.toContain(
 			'creates a fresh autosaved Playground'

--- a/packages/playground/website/src/components/blueprint-editor/BlueprintBundleEditor.spec.tsx
+++ b/packages/playground/website/src/components/blueprint-editor/BlueprintBundleEditor.spec.tsx
@@ -356,6 +356,9 @@ describe('BlueprintBundleEditor Run barrier', () => {
 		expect(container.textContent).toContain(
 			'Discard current Playground & run Blueprint'
 		);
+		expect(
+			container.querySelector('button.is-destructive')?.textContent
+		).toContain('Discard current Playground & run Blueprint');
 		expect(container.textContent).not.toContain('Run in a new Playground');
 		expect(container.textContent).not.toContain(
 			'creates a fresh autosaved Playground'

--- a/packages/playground/website/src/components/blueprint-editor/BlueprintBundleEditor.spec.tsx
+++ b/packages/playground/website/src/components/blueprint-editor/BlueprintBundleEditor.spec.tsx
@@ -3,23 +3,32 @@
 import { act, createRef } from 'react';
 import { createRoot } from 'react-dom/client';
 import type { Root } from 'react-dom/client';
-import type { AsyncWritableFilesystem } from '@wp-playground/storage';
-import type { SiteInfo } from '../../lib/state/redux/slice-sites';
+import type { EventedFilesystem } from '@wp-playground/storage';
+import type * as SliceSitesModule from '../../lib/state/redux/slice-sites';
+import type * as SliceUiModule from '../../lib/state/redux/slice-ui';
 import {
 	BlueprintBundleEditor,
 	type BlueprintBundleEditorHandle,
 } from './BlueprintBundleEditor';
 
+type SiteInfo = SliceSitesModule.SiteInfo;
+
 const EDITED_BLUEPRINT = '{"steps":[{"step":"login"}]}';
 const mocks = vi.hoisted(() => ({
 	changeCode: undefined as ((code: string) => void) | undefined,
+	createStoredSite: vi.fn(),
 	dispatch: vi.fn(),
 	fileExplorerProps: undefined as Record<string, unknown> | undefined,
+	loggerError: vi.fn(),
+	pruneAutosavedSites: vi.fn(),
 	resolveRuntimeConfiguration: vi.fn(),
+	setActiveSite: vi.fn(),
+	setSiteManagerOpen: vi.fn(),
+	updateSite: vi.fn(),
 }));
 
 vi.mock('@php-wasm/logger', () => ({
-	logger: { error: vi.fn() },
+	logger: { error: mocks.loggerError },
 }));
 
 vi.mock('@wp-playground/blueprints', () => ({
@@ -48,17 +57,31 @@ vi.mock('../../lib/hooks/use-blueprint-url-hash', () => ({
 
 vi.mock('../../lib/state/redux/store', () => ({
 	useAppDispatch: () => mocks.dispatch,
-	useAppSelector: () => undefined,
+	setActiveSite: mocks.setActiveSite,
+}));
+
+vi.mock('../../lib/state/redux/slice-sites', async (importOriginal) => ({
+	...(await importOriginal<typeof SliceSitesModule>()),
+	createStoredSite: mocks.createStoredSite,
+	pruneAutosavedSites: mocks.pruneAutosavedSites,
+	updateSite: mocks.updateSite,
+}));
+
+vi.mock('../../lib/state/redux/slice-ui', async (importOriginal) => ({
+	...(await importOriginal<typeof SliceUiModule>()),
+	setSiteManagerOpen: mocks.setSiteManagerOpen,
 }));
 
 describe('BlueprintBundleEditor Run barrier', () => {
 	let container: HTMLDivElement;
 	let root: Root;
-	let filesystem: AsyncWritableFilesystem;
+	let filesystem: EventedFilesystem;
+	let filesystemBackend: EventedFilesystem['backend'];
 	let writeFile: ReturnType<typeof vi.fn>;
-	const site = {
+	const temporarySite = {
 		metadata: {
 			initialOpfsSyncPending: false,
+			name: 'Temporary Playground',
 			originalBlueprint: null,
 			storage: 'none',
 		},
@@ -78,14 +101,30 @@ describe('BlueprintBundleEditor Run barrier', () => {
 		document.body.append(container);
 		root = createRoot(container);
 		writeFile = vi.fn();
+		filesystemBackend = {} as EventedFilesystem['backend'];
 		filesystem = {
+			backend: filesystemBackend,
 			readFileAsText: vi.fn().mockResolvedValue('{}'),
 			writeFile,
-		} as unknown as AsyncWritableFilesystem;
+		} as unknown as EventedFilesystem;
 		mocks.changeCode = undefined;
+		mocks.createStoredSite.mockReset();
 		mocks.fileExplorerProps = undefined;
 		mocks.dispatch.mockReset();
+		mocks.loggerError.mockReset();
+		mocks.pruneAutosavedSites.mockReset();
 		mocks.resolveRuntimeConfiguration.mockReset();
+		mocks.setActiveSite.mockReset();
+		mocks.setActiveSite.mockImplementation((slug) => ({
+			type: 'set-active-site',
+			payload: slug,
+		}));
+		mocks.setSiteManagerOpen.mockReset();
+		mocks.setSiteManagerOpen.mockImplementation((open) => ({
+			type: 'set-site-manager-open',
+			payload: open,
+		}));
+		mocks.updateSite.mockReset();
 	});
 
 	afterEach(() => {
@@ -93,7 +132,7 @@ describe('BlueprintBundleEditor Run barrier', () => {
 		container.remove();
 	});
 
-	it('does not recreate when the pending edit cannot be saved', async () => {
+	it('does not run when the pending edit cannot be saved', async () => {
 		let failWrite!: (error: Error) => void;
 		writeFile.mockReturnValue(
 			new Promise<void>((_resolve, reject) => {
@@ -103,9 +142,9 @@ describe('BlueprintBundleEditor Run barrier', () => {
 		const editorRef = await renderEditor();
 		act(() => mocks.changeCode!(EDITED_BLUEPRINT));
 
-		let recreate!: Promise<void>;
+		let run!: Promise<void>;
 		act(() => {
-			recreate = editorRef.current!.triggerRecreate();
+			run = editorRef.current!.runBlueprint();
 		});
 		await act(async () => Promise.resolve());
 
@@ -118,7 +157,7 @@ describe('BlueprintBundleEditor Run barrier', () => {
 
 		await act(async () => {
 			failWrite(new Error('disk full'));
-			await recreate;
+			await run;
 		});
 
 		expect(mocks.resolveRuntimeConfiguration).not.toHaveBeenCalled();
@@ -128,9 +167,197 @@ describe('BlueprintBundleEditor Run barrier', () => {
 		);
 	});
 
+	it('runs an autosaved Blueprint in a new Playground', async () => {
+		const sourceSite = createStoredSiteInfo('autosave');
+		const newSite = createStoredSiteInfo('autosave', 'blueprint-copy');
+		const createAction = { type: 'create-stored-site' };
+		const pruneAction = { type: 'prune-autosaves' };
+		mocks.createStoredSite.mockReturnValue(createAction);
+		mocks.pruneAutosavedSites.mockReturnValue(pruneAction);
+		mocks.dispatch.mockImplementation((action) => {
+			if (action === createAction) {
+				return Promise.resolve(newSite);
+			}
+			return action;
+		});
+		const editorRef = await renderEditor({ site: sourceSite });
+
+		await act(async () => editorRef.current!.runBlueprint());
+
+		expect(mocks.createStoredSite).toHaveBeenCalledWith(
+			sourceSite.metadata.name,
+			filesystemBackend,
+			undefined,
+			{ persistence: 'autosave' }
+		);
+		expect(mocks.pruneAutosavedSites).toHaveBeenCalledWith({
+			excludeSlugs: [sourceSite.slug, newSite.slug],
+		});
+		expect(mocks.setSiteManagerOpen).toHaveBeenCalledWith(false);
+		expect(mocks.setActiveSite).toHaveBeenCalledWith(newSite.slug);
+		expect(mocks.resolveRuntimeConfiguration).not.toHaveBeenCalled();
+	});
+
+	it('keeps running a temporary Blueprint in the current Playground', async () => {
+		const runtimeConfiguration = {
+			phpVersion: '8.3',
+			wpVersion: 'latest',
+		};
+		const updateAction = { type: 'update-site' };
+		mocks.resolveRuntimeConfiguration.mockResolvedValue(
+			runtimeConfiguration
+		);
+		mocks.updateSite.mockReturnValue(updateAction);
+		mocks.dispatch.mockImplementation((action) => action);
+		const editorRef = await renderEditor();
+
+		await act(async () => editorRef.current!.runBlueprint());
+
+		expect(mocks.createStoredSite).not.toHaveBeenCalled();
+		expect(mocks.resolveRuntimeConfiguration).toHaveBeenCalledWith(
+			filesystem
+		);
+		expect(mocks.updateSite).toHaveBeenCalledWith({
+			slug: temporarySite.slug,
+			changes: {
+				metadata: {
+					...temporarySite.metadata,
+					originalBlueprintSource: { type: 'none' },
+					originalBlueprint: filesystem,
+					runtimeConfiguration,
+					initialOpfsSyncPending: false,
+					playgroundDefinedConstants: undefined,
+					whenCreated: expect.any(Number),
+				},
+				originalUrlParams: undefined,
+			},
+		});
+	});
+
+	it('ignores a second run while Playground creation is pending', async () => {
+		const sourceSite = createStoredSiteInfo('autosave');
+		const newSite = createStoredSiteInfo('autosave', 'blueprint-copy');
+		const createAction = { type: 'create-stored-site' };
+		let finishCreation!: (site: SiteInfo) => void;
+		mocks.createStoredSite.mockReturnValue(createAction);
+		mocks.pruneAutosavedSites.mockReturnValue({ type: 'prune-autosaves' });
+		mocks.dispatch.mockImplementation((action) => {
+			if (action === createAction) {
+				return new Promise<SiteInfo>((resolve) => {
+					finishCreation = resolve;
+				});
+			}
+			return action;
+		});
+		const editorRef = await renderEditor({ site: sourceSite });
+
+		let firstRun!: Promise<void>;
+		let secondRun!: Promise<void>;
+		act(() => {
+			firstRun = editorRef.current!.runBlueprint();
+			secondRun = editorRef.current!.runBlueprint();
+		});
+		await act(async () => Promise.resolve());
+
+		expect(mocks.createStoredSite).toHaveBeenCalledOnce();
+
+		await act(async () => {
+			finishCreation(newSite);
+			await Promise.all([firstRun, secondRun]);
+		});
+	});
+
+	it('allows retrying after Playground creation fails', async () => {
+		const sourceSite = createStoredSiteInfo('autosave');
+		const newSite = createStoredSiteInfo('autosave', 'blueprint-copy');
+		const createAction = { type: 'create-stored-site' };
+		let creationAttempts = 0;
+		mocks.createStoredSite.mockReturnValue(createAction);
+		mocks.pruneAutosavedSites.mockReturnValue({
+			type: 'prune-autosaves',
+		});
+		mocks.dispatch.mockImplementation((action) => {
+			if (action === createAction) {
+				creationAttempts++;
+				return creationAttempts === 1
+					? Promise.reject(new Error('Could not create site'))
+					: Promise.resolve(newSite);
+			}
+			return action;
+		});
+		const editorRef = await renderEditor({ site: sourceSite });
+
+		await act(async () => editorRef.current!.runBlueprint());
+
+		expect(container.textContent).toContain(
+			'Could not create Playground. Try again.'
+		);
+
+		await act(async () => editorRef.current!.runBlueprint());
+
+		expect(mocks.createStoredSite).toHaveBeenCalledTimes(2);
+		expect(mocks.setActiveSite).toHaveBeenCalledWith(newSite.slug);
+	});
+
+	it('keeps a committed Playground when autosave pruning fails', async () => {
+		const sourceSite = createStoredSiteInfo('autosave');
+		const newSite = createStoredSiteInfo('autosave', 'blueprint-copy');
+		const createAction = { type: 'create-stored-site' };
+		const pruneAction = { type: 'prune-autosaves' };
+		mocks.createStoredSite.mockReturnValue(createAction);
+		mocks.pruneAutosavedSites.mockReturnValue(pruneAction);
+		mocks.dispatch.mockImplementation((action) => {
+			if (action === createAction) {
+				return Promise.resolve(newSite);
+			}
+			if (action === pruneAction) {
+				return Promise.reject(new Error('Could not prune'));
+			}
+			return action;
+		});
+		const editorRef = await renderEditor({ site: sourceSite });
+
+		await act(async () => editorRef.current!.runBlueprint());
+
+		expect(mocks.setActiveSite).toHaveBeenCalledWith(newSite.slug);
+		expect(container.textContent).not.toContain(
+			'Could not create Playground. Try again.'
+		);
+		expect(mocks.loggerError).toHaveBeenCalledWith(
+			'Failed to prune autosaved Playgrounds',
+			expect.any(Error)
+		);
+	});
+
+	it('shows that stored Blueprints run in a fresh Playground', async () => {
+		const sourceSite = createStoredSiteInfo('autosave');
+		await renderEditor({ site: sourceSite });
+
+		expect(container.textContent).toContain('Run in a new Playground');
+		expect(container.textContent).toContain(
+			`“${sourceSite.metadata.name}” stays in Recent autosaves.`
+		);
+		expect(container.textContent).not.toContain('reset site');
+		expect(container.textContent).not.toContain('replace all its files');
+	});
+
+	it('shows that explicitly saved Playgrounds remain saved', async () => {
+		const sourceSite = createStoredSiteInfo('explicit');
+		await renderEditor({ site: sourceSite });
+
+		expect(container.textContent).toContain(
+			`“${sourceSite.metadata.name}” stays in Saved Playgrounds.`
+		);
+	});
+
 	it('keeps the existing presentation by default', async () => {
 		await renderEditor();
 
+		expect(container.textContent).toContain('Run Blueprint');
+		expect(container.textContent).not.toContain('Run in a new Playground');
+		expect(container.textContent).not.toContain(
+			'creates a fresh autosaved Playground'
+		);
 		expect(container.textContent).not.toContain('Export');
 		expect(
 			container.querySelector(
@@ -141,7 +368,7 @@ describe('BlueprintBundleEditor Run barrier', () => {
 	});
 
 	it('can render the Blueprint editor as Dock content', async () => {
-		await renderEditor(true);
+		await renderEditor({ dockPresentation: true });
 
 		expect(container.textContent).toContain('Export');
 		expect(
@@ -157,9 +384,13 @@ describe('BlueprintBundleEditor Run barrier', () => {
 		});
 	});
 
-	async function renderEditor(
-		dockPresentation = false
-	): Promise<React.RefObject<BlueprintBundleEditorHandle>> {
+	async function renderEditor({
+		dockPresentation = false,
+		site = temporarySite,
+	}: {
+		dockPresentation?: boolean;
+		site?: SiteInfo;
+	} = {}): Promise<React.RefObject<BlueprintBundleEditorHandle>> {
 		const editorRef = createRef<BlueprintBundleEditorHandle>();
 		await act(async () => {
 			root.render(
@@ -175,5 +406,21 @@ describe('BlueprintBundleEditor Run barrier', () => {
 		expect(editorRef.current).not.toBeNull();
 		expect(mocks.changeCode).toBeTypeOf('function');
 		return editorRef;
+	}
+
+	function createStoredSiteInfo(
+		persistence: 'autosave' | 'explicit',
+		slug = 'source-site'
+	): SiteInfo {
+		return {
+			slug,
+			metadata: {
+				...temporarySite.metadata,
+				id: slug,
+				name: 'Source Playground',
+				persistence,
+				storage: 'opfs',
+			},
+		} as SiteInfo;
 	}
 });

--- a/packages/playground/website/src/components/blueprint-editor/BlueprintBundleEditor.tsx
+++ b/packages/playground/website/src/components/blueprint-editor/BlueprintBundleEditor.tsx
@@ -910,6 +910,7 @@ export const BlueprintBundleEditor = forwardRef<
 								{!readOnly && (
 									<Button
 										variant="primary"
+										isDestructive={!isStored}
 										className={classNames(
 											styles.editorToolbarButton,
 											{

--- a/packages/playground/website/src/components/blueprint-editor/BlueprintBundleEditor.tsx
+++ b/packages/playground/website/src/components/blueprint-editor/BlueprintBundleEditor.tsx
@@ -933,7 +933,7 @@ export const BlueprintBundleEditor = forwardRef<
 										/>
 										{isStored
 											? 'Run in a new Playground'
-											: 'Run Blueprint'}
+											: 'Discard current Playground & run Blueprint'}
 									</Button>
 								)}
 							</div>

--- a/packages/playground/website/src/components/blueprint-editor/BlueprintBundleEditor.tsx
+++ b/packages/playground/website/src/components/blueprint-editor/BlueprintBundleEditor.tsx
@@ -21,7 +21,10 @@ import {
 	resolveRuntimeConfiguration,
 	type BlueprintValidationResult,
 } from '@wp-playground/blueprints';
-import type { AsyncWritableFilesystem } from '@wp-playground/storage';
+import type {
+	AsyncWritableFilesystem,
+	EventedFilesystem,
+} from '@wp-playground/storage';
 import { BlobWriter, Uint8ArrayReader, ZipWriter } from '@zip.js/zip.js';
 import classNames from 'classnames';
 import {
@@ -51,30 +54,20 @@ import {
 import { StringEditorModal } from './string-editor-modal';
 import { useBlueprintUrlHash } from '../../lib/hooks/use-blueprint-url-hash';
 import { useDebouncedCallback } from '../../lib/hooks/use-debounced-callback';
-import {
-	removeClientInfo,
-	selectClientInfoBySiteSlug,
-} from '../../lib/state/redux/slice-clients';
+import { removeClientInfo } from '../../lib/state/redux/slice-clients';
 import {
 	createStoredSite,
 	isAutosavedSite,
-	isExplicitlySavedSite,
+	isStoredSite,
 	pruneAutosavedSites,
-	sitesSlice,
 	type SiteInfo,
 	updateSite,
 } from '../../lib/state/redux/slice-sites';
-import {
-	setActiveSite,
-	useAppDispatch,
-	useAppSelector,
-} from '../../lib/state/redux/store';
-import { resetAutosavedSiteFilesWithPendingMarker } from '../../lib/state/opfs/opfs-autosave-reset';
+import { setActiveSite, useAppDispatch } from '../../lib/state/redux/store';
 import { setSiteManagerOpen } from '../../lib/state/redux/slice-ui';
 import styles from './blueprint-bundle-editor.module.css';
 import hideRootStyles from './hide-root.module.css';
 import validationStyles from './validation-panel.module.css';
-import type { EventedFilesystem } from '@wp-playground/storage';
 
 const BLUEPRINT_JSON_PATH = '/blueprint.json';
 
@@ -276,7 +269,7 @@ const PlayIcon = ({ className }: { className?: string }) => (
  * Inner editor that assumes the filesystem never changes.
  */
 export type BlueprintBundleEditorProps = {
-	filesystem: AsyncWritableFilesystem;
+	filesystem: EventedFilesystem;
 	className?: string;
 	site?: SiteInfo;
 	autoRunToken?: number;
@@ -287,7 +280,7 @@ export type BlueprintBundleEditorProps = {
 export interface BlueprintBundleEditorHandle {
 	downloadBundle: () => Promise<void>;
 	getBundle: () => Promise<AsyncWritableFilesystem | null>;
-	triggerRecreate: () => Promise<void>;
+	runBlueprint: () => Promise<void>;
 }
 
 export const BlueprintBundleEditor = forwardRef<
@@ -318,6 +311,8 @@ export const BlueprintBundleEditor = forwardRef<
 	const [isRunningBlueprint, setIsRunningBlueprint] = useState(false);
 	const [validationResult, setValidationResult] =
 		useState<BlueprintValidationResult | null>(null);
+	const hasValidationErrors =
+		validationResult !== null && !validationResult.valid;
 	const [stringEditorState, setStringEditorState] =
 		useState<StringEditorState>({
 			isOpen: false,
@@ -356,10 +351,8 @@ export const BlueprintBundleEditor = forwardRef<
 	 * earlier in-flight writes, so Run can wait before reading the Blueprint bundle.
 	 */
 	const saveBarrierRef = useRef<Promise<boolean>>(Promise.resolve(true));
+	const runInProgressRef = useRef(false);
 	const dispatch = useAppDispatch();
-	const playgroundClient = useAppSelector((state) =>
-		site ? selectClientInfoBySiteSlug(state, site.slug)?.client : undefined
-	);
 
 	// Save file to filesystem
 	const saveFile = useDebouncedCallback(enqueueSave, 200, [filesystem]);
@@ -423,10 +416,16 @@ export const BlueprintBundleEditor = forwardRef<
 	}, [newUrl]);
 
 	const handleRunBlueprint = useCallback(async () => {
-		if (!site || readOnly) {
+		if (
+			!site ||
+			readOnly ||
+			hasValidationErrors ||
+			runInProgressRef.current
+		) {
 			return;
 		}
-		const runInNewPlayground = isExplicitlySavedSite(site);
+		runInProgressRef.current = true;
+		const runInNewPlayground = isStoredSite(site);
 		try {
 			setIsRunningBlueprint(true);
 			saveFile.flush();
@@ -434,93 +433,58 @@ export const BlueprintBundleEditor = forwardRef<
 				return;
 			}
 			setSaveError(null);
-			const isAutosaved = isAutosavedSite(site);
-			const bundle =
-				(filesystem as EventedFilesystem | null) ??
-				((site.metadata.originalBlueprint ||
-					null) as EventedFilesystem | null);
-			if (!bundle) {
-				throw new Error('Blueprint bundle is not available.');
-			}
 			if (runInNewPlayground) {
 				const newSite = await dispatch(
 					createStoredSite(
 						site.metadata.name,
-						(filesystem as EventedFilesystem).backend,
+						filesystem.backend,
 						undefined,
 						{ persistence: 'autosave' }
 					)
 				);
-				await dispatch(
-					pruneAutosavedSites({
-						excludeSlugs: [newSite.slug],
-					})
-				);
+				try {
+					await dispatch(
+						pruneAutosavedSites({
+							excludeSlugs: [site.slug, newSite.slug],
+						})
+					);
+				} catch (error) {
+					// The new Playground is already committed. Retention cleanup is
+					// housekeeping and must not turn a successful run into a retry
+					// that creates a duplicate Playground.
+					logger.error(
+						'Failed to prune autosaved Playgrounds',
+						error
+					);
+				}
 				dispatch(setSiteManagerOpen(false));
 				dispatch(setActiveSite(newSite.slug));
 				return;
 			}
 			const runtimeConfiguration = await resolveRuntimeConfiguration(
-				bundle as any
+				filesystem as any
 			);
 			const changes = {
-				...(isAutosaved ? { loadedFromStorage: false } : {}),
 				metadata: {
 					...site.metadata,
-					originalBlueprintSource: isAutosaved
-						? { type: 'opfs-site' as const }
-						: { type: 'none' as const },
-					originalBlueprint: isAutosaved
-						? (filesystem as EventedFilesystem).backend
-						: bundle,
+					originalBlueprintSource: { type: 'none' as const },
+					originalBlueprint: filesystem,
 					runtimeConfiguration,
 					initialOpfsSyncPending:
-						isAutosaved || site.metadata.initialOpfsSyncPending,
-					/**
-					 * Recreating an autosaved Playground discards the old
-					 * WordPress files and boots from the edited Blueprint.
-					 * Constants discovered from the previous runtime may no
-					 * longer exist in the recreated site, so they must be
-					 * rediscovered after the first OPFS sync.
-					 */
-					playgroundDefinedConstants: isAutosaved
-						? undefined
-						: site.metadata.playgroundDefinedConstants,
+						site.metadata.initialOpfsSyncPending,
+					playgroundDefinedConstants:
+						site.metadata.playgroundDefinedConstants,
 					whenCreated: Date.now(),
 				},
 				originalUrlParams: undefined,
 			};
-			if (isAutosaved) {
-				await playgroundClient?.unmountOpfs('/wordpress');
-				dispatch(removeClientInfo(site.slug));
-				// "Run Blueprint and reset site" changes the setup for this
-				// autosave. Delete the old WordPress files with
-				// `opfsSiteRemovalPending` so a tab close after the metadata
-				// write cannot leave the old site booting under the edited
-				// Blueprint.
-				const completedChanges =
-					await resetAutosavedSiteFilesWithPendingMarker(
-						site.slug,
-						changes
-					);
-				// The helper already wrote these changes to OPFS before and
-				// after deleting files. Update Redux without writing the same
-				// metadata a third time.
-				dispatch(
-					sitesSlice.actions.updateSite({
-						id: site.slug,
-						changes: completedChanges,
-					})
-				);
-			} else {
-				dispatch(removeClientInfo(site.slug));
-				await dispatch(
-					updateSite({
-						slug: site.slug,
-						changes,
-					})
-				);
-			}
+			dispatch(removeClientInfo(site.slug));
+			await dispatch(
+				updateSite({
+					slug: site.slug,
+					changes,
+				})
+			);
 		} catch (error) {
 			logger.error('Failed to run Blueprint', error);
 			setSaveError(
@@ -529,9 +493,10 @@ export const BlueprintBundleEditor = forwardRef<
 					: 'Could not recreate Playground. Try again.'
 			);
 		} finally {
+			runInProgressRef.current = false;
 			setIsRunningBlueprint(false);
 		}
-	}, [dispatch, filesystem, playgroundClient, readOnly, saveFile, site]);
+	}, [dispatch, filesystem, hasValidationErrors, readOnly, saveFile, site]);
 
 	// autorun token hook
 	useEffect(() => {
@@ -687,9 +652,6 @@ export const BlueprintBundleEditor = forwardRef<
 		[handleValidationChange, openStringEditor]
 	);
 
-	const hasValidationErrors =
-		validationResult !== null && !validationResult.valid;
-
 	const handleDownloadBundle = useCallback(async () => {
 		try {
 			const zipWriter = new ZipWriter(new BlobWriter('application/zip'));
@@ -753,13 +715,13 @@ export const BlueprintBundleEditor = forwardRef<
 		() => ({
 			downloadBundle: handleDownloadBundle,
 			getBundle: async () => filesystem,
-			triggerRecreate: handleRunBlueprint,
+			runBlueprint: handleRunBlueprint,
 		}),
 		[handleDownloadBundle, filesystem, handleRunBlueprint]
 	);
 
 	const isAutosaved = site ? isAutosavedSite(site) : false;
-	const isExplicitlySaved = site ? isExplicitlySavedSite(site) : false;
+	const isStored = site ? isStoredSite(site) : false;
 	const disableRunButton = isRunningBlueprint || !site || hasValidationErrors;
 	return (
 		<>
@@ -969,11 +931,9 @@ export const BlueprintBundleEditor = forwardRef<
 												styles.editorToolbarPlayIcon
 											}
 										/>
-										{isExplicitlySaved
+										{isStored
 											? 'Run in a new Playground'
-											: isAutosaved
-												? 'Run Blueprint and reset site'
-												: 'Run Blueprint'}
+											: 'Run Blueprint'}
 									</Button>
 								)}
 							</div>
@@ -1004,14 +964,15 @@ export const BlueprintBundleEditor = forwardRef<
 								</Notice>
 							</div>
 						) : null}
-						{isAutosaved ? (
-							<div style={{ padding: '8px 16px' }}>
-								<Notice status="warning" isDismissible={false}>
-									Running this Blueprint will recreate this
-									autosaved Playground under the same name and
-									replace all its files.
-								</Notice>
-							</div>
+						{isStored ? (
+							<p className={styles.runHint}>
+								Running this Blueprint creates a fresh autosaved
+								Playground. “{site?.metadata.name}” stays in{' '}
+								{isAutosaved
+									? 'Recent autosaves'
+									: 'Saved Playgrounds'}
+								.
+							</p>
 						) : null}
 						{currentPath || code || messageContent ? (
 							messageContent ? (

--- a/packages/playground/website/src/components/blueprint-editor/SiteBlueprintBundleEditor.tsx
+++ b/packages/playground/website/src/components/blueprint-editor/SiteBlueprintBundleEditor.tsx
@@ -243,9 +243,10 @@ export const SiteBlueprintBundleEditor = forwardRef<
 
 	const innerEditorRef = useRef<BlueprintBundleEditorHandle | null>(null);
 
-	// Autosaves edit their own persisted Blueprint bundle. Explicit saves edit
-	// an in-memory copy and can run it in a new Playground without changing the
-	// preserved site.
+	// Autosaves edit their own persisted Blueprint draft so changes survive a
+	// reload. Running that draft copies it into a fresh Playground instead of
+	// replacing the autosave's WordPress files. Explicit saves use an in-memory
+	// draft so editing cannot change the preserved Blueprint.
 	const isAutosaved = isAutosavedSite(site);
 	const isExplicitlySaved = isExplicitlySavedSite(site);
 

--- a/packages/playground/website/src/components/blueprint-editor/blueprint-bundle-editor.module.css
+++ b/packages/playground/website/src/components/blueprint-editor/blueprint-bundle-editor.module.css
@@ -185,6 +185,16 @@
 	padding: 8px 12px 4px;
 }
 
+.runHint {
+	background: var(--paper-2, #ffffff);
+	border-bottom: 1px solid var(--line-subtle, #ddd);
+	color: var(--ink-muted, #50575e);
+	font-size: 13px;
+	line-height: 1.5;
+	margin: 0;
+	padding: 10px 16px;
+}
+
 .editorDocsLink {
 	align-items: center;
 	border-radius: 6px;

--- a/packages/playground/website/src/lib/state/opfs/opfs-autosave-reset.ts
+++ b/packages/playground/website/src/lib/state/opfs/opfs-autosave-reset.ts
@@ -12,13 +12,12 @@ type SiteResetChanges = {
  *
  * Why the files need to be deleted:
  *
- * Autosaved Playgrounds keep the same sidebar entry and OPFS directory when the
- * user clicks "Apply Settings & Recreate Playground" or "Run Blueprint and
- * reset site". The metadata changes first: `wp-runtime.json` starts describing
- * the new setup or edited Blueprint. The WordPress files in that OPFS directory
- * still came from the previous setup, so they must be removed before the next
- * boot. Otherwise Playground would open the previous WordPress site while the
- * metadata says it should be using the new setup.
+ * The public autosave-recreation API keeps the same sidebar entry and OPFS
+ * directory while changing its setup. The metadata changes first:
+ * `wp-runtime.json` starts describing the new setup while the WordPress files in
+ * that OPFS directory still came from the previous setup. They must be removed
+ * before the next boot, or Playground would open the previous WordPress site
+ * while its metadata describes the replacement.
  *
  * How this makes that deletion safe across tab closes:
  *
@@ -34,9 +33,9 @@ type SiteResetChanges = {
  *
  * Do not use this when the existing WordPress files can keep running, such as
  * changing PHP version or networking. Those should update metadata and reboot
- * the same files. Longer term, the Dock UI should create a new Playground for
- * setup changes instead of deleting files from the current autosave; this
- * helper only protects today's behavior of deleting and recreating files under
+ * the same files. The Dock UI creates a fresh Playground for setup changes that
+ * need different WordPress files and for Blueprint runs; this helper only
+ * protects the public API's compatibility behavior of recreating files under
  * the same autosaved slug.
  */
 export async function resetAutosavedSiteFilesWithPendingMarker(

--- a/packages/playground/website/src/lib/state/opfs/opfs-site-storage.ts
+++ b/packages/playground/website/src/lib/state/opfs/opfs-site-storage.ts
@@ -276,11 +276,10 @@ class OpfsSiteStorage {
 	 * Removes WordPress files from an OPFS-backed site while preserving the
 	 * site metadata file and the editable Blueprint bundle directory.
 	 *
-	 * Autosaved reset paths use this after the user chooses to keep the same
-	 * sidebar entry but boot it from new settings or an edited Blueprint. Keep
-	 * the metadata file and editable Blueprint bundle; delete everything else
-	 * because those entries are the old WordPress runtime tree that the next
-	 * boot must recreate from the new setup.
+	 * The public autosave-recreation API uses this to keep the same sidebar entry
+	 * while booting from new settings. Keep the metadata file and editable
+	 * Blueprint bundle; delete everything else because those entries are the old
+	 * WordPress runtime tree that the next boot must recreate from the new setup.
 	 */
 	async removeWordPressFilesKeepMetadata(slug: string): Promise<void> {
 		const siteDirName = await this.findExistingSiteDirName(slug);

--- a/packages/playground/website/src/lib/state/redux/slice-sites.spec.ts
+++ b/packages/playground/website/src/lib/state/redux/slice-sites.spec.ts
@@ -434,6 +434,32 @@ describe('stored site creation', () => {
 		expect(createSite).not.toHaveBeenCalled();
 	});
 
+	it('removes a partial Blueprint bundle when copying it fails', async () => {
+		const { createStoredSite } = await import('./slice-sites');
+		resolveRuntimeConfiguration.mockResolvedValue({
+			phpVersion: '8.3',
+			wpVersion: 'latest',
+			intl: false,
+			networking: true,
+			extraLibraries: [],
+			constants: {},
+		});
+		persistBlueprintBundle.mockRejectedValue(
+			new Error('Could not copy bundle')
+		);
+
+		await expect(
+			createStoredSite(
+				'Edited Blueprint',
+				createBundleBlueprint(),
+				'edited-blueprint'
+			)(createThunkDispatch() as any, createEmptyGetState() as any)
+		).rejects.toThrow('Could not copy bundle');
+
+		expect(deleteBlueprintBundle).toHaveBeenCalledWith('edited-blueprint');
+		expect(createSite).not.toHaveBeenCalled();
+	});
+
 	it('removes an edited Blueprint bundle when site creation fails', async () => {
 		const { createStoredSite } = await import('./slice-sites');
 		resolveRuntimeConfiguration.mockResolvedValue({

--- a/packages/playground/website/src/lib/state/redux/slice-sites.ts
+++ b/packages/playground/website/src/lib/state/redux/slice-sites.ts
@@ -623,7 +623,6 @@ export function createStoredSite(
 			? blueprint
 			: undefined;
 		if (blueprintBundle) {
-			await persistBlueprintBundle(siteSlug, blueprintBundle);
 			originalBlueprintSource = {
 				type: 'opfs-site',
 			};
@@ -652,6 +651,9 @@ export function createStoredSite(
 		};
 
 		try {
+			if (blueprintBundle) {
+				await persistBlueprintBundle(siteSlug, blueprintBundle);
+			}
 			await dispatch(addSite(newSiteInfo));
 		} catch (error) {
 			if (blueprintBundle) {


### PR DESCRIPTION
Running an edited Blueprint now creates a new autosaved Playground instead of deleting the source site's WordPress files.

## Background

Before this PR, running a Blueprint from an autosaved Playground did three things:

1. Stored the edited Blueprint under the existing site slug.
2. Deleted that site's WordPress files.
3. Booted the edited Blueprint under the same site identity.

That destroyed the site used to author the Blueprint. Explicitly saved Playgrounds already ran edited Blueprints in a new Playground, so the same button had different consequences depending on how the source was stored.

## This change

All stored Playgrounds now copy the edited Blueprint bundle into a fresh autosave and activate it. The source Playground, its WordPress files, and its identity remain available. Autosaved Blueprint drafts also remain attached to their source. Temporary Playgrounds still reuse the current site because there is no stored source to preserve. Their action says `Discard current Playground & run Blueprint`.

## Screenshots

### Before

An autosaved Playground was reset in place

![Before: the Blueprint Dock warned that running the Blueprint would reset the autosaved Playground and replace its files](https://gist.githubusercontent.com/adamziel/c01827b1d497b99806f6fca027c71332/raw/b9b87f4c61572cfaee65d63b54f6954805eb51be/pr4067-before-reset-in-place.svg)

### After

When editing a stored Playground's Blueprint, offer to run the updated Blueprint in a dedicated new Playground

![After: a stored Playground shows Run in a new Playground and says where the source remains available](https://gist.githubusercontent.com/adamziel/c01827b1d497b99806f6fca027c71332/raw/931522f57ba4741ba9b9e8401739e03d84ad0247/pr4067-after-stored.svg)

When editing an unsaved Playground's Blueprint – explicitly explain the unsaved Playground will be discarded

![After: a temporary Playground shows the red Discard current Playground and run Blueprint action](https://gist.githubusercontent.com/adamziel/c01827b1d497b99806f6fca027c71332/raw/1f8f1a9b9d57701f8bf01f4a0be7a421e734d2e3/pr4067-after-temporary.svg)

The Run action waits for the pending editor write before copying the bundle. A synchronous guard ignores repeated clicks while creation is in progress. Autosave pruning excludes both the source and destination. A pruning failure is logged after the new Playground is committed; reporting the run as failed would invite a retry and create a duplicate. If copying the bundle or writing site metadata fails, `createStoredSite()` removes the partial bundle.

## Testing

The unit tests cover temporary and stored runs, the save barrier, repeated clicks, retry after creation failure, pruning failure, the text shown for preserved sources, and partial-bundle cleanup. The browser tests verify that autosaved and explicitly saved sources survive while the edited Blueprint boots in a new autosave.

Test with:

```
npm exec nx -- test playground-website --runInBand
npm exec nx -- run playground-website:lint
npm exec nx -- run playground-website:typecheck
npm exec nx -- run playground-website:build:standalone
npm exec nx -- run playground-website:e2e:playwright -- website-ui.spec.ts --project=chromium --grep="should edit a Blueprint for an autosaved Playground"
npm exec nx -- run playground-website:e2e:playwright -- website-ui.spec.ts --project=chromium --grep="should edit a Blueprint for a saved Playground"
```



