### PR TITLE
[Website] Use graphite icons for dock pane actions

### DIFF
--- a/packages/playground/website/src/components/dock/style.module.css
+++ b/packages/playground/website/src/components/dock/style.module.css
@@ -228,6 +228,7 @@
 	--ink-soft: #2f2d28;
 	--ink-muted: #5f5b54;
 	--ink-faint: #8a857b;
+	--action-icon: #4f4b45;
 	--accent: #3858e9;
 	--accent-hover: #2f4ad1;
 	--accent-link: #2645c9;

--- a/packages/playground/website/src/components/saved-playgrounds-panel/style.module.css
+++ b/packages/playground/website/src/components/saved-playgrounds-panel/style.module.css
@@ -822,16 +822,8 @@
 }
 
 .playgrounds-pane.new-pane .creationIcon :global(svg) {
-	color: inherit;
-	fill: currentColor;
 	height: 20px;
 	width: 20px;
-}
-
-/* One icon language: every glyph (incl. the solid octocat) follows currentColor
-   so the tab icons read as one set. */
-.playgrounds-pane.new-pane .creationIcon :global(svg path) {
-	fill: currentColor;
 }
 
 .playgrounds-pane.new-pane .creationTitle {
@@ -1216,6 +1208,12 @@
 .playgrounds-pane .creationIcon :global(svg) {
 	color: var(--action-icon, #4f4b45);
 	fill: currentColor;
+}
+
+/* One icon language: every glyph (incl. the solid octocat) follows currentColor
+   so the action icons read as one set. */
+.playgrounds-pane .creationIcon :global(svg [stroke]:not([stroke='none'])) {
+	stroke: currentColor;
 }
 
 /* The WordPress mark hardcodes a white path fill, which an svg-level rule can't

--- a/packages/playground/website/src/components/saved-playgrounds-panel/style.module.css
+++ b/packages/playground/website/src/components/saved-playgrounds-panel/style.module.css
@@ -813,7 +813,7 @@
 
 .playgrounds-pane.new-pane .creationIcon {
 	align-items: center;
-	color: var(--ink-soft, #2f2d28);
+	color: var(--action-icon, #4f4b45);
 	display: flex;
 	flex: none;
 	height: 20px;
@@ -822,6 +822,8 @@
 }
 
 .playgrounds-pane.new-pane .creationIcon :global(svg) {
+	color: inherit;
+	fill: currentColor;
 	height: 20px;
 	width: 20px;
 }
@@ -863,8 +865,8 @@
 	}
 }
 
-/* Active tab: a raised white segment with a defined edge and an accent icon —
-   it reads above the resting cells by value, not by shadow alone. */
+/* Active tab: a raised white segment with a defined edge; it reads above
+   the resting cells by value, not by shadow alone. */
 .playgrounds-pane.new-pane .creationButtonActive,
 .playgrounds-pane.new-pane .creationButtonActive:hover:not(:disabled) {
 	background: #ffffff;
@@ -881,7 +883,7 @@
 }
 
 .playgrounds-pane.new-pane .creationButtonActive .creationIcon {
-	color: var(--accent, #3858e9);
+	color: var(--action-icon, #4f4b45);
 }
 
 /* The active tab's flow scrolls within this panel; a sticky heading names it. */
@@ -1212,8 +1214,8 @@
 
 .playgrounds-pane .creationIcon,
 .playgrounds-pane .creationIcon :global(svg) {
-	color: #3858e9;
-	fill: #3858e9;
+	color: var(--action-icon, #4f4b45);
+	fill: currentColor;
 }
 
 /* The WordPress mark hardcodes a white path fill, which an svg-level rule can't

--- a/packages/playground/website/src/components/site-manager/site-share-panel/style.module.css
+++ b/packages/playground/website/src/components/site-manager/site-share-panel/style.module.css
@@ -139,7 +139,7 @@
 	align-items: center;
 	background: var(--paper-3);
 	border-radius: var(--radius-card);
-	color: var(--accent-link);
+	color: var(--action-icon, #4f4b45);
 	display: flex;
 	flex-shrink: 0;
 	height: 38px;

--- a/packages/playground/website/src/components/site-manager/site-share-panel/style.module.css
+++ b/packages/playground/website/src/components/site-manager/site-share-panel/style.module.css
@@ -151,6 +151,10 @@
 	fill: currentColor;
 }
 
+.group-icon :global(svg [stroke]:not([stroke='none'])) {
+	stroke: currentColor;
+}
+
 .group-body {
 	display: flex;
 	flex: 1;


### PR DESCRIPTION
The New Playground and Export panes used bright blue for passive action-choice icons. That made them compete with the real accent affordances: primary buttons, links, focus rings, and status marks.

Use a soft graphite action-icon token for those pane action icons instead. The change applies it to the New Playground creation tabs and the Export option groups, and makes those SVGs follow `currentColor` so the WordPress, GitHub, custom pull request, and stroke-based glyphs stay visually consistent.

| Before | After |
| --- | --- |
| ![New Playground pane with blue action icons](https://raw.githubusercontent.com/WordPress/wordpress-playground/adamziel/yerevan-pr-4068-screenshots/screenshots/pr-4068/before-new-playground-blue-icons.png) | ![New Playground pane with graphite action icons](https://raw.githubusercontent.com/WordPress/wordpress-playground/adamziel/yerevan-pr-4068-screenshots/screenshots/pr-4068/after-new-playground-graphite-icons.png) |

Testing: `git diff --check origin/trunk...HEAD`

Not run: `nx format` or package tests. This checkout has no Nx modules installed; the commit hook attempted `nx format --fix --parallel --uncommitted` and reported that Nx modules were missing.
