### PR TITLE
[Website] Put the Blueprint URL export hint inside the disabled item

### DIFF
--- a/packages/playground/website/src/components/blueprint-editor/BlueprintBundleEditor.tsx
+++ b/packages/playground/website/src/components/blueprint-editor/BlueprintBundleEditor.tsx
@@ -852,7 +852,25 @@ export const BlueprintBundleEditor = forwardRef<
 																onClose();
 															}}
 														>
-															Copy Blueprint URL
+															<span
+																className={
+																	styles.exportMenuItemBody
+																}
+															>
+																<span>
+																	Copy Blueprint
+																	URL
+																</span>
+																{!isBundleShareable && (
+																	<span
+																		className={
+																			styles.exportMenuItemHint
+																		}
+																	>
+																		Multi-file Blueprints can’t be shared as a URL — download a zip instead.
+																	</span>
+																)}
+															</span>
 														</MenuItem>
 														<MenuItem
 															icon={download}
@@ -864,19 +882,6 @@ export const BlueprintBundleEditor = forwardRef<
 															Download Zip
 														</MenuItem>
 													</MenuGroup>
-													{!isBundleShareable && (
-														<p
-															className={
-																styles.exportHint
-															}
-														>
-															Multi-file
-															Blueprints can’t be
-															shared as a URL —
-															download a zip
-															instead.
-														</p>
-													)}
 												</>
 											)}
 										/>

--- a/packages/playground/website/src/components/blueprint-editor/BlueprintBundleEditor.tsx
+++ b/packages/playground/website/src/components/blueprint-editor/BlueprintBundleEditor.tsx
@@ -844,6 +844,9 @@ export const BlueprintBundleEditor = forwardRef<
 													<MenuGroup>
 														<MenuItem
 															icon={link}
+															className={
+																styles.exportMenuItemWithHint
+															}
 															disabled={
 																!isBundleShareable
 															}
@@ -858,7 +861,8 @@ export const BlueprintBundleEditor = forwardRef<
 																}
 															>
 																<span>
-																	Copy Blueprint
+																	Copy
+																	Blueprint
 																	URL
 																</span>
 																{!isBundleShareable && (
@@ -867,7 +871,15 @@ export const BlueprintBundleEditor = forwardRef<
 																			styles.exportMenuItemHint
 																		}
 																	>
-																		Multi-file Blueprints can’t be shared as a URL — download a zip instead.
+																		Multi-file
+																		Blueprints
+																		can’t be
+																		shared
+																		as a URL
+																		—
+																		download
+																		a zip
+																		instead.
 																	</span>
 																)}
 															</span>

--- a/packages/playground/website/src/components/blueprint-editor/BlueprintBundleEditor.tsx
+++ b/packages/playground/website/src/components/blueprint-editor/BlueprintBundleEditor.tsx
@@ -842,70 +842,65 @@ export const BlueprintBundleEditor = forwardRef<
 												</Button>
 											)}
 											renderContent={({ onClose }) => (
-												<>
-													<MenuGroup>
-														<MenuItem
-															icon={link}
+												<MenuGroup>
+													<MenuItem
+														icon={link}
+														className={
+															styles.exportMenuItemWithHint
+														}
+														aria-label="Copy Blueprint URL"
+														aria-describedby={
+															!isBundleShareable
+																? copyBlueprintUrlHintId
+																: undefined
+														}
+														disabled={
+															!isBundleShareable
+														}
+														onClick={() => {
+															handleShareBlueprint();
+															onClose();
+														}}
+													>
+														<span
 															className={
-																styles.exportMenuItemWithHint
+																styles.exportMenuItemBody
 															}
-															aria-label="Copy Blueprint URL"
-															aria-describedby={
-																!isBundleShareable
-																	? copyBlueprintUrlHintId
-																	: undefined
-															}
-															disabled={
-																!isBundleShareable
-															}
-															onClick={() => {
-																handleShareBlueprint();
-																onClose();
-															}}
 														>
-															<span
-																className={
-																	styles.exportMenuItemBody
-																}
-															>
-																<span>
-																	Copy
-																	Blueprint
-																	URL
-																</span>
-																{!isBundleShareable && (
-																	<span
-																		id={
-																			copyBlueprintUrlHintId
-																		}
-																		className={
-																			styles.exportMenuItemHint
-																		}
-																	>
-																		Multi-file
-																		Blueprints
-																		can’t be
-																		shared
-																		as a URL
-																		—
-																		download
-																		a zip
-																		instead.
-																	</span>
-																)}
+															<span>
+																Copy Blueprint
+																URL
 															</span>
-														</MenuItem>
-														<MenuItem
-															icon={download}
-															onClick={() => {
-																handleDownloadBundle();
-																onClose();
-															}}
-														>
-															Download Zip
-														</MenuItem>
-													</MenuGroup>
-												</>
+															{!isBundleShareable && (
+																<span
+																	id={
+																		copyBlueprintUrlHintId
+																	}
+																	className={
+																		styles.exportMenuItemHint
+																	}
+																>
+																	Multi-file
+																	Blueprints
+																	can’t be
+																	shared as a
+																	URL —
+																	download a
+																	zip instead.
+																</span>
+															)}
+														</span>
+													</MenuItem>
+													<MenuItem
+														icon={download}
+														onClick={() => {
+															handleDownloadBundle();
+															onClose();
+														}}
+													>
+														Download Zip
+													</MenuItem>
+												</MenuGroup>
 											)}
 										/>
 									</>

--- a/packages/playground/website/src/components/blueprint-editor/BlueprintBundleEditor.tsx
+++ b/packages/playground/website/src/components/blueprint-editor/BlueprintBundleEditor.tsx
@@ -31,6 +31,7 @@ import {
 	forwardRef,
 	useCallback,
 	useEffect,
+	useId,
 	useImperativeHandle,
 	useMemo,
 	useRef,
@@ -313,6 +314,7 @@ export const BlueprintBundleEditor = forwardRef<
 		useState<BlueprintValidationResult | null>(null);
 	const hasValidationErrors =
 		validationResult !== null && !validationResult.valid;
+	const copyBlueprintUrlHintId = useId();
 	const [stringEditorState, setStringEditorState] =
 		useState<StringEditorState>({
 			isOpen: false,
@@ -847,6 +849,12 @@ export const BlueprintBundleEditor = forwardRef<
 															className={
 																styles.exportMenuItemWithHint
 															}
+															aria-label="Copy Blueprint URL"
+															aria-describedby={
+																!isBundleShareable
+																	? copyBlueprintUrlHintId
+																	: undefined
+															}
 															disabled={
 																!isBundleShareable
 															}
@@ -867,6 +875,9 @@ export const BlueprintBundleEditor = forwardRef<
 																</span>
 																{!isBundleShareable && (
 																	<span
+																		id={
+																			copyBlueprintUrlHintId
+																		}
 																		className={
 																			styles.exportMenuItemHint
 																		}

--- a/packages/playground/website/src/components/blueprint-editor/blueprint-bundle-editor.module.css
+++ b/packages/playground/website/src/components/blueprint-editor/blueprint-bundle-editor.module.css
@@ -175,14 +175,19 @@
 	margin-right: -2px;
 }
 
-.exportHint {
-	border-top: 1px solid var(--line-subtle, #e0e0e0);
+.exportMenuItemBody {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+	white-space: normal;
+}
+
+.exportMenuItemHint {
 	color: var(--ink-muted, #50575e);
 	font-size: 12px;
+	font-weight: 400;
 	line-height: 1.4;
-	margin: 4px 0 0;
 	max-width: 240px;
-	padding: 8px 12px 4px;
 }
 
 .runHint {

--- a/packages/playground/website/src/components/blueprint-editor/blueprint-bundle-editor.module.css
+++ b/packages/playground/website/src/components/blueprint-editor/blueprint-bundle-editor.module.css
@@ -175,10 +175,27 @@
 	margin-right: -2px;
 }
 
+.exportMenuItemWithHint {
+	height: auto;
+	justify-content: flex-start;
+	min-height: 52px;
+	padding-bottom: 8px;
+	padding-top: 8px;
+	text-align: left;
+}
+
+.exportMenuItemWithHint :global(.components-menu-item__item) {
+	align-items: flex-start;
+	min-width: 0;
+	white-space: normal;
+}
+
 .exportMenuItemBody {
+	align-items: flex-start;
 	display: flex;
 	flex-direction: column;
 	gap: 4px;
+	line-height: 1.4;
 	white-space: normal;
 }
 
@@ -188,6 +205,7 @@
 	font-weight: 400;
 	line-height: 1.4;
 	max-width: 240px;
+	white-space: normal;
 }
 
 .runHint {


### PR DESCRIPTION
The Blueprint editor export menu explained a disabled action in a detached footer. That made the reason easy to miss because the disabled item and its explanation were separated by another action.

Put the multi-file Blueprint explanation inside the disabled “Copy Blueprint URL” item and let that menu item expand to fit its contextual hint. “Download Zip” remains the available action directly below it, without adding a divider between the two actions.

| Before | After |
| --- | --- |
| ![Export menu with detached disabled action explanation](https://raw.githubusercontent.com/WordPress/wordpress-playground/adamziel/contextual-disabled-blueprint-url-screenshots/screenshots/contextual-disabled-blueprint-url/before-chrome-devtools.png) | ![Export menu with disabled action explanation inside the disabled item](https://raw.githubusercontent.com/WordPress/wordpress-playground/adamziel/contextual-disabled-blueprint-url-screenshots/screenshots/contextual-disabled-blueprint-url/after-chrome-devtools-reclipped.png) |

Testing:
- `npm run format:uncommitted`
- `npx nx run playground-website:lint`
- `git diff --check refs/remotes/origin/trunk...HEAD`

