### PR TITLE
[Website] Rename Site Settings and defer settings action choices

### DIFF
--- a/packages/playground/website/playwright/e2e/opfs.spec.ts
+++ b/packages/playground/website/playwright/e2e/opfs.spec.ts
@@ -525,7 +525,7 @@ test('should rename a saved Playground and persist after reload', async ({
 
 	await website.ensureSiteManagerIsOpen();
 
-	// Rename from the Site details header.
+	// Rename from the Site Settings header.
 	await website.page
 		.getByRole('button', { name: 'Rename Playground' })
 		.click();

--- a/packages/playground/website/playwright/e2e/website-ui.spec.ts
+++ b/packages/playground/website/playwright/e2e/website-ui.spec.ts
@@ -267,19 +267,19 @@ test('should keep a settings draft across Dock destinations and close', async ({
 	website,
 }) => {
 	await website.goto('./?storage=temp');
-	await website.openDockPane('Site details');
+	await website.openDockPane('Site Settings');
 	const networking = website.page.getByLabel('Network access');
 	await expect(networking).toBeChecked();
 	await networking.uncheck();
 
 	await website.openDockPane('Database');
 	await expect(networking).not.toBeVisible();
-	await website.openDockPane('Site details');
+	await website.openDockPane('Site Settings');
 	await expect(networking).not.toBeChecked();
 
 	await website.page.keyboard.press('Escape');
 	await expect(networking).not.toBeVisible();
-	await website.openDockPane('Site details');
+	await website.openDockPane('Site Settings');
 	await expect(networking).not.toBeChecked();
 });
 
@@ -287,9 +287,9 @@ test('should offer only the destructive fresh-site action for a temporary Playgr
 	website,
 }) => {
 	await website.goto('./?storage=temp');
-	await website.openDockPane('Site details');
+	await website.openDockPane('Site Settings');
 	const pane = website.page.getByRole('dialog', {
-		name: 'Site details pane',
+		name: 'Site Settings pane',
 	});
 	await expect(
 		pane.getByRole('button', {
@@ -877,7 +877,7 @@ test('should make every Dock tool reachable on mobile', async ({ website }) => {
 		['New Playground', 'New Playground pane'],
 		['Your Playgrounds', 'Your Playgrounds pane'],
 		['Current Blueprint', 'Blueprint pane'],
-		['Site details', 'Site details pane'],
+		['Site Settings', 'Site Settings pane'],
 		['Database', 'Database pane'],
 		['Files', 'Files pane'],
 		['Logs', 'Logs pane'],
@@ -910,9 +910,9 @@ test('should make every Dock tool reachable on mobile', async ({ website }) => {
 	await expect(dock.getByRole('button', { name: 'Export' })).toBeFocused();
 
 	await website.page.setViewportSize({ width: 320, height: 700 });
-	await website.openDockPane('Site details');
+	await website.openDockPane('Site Settings');
 	const siteDetailsPane = website.page.getByRole('dialog', {
-		name: 'Site details pane',
+		name: 'Site Settings pane',
 	});
 	const closeBounds = await siteDetailsPane
 		.getByRole('button', { name: 'Close' })
@@ -1506,7 +1506,7 @@ test.describe('Default Playground storage', () => {
 		});
 		const autosavedSite = await getActivePlaygroundSite(website.page);
 
-		await website.openDockPane('Site details');
+		await website.openDockPane('Site Settings');
 
 		await expect(
 			website.page.getByText(
@@ -1548,10 +1548,36 @@ test.describe('Default Playground storage', () => {
 		await website.page.keyboard.press('End');
 		await expect(freshMenuItem).toBeFocused();
 
-		await website.page.keyboard.press('Escape');
 		const body = wordpress.locator('body');
 		await body.evaluate((element) =>
 			element.setAttribute('data-settings-no-op-marker', 'present')
+		);
+		await freshMenuItem.click();
+		await expect(
+			website.page.getByRole('button', {
+				name: 'Create a fresh Playground',
+				exact: true,
+			})
+		).toBeEnabled();
+		await expect(body).toHaveAttribute(
+			'data-settings-no-op-marker',
+			'present'
+		);
+		await website.page
+			.getByRole('button', { name: 'More settings actions' })
+			.click();
+		await website.page
+			.getByRole('menuitem', { name: /Apply to this Playground/ })
+			.click();
+		await expect(
+			website.page.getByRole('button', {
+				name: 'Apply to this Playground',
+				exact: true,
+			})
+		).toBeEnabled();
+		await expect(body).toHaveAttribute(
+			'data-settings-no-op-marker',
+			'present'
 		);
 		await website.page
 			.getByRole('button', {
@@ -1582,7 +1608,7 @@ test.describe('Default Playground storage', () => {
 		).toBeVisible({ timeout: 120000 });
 		const originalSite = await getActivePlaygroundSite(website.page);
 
-		await website.openDockPane('Site details');
+		await website.openDockPane('Site Settings');
 		const phpSelect = website.page.getByLabel('PHP version');
 		const currentPhpVersion = await phpSelect.inputValue();
 		const nextPhpVersion = currentPhpVersion === '8.4' ? '8.3' : '8.4';
@@ -1621,7 +1647,7 @@ test.describe('Default Playground storage', () => {
 			)
 			.toBe(1);
 
-		await website.openDockPane('Site details');
+		await website.openDockPane('Site Settings');
 		await expect(website.page.getByLabel('PHP version')).toHaveValue(
 			nextPhpVersion
 		);
@@ -1645,7 +1671,7 @@ test.describe('Default Playground storage', () => {
 			() => (window as any).playgroundSites.list().length
 		);
 
-		await website.openDockPane('Site details');
+		await website.openDockPane('Site Settings');
 		const wpSelect = website.page.getByLabel('WordPress version');
 		const currentWpVersion = await wpSelect.inputValue();
 		const nextWpVersion = Object.keys(MinifiedWordPressVersions).find(
@@ -1684,7 +1710,7 @@ test.describe('Default Playground storage', () => {
 			button.click();
 		});
 		await expect(
-			website.page.getByRole('dialog', { name: 'Site details pane' })
+			website.page.getByRole('dialog', { name: 'Site Settings pane' })
 		).not.toBeVisible({ timeout: 120000 });
 
 		await expect
@@ -1732,7 +1758,7 @@ test.describe('Default Playground storage', () => {
 		).toBeVisible();
 		const storedSite = await getActivePlaygroundSite(website.page);
 
-		await website.openDockPane('Site details');
+		await website.openDockPane('Site Settings');
 		await expect(
 			website.page.getByLabel('WordPress version')
 		).toBeEnabled();
@@ -1757,7 +1783,7 @@ test.describe('Default Playground storage', () => {
 			})
 			.click();
 		await expect(
-			website.page.getByRole('dialog', { name: 'Site details pane' })
+			website.page.getByRole('dialog', { name: 'Site Settings pane' })
 		).not.toBeVisible({ timeout: 120000 });
 		const freshSite = await getActivePlaygroundSite(website.page);
 		expect(freshSite.slug).not.toBe(storedSite.slug);
@@ -1890,9 +1916,9 @@ test.describe('Default Playground storage', () => {
 			0
 		);
 
-		await website.openDockPane('Site details');
+		await website.openDockPane('Site Settings');
 		const settingsPane = website.page.getByRole('dialog', {
-			name: 'Site details pane',
+			name: 'Site Settings pane',
 		});
 		await expect(notice).toBeVisible();
 		await notice.evaluate(async (element) => {
@@ -2632,7 +2658,7 @@ test.describe('Default Playground storage', () => {
 		).toHaveCount(0);
 	});
 
-	test('should show autosaved status without an unsaved Site details warning', async ({
+	test('should show autosaved status without an unsaved Site Settings warning', async ({
 		website,
 		browserName,
 	}) => {
@@ -3183,7 +3209,7 @@ echo get_option('blogname');
 		);
 	});
 
-	test('should not duplicate the unsaved warning in Site details', async ({
+	test('should not duplicate the unsaved warning in Site Settings', async ({
 		website,
 	}) => {
 		await website.goto('./?storage=temp');

--- a/packages/playground/website/playwright/website-page.ts
+++ b/packages/playground/website/playwright/website-page.ts
@@ -69,7 +69,7 @@ export class WebsitePage {
 			name: 'Playground tools',
 		});
 		if (await dock.isVisible()) {
-			await this.openDockPane('Site details', 'Site details pane');
+			await this.openDockPane('Site Settings', 'Site Settings pane');
 			return;
 		}
 

--- a/packages/playground/website/src/components/dock/dock.tsx
+++ b/packages/playground/website/src/components/dock/dock.tsx
@@ -102,8 +102,8 @@ const DOCK_ITEMS: DockItem[] = [
 	},
 	{
 		section: 'settings',
-		label: 'Site details',
-		ariaLabel: 'Site details',
+		label: 'Site Settings',
+		ariaLabel: 'Site Settings',
 		icon: <Icon icon={wordpress} size={24} />,
 	},
 	{
@@ -150,7 +150,7 @@ const PANE_COPY: Record<
 			'Review and edit the Blueprint that describes this Playground.',
 	},
 	settings: {
-		title: 'Site details',
+		title: 'Site Settings',
 		description:
 			'Change this Playground’s WordPress, PHP, language, and network settings.',
 	},

--- a/packages/playground/website/src/components/dock/style.module.css
+++ b/packages/playground/website/src/components/dock/style.module.css
@@ -184,7 +184,7 @@
 	letter-spacing: 0.015em;
 	line-height: 1;
 	/* One line per label so every tool button is the same height and the icons
-	   stay on a shared baseline (a 2-line label like "Site details" otherwise
+	   stay on a shared baseline (a 2-line label like "Site Settings" otherwise
 	   made its button taller than its neighbours). */
 	white-space: nowrap;
 }
@@ -286,7 +286,7 @@
 	overflow: hidden;
 }
 
-/* Site details and Export hold short forms, so they get a
+/* Site Settings and Export hold short forms, so they get a
    narrower pane. Compound selector so it also beats the `.pane` width override
    in the mobile media query below (equal specificity, later in source). */
 .pane.pane-compact {

--- a/packages/playground/website/src/components/site-manager/blueprints-panel/style.module.css
+++ b/packages/playground/website/src/components/site-manager/blueprints-panel/style.module.css
@@ -1,4 +1,4 @@
-/* Site details */
+/* Site Settings */
 
 .blueprints-panel {
 	--padding-size: 24px;

--- a/packages/playground/website/src/components/site-manager/site-info-panel/style.module.css
+++ b/packages/playground/website/src/components/site-manager/site-info-panel/style.module.css
@@ -1,4 +1,4 @@
-/* Site details */
+/* Site Settings */
 
 .site-info-panel {
 	--padding-size: 24px;

--- a/packages/playground/website/src/components/site-manager/site-settings-form/site-settings-action-footer.spec.tsx
+++ b/packages/playground/website/src/components/site-manager/site-settings-form/site-settings-action-footer.spec.tsx
@@ -164,9 +164,7 @@ describe('settings action footer', () => {
 		callback(defaults)) as SiteSettingsFormFooterContext['submit'];
 
 	function getButton(name: string): HTMLButtonElement {
-		const button = Array.from(
-			document.body.querySelectorAll('button')
-		).find(
+		const button = Array.from(container.querySelectorAll('button')).find(
 			(candidate) =>
 				candidate.textContent?.trim() === name ||
 				candidate.getAttribute('aria-label') === name

--- a/packages/playground/website/src/components/site-manager/site-settings-form/site-settings-action-footer.spec.tsx
+++ b/packages/playground/website/src/components/site-manager/site-settings-form/site-settings-action-footer.spec.tsx
@@ -164,7 +164,9 @@ describe('settings action footer', () => {
 		callback(defaults)) as SiteSettingsFormFooterContext['submit'];
 
 	function getButton(name: string): HTMLButtonElement {
-		const button = Array.from(container.querySelectorAll('button')).find(
+		const button = Array.from(
+			document.body.querySelectorAll('button')
+		).find(
 			(candidate) =>
 				candidate.textContent?.trim() === name ||
 				candidate.getAttribute('aria-label') === name

--- a/packages/playground/website/src/components/site-manager/site-settings-form/site-settings-action-footer.tsx
+++ b/packages/playground/website/src/components/site-manager/site-settings-form/site-settings-action-footer.tsx
@@ -3,7 +3,7 @@ import {
 	Dropdown,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import {
 	MAX_AUTOSAVED_SITES,
 	type SitePersistence,
@@ -12,6 +12,8 @@ import type { SiteFormData } from './unconnected-site-settings-form';
 import type { SiteSettingsFormFooterContext } from './unconnected-site-settings-form';
 import { getFreshPlaygroundReason } from './site-settings-actions';
 import css from './style.module.css';
+
+type SettingsAction = 'apply' | 'fresh';
 
 export function SiteSettingsActionFooter({
 	siteName,
@@ -37,6 +39,21 @@ export function SiteSettingsActionFooter({
 	);
 	const applyUnavailableReason = freshPlaygroundReason;
 	const canApplyToCurrent = !applyUnavailableReason;
+	const [selectedAction, setSelectedAction] =
+		useState<SettingsAction>('apply');
+	const forcedFreshActionRef = useRef(false);
+	const primaryAction =
+		selectedAction === 'apply' && canApplyToCurrent ? 'apply' : 'fresh';
+
+	useEffect(() => {
+		if (!canApplyToCurrent) {
+			forcedFreshActionRef.current = true;
+			setSelectedAction('fresh');
+		} else if (forcedFreshActionRef.current) {
+			forcedFreshActionRef.current = false;
+			setSelectedAction('apply');
+		}
+	}, [canApplyToCurrent]);
 
 	return (
 		<VStack
@@ -47,22 +64,22 @@ export function SiteSettingsActionFooter({
 		>
 			<div className={css.splitButton}>
 				<Button
-					type={canApplyToCurrent ? 'submit' : 'button'}
+					type={primaryAction === 'apply' ? 'submit' : 'button'}
 					variant="primary"
 					className={
-						canApplyToCurrent
+						primaryAction === 'apply'
 							? css.applyButton
 							: css.createFreshButton
 					}
 					onClick={
-						canApplyToCurrent
+						primaryAction === 'apply'
 							? undefined
 							: () => void submit(onCreateFresh)()
 					}
 					disabled={isPending}
 					isBusy={isPending}
 				>
-					{canApplyToCurrent
+					{primaryAction === 'apply'
 						? 'Apply to this Playground'
 						: 'Create a fresh Playground'}
 				</Button>
@@ -78,7 +95,7 @@ export function SiteSettingsActionFooter({
 							type="button"
 							variant="primary"
 							className={
-								canApplyToCurrent
+								primaryAction === 'apply'
 									? css.splitButtonToggle
 									: `${css.splitButtonToggle} ${css.createFreshButton}`
 							}
@@ -95,15 +112,18 @@ export function SiteSettingsActionFooter({
 						<SettingsActionMenu
 							canApplyToCurrent={canApplyToCurrent}
 							applyUnavailableReason={applyUnavailableReason}
+							selectedAction={primaryAction}
 							siteName={siteName}
 							sitePersistence={sitePersistence}
-							onApply={() => {
+							onSelectApply={() => {
 								onClose();
-								void submit(onApply)();
+								forcedFreshActionRef.current = false;
+								setSelectedAction('apply');
 							}}
-							onCreateFresh={() => {
+							onSelectCreateFresh={() => {
 								onClose();
-								void submit(onCreateFresh)();
+								forcedFreshActionRef.current = false;
+								setSelectedAction('fresh');
 							}}
 						/>
 					)}
@@ -121,25 +141,30 @@ export function SiteSettingsActionFooter({
 function SettingsActionMenu({
 	canApplyToCurrent,
 	applyUnavailableReason,
+	selectedAction,
 	siteName,
 	sitePersistence,
-	onApply,
-	onCreateFresh,
+	onSelectApply,
+	onSelectCreateFresh,
 }: {
 	canApplyToCurrent: boolean;
 	applyUnavailableReason?: string;
+	selectedAction: SettingsAction;
 	siteName: string;
 	sitePersistence: SitePersistence;
-	onApply: () => void;
-	onCreateFresh: () => void;
+	onSelectApply: () => void;
+	onSelectCreateFresh: () => void;
 }) {
 	const applyRef = useRef<HTMLButtonElement>(null);
 	const freshRef = useRef<HTMLButtonElement>(null);
 	const items = [applyRef, freshRef];
 
 	useEffect(() => {
-		(canApplyToCurrent ? applyRef : freshRef).current?.focus();
-	}, [canApplyToCurrent]);
+		(selectedAction === 'apply' && canApplyToCurrent
+			? applyRef
+			: freshRef
+		).current?.focus();
+	}, [canApplyToCurrent, selectedAction]);
 
 	const moveFocus = (event: React.KeyboardEvent, nextIndex: number) => {
 		event.preventDefault();
@@ -174,9 +199,11 @@ function SettingsActionMenu({
 				role="menuitem"
 				aria-disabled={!!applyUnavailableReason}
 				className={`${css.actionMenuItem} ${
-					canApplyToCurrent ? css.selectedApplyMenuItem : ''
+					selectedAction === 'apply' && canApplyToCurrent
+						? css.selectedApplyMenuItem
+						: ''
 				}`}
-				onClick={() => !applyUnavailableReason && onApply()}
+				onClick={() => !applyUnavailableReason && onSelectApply()}
 			>
 				<span className={css.actionMenuTitle}>
 					Apply to this Playground
@@ -192,7 +219,7 @@ function SettingsActionMenu({
 				type="button"
 				role="menuitem"
 				className={`${css.actionMenuItem} ${css.createFreshMenuItem}`}
-				onClick={onCreateFresh}
+				onClick={onSelectCreateFresh}
 			>
 				<span className={css.actionMenuTitle}>
 					Create a fresh Playground

--- a/packages/playground/website/src/components/site-manager/site-settings-form/site-settings-action-footer.tsx
+++ b/packages/playground/website/src/components/site-manager/site-settings-form/site-settings-action-footer.tsx
@@ -47,13 +47,15 @@ export function SiteSettingsActionFooter({
 
 	useEffect(() => {
 		if (!canApplyToCurrent) {
-			forcedFreshActionRef.current = true;
-			setSelectedAction('fresh');
+			if (selectedAction === 'apply') {
+				forcedFreshActionRef.current = true;
+				setSelectedAction('fresh');
+			}
 		} else if (forcedFreshActionRef.current) {
 			forcedFreshActionRef.current = false;
 			setSelectedAction('apply');
 		}
-	}, [canApplyToCurrent]);
+	}, [canApplyToCurrent, selectedAction]);
 
 	return (
 		<VStack
@@ -198,12 +200,13 @@ function SettingsActionMenu({
 				type="button"
 				role="menuitem"
 				aria-disabled={!!applyUnavailableReason}
+				disabled={!!applyUnavailableReason}
 				className={`${css.actionMenuItem} ${
 					selectedAction === 'apply' && canApplyToCurrent
 						? css.selectedApplyMenuItem
 						: ''
 				}`}
-				onClick={() => !applyUnavailableReason && onSelectApply()}
+				onClick={onSelectApply}
 			>
 				<span className={css.actionMenuTitle}>
 					Apply to this Playground

--- a/packages/playground/website/src/components/site-manager/site-settings-form/style.module.css
+++ b/packages/playground/website/src/components/site-manager/site-settings-form/style.module.css
@@ -228,16 +228,16 @@
 	color: #304bd1;
 }
 
-.action-menu-item[aria-disabled='true'] {
+.action-menu-item:disabled {
 	color: #757575;
 	cursor: not-allowed;
 }
 
-.action-menu-item[aria-disabled='true'] .action-menu-description {
+.action-menu-item:disabled .action-menu-description {
 	color: inherit;
 }
 
-.action-menu-item[aria-disabled='true']:focus-visible {
+.action-menu-item:disabled:focus-visible {
 	box-shadow: inset 0 0 0 2px #949494;
 }
 

--- a/packages/playground/website/src/components/site-manager/site-settings-form/style.module.css
+++ b/packages/playground/website/src/components/site-manager/site-settings-form/style.module.css
@@ -68,8 +68,6 @@
 }
 
 .footer {
-	background-color: #f3f6fd;
-	border-top: 1px solid var(--line-subtle);
 	padding-top: var(--space-4);
 	position: relative;
 	button {

--- a/packages/playground/website/src/components/site-manager/site-settings-form/style.module.css
+++ b/packages/playground/website/src/components/site-manager/site-settings-form/style.module.css
@@ -68,7 +68,7 @@
 }
 
 .footer {
-	padding-top: var(--space-4);
+	padding-top: 0;
 	position: relative;
 	button {
 		width: 100%;


### PR DESCRIPTION
The settings Dock item now says “Site Settings,” which matches the panel’s purpose better than “Site details.” The panel edits runtime and site configuration, not just metadata.

The settings action dropdown now only chooses which action the primary button will run. Selecting “Create a fresh Playground” from the dropdown updates the primary button label, but it does not submit the form. Users still need to click the primary button. The apply action also stays available for unchanged forms, so a no-op apply can still recreate the current Playground when needed.

## Screenshots

| Before | After |
| --- | --- |
| ![Before: Dock item labeled Site details](https://raw.githubusercontent.com/WordPress/wordpress-playground/c3cc6ac4cd352e81e46195744c85bbeadae6b306/pr-screenshots/4071/before-dock-context.png) | ![After: Dock item labeled Site Settings](https://raw.githubusercontent.com/WordPress/wordpress-playground/c3cc6ac4cd352e81e46195744c85bbeadae6b306/pr-screenshots/4071/after-dock-context.png) |

After Site Settings pane:

![After: Site Settings pane with enabled Apply button](https://raw.githubusercontent.com/WordPress/wordpress-playground/c3cc6ac4cd352e81e46195744c85bbeadae6b306/pr-screenshots/4071/after-settings-pane-context.png)

Validation:
- `npm exec nx test playground-website --testFile=site-settings-action-footer.spec.tsx`
- `npm exec nx lint playground-website`
- `npm exec nx typecheck playground-website`
- `npx playwright test --config=packages/playground/website/playwright/playwright.config.ts --project=chromium -g "should offer full settings for an autosaved Playground"`
