### PR TITLE
[Website] Center the Playground file-loading message

### DIFF
--- a/packages/playground/website/src/components/pane-loading/index.tsx
+++ b/packages/playground/website/src/components/pane-loading/index.tsx
@@ -10,7 +10,7 @@ import css from './style.module.css';
 export function PaneLoading({ message }: { message: string }) {
 	return (
 		<div className={css.paneLoading} role="status" aria-live="polite">
-			<Spinner size={28} />
+			<Spinner size={32} />
 			<p className={css.paneLoadingText}>{message}</p>
 		</div>
 	);

--- a/packages/playground/website/src/components/pane-loading/style.module.css
+++ b/packages/playground/website/src/components/pane-loading/style.module.css
@@ -1,6 +1,8 @@
 .pane-loading {
+	--spinner-color: currentColor;
+
 	align-items: center;
-	color: var(--ink-muted, #5f5b54);
+	color: var(--ink, #21201d);
 	display: flex;
 	flex: 1;
 	flex-direction: column;
@@ -12,8 +14,8 @@
 }
 
 .pane-loading-text {
-	font-size: 13px;
-	line-height: 1.4;
+	font-size: 16px;
+	line-height: 1.5;
 	margin: 0;
 }
 

--- a/packages/playground/website/src/components/site-manager/site-info-panel/index.tsx
+++ b/packages/playground/website/src/components/site-manager/site-info-panel/index.tsx
@@ -38,7 +38,10 @@ export function SiteInfoPanel({
 				expanded={true}
 				className={css.siteInfoPanelContent}
 			>
-				<FlexItem style={{ flexGrow: 1 }}>
+				<FlexItem
+					className={css.siteInfoPanelTools}
+					style={{ flexGrow: 1 }}
+				>
 					<SiteToolPanels
 						site={site}
 						playground={playground}

--- a/packages/playground/website/src/components/site-manager/site-info-panel/index.tsx
+++ b/packages/playground/website/src/components/site-manager/site-info-panel/index.tsx
@@ -39,8 +39,12 @@ export function SiteInfoPanel({
 				className={css.siteInfoPanelContent}
 			>
 				<FlexItem
-					className={css.siteInfoPanelTools}
-					style={{ flexGrow: 1 }}
+					style={{
+						display: 'flex',
+						flexDirection: 'column',
+						flexGrow: 1,
+						minHeight: 0,
+					}}
 				>
 					<SiteToolPanels
 						site={site}

--- a/packages/playground/website/src/components/site-manager/site-info-panel/site-tool-panels.spec.tsx
+++ b/packages/playground/website/src/components/site-manager/site-info-panel/site-tool-panels.spec.tsx
@@ -116,16 +116,29 @@ describe('SiteToolPanels', () => {
 		).toBe('true');
 	});
 
+	it('explains that Playground files are still loading', async () => {
+		const bootingPlayground = {
+			documentRoot: new Promise(() => {}),
+		} as PlaygroundClient;
+
+		await renderPanels('files', bootingPlayground);
+
+		expect(container.textContent).toContain(
+			'Playground files are still loading…'
+		);
+	});
+
 	async function renderPanels(
 		activeTabName: React.ComponentProps<
 			typeof SiteToolPanels
-		>['activeTabName']
+		>['activeTabName'],
+		client = playground
 	) {
 		await act(async () => {
 			root.render(
 				<SiteToolPanels
 					site={site}
-					playground={playground}
+					playground={client}
 					activeTabName={activeTabName}
 				/>
 			);

--- a/packages/playground/website/src/components/site-manager/site-info-panel/site-tool-panels.spec.tsx
+++ b/packages/playground/website/src/components/site-manager/site-info-panel/site-tool-panels.spec.tsx
@@ -94,7 +94,7 @@ describe('SiteToolPanels', () => {
 	});
 
 	it('mounts tools on first visit and keeps them mounted when hidden', async () => {
-		await renderPanels('database');
+		await renderPanels('database', playground);
 
 		const database = findTool('database');
 		expect(database.closest('[hidden]')).toBeNull();
@@ -102,14 +102,14 @@ describe('SiteToolPanels', () => {
 			expect(findOptionalTool(name)).toBeNull();
 		}
 
-		await renderPanels('logs');
+		await renderPanels('logs', playground);
 		expect(findTool('database')).toBe(database);
 		expect(database.closest('[hidden]')).not.toBeNull();
 		expect(findTool('logs').closest('[hidden]')).toBeNull();
 	});
 
 	it('enables the Blueprint editor Dock presentation', async () => {
-		await renderPanels('blueprint');
+		await renderPanels('blueprint', playground);
 
 		expect(
 			findTool('blueprint').getAttribute('data-dock-presentation')
@@ -117,13 +117,9 @@ describe('SiteToolPanels', () => {
 	});
 
 	it('explains that Playground files are still loading', async () => {
-		const bootingPlayground = {
-			documentRoot: new Promise(() => {}),
-		} as PlaygroundClient;
+		await renderPanels('files', undefined);
 
-		await renderPanels('files', bootingPlayground);
-
-		expect(container.textContent).toContain(
+		expect(container.querySelector('[role="status"]')?.textContent).toBe(
 			'Playground files are still loading…'
 		);
 	});
@@ -132,7 +128,7 @@ describe('SiteToolPanels', () => {
 		activeTabName: React.ComponentProps<
 			typeof SiteToolPanels
 		>['activeTabName'],
-		client = playground
+		client: PlaygroundClient | undefined
 	) {
 		await act(async () => {
 			root.render(

--- a/packages/playground/website/src/components/site-manager/site-info-panel/site-tool-panels.tsx
+++ b/packages/playground/website/src/components/site-manager/site-info-panel/site-tool-panels.tsx
@@ -122,7 +122,7 @@ export function SiteToolPanels({
 						) : (
 							// The file browser needs the booted WordPress runtime;
 							// show a clear loading state instead of a blank pane.
-							<PaneLoading message="Waiting for the Playground to finish loading…" />
+							<PaneLoading message="Playground files are still loading…" />
 						)}
 					</Suspense>
 				</div>

--- a/packages/playground/website/src/components/site-manager/site-info-panel/style.module.css
+++ b/packages/playground/website/src/components/site-manager/site-info-panel/style.module.css
@@ -20,6 +20,13 @@
 }
 
 .site-info-panel-content {
+	flex: 1;
+	min-height: 0;
+}
+
+.site-info-panel-content > .site-info-panel-tools {
+	display: flex;
+	flex-direction: column;
 	min-height: 0;
 }
 

--- a/packages/playground/website/src/components/site-manager/site-info-panel/style.module.css
+++ b/packages/playground/website/src/components/site-manager/site-info-panel/style.module.css
@@ -24,12 +24,6 @@
 	min-height: 0;
 }
 
-.site-info-panel-content > .site-info-panel-tools {
-	display: flex;
-	flex-direction: column;
-	min-height: 0;
-}
-
 .padded {
 	padding: var(--padding-size);
 }

--- a/packages/playground/website/src/components/spinner/style.module.css
+++ b/packages/playground/website/src/components/spinner/style.module.css
@@ -9,8 +9,9 @@
 	width: 80%;
 	height: 80%;
 	border-radius: 50%;
-	border: 2px solid #fff;
-	border-color: #fff transparent #fff transparent;
+	border: 2px solid var(--spinner-color, #fff);
+	border-color: var(--spinner-color, #fff) transparent
+		var(--spinner-color, #fff) transparent;
 	animation: spinner 1.2s linear infinite;
 }
 @keyframes spinner {

--- a/packages/playground/website/src/components/spinner/style.module.css
+++ b/packages/playground/website/src/components/spinner/style.module.css
@@ -9,9 +9,8 @@
 	width: 80%;
 	height: 80%;
 	border-radius: 50%;
-	border: 2px solid var(--spinner-color, #fff);
-	border-color: var(--spinner-color, #fff) transparent
-		var(--spinner-color, #fff) transparent;
+	border: 2px solid;
+	border-color: var(--spinner-color, #fff) transparent;
 	animation: spinner 1.2s linear infinite;
 }
 @keyframes spinner {


### PR DESCRIPTION
The Files pane now makes the boot wait obvious instead of showing a faint loader at the top of an otherwise empty pane.

The pane fills its available height and centers a larger dark spinner with the message “Playground files are still loading…”. The same loading-state component now uses readable 16px text, and a focused test locks the boot-time copy.

| Before | After |
| --- | --- |
| ![The faint file-loading state aligned near the top of the Files pane](https://raw.githubusercontent.com/articles-adamziel-com/wordpress-playground/c1ed77789864b502445fddc4517ed6992d8d72b8/.github/pr-assets/4072/before.png) | ![The darker file-loading state centered vertically in the Files pane](https://raw.githubusercontent.com/articles-adamziel-com/wordpress-playground/c1ed77789864b502445fddc4517ed6992d8d72b8/.github/pr-assets/4072/after.png) |

## Tests

- `npm exec -- nx test playground-website --testFile=site-tool-panels.spec.tsx`
- `npm exec -- nx typecheck playground-website`
- `npm exec -- nx lint playground-website`
