### PR TITLE
[CLI] Use preferredVersions.wp in Playground CLI

### DIFF
--- a/packages/playground/cli/src/blueprints-v1/blueprints-v1-handler.ts
+++ b/packages/playground/cli/src/blueprints-v1/blueprints-v1-handler.ts
@@ -65,6 +65,9 @@ export class BlueprintsV1Handler {
 		playground: Pooled<PlaygroundCliWorker>,
 		workerPostInstallMountsPort: NodeMessagePort
 	) {
+		const runtimeConfiguration = await resolveRuntimeConfiguration(
+			this.getEffectiveBlueprint()
+		);
 		let wpDetails: any = undefined;
 		let wordPressZip: any = undefined;
 		let preinstalledWpContentPath: string | undefined = undefined;
@@ -95,7 +98,9 @@ export class BlueprintsV1Handler {
 				);
 			}) as any);
 
-			wpDetails = await resolveWordPressRelease(this.args.wp);
+			wpDetails = await resolveWordPressRelease(
+				runtimeConfiguration.wpVersion
+			);
 			preinstalledWpContentPath = path.join(
 				CACHE_FOLDER,
 				`prebuilt-wp-content-for-wp-${wpDetails.version}.zip`
@@ -120,7 +125,7 @@ export class BlueprintsV1Handler {
 			this.cliOutput.updateProgress('Preparing SQLite database');
 			// Use pre-patched v3.0.0-rc.3 for legacy PHP (closures replaced
 			// with named functions, PHP 5.2 polyfills added offline).
-			const phpVersion = this.args.php || RecommendedPHPVersion;
+			const phpVersion = runtimeConfiguration.phpVersion;
 			const isLegacyPhp = isLegacyPHPVersion(phpVersion);
 			const sqliteVersion = isLegacyPhp ? 'v3.0.0-rc.3-php52' : 'trunk';
 			sqliteIntegrationPluginZip =
@@ -128,10 +133,6 @@ export class BlueprintsV1Handler {
 		}
 
 		this.cliOutput.updateProgress('Booting WordPress');
-
-		const runtimeConfiguration = await resolveRuntimeConfiguration(
-			this.getEffectiveBlueprint()
-		);
 
 		// TODO: Fix this type issue that requires the cast to unknown
 		await (

--- a/packages/playground/cli/tests/blueprints-v1-handler.spec.ts
+++ b/packages/playground/cli/tests/blueprints-v1-handler.spec.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { BlueprintsV1Handler } from '../src/blueprints-v1/blueprints-v1-handler';
+import type { RunCLIArgs } from '../src/run-cli';
+import type { CLIOutput } from '../src/cli-output';
+import { resolveWordPressRelease } from '@wp-playground/wordpress';
+import { fetchSqliteIntegration } from '../src/blueprints-v1/download';
+
+vi.mock('../src/blueprints-v1/download', async (importOriginal) => {
+	const actual = (await importOriginal()) as Record<string, unknown>;
+	return {
+		...actual,
+		cachedDownload: vi.fn(
+			async () => new File(['WordPress'], 'wordpress.zip')
+		),
+		fetchSqliteIntegration: vi.fn(
+			async () => new File(['SQLite'], 'sqlite.zip')
+		),
+	};
+});
+
+vi.mock('@wp-playground/wordpress', async (importOriginal) => {
+	const actual = (await importOriginal()) as Record<string, unknown>;
+	return {
+		...actual,
+		resolveWordPressRelease: vi.fn(async (version: string) => ({
+			releaseUrl: `https://wordpress.org/wordpress-${version}.zip`,
+			version,
+			source: 'inferred',
+		})),
+	};
+});
+
+describe('BlueprintsV1Handler', () => {
+	const cliOutput = {
+		updateProgress: vi.fn(),
+	} as unknown as CLIOutput;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	test('prepares the WordPress version declared by the Blueprint', async () => {
+		const handler = new BlueprintsV1Handler(
+			{
+				command: 'server',
+				wordpressInstallMode: 'download-and-install',
+				'mount-before-install': [
+					{
+						hostPath: '/mounted',
+						vfsPath: '/wordpress',
+					},
+				],
+				blueprint: {
+					preferredVersions: {
+						php: '7.4',
+						wp: '6.2',
+					},
+				},
+			} as RunCLIArgs,
+			{
+				siteUrl: 'http://127.0.0.1:9400',
+				cliOutput,
+			}
+		);
+		const playground = {
+			bootWordPress: vi.fn().mockResolvedValue(undefined),
+		};
+
+		await handler.bootWordPress(playground as any, {} as any);
+
+		expect(resolveWordPressRelease).toHaveBeenCalledWith('6.2');
+		expect(fetchSqliteIntegration).toHaveBeenCalledWith('trunk');
+		expect(playground.bootWordPress).toHaveBeenCalledWith(
+			expect.objectContaining({
+				phpVersion: '7.4',
+				wpVersion: '6.2',
+			}),
+			expect.anything()
+		);
+	});
+});


### PR DESCRIPTION
V1 CLI Blueprints can request a specific WordPress release:

```json
{
  "preferredVersions": {
    "wp": "6.2"
  }
}
```

Before this change, the CLI ignored that value while downloading WordPress. With no `--wp` flag, it did this:

```ts
resolveWordPressRelease(this.args.wp); // undefined → latest
```

The worker then unzipped that `latest` archive. Passing `wpVersion: '6.2'` later did not change the files already in the archive, so the Blueprint silently ran the current WordPress release instead of WordPress 6.2.

This change resolves the Blueprint runtime before downloading WordPress and passes its requested version to `resolveWordPressRelease()`. The downloaded archive and the running site now match the Blueprint.

The regression test uses a Blueprint requesting WordPress 6.2 and verifies that the CLI resolves WordPress 6.2 before booting the worker.

## Testing

Start a V1 CLI Blueprint with `preferredVersions.wp` set to `6.2`. Check that `wp-includes/version.php` reports WordPress 6.2.
