### PR TITLE
[Website] Hide database tools until Playground is ready

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -191,6 +191,30 @@ Version-specific builds: `@php-wasm/web-7-4` through `@php-wasm/web-8-5` (and co
 - **E2E tests**: Playwright and Cypress for website testing
 - **Always fix failing tests**: Never skip failing tests; fix the code to make tests pass
 
+#### Test-value gate
+
+Tests are maintenance code. Do not add one merely because production code
+changed.
+
+Do not test:
+
+- literal JSX or static configuration;
+- copy, CSS classes, visual variants, element counts, or ordering;
+- presentation-only visibility controlled by an adjacent conditional;
+- behavior that would change only when someone intentionally reverses the
+  product decision.
+
+Before adding a test, name all three:
+
+1. The stable contract it protects.
+2. A plausible accidental regression.
+3. The independent code path that could cause that regression.
+
+If you cannot name all three concretely, do not add the test.
+
+Use screenshots and manual interaction for visual-only changes. Tests are not
+required for every PR. Never add tests simply to make a PR appear complete.
+
 ### Package Structure
 
 All published packages follow this pattern:

--- a/packages/playground/website/src/components/site-manager/site-database-panel/adminer-button.tsx
+++ b/packages/playground/website/src/components/site-manager/site-database-panel/adminer-button.tsx
@@ -129,7 +129,7 @@ export function AdminerButton({
 		<>
 			<Flex direction="column" gap={0} expanded={false}>
 				<Button
-					variant="primary"
+					variant="secondary"
 					disabled={!playground || isLoading}
 					isBusy={isLoading}
 					onClick={handleOpenAdminer}

--- a/packages/playground/website/src/components/site-manager/site-database-panel/index.tsx
+++ b/packages/playground/website/src/components/site-manager/site-database-panel/index.tsx
@@ -137,20 +137,21 @@ export function SiteDatabasePanel({
 				</p>
 			</Notice>
 
-			<PlaygroundBootNotice
-				show={!playground}
-				gap="var(--space-6)"
-				message="The Playground is still loading — database tools will be ready in a moment."
-			/>
-
-			<div className={css.buttonGroup}>
-				<AdminerButton playground={playground} />
-				<DownloadButton
-					playground={playground}
-					databasePath={databasePath}
+			{playground ? (
+				<div className={css.buttonGroup}>
+					<AdminerButton playground={playground} />
+					<PhpMyAdminButton playground={playground} />
+					<DownloadButton
+						playground={playground}
+						databasePath={databasePath}
+					/>
+				</div>
+			) : (
+				<PlaygroundBootNotice
+					show
+					message="The Playground is still loading — database tools will be ready in a moment."
 				/>
-				<PhpMyAdminButton playground={playground} />
-			</div>
+			)}
 		</div>
 	);
 }

--- a/packages/playground/website/src/components/site-manager/site-database-panel/phpmyadmin-button.tsx
+++ b/packages/playground/website/src/components/site-manager/site-database-panel/phpmyadmin-button.tsx
@@ -99,7 +99,7 @@ export function PhpMyAdminButton({
 		<>
 			<Flex direction="column" gap={0} expanded={false}>
 				<Button
-					variant="primary"
+					variant="secondary"
 					disabled={!playground || isLoading}
 					isBusy={isLoading}
 					onClick={handleOpenPhpMyAdmin}

--- a/packages/playground/website/src/components/spinner/style.module.css
+++ b/packages/playground/website/src/components/spinner/style.module.css
@@ -10,7 +10,7 @@
 	height: 80%;
 	border-radius: 50%;
 	border: 2px solid;
-	border-color: var(--spinner-color, #fff) transparent;
+	border-color: var(--spinner-color, currentColor) transparent;
 	animation: spinner 1.2s linear infinite;
 }
 @keyframes spinner {


### PR DESCRIPTION
The Database pane now hides its tools until the Playground is ready. Disabled controls no longer compete for attention with the loader.

Once ready, Adminer, phpMyAdmin, and the SQLite download appear as three neutral buttons. The two browser tools stay together. The shared spinner now uses `currentColor` instead of assuming white, so it keeps the right contrast on light and dark surfaces.

## Screenshots

| Before | Loading | Ready |
| --- | --- | --- |
| ![The Database pane showed disabled tools and a white spinner while loading](https://raw.githubusercontent.com/articles-adamziel-com/wordpress-playground/abd4ed547fbe281cd5dbe2797b5b4b7f490ed1ff/database-tools-before.png) | ![The Database pane shows only a dark loading indicator while the Playground starts](https://raw.githubusercontent.com/articles-adamziel-com/wordpress-playground/abd4ed547fbe281cd5dbe2797b5b4b7f490ed1ff/database-tools-loading.png) | ![The Database pane shows three neutral tools after the Playground is ready](https://raw.githubusercontent.com/articles-adamziel-com/wordpress-playground/abd4ed547fbe281cd5dbe2797b5b4b7f490ed1ff/database-tools-ready.png) |
