### PR TITLE
[CI] Fix NPM package publishing error

### DIFF
--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -90,7 +90,7 @@ jobs:
 
             # npm 11.5.1+ is required for trusted publisher OIDC authentication
             - name: Upgrade npm for trusted publishing
-              run: npm install -g npm@latest lerna@9
+              run: npm install -g npm@11 lerna@9
 
             - uses: ./.github/actions/prepare-playground
 


### PR DESCRIPTION
## Motivation for the change, related issues

Our NPM publishing workflow is currently broken because an install of `npm@latest` is bringing npm version 12.x which doesn't support the Node.js 20.x version we've selected. 

## Implementation details

To stop the bleeding, let's explicitly install npm@11 so publishing works again. Using an explicit major NPM version is probably preferable anyway to avoid these kinds of issues in the future.

## Testing Instructions (or ideally a Blueprint)

Merge this one-line change and test. This isn't too risky since the workflow is already broken and the PR is just an npm version change.
