### PR TITLE
[Website] Name Dock pane state after the Dock

### DIFF
--- a/packages/playground/website/src/components/blueprint-editor/BlueprintBundleEditor.spec.tsx
+++ b/packages/playground/website/src/components/blueprint-editor/BlueprintBundleEditor.spec.tsx
@@ -23,7 +23,7 @@ const mocks = vi.hoisted(() => ({
 	pruneAutosavedSites: vi.fn(),
 	resolveRuntimeConfiguration: vi.fn(),
 	setActiveSite: vi.fn(),
-	setSiteManagerOpen: vi.fn(),
+	setDockPaneOpen: vi.fn(),
 	updateSite: vi.fn(),
 }));
 
@@ -69,7 +69,7 @@ vi.mock('../../lib/state/redux/slice-sites', async (importOriginal) => ({
 
 vi.mock('../../lib/state/redux/slice-ui', async (importOriginal) => ({
 	...(await importOriginal<typeof SliceUiModule>()),
-	setSiteManagerOpen: mocks.setSiteManagerOpen,
+	setDockPaneOpen: mocks.setDockPaneOpen,
 }));
 
 describe('BlueprintBundleEditor Run barrier', () => {
@@ -119,8 +119,8 @@ describe('BlueprintBundleEditor Run barrier', () => {
 			type: 'set-active-site',
 			payload: slug,
 		}));
-		mocks.setSiteManagerOpen.mockReset();
-		mocks.setSiteManagerOpen.mockImplementation((open) => ({
+		mocks.setDockPaneOpen.mockReset();
+		mocks.setDockPaneOpen.mockImplementation((open) => ({
 			type: 'set-site-manager-open',
 			payload: open,
 		}));
@@ -193,7 +193,7 @@ describe('BlueprintBundleEditor Run barrier', () => {
 		expect(mocks.pruneAutosavedSites).toHaveBeenCalledWith({
 			excludeSlugs: [sourceSite.slug, newSite.slug],
 		});
-		expect(mocks.setSiteManagerOpen).toHaveBeenCalledWith(false);
+		expect(mocks.setDockPaneOpen).toHaveBeenCalledWith(false);
 		expect(mocks.setActiveSite).toHaveBeenCalledWith(newSite.slug);
 		expect(mocks.resolveRuntimeConfiguration).not.toHaveBeenCalled();
 	});

--- a/packages/playground/website/src/components/blueprint-editor/BlueprintBundleEditor.tsx
+++ b/packages/playground/website/src/components/blueprint-editor/BlueprintBundleEditor.tsx
@@ -65,7 +65,7 @@ import {
 	updateSite,
 } from '../../lib/state/redux/slice-sites';
 import { setActiveSite, useAppDispatch } from '../../lib/state/redux/store';
-import { setSiteManagerOpen } from '../../lib/state/redux/slice-ui';
+import { setDockPaneOpen } from '../../lib/state/redux/slice-ui';
 import styles from './blueprint-bundle-editor.module.css';
 import hideRootStyles from './hide-root.module.css';
 import validationStyles from './validation-panel.module.css';
@@ -459,7 +459,7 @@ export const BlueprintBundleEditor = forwardRef<
 						error
 					);
 				}
-				dispatch(setSiteManagerOpen(false));
+				dispatch(setDockPaneOpen(false));
 				dispatch(setActiveSite(newSite.slug));
 				return;
 			}

--- a/packages/playground/website/src/components/blueprint-url-modal/index.tsx
+++ b/packages/playground/website/src/components/blueprint-url-modal/index.tsx
@@ -3,7 +3,7 @@ import { TextControl } from '@wordpress/components';
 import { useAppDispatch } from '../../lib/state/redux/store';
 import {
 	setActiveModal,
-	setSiteManagerOpen,
+	setDockPaneOpen,
 } from '../../lib/state/redux/slice-ui';
 import { Modal } from '../modal';
 import ModalButtons from '../modal/modal-buttons';
@@ -26,7 +26,7 @@ export function BlueprintUrlModal() {
 		if (!trimmed) {
 			return;
 		}
-		dispatch(setSiteManagerOpen(false));
+		dispatch(setDockPaneOpen(false));
 		closeModal();
 		redirectTo(
 			PlaygroundRoute.newSite({

--- a/packages/playground/website/src/components/browser-chrome/save-status-indicator.tsx
+++ b/packages/playground/website/src/components/browser-chrome/save-status-indicator.tsx
@@ -8,8 +8,8 @@ import {
 	useAppDispatch,
 } from '../../lib/state/redux/store';
 import {
-	setSiteManagerOpen,
-	setSiteManagerSection,
+	setDockPaneOpen,
+	setDockPaneSection,
 	setSiteSlugToSave,
 } from '../../lib/state/redux/slice-ui';
 import { Icon, Tooltip, Dropdown, Button } from '@wordpress/components';
@@ -113,8 +113,8 @@ export function SaveStatusIndicator({
 		// The status always acts on the active Playground, not an inactive site
 		// that may have opened the standalone save modal earlier.
 		dispatch(setSiteSlugToSave(undefined));
-		dispatch(setSiteManagerSection('save'));
-		dispatch(setSiteManagerOpen(true));
+		dispatch(setDockPaneSection('save'));
+		dispatch(setDockPaneOpen(true));
 	};
 
 	// Re-reads the linked local directory into the running Playground so edits

--- a/packages/playground/website/src/components/dock/dock.tsx
+++ b/packages/playground/website/src/components/dock/dock.tsx
@@ -24,12 +24,12 @@ import {
 	plus,
 	wordpress,
 } from '@wordpress/icons';
-import type { SiteManagerSection } from '../../lib/state/redux/slice-ui';
+import type { DockPaneSection } from '../../lib/state/redux/slice-ui';
 import {
 	setDockOperationNotice,
 	setShareExportOpen,
-	setSiteManagerOpen,
-	setSiteManagerSection,
+	setDockPaneOpen,
+	setDockPaneSection,
 } from '../../lib/state/redux/slice-ui';
 import {
 	readDockFullWidth,
@@ -64,7 +64,7 @@ import { DockBlueprintIcon, DockDatabaseIcon } from './icons';
 import css from './style.module.css';
 
 type DockItem = {
-	section: SiteManagerSection;
+	section: DockPaneSection;
 	label: string;
 	ariaLabel: string;
 	icon: JSX.Element;
@@ -133,7 +133,7 @@ const DOCK_ITEMS: DockItem[] = [
 ];
 
 const PANE_COPY: Record<
-	SiteManagerSection,
+	DockPaneSection,
 	{ title: string; description: string }
 > = {
 	new: {
@@ -186,11 +186,9 @@ export function Dock({
 	onPaneCloseBlockedChange,
 }: DockProps) {
 	const dispatch = useAppDispatch();
-	const siteManagerIsOpen = useAppSelector(
-		(state) => state.ui.siteManagerIsOpen
-	);
+	const dockPaneIsOpen = useAppSelector((state) => state.ui.dockPaneIsOpen);
 	const activeModal = useAppSelector((state) => state.ui.activeModal);
-	const section = useAppSelector((state) => state.ui.siteManagerSection);
+	const section = useAppSelector((state) => state.ui.dockPaneSection);
 	const shareExportOpen = useAppSelector((state) => state.ui.shareExportOpen);
 	const [newPlaygroundHeaderOverride, setNewPlaygroundHeaderOverride] =
 		useState<DockPaneHeaderOverride>();
@@ -208,7 +206,7 @@ export function Dock({
 	const isFixedHeightSection =
 		section === 'new' || (section === 'share' && shareExportOpen);
 	const showSharedHeader = !isEditorSection;
-	const siteDetailsVisible = siteManagerIsOpen && section === 'settings';
+	const siteSettingsVisible = dockPaneIsOpen && section === 'settings';
 	const playgroundTitle =
 		activeSite?.metadata.storage === 'none'
 			? 'Unsaved Playground'
@@ -276,11 +274,10 @@ export function Dock({
 	const [isFolding, setIsFolding] = useState(false);
 	const [isUnfolding, setIsUnfolding] = useState(false);
 	const [isMaximizing, setIsMaximizing] = useState(false);
-	const [paneExitComplete, setPaneExitComplete] =
-		useState(!siteManagerIsOpen);
+	const [paneExitComplete, setPaneExitComplete] = useState(!dockPaneIsOpen);
 	// Retain the full pane body until its exit motion finishes. Hiding it when
 	// close starts would collapse the surface to its header before it can leave.
-	const paneContentVisible = siteManagerIsOpen || !paneExitComplete;
+	const paneContentVisible = dockPaneIsOpen || !paneExitComplete;
 
 	useEffect(() => {
 		if (typeof ResizeObserver === 'undefined') {
@@ -325,7 +322,7 @@ export function Dock({
 
 	useLayoutEffect(() => {
 		const pane = paneRef.current;
-		if (!siteManagerIsOpen || !pane) {
+		if (!dockPaneIsOpen || !pane) {
 			setPaneHeight(0);
 			return;
 		}
@@ -339,7 +336,7 @@ export function Dock({
 		const observer = new ResizeObserver(updatePaneHeight);
 		observer.observe(pane);
 		return () => observer.disconnect();
-	}, [section, siteManagerIsOpen]);
+	}, [section, dockPaneIsOpen]);
 
 	useLayoutEffect(() => {
 		const toast = operationToastRef.current;
@@ -396,7 +393,7 @@ export function Dock({
 	useEffect(() => {
 		// Opening Store permanently from the visible status must not unfold a
 		// collapsed Dock. Tool buttons unfold explicitly in openSection().
-		if (!siteManagerIsOpen || section === 'save') {
+		if (!dockPaneIsOpen || section === 'save') {
 			return;
 		}
 		setIsCollapsed(false);
@@ -404,13 +401,13 @@ export function Dock({
 		setCornerSide(null);
 		setIsFolding(false);
 		setIsMaximizing(false);
-	}, [section, siteManagerIsOpen]);
+	}, [section, dockPaneIsOpen]);
 
 	// The overlay query parameter only describes New and Playgrounds. Remove it
 	// when that requested pane closes or another Dock destination replaces it.
 	useEffect(() => {
 		if (
-			siteManagerIsOpen &&
+			dockPaneIsOpen &&
 			(section === 'new' || section === 'playgrounds')
 		) {
 			return;
@@ -421,7 +418,7 @@ export function Dock({
 		}
 		url.searchParams.delete('overlay');
 		window.history.replaceState(window.history.state, '', url);
-	}, [section, siteManagerIsOpen]);
+	}, [section, dockPaneIsOpen]);
 
 	useEffect(() => {
 		if (!isMobile) {
@@ -459,14 +456,14 @@ export function Dock({
 		if (!pane) {
 			return;
 		}
-		if (siteManagerIsOpen) {
+		if (dockPaneIsOpen) {
 			pane.removeAttribute('aria-hidden');
 			pane.removeAttribute('inert');
 		} else {
 			pane.setAttribute('aria-hidden', 'true');
 			pane.setAttribute('inert', '');
 		}
-	}, [siteManagerIsOpen]);
+	}, [dockPaneIsOpen]);
 
 	useEffect(() => {
 		/** Lets the active modal or popover consume Escape before the Dock does. */
@@ -474,7 +471,7 @@ export function Dock({
 			if (
 				event.key !== 'Escape' ||
 				activeModal ||
-				!siteManagerIsOpen ||
+				!dockPaneIsOpen ||
 				paneCloseBlocked
 			) {
 				return;
@@ -486,15 +483,15 @@ export function Dock({
 			) {
 				return;
 			}
-			dispatch(setSiteManagerOpen(false));
+			dispatch(setDockPaneOpen(false));
 		};
 		document.addEventListener('keydown', closeOnEscape, true);
 		return () =>
 			document.removeEventListener('keydown', closeOnEscape, true);
-	}, [activeModal, dispatch, paneCloseBlocked, siteManagerIsOpen]);
+	}, [activeModal, dispatch, paneCloseBlocked, dockPaneIsOpen]);
 
 	useEffect(() => {
-		if (siteManagerIsOpen) {
+		if (dockPaneIsOpen) {
 			hasOpenedPaneRef.current = true;
 			if (!focusBeforePaneRef.current) {
 				focusBeforePaneRef.current =
@@ -521,29 +518,29 @@ export function Dock({
 		if (document.activeElement === document.body) {
 			collapseButtonRef.current?.focus();
 		}
-	}, [section, siteManagerIsOpen]);
+	}, [section, dockPaneIsOpen]);
 
 	/** Opens one tool, or closes it when its already-active button is pressed. */
 	const openSection = useCallback(
-		(nextSection: SiteManagerSection) => {
+		(nextSection: DockPaneSection) => {
 			if (paneCloseBlocked) {
 				return;
 			}
-			if (siteManagerIsOpen && section === nextSection) {
-				dispatch(setSiteManagerOpen(false));
+			if (dockPaneIsOpen && section === nextSection) {
+				dispatch(setDockPaneOpen(false));
 				return;
 			}
-			if (siteManagerIsOpen) {
+			if (dockPaneIsOpen) {
 				focusBeforePaneRef.current =
 					document.activeElement as HTMLElement | null;
 			}
 			setIsCollapsed(false);
 			dragSideRef.current = null;
 			setCornerSide(null);
-			dispatch(setSiteManagerSection(nextSection));
-			dispatch(setSiteManagerOpen(true));
+			dispatch(setDockPaneSection(nextSection));
+			dispatch(setDockPaneOpen(true));
 		},
-		[dispatch, paneCloseBlocked, section, siteManagerIsOpen]
+		[dispatch, paneCloseBlocked, section, dockPaneIsOpen]
 	);
 
 	// The Dock can move only while it floats. Full-width and mobile modes are
@@ -700,7 +697,7 @@ export function Dock({
 				setDockSheen(0);
 			}
 
-			if (dragSideRef.current !== null && siteManagerIsOpen) {
+			if (dragSideRef.current !== null && dockPaneIsOpen) {
 				// An open pane owns the expanded Dock. Refuse a fold that would hide
 				// both the tool in use and its launcher.
 				dragSideRef.current = null;
@@ -832,8 +829,8 @@ export function Dock({
 		if (paneCloseBlocked) {
 			return;
 		}
-		if (siteManagerIsOpen) {
-			dispatch(setSiteManagerOpen(false));
+		if (dockPaneIsOpen) {
+			dispatch(setDockPaneOpen(false));
 		}
 		setIsCollapsed((collapsed) => !collapsed);
 	};
@@ -976,7 +973,7 @@ export function Dock({
 		viewportSize,
 		paneHeight,
 		toastHeight: operationToastHeight,
-		paneOpen: siteManagerIsOpen,
+		paneOpen: dockPaneIsOpen,
 		isEditorSection,
 	});
 
@@ -1017,7 +1014,7 @@ export function Dock({
 			)}
 			<CSSTransition
 				nodeRef={paneRef}
-				in={siteManagerIsOpen}
+				in={dockPaneIsOpen}
 				timeout={240}
 				mountOnEnter
 				onEnter={() => setPaneExitComplete(false)}
@@ -1092,7 +1089,7 @@ export function Dock({
 					headerOverride={paneHeaderOverride}
 					className={classNames({
 						[css.hostPaneHidden]:
-							!siteManagerIsOpen && paneExitComplete,
+							!dockPaneIsOpen && paneExitComplete,
 						[css.paneSave]: section === 'save',
 					})}
 					style={paneStyle}
@@ -1112,7 +1109,7 @@ export function Dock({
 					}
 					onClose={() => {
 						if (!paneCloseBlocked) {
-							dispatch(setSiteManagerOpen(false));
+							dispatch(setDockPaneOpen(false));
 						}
 					}}
 				>
@@ -1202,12 +1199,12 @@ export function Dock({
 								<span
 									className={css.dockSiteName}
 									aria-label={
-										siteDetailsVisible
+										siteSettingsVisible
 											? undefined
 											: 'Playground title'
 									}
 									aria-hidden={
-										siteDetailsVisible || undefined
+										siteSettingsVisible || undefined
 									}
 									title={playgroundTitle}
 								>
@@ -1240,8 +1237,7 @@ export function Dock({
 								icon={item.icon}
 								isPrimary={item.isPrimary}
 								isActive={
-									siteManagerIsOpen &&
-									section === item.section
+									dockPaneIsOpen && section === item.section
 								}
 								disabled={paneCloseBlocked}
 								hasNotification={

--- a/packages/playground/website/src/components/layout/index.tsx
+++ b/packages/playground/website/src/components/layout/index.tsx
@@ -19,7 +19,7 @@ import { MissingSiteModal } from '../missing-site-modal';
 import { RenameSiteModal } from '../rename-site-modal';
 import { DeleteSiteModal } from '../delete-site-modal';
 import { SaveSiteModal } from '../save-site-modal';
-import { modalSlugs, setSiteManagerOpen } from '../../lib/state/redux/slice-ui';
+import { modalSlugs, setDockPaneOpen } from '../../lib/state/redux/slice-ui';
 import { GitHubPrivateRepoAuthModal } from '../github-private-repo-auth-modal';
 import { BlueprintUrlModal } from '../blueprint-url-modal';
 import { ModalLoadingFallback } from '../modal-loading-fallback';
@@ -61,9 +61,7 @@ function getDisplayModeFromQuery(): DisplayMode {
 }
 
 export function Layout() {
-	const siteManagerIsOpen = useAppSelector(
-		(state) => state.ui.siteManagerIsOpen
-	);
+	const dockPaneIsOpen = useAppSelector((state) => state.ui.dockPaneIsOpen);
 	const dispatch = useAppDispatch();
 	const [paneCloseBlocked, setPaneCloseBlocked] = useState(false);
 	const siteViewContentRef = useRef<HTMLDivElement>(null);
@@ -76,17 +74,17 @@ export function Layout() {
 		if (!siteViewContent) {
 			return;
 		}
-		if (showDock && siteManagerIsOpen) {
+		if (showDock && dockPaneIsOpen) {
 			siteViewContent.setAttribute('inert', '');
 		} else {
 			siteViewContent.removeAttribute('inert');
 		}
-	}, [showDock, siteManagerIsOpen]);
+	}, [showDock, dockPaneIsOpen]);
 
 	/** Closes the active pane unless its current operation owns the surface. */
 	const closeDockPane = () => {
 		if (!paneCloseBlocked) {
-			dispatch(setSiteManagerOpen(false));
+			dispatch(setDockPaneOpen(false));
 		}
 	};
 
@@ -94,7 +92,7 @@ export function Layout() {
 		<GitHubExportSessionProvider>
 			<div
 				className={classNames(css.layout, {
-					[css.hasDockPane]: showDock && siteManagerIsOpen,
+					[css.hasDockPane]: showDock && dockPaneIsOpen,
 				})}
 			>
 				<Modals />
@@ -103,7 +101,7 @@ export function Layout() {
 						ref={siteViewContentRef}
 						className={classNames(css.siteViewContent, {
 							[css.siteViewContentBlurred]:
-								showDock && siteManagerIsOpen,
+								showDock && dockPaneIsOpen,
 						})}
 					>
 						<PlaygroundViewport displayMode={displayMode} />
@@ -112,11 +110,11 @@ export function Layout() {
 						<button
 							type="button"
 							className={classNames(css.previewDismiss, {
-								[css.previewDismissVisible]: siteManagerIsOpen,
+								[css.previewDismissVisible]: dockPaneIsOpen,
 							})}
 							aria-label="Close Playground tools"
-							aria-hidden={siteManagerIsOpen ? undefined : true}
-							tabIndex={siteManagerIsOpen ? 0 : -1}
+							aria-hidden={dockPaneIsOpen ? undefined : true}
+							tabIndex={dockPaneIsOpen ? 0 : -1}
 							disabled={paneCloseBlocked}
 							onClick={closeDockPane}
 						/>

--- a/packages/playground/website/src/components/saved-playgrounds-panel/index.tsx
+++ b/packages/playground/website/src/components/saved-playgrounds-panel/index.tsx
@@ -56,8 +56,8 @@ import {
 	modalSlugs,
 	setActiveModal,
 	setDockOperationNotice,
-	setSiteManagerOpen,
-	setSiteManagerSection,
+	setDockPaneOpen,
+	setDockPaneSection,
 	setSiteSlugToDelete,
 	setWriteOwnBlueprintDraft,
 	setWriteOwnSeededSlug,
@@ -770,7 +770,7 @@ export function SavedPlaygroundsPanel({
 		if (isImportingZip) {
 			return;
 		}
-		dispatch(setSiteManagerOpen(false));
+		dispatch(setDockPaneOpen(false));
 		redirectTo(
 			PlaygroundRoute.newSite({
 				query: {
@@ -789,7 +789,7 @@ export function SavedPlaygroundsPanel({
 		if (isImportingZip) {
 			return;
 		}
-		dispatch(setSiteManagerOpen(false));
+		dispatch(setDockPaneOpen(false));
 		// "New Playground" means start fresh. The URL change makes the
 		// selected-site guard handle this as an in-app new-site navigation.
 		redirectTo(PlaygroundRoute.newSite());
@@ -826,7 +826,7 @@ export function SavedPlaygroundsPanel({
 		if (!trimmed) {
 			return;
 		}
-		dispatch(setSiteManagerOpen(false));
+		dispatch(setDockPaneOpen(false));
 		redirectTo(
 			PlaygroundRoute.newSite({ query: { 'blueprint-url': trimmed } })
 		);
@@ -844,7 +844,7 @@ export function SavedPlaygroundsPanel({
 		if (isImportingZip || !isWriteOwnValid) {
 			return;
 		}
-		dispatch(setSiteManagerOpen(false));
+		dispatch(setDockPaneOpen(false));
 		redirectTo(
 			PlaygroundRoute.newSite({
 				hash: encodeURIComponent(writeOwnDraft),
@@ -886,7 +886,7 @@ export function SavedPlaygroundsPanel({
 				// Blueprint rather than blocking the handoff.
 			}
 		}
-		dispatch(setSiteManagerSection('blueprint'));
+		dispatch(setDockPaneSection('blueprint'));
 	};
 
 	/**

--- a/packages/playground/website/src/components/site-manager/index.tsx
+++ b/packages/playground/website/src/components/site-manager/index.tsx
@@ -1,6 +1,6 @@
 import classNames from 'classnames';
 import { forwardRef, useCallback, useEffect, useState } from 'react';
-import { setSiteManagerOpen } from '../../lib/state/redux/slice-ui';
+import { setDockPaneOpen } from '../../lib/state/redux/slice-ui';
 import {
 	useActiveSite,
 	useAppDispatch,
@@ -38,7 +38,7 @@ export const SiteManager = forwardRef<HTMLDivElement, SiteManagerProps>(
 		const dispatch = useAppDispatch();
 		const activeSite = useActiveSite();
 		const activeSection = useAppSelector(
-			(state) => state.ui.siteManagerSection
+			(state) => state.ui.dockPaneSection
 		);
 		const selectedSiteTab: SiteInfoTabName | null =
 			activeSection === 'settings' ||
@@ -58,7 +58,7 @@ export const SiteManager = forwardRef<HTMLDivElement, SiteManagerProps>(
 			useState<'new' | 'playgrounds'>('playgrounds');
 		const [sharePanelMounted, setSharePanelMounted] = useState(false);
 		const closeSavePane = useCallback(
-			() => dispatch(setSiteManagerOpen(false)),
+			() => dispatch(setDockPaneOpen(false)),
 			[dispatch]
 		);
 
@@ -117,7 +117,7 @@ export const SiteManager = forwardRef<HTMLDivElement, SiteManagerProps>(
 									? activeSection
 									: lastSavedPlaygroundsPanel
 							}
-							onClose={() => dispatch(setSiteManagerOpen(false))}
+							onClose={() => dispatch(setDockPaneOpen(false))}
 							onCloseBlockedChange={onPaneCloseBlockedChange}
 							onPaneHeaderChange={onNewPlaygroundHeaderChange}
 						/>

--- a/packages/playground/website/src/components/site-manager/site-info-panel/site-tool-panels.tsx
+++ b/packages/playground/website/src/components/site-manager/site-info-panel/site-tool-panels.tsx
@@ -2,7 +2,7 @@ import classNames from 'classnames';
 import { lazy, Suspense, useEffect, useState } from 'react';
 import type { PlaygroundClient } from '@wp-playground/client';
 import type { SiteInfo } from '../../../lib/state/redux/slice-sites';
-import { setSiteManagerOpen } from '../../../lib/state/redux/slice-ui';
+import { setDockPaneOpen } from '../../../lib/state/redux/slice-ui';
 import { useAppDispatch, useAppSelector } from '../../../lib/state/redux/store';
 import { SiteLogs } from '../../log-modal';
 import { OfflineNotice } from '../../offline-notice';
@@ -96,7 +96,7 @@ export function SiteToolPanels({
 					) : null}
 
 					<ActiveSiteSettingsForm
-						onSubmit={() => dispatch(setSiteManagerOpen(false))}
+						onSubmit={() => dispatch(setDockPaneOpen(false))}
 					/>
 				</div>
 			)}

--- a/packages/playground/website/src/lib/state/redux/slice-ui.ts
+++ b/packages/playground/website/src/lib/state/redux/slice-ui.ts
@@ -19,7 +19,7 @@ export type SiteError =
 	| 'network-firewall-interference'
 	| 'resource-download-failed';
 
-export type SiteManagerSection =
+export type DockPaneSection =
 	| 'new'
 	| 'playgrounds'
 	| 'blueprint'
@@ -171,8 +171,8 @@ export interface UIState {
 	githubAuthRepoUrl?: string;
 	offline: boolean;
 	shareExportOpen: boolean;
-	siteManagerIsOpen: boolean;
-	siteManagerSection: SiteManagerSection;
+	dockPaneIsOpen: boolean;
+	dockPaneSection: DockPaneSection;
 	/**
 	 * Draft kept by the New pane's "Write a Blueprint" editor so closing the
 	 * pane does not discard the user's work.
@@ -189,7 +189,7 @@ export interface UIState {
 const query = new URL(document.location.href).searchParams;
 const isEmbeddedInAnIframe = window.self !== window.top;
 
-const shouldOpenSiteManagerByDefault = false;
+const shouldOpenDockPaneByDefault = false;
 
 const initialState: UIState = {
 	/**
@@ -212,22 +212,22 @@ const initialState: UIState = {
 			: query.get('modal') || null,
 	offline: !navigator.onLine,
 	shareExportOpen: false,
-	// NOTE: Please do not eliminate the cases in this siteManagerIsOpen expression,
-	// even if they seem redundant. We may experiment which toggling the manager
-	// to be open by default or closed by default, and we do not want to lose
-	// specific reasons for the manager to be closed.
-	siteManagerIsOpen:
-		// The site manager should not be shown at all in seamless mode.
+	// NOTE: Please do not eliminate the cases in this dockPaneIsOpen expression,
+	// even if they seem redundant. We may experiment with toggling the Dock
+	// pane to be open by default or closed by default, and we do not want to
+	// lose specific reasons for the Dock pane to be closed.
+	dockPaneIsOpen:
+		// The Dock pane should not be shown at all in seamless mode.
 		query.get('mode') !== 'seamless' &&
 		(query.get('overlay') !== null ||
-			(shouldOpenSiteManagerByDefault &&
+			(shouldOpenDockPaneByDefault &&
 				// We do not expect to render the Playground app UI in an iframe.
 				!isEmbeddedInAnIframe &&
-				// Don't default to the site manager on small screens (mobile/tablet),
+				// Don't default to the Dock pane on small screens (mobile/tablet),
 				// as that would mean seeing something that's not Playground filling
 				// your entire screen – quite a confusing experience.
 				window.innerWidth >= BREAKPOINTS.tablet)),
-	siteManagerSection:
+	dockPaneSection:
 		query.get('overlay') === 'blueprints' || query.get('overlay') === 'new'
 			? 'new'
 			: query.get('overlay') !== null
@@ -294,17 +294,14 @@ const uiSlice = createSlice({
 		setOffline: (state, action: PayloadAction<boolean>) => {
 			state.offline = action.payload;
 		},
-		setSiteManagerOpen: (state, action: PayloadAction<boolean>) => {
-			state.siteManagerIsOpen = action.payload;
+		setDockPaneOpen: (state, action: PayloadAction<boolean>) => {
+			state.dockPaneIsOpen = action.payload;
 		},
 		setShareExportOpen: (state, action: PayloadAction<boolean>) => {
 			state.shareExportOpen = action.payload;
 		},
-		setSiteManagerSection: (
-			state,
-			action: PayloadAction<SiteManagerSection>
-		) => {
-			state.siteManagerSection = action.payload;
+		setDockPaneSection: (state, action: PayloadAction<DockPaneSection>) => {
+			state.dockPaneSection = action.payload;
 		},
 		setWriteOwnBlueprintDraft: (
 			state,
@@ -385,8 +382,8 @@ export const {
 	setGitHubAuthRepoUrl,
 	setOffline,
 	setShareExportOpen,
-	setSiteManagerOpen,
-	setSiteManagerSection,
+	setDockPaneOpen,
+	setDockPaneSection,
 	setWriteOwnBlueprintDraft,
 	setWriteOwnSeededSlug,
 	setDockOperationNotice,


### PR DESCRIPTION
This gives the Dock pane state the same name as the UI that owns it. The old `siteManager*` names made Dock routing look like Site Manager state even though the `SiteManager` component is now only one pane body inside the Dock.

The branch renames the UI slice fields, actions, type, selectors, mocks, and local variables from `SiteManagerSection` / `siteManagerIsOpen` / `siteManagerSection` to `DockPaneSection` / `dockPaneIsOpen` / `dockPaneSection`. It also renames `siteDetailsVisible` to `siteSettingsVisible` where it describes the settings pane title state.

This intentionally does not rename the `SiteManager` component or directory, move `SaveStatusIndicator`, simplify the initial-state expression, or change the public `overlay` query parameter. `overlay=blueprints` still opens the New Playground pane.

Verified with:

```bash
source "$HOME/.nvm/nvm.sh" && nvm use
git diff --check origin/trunk...HEAD
! git grep -n -E 'SiteManagerSection|siteManagerIsOpen|siteManagerSection|setSiteManager(Open|Section)|shouldOpenSiteManagerByDefault|siteDetailsVisible' -- packages/playground/website/src
npm exec nx lint playground-website
npm exec nx typecheck playground-website
npm exec nx test playground-website
npm exec nx run playground-website:e2e:playwright -- --grep "should route tools through one Dock pane|should keep a settings draft across Dock destinations and close|should keep the selected New method and its draft across Dock destinations|overlay query parameter|should make every Dock tool reachable on mobile" packages/playground/website/playwright/e2e/website-ui.spec.ts
```

I also checked the Dock manually in Chromium: default load leaves the pane closed, each Dock destination opens its pane, the active destination closes on second click, Escape closes the pane, and both `?overlay=blueprints` and `?overlay=new` open New Playground.

A full local `npm exec nx run playground-website:e2e:playwright` run was attempted, but the local run timed out across unrelated long-running Blueprint/deployment/snippet tests. This PR does not touch those paths; GitHub CI will run the full matrix.
