### PR TITLE
[Website] Separate Dock creation from selection and reveal mobile overflow

### DIFF
--- a/packages/playground/website/src/components/dock/dock-item-button.spec.tsx
+++ b/packages/playground/website/src/components/dock/dock-item-button.spec.tsx
@@ -38,6 +38,20 @@ describe('DockItemButton', () => {
 		expect(hiddenMarkerCount).toBe(2);
 	});
 
+	it('gives create actions a distinct role without marking them active', () => {
+		const markup = renderToStaticMarkup(
+			<DockItemButton
+				label="New"
+				ariaLabel="New Playground"
+				icon={<span>Plus icon</span>}
+				variant="create"
+			/>
+		);
+
+		expect(markup).toMatch(/class="[^"]*dockItemCreate/);
+		expect(markup).toContain('aria-pressed="false"');
+	});
+
 	it('can disable unavailable actions', () => {
 		const markup = renderToStaticMarkup(
 			<DockItemButton

--- a/packages/playground/website/src/components/dock/dock-item-button.tsx
+++ b/packages/playground/website/src/components/dock/dock-item-button.tsx
@@ -3,12 +3,14 @@ import { forwardRef } from 'react';
 import type { MouseEventHandler, ReactNode } from 'react';
 import css from './style.module.css';
 
+export type DockItemButtonVariant = 'destination' | 'create';
+
 export type DockItemButtonProps = {
 	label: string;
 	ariaLabel: string;
 	icon: ReactNode;
 	isActive?: boolean;
-	isPrimary?: boolean;
+	variant?: DockItemButtonVariant;
 	hasSeparator?: boolean;
 	hasNotification?: boolean;
 	notificationAriaSuffix?: string;
@@ -18,8 +20,8 @@ export type DockItemButtonProps = {
 };
 
 /**
- * A reusable two-line dock tool button: icon above label, optional primary
- * treatment, optional group divider, and optional notification dot.
+ * A reusable two-line Dock control: icon above label, semantic product role,
+ * optional group divider, and optional notification dot.
  */
 export const DockItemButton = forwardRef<
 	HTMLButtonElement,
@@ -30,7 +32,7 @@ export const DockItemButton = forwardRef<
 		ariaLabel,
 		icon,
 		isActive = false,
-		isPrimary = false,
+		variant = 'destination',
 		hasSeparator = false,
 		hasNotification = false,
 		notificationAriaSuffix = 'notification available',
@@ -54,7 +56,7 @@ export const DockItemButton = forwardRef<
 				type="button"
 				ref={ref}
 				className={classNames(css.dockItem, {
-					[css.dockItemPrimary]: isPrimary,
+					[css.dockItemCreate]: variant === 'create',
 					[css.dockItemActive]: isActive,
 				})}
 				aria-label={buttonAriaLabel}

--- a/packages/playground/website/src/components/dock/dock-tools-overflow.spec.ts
+++ b/packages/playground/website/src/components/dock/dock-tools-overflow.spec.ts
@@ -1,0 +1,62 @@
+import { getDockToolsOverflow } from './dock-tools-overflow';
+
+describe('getDockToolsOverflow', () => {
+	it('reports no hidden destinations when every item fits', () => {
+		expect(
+			getDockToolsOverflow({
+				clientWidth: 600,
+				scrollLeft: 0,
+				scrollWidth: 600,
+			})
+		).toEqual({
+			canScrollBackward: false,
+			canScrollForward: false,
+		});
+	});
+
+	it.each([
+		[0, false, true],
+		[100, true, true],
+		[240, true, false],
+	] as const)(
+		'reports the available directions at scrollLeft %d',
+		(scrollLeft, canScrollBackward, canScrollForward) => {
+			expect(
+				getDockToolsOverflow({
+					clientWidth: 360,
+					scrollLeft,
+					scrollWidth: 600,
+				})
+			).toEqual({ canScrollBackward, canScrollForward });
+		}
+	);
+
+	it('treats a one-pixel remainder as the end of the strip', () => {
+		expect(
+			getDockToolsOverflow({
+				clientWidth: 360,
+				scrollLeft: 239,
+				scrollWidth: 600,
+			})
+		).toEqual({
+			canScrollBackward: true,
+			canScrollForward: false,
+		});
+	});
+
+	it.each([
+		[-18, false, true],
+		[258, true, false],
+	] as const)(
+		'clamps elastic overscroll at scrollLeft %d',
+		(scrollLeft, canScrollBackward, canScrollForward) => {
+			expect(
+				getDockToolsOverflow({
+					clientWidth: 360,
+					scrollLeft,
+					scrollWidth: 600,
+				})
+			).toEqual({ canScrollBackward, canScrollForward });
+		}
+	);
+});

--- a/packages/playground/website/src/components/dock/dock-tools-overflow.ts
+++ b/packages/playground/website/src/components/dock/dock-tools-overflow.ts
@@ -1,0 +1,27 @@
+export type DockToolsScrollMetrics = {
+	clientWidth: number;
+	scrollLeft: number;
+	scrollWidth: number;
+};
+
+const SCROLL_EDGE_TOLERANCE = 1;
+
+/** Reports which horizontal edges have more Dock destinations beyond them. */
+export function getDockToolsOverflow({
+	clientWidth,
+	scrollLeft,
+	scrollWidth,
+}: DockToolsScrollMetrics) {
+	const maxScrollLeft = Math.max(0, scrollWidth - clientWidth);
+	// Elastic scrolling can briefly report positions outside the real range.
+	const clampedScrollLeft = Math.min(
+		Math.max(0, scrollLeft),
+		maxScrollLeft
+	);
+
+	return {
+		canScrollBackward: clampedScrollLeft > SCROLL_EDGE_TOLERANCE,
+		canScrollForward:
+			maxScrollLeft - clampedScrollLeft > SCROLL_EDGE_TOLERANCE,
+	};
+}

--- a/packages/playground/website/src/components/dock/dock.tsx
+++ b/packages/playground/website/src/components/dock/dock.tsx
@@ -51,9 +51,11 @@ import { useRecentAutosaveNudgeVisible } from '../ensure-playground-site/recent-
 import { TruncatedText } from '../truncated-text';
 import { DockCornerLauncher } from './dock-corner-launcher';
 import { DockItemButton } from './dock-item-button';
+import type { DockItemButtonVariant } from './dock-item-button';
 import { DockPane } from './dock-pane';
 import type { DockPaneHeaderOverride } from './dock-pane';
 import { DockTogglePill } from './dock-toggle-pill';
+import { getDockToolsOverflow } from './dock-tools-overflow';
 import {
 	DOCK_DRAG_EDGE,
 	DOCK_OPERATION_TOAST_MIN_HEIGHT,
@@ -68,7 +70,8 @@ type DockItem = {
 	label: string;
 	ariaLabel: string;
 	icon: JSX.Element;
-	isPrimary?: boolean;
+	variant?: DockItemButtonVariant;
+	startsGroup?: boolean;
 };
 
 export type DockProps = {
@@ -80,19 +83,20 @@ const DRAG_THRESHOLD = 4;
 const CORNER_OVERDRAG = 36;
 const MOBILE_QUERY = '(max-width: 1024px)';
 
-const DOCK_ITEMS: DockItem[] = [
+const DOCK_ITEMS = [
 	{
 		section: 'new',
 		label: 'New',
 		ariaLabel: 'New Playground',
 		icon: <Icon icon={plus} size={24} />,
-		isPrimary: true,
+		variant: 'create',
 	},
 	{
 		section: 'playgrounds',
 		label: 'Playgrounds',
 		ariaLabel: 'Your Playgrounds',
 		icon: <Icon icon={grid} size={22} />,
+		startsGroup: true,
 	},
 	{
 		section: 'blueprint',
@@ -130,7 +134,7 @@ const DOCK_ITEMS: DockItem[] = [
 		ariaLabel: 'Export',
 		icon: <Icon icon={download} size={24} />,
 	},
-];
+] satisfies readonly DockItem[];
 
 const PANE_COPY: Record<
 	DockPaneSection,
@@ -261,6 +265,10 @@ export function Dock({
 		DOCK_OPERATION_TOAST_MIN_HEIGHT
 	);
 	const [toolsHeight, setToolsHeight] = useState(0);
+	const [toolsOverflow, setToolsOverflow] = useState({
+		canScrollBackward: false,
+		canScrollForward: false,
+	});
 	const [viewportSize, setViewportSize] = useState(() => ({
 		width: window.innerWidth,
 		height: window.innerHeight,
@@ -306,6 +314,41 @@ export function Dock({
 			observer.observe(toolsRef.current);
 		}
 		return () => observer.disconnect();
+	}, []);
+
+	useLayoutEffect(() => {
+		const tools = toolsRef.current;
+		if (!tools) {
+			return;
+		}
+
+		/** Keeps the mobile edge cues aligned with the visible destinations. */
+		const updateToolsOverflow = () => {
+			const next = getDockToolsOverflow(tools);
+			setToolsOverflow((current) =>
+				current.canScrollBackward === next.canScrollBackward &&
+				current.canScrollForward === next.canScrollForward
+					? current
+					: next
+			);
+		};
+
+		updateToolsOverflow();
+		tools.addEventListener('scroll', updateToolsOverflow, {
+			passive: true,
+		});
+		let observer: ResizeObserver | undefined;
+		if (typeof ResizeObserver === 'undefined') {
+			window.addEventListener('resize', updateToolsOverflow);
+		} else {
+			observer = new ResizeObserver(updateToolsOverflow);
+			observer.observe(tools);
+		}
+		return () => {
+			tools.removeEventListener('scroll', updateToolsOverflow);
+			window.removeEventListener('resize', updateToolsOverflow);
+			observer?.disconnect();
+		};
 	}, []);
 
 	useEffect(() => {
@@ -1228,32 +1271,42 @@ export function Dock({
 							/>
 						)}
 					</div>
-					<div className={css.dockTools} ref={toolsRef}>
-						{DOCK_ITEMS.map((item, index) => (
-							<DockItemButton
-								key={item.section}
-								label={item.label}
-								ariaLabel={item.ariaLabel}
-								icon={item.icon}
-								isPrimary={item.isPrimary}
-								isActive={
-									dockPaneIsOpen && section === item.section
-								}
-								disabled={paneCloseBlocked}
-								hasNotification={
-									item.section === 'playgrounds' &&
-									recentAutosaveNudgeVisible
-								}
-								notificationAriaSuffix="recent autosave available"
-								hasSeparator={index === 2}
-								onClick={(event) => {
-									// Safari does not focus buttons on click. Do it here so
-									// closing a pane returns focus to its Dock control.
-									event.currentTarget.focus();
-									openSection(item.section);
-								}}
-							/>
-						))}
+					<div
+						className={classNames(css.dockToolsViewport, {
+							[css.dockToolsOverflowBackward]:
+								toolsOverflow.canScrollBackward,
+							[css.dockToolsOverflowForward]:
+								toolsOverflow.canScrollForward,
+						})}
+					>
+						<div className={css.dockTools} ref={toolsRef}>
+							{DOCK_ITEMS.map((item) => (
+								<DockItemButton
+									key={item.section}
+									label={item.label}
+									ariaLabel={item.ariaLabel}
+									icon={item.icon}
+									variant={item.variant}
+									isActive={
+										dockPaneIsOpen &&
+										section === item.section
+									}
+									disabled={paneCloseBlocked}
+									hasNotification={
+										item.section === 'playgrounds' &&
+										recentAutosaveNudgeVisible
+									}
+									notificationAriaSuffix="recent autosave available"
+									hasSeparator={item.startsGroup}
+									onClick={(event) => {
+										// Safari does not focus buttons on click. Do it here so
+										// closing a pane returns focus to its Dock control.
+										event.currentTarget.focus();
+										openSection(item.section);
+									}}
+								/>
+							))}
+						</div>
 					</div>
 				</div>
 			</nav>

--- a/packages/playground/website/src/components/dock/style.module.css
+++ b/packages/playground/website/src/components/dock/style.module.css
@@ -94,7 +94,12 @@
 	gap: 2px;
 }
 
-/* Group divider before the "Blueprint" tool. The line is a short, vertically
+.dock-tools-viewport {
+	min-width: 0;
+	position: relative;
+}
+
+/* Group divider before the first destination. The line is a short, vertically
    centered pseudo-element living in the gap — it doesn't pad or border the
    button, so the button's rounded hover/active highlight stays flush in its own
    box (no offset dead strip beside the rounded corners). */
@@ -153,16 +158,26 @@
 	outline-offset: 3px;
 }
 
-.dock-item-primary {
-	background: #3858e9;
+.dock-item-create .dock-icon {
 	color: #ffffff;
+	position: relative;
+	z-index: 0;
 }
 
-.dock-item-primary:hover,
-.dock-item-primary.dock-item-active {
-	/* Matches the surface accent-hover (#2f4ad1) used in pane content. */
+/* New is an action, not a second selected destination. Keep its accent inside
+   the icon while the common full-tile active state remains selection-only. */
+.dock-item-create .dock-icon::before {
+	background: #3858e9;
+	border-radius: 8px;
+	content: '';
+	inset: -2px;
+	position: absolute;
+	transition: background 120ms ease;
+	z-index: -1;
+}
+
+.dock-item-create:hover:not(:disabled) .dock-icon::before {
 	background: #2f4ad1;
-	color: #ffffff;
 }
 
 .dock-icon {
@@ -720,6 +735,36 @@
 		display: none;
 	}
 
+	/* Directional fades make the otherwise hidden horizontal overflow visible.
+	   They describe scroll state without covering the strip with new controls. */
+	.dock-tools-viewport::before,
+	.dock-tools-viewport::after {
+		bottom: 0;
+		content: '';
+		opacity: 0;
+		pointer-events: none;
+		position: absolute;
+		top: 0;
+		transition: opacity 120ms ease;
+		width: 32px;
+		z-index: 2;
+	}
+
+	.dock-tools-viewport::before {
+		background: linear-gradient(90deg, #21201d 15%, rgba(33, 32, 29, 0));
+		left: 0;
+	}
+
+	.dock-tools-viewport::after {
+		background: linear-gradient(270deg, #21201d 15%, rgba(33, 32, 29, 0));
+		right: 0;
+	}
+
+	.dock-tools-overflow-backward::before,
+	.dock-tools-overflow-forward::after {
+		opacity: 1;
+	}
+
 	.dock-item {
 		flex-shrink: 0;
 		min-width: 60px;
@@ -836,6 +881,13 @@
 
 	.pane-close svg {
 		fill: currentColor;
+	}
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.dock-tools-viewport::before,
+	.dock-tools-viewport::after {
+		transition: none;
 	}
 }
 


### PR DESCRIPTION
Dock navigation now reserves the full-tile treatment for the selected destination. **New** remains prominent as a contained create action, the destination group has an explicit boundary, and stateful mobile edge fades reveal destinations outside the visible strip.

This gives desktop and mobile one navigation grammar without changing pane content or workflows. It complements #4084, which covers pane anatomy and mobile controls.

## Outcome

- Distinguish the create action from destination selection.
- Keep exactly one full Dock tile selected when a pane is open.
- Make the create/destination group boundary survive reordering.
- Reveal mobile horizontal overflow at the start, middle, and end of the strip.
- Preserve accessible names, `aria-pressed`, disabled behavior, notifications, and focus restoration.

## Non-goals

- Pane headers, editor toolbars, mobile target sizing, or responsive forms covered by #4084.
- Portal/WordPress UI theming or shared pane/footer/form primitives.
- Destination reordering, a **More** menu, or changes to persistence and export workflows.
- Product screenshot baselines; images below are review evidence.

## Method inventory

| Surface | Change | Resulting contract |
| --- | --- | --- |
| `Dock` | Observe and classify horizontal strip overflow | Selection and close-blocking behavior stay independent from scroll state |
| `DockItemButton` | Replace `isPrimary` with `variant="create"` | `variant` describes role; `isActive` alone describes selection |
| `getDockToolsOverflow` | Derive backward/forward availability from scroll metrics | Pure and tolerant of rounding and elastic overscroll |
| Overflow layout effect | Measure on mount/resize and listen passively for scrolling | State changes only at edges; all listeners and observers are cleaned up |
| Dock CSS | Contain the create accent and render directional fades | Fades communicate overflow and never intercept input |

## Array-shape documentation inventory

- `DOCK_ITEMS` now uses `satisfies readonly DockItem[]`.
- Grouping is encoded by `startsGroup` on the first destination rather than `index === 2`.
- Icons remain explicitly typed `JSX.Element` values; no tuple, serialized array, or variadic contract is introduced.
- Screenshot matrices use deterministic state order outside the product tree.

## Guard/trust-boundary inventory

- Measurements read only `clientWidth`, `scrollWidth`, and `scrollLeft` from the owned strip element.
- A one-pixel tolerance absorbs fractional layout values.
- Negative and beyond-end Safari elastic positions are clamped.
- `ResizeObserver` has a window-resize fallback.
- Scroll/resize listeners and the observer are removed on cleanup.
- Repeated scroll pixels reuse the current React state unless an edge boolean changes.
- Fades use `pointer-events: none` and reduced-motion removes their transition.
- Existing `paneCloseBlocked`, keyboard, notification, and focus-return contracts remain intact.

## Failure and interruption taxonomy

| Case | Expected result |
| --- | --- |
| No overflow | No edge fade |
| Start / middle / end | Forward only / both / backward only |
| Fractional metrics | A one-pixel remainder counts as the edge |
| Elastic overscroll | State clamps to the nearest real edge |
| Resize or rotation | Geometry is remeasured |
| Pane switch while scrolled | Selection changes independently of overflow |
| Blocked operation | Existing disabled navigation remains authoritative |
| Missing `ResizeObserver` | Initial measurement and window resize still work |
| Unmount or HMR | No stale subscriptions remain |
| Reduced motion | State remains visible without animation |

## Required tests

- Create-role rendering without accidental selection.
- No-overflow, start, middle, end, rounding, and elastic-overscroll unit cases.
- Complete Playground website unit suite, typecheck, and lint.
- Chrome DevTools review of every Dock state at 1440×1000 and 390×844.
- Mobile start/middle/end measurements, keyboard activation and focus return, document overflow, and console errors.

## Verification commands

```bash
npm run format:uncommitted
NX_DAEMON=false NX_TUI=false npm exec nx -- test playground-website --output-style=static
NX_DAEMON=false NX_TUI=false npm exec nx -- typecheck playground-website --output-style=static
NX_DAEMON=false NX_TUI=false npm exec nx -- lint playground-website --output-style=static
git diff --check
```

All commands pass. The test target completed 57 files and 318 tests.

## Completion matrix

| Check | Desktop 1440×1000 | Mobile 390×844 |
| --- | --- | --- |
| Idle + New + 8 destination/workflow states | Pass | Pass |
| Exactly one selected tile | Pass | Pass |
| Create action remains distinct | Pass | Pass |
| Start / middle / end overflow cues | N/A | Pass |
| Document horizontal overflow | 0 px | 0 px |
| Keyboard open / Escape / focus return | Pass | Pass |
| Console errors | 0 | 0 |

Chrome DevTools reported mobile edge opacities of `0/1`, `1/1`, and `1/0` at the start, middle, and end. Two unrelated development warnings remain: Vite's externalized `os` module and the WordPress 7.0 build differing from the `latest` alias.

## Before and after

### Desktop — 1440×1000

![Desktop Dock states before and after](https://raw.githubusercontent.com/WordPress/wordpress-playground/70a1ad164ddcdb1855ad22998c54fbb07dae4d5c/pr-assets/4087/desktop-before-after.jpg)

[Full desktop before matrix](https://raw.githubusercontent.com/WordPress/wordpress-playground/70a1ad164ddcdb1855ad22998c54fbb07dae4d5c/pr-assets/4087/desktop-before-contact-sheet.jpg) · [Full desktop after matrix](https://raw.githubusercontent.com/WordPress/wordpress-playground/70a1ad164ddcdb1855ad22998c54fbb07dae4d5c/pr-assets/4087/desktop-after-contact-sheet.jpg)

### Mobile — 390×844

![Mobile Dock states before and after](https://raw.githubusercontent.com/WordPress/wordpress-playground/70a1ad164ddcdb1855ad22998c54fbb07dae4d5c/pr-assets/4087/mobile-before-after.jpg)

[Full mobile before matrix](https://raw.githubusercontent.com/WordPress/wordpress-playground/70a1ad164ddcdb1855ad22998c54fbb07dae4d5c/pr-assets/4087/mobile-before-contact-sheet.jpg) · [Full mobile after matrix](https://raw.githubusercontent.com/WordPress/wordpress-playground/70a1ad164ddcdb1855ad22998c54fbb07dae4d5c/pr-assets/4087/mobile-after-contact-sheet.jpg)
