### PR TITLE
[Website] Add a square mobile Dock with a tools toggle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -204,6 +204,8 @@ Do not test:
 
 - literal JSX or static configuration;
 - copy, CSS classes, visual variants, element counts, or ordering;
+- exact pixel dimensions, spacing values, or other CSS outcomes copied into
+  unit-test fixtures;
 - presentation-only visibility controlled by an adjacent conditional;
 - behavior that would change only when someone intentionally reverses the
   product decision.
@@ -215,6 +217,9 @@ Before adding a test, name all three:
 3. The independent code path that could cause that regression.
 
 If you cannot name all three concretely, do not add the test.
+
+A test is not independent when its expected value must be edited whenever
+adjacent CSS changes. Delete or avoid that test instead of updating its numbers.
 
 Use screenshots and manual interaction for visual-only changes. Tests are not
 required for every PR. Never add tests simply to make a PR appear complete.

--- a/packages/playground/website/playwright/e2e/website-ui.spec.ts
+++ b/packages/playground/website/playwright/e2e/website-ui.spec.ts
@@ -970,9 +970,9 @@ test('should make every Dock tool reachable on mobile', async ({ website }) => {
 		await expect(pane.getByRole('button', { name: 'Close' })).toBeVisible();
 	}
 
-	await expect(dock.getByRole('button', { name: 'Hide tools' })).toHaveCount(
-		0
-	);
+	await expect(
+		dock.getByRole('button', { name: 'Hide tools' })
+	).toBeVisible();
 	await expect(dock.getByRole('button', { name: 'Full width' })).toHaveCount(
 		0
 	);
@@ -987,6 +987,19 @@ test('should make every Dock tool reachable on mobile', async ({ website }) => {
 	await expect(exportPane).not.toBeVisible();
 	await expect(preview).not.toHaveAttribute('inert', /.*/);
 	await expect(dock.getByRole('button', { name: 'Export' })).toBeFocused();
+
+	await dock.getByRole('button', { name: 'Hide tools' }).click();
+	await expect(
+		dock.getByRole('button', { name: 'Show tools' })
+	).toBeVisible();
+	await expect(
+		dock.getByRole('button', { name: 'New Playground' })
+	).not.toBeVisible();
+	await expect(dock.getByRole('combobox')).toBeVisible();
+	await dock.getByRole('button', { name: 'Show tools' }).click();
+	await expect(
+		dock.getByRole('button', { name: 'New Playground' })
+	).toBeVisible();
 
 	await website.page.setViewportSize({ width: 320, height: 700 });
 	await website.openDockPane('Site Settings');

--- a/packages/playground/website/src/components/dock/dock-positioning.spec.ts
+++ b/packages/playground/website/src/components/dock/dock-positioning.spec.ts
@@ -104,8 +104,8 @@ describe('Dock positioning', () => {
 		expect(
 			getDockOperationToastStyle({
 				isMobile: true,
-				dockSize: { width: 390, height: 66 },
-				toolsHeight: 66,
+				dockSize: { width: 390, height: 50 },
+				toolsHeight: 50,
 				isCollapsed: true,
 				dockCenter: null,
 				viewportSize: { width: 390, height: 844 },
@@ -114,7 +114,7 @@ describe('Dock positioning', () => {
 				paneOpen: false,
 				isEditorSection: false,
 			})
-		).toEqual({ bottom: '78px', left: '195px' });
+		).toEqual({ bottom: '62px', left: '195px' });
 	});
 
 	it('centers operation notices when the viewport is narrower than its gaps', () => {

--- a/packages/playground/website/src/components/dock/dock-positioning.spec.ts
+++ b/packages/playground/website/src/components/dock/dock-positioning.spec.ts
@@ -100,6 +100,23 @@ describe('Dock positioning', () => {
 		).toEqual({ bottom: '504px', left: '308px' });
 	});
 
+	it('uses the measured mobile height after the tools are hidden', () => {
+		expect(
+			getDockOperationToastStyle({
+				isMobile: true,
+				dockSize: { width: 390, height: 66 },
+				toolsHeight: 66,
+				isCollapsed: true,
+				dockCenter: null,
+				viewportSize: { width: 390, height: 844 },
+				paneHeight: 0,
+				toastHeight: 62,
+				paneOpen: false,
+				isEditorSection: false,
+			})
+		).toEqual({ bottom: '78px', left: '195px' });
+	});
+
 	it('centers operation notices when the viewport is narrower than its gaps', () => {
 		expect(
 			getDockOperationToastStyle({

--- a/packages/playground/website/src/components/dock/dock-positioning.spec.ts
+++ b/packages/playground/website/src/components/dock/dock-positioning.spec.ts
@@ -100,23 +100,6 @@ describe('Dock positioning', () => {
 		).toEqual({ bottom: '504px', left: '308px' });
 	});
 
-	it('uses the measured mobile height after the tools are hidden', () => {
-		expect(
-			getDockOperationToastStyle({
-				isMobile: true,
-				dockSize: { width: 390, height: 50 },
-				toolsHeight: 50,
-				isCollapsed: true,
-				dockCenter: null,
-				viewportSize: { width: 390, height: 844 },
-				paneHeight: 0,
-				toastHeight: 62,
-				paneOpen: false,
-				isEditorSection: false,
-			})
-		).toEqual({ bottom: '62px', left: '195px' });
-	});
-
 	it('centers operation notices when the viewport is narrower than its gaps', () => {
 		expect(
 			getDockOperationToastStyle({

--- a/packages/playground/website/src/components/dock/dock-positioning.ts
+++ b/packages/playground/website/src/components/dock/dock-positioning.ts
@@ -87,9 +87,12 @@ export function getDockOperationToastStyle({
 		return undefined;
 	}
 
-	const visibleDockHeight = isCollapsed
-		? Math.max(0, dockSize.height - toolsHeight)
-		: dockSize.height;
+	// Mobile collapse removes the tools from layout, so dockSize is already the
+	// visible height. Desktop collapse translates them out without reflowing.
+	const visibleDockHeight =
+		isCollapsed && !isMobile
+			? Math.max(0, dockSize.height - toolsHeight)
+			: dockSize.height;
 	const desiredBottom =
 		visibleDockHeight +
 		DOCK_PANE_GAP +

--- a/packages/playground/website/src/components/dock/dock-toggle-pill.tsx
+++ b/packages/playground/website/src/components/dock/dock-toggle-pill.tsx
@@ -52,7 +52,7 @@ export function DockTogglePill({
 			</button>
 			<button
 				type="button"
-				className={css.dockPillBtn}
+				className={classNames(css.dockPillBtn, css.dockPillFullWidth)}
 				aria-label={isFullWidth ? 'Exit full width' : 'Full width'}
 				aria-pressed={isFullWidth}
 				title={isFullWidth ? 'Exit full width' : 'Full width'}

--- a/packages/playground/website/src/components/dock/dock.tsx
+++ b/packages/playground/website/src/components/dock/dock.tsx
@@ -376,7 +376,11 @@ export function Dock({
 	useEffect(() => {
 		const root = document.documentElement;
 		const headerHeight = Math.max(0, dockSize.height - toolsHeight);
-		const visibleHeight = isCollapsed ? headerHeight : dockSize.height;
+		// Desktop collapse moves the tools below the viewport without changing the
+		// Dock's measured height. Mobile removes the tools from layout, so its live
+		// measurement already is the visible height.
+		const visibleHeight =
+			isCollapsed && !isMobile ? headerHeight : dockSize.height;
 		if (visibleHeight > 0) {
 			root.style.setProperty(
 				'--dock-docked-height',
@@ -1217,16 +1221,14 @@ export function Dock({
 								/>
 							)}
 						</div>
-						{!isMobile && (
-							<DockTogglePill
-								isCollapsed={isCollapsed}
-								isFullWidth={isFullWidth}
-								collapseDisabled={paneCloseBlocked}
-								collapseButtonRef={collapseButtonRef}
-								onToggleCollapsed={toggleCollapsed}
-								onToggleFullWidth={toggleFullWidth}
-							/>
-						)}
+						<DockTogglePill
+							isCollapsed={isCollapsed}
+							isFullWidth={isFullWidth}
+							collapseDisabled={paneCloseBlocked}
+							collapseButtonRef={collapseButtonRef}
+							onToggleCollapsed={toggleCollapsed}
+							onToggleFullWidth={toggleFullWidth}
+						/>
 					</div>
 					<div className={css.dockTools} ref={toolsRef}>
 						{DOCK_ITEMS.map((item, index) => (

--- a/packages/playground/website/src/components/dock/style.module.css
+++ b/packages/playground/website/src/components/dock/style.module.css
@@ -1267,6 +1267,12 @@
 		padding: 8px 8px calc(8px + env(safe-area-inset-bottom, 0px));
 	}
 
+	/* Give the tool buttons more separation from the preview without making the
+	   collapsed address row taller. */
+	.dock:not(.dock-collapsed) .dock-body {
+		padding-top: 16px;
+	}
+
 	/* On mobile the address row stays docked while the arrow removes the tools
 	   row from layout. This lets the measured Dock height follow what is visible. */
 	.dock-collapsed .dock-tools {

--- a/packages/playground/website/src/components/dock/style.module.css
+++ b/packages/playground/website/src/components/dock/style.module.css
@@ -689,6 +689,7 @@
 	   visual stack on mobile. */
 	.dock {
 		border-radius: 0;
+		clip-path: inset(0);
 		bottom: 0;
 		left: 0;
 		right: 0;
@@ -1247,19 +1248,26 @@
 
 @media (max-width: 1024px) {
 	.dock-collapsed {
-		transform: translateY(var(--dock-body-h, 56px));
+		transform: none;
 	}
 
-	/* The mobile bar is fixed and full-screen-panelled: no drag (so no sheen),
-	   and the width/collapse toggles don't apply. */
+	/* The mobile bar is fixed and full-screen-panelled, so it cannot be dragged
+	   or switched into the desktop full-width mode. The collapse half remains as
+	   the arrow that shows and hides the tools row. */
 	.dock-sheen,
-	.dock-toggle-pill {
+	.dock-pill-full-width {
 		display: none;
 	}
 
 	.dock-body {
 		flex-direction: column-reverse;
 		padding: 8px 8px calc(8px + env(safe-area-inset-bottom, 0px));
+	}
+
+	/* On mobile the address row stays docked while the arrow removes the tools
+	   row from layout. This lets the measured Dock height follow what is visible. */
+	.dock-collapsed .dock-tools {
+		display: none;
 	}
 }
 

--- a/packages/playground/website/src/components/dock/style.module.css
+++ b/packages/playground/website/src/components/dock/style.module.css
@@ -689,7 +689,10 @@
 	   visual stack on mobile. */
 	.dock {
 		border-radius: 0;
-		clip-path: inset(0);
+		clip-path: none;
+		/* The square bar uses the mobile box-shadow below; retaining the desktop
+		   drop-shadow would stack both elevation effects. */
+		filter: none;
 		bottom: 0;
 		left: 0;
 		right: 0;

--- a/packages/playground/website/src/components/dock/style.module.css
+++ b/packages/playground/website/src/components/dock/style.module.css
@@ -696,7 +696,9 @@
 		top: auto;
 		max-width: none;
 		width: auto;
-		padding: 8px 8px calc(8px + env(safe-area-inset-bottom, 0px));
+		/* Keep the 16px side gutter, but let dock-body own the vertical frame and
+		   safe-area clearance so the two Dock rows do not get double padding. */
+		padding: 0 8px;
 		transform: none;
 		cursor: default;
 		box-shadow:
@@ -1261,6 +1263,7 @@
 
 	.dock-body {
 		flex-direction: column-reverse;
+		gap: 8px;
 		padding: 8px 8px calc(8px + env(safe-area-inset-bottom, 0px));
 	}
 


### PR DESCRIPTION
The mobile Dock is now a square, full-width bottom bar with a chevron that hides the tool buttons. The address and save-status row stays visible when the tools are hidden, and **New** remains the full-size primary button. The expanded bar leaves 16px above the tools and keeps its outer shadow instead of clipping it.

Desktop keeps the rounded Dock and both existing toggle actions. AGENTS.md also makes the test rule explicit: current CSS dimensions belong in screenshots and manual review, not unit-test fixtures.

| Before | After: tools shown | After: tools hidden |
| --- | --- | --- |
| ![Mobile Dock before the square bottom-bar treatment](https://raw.githubusercontent.com/WordPress/wordpress-playground/7c2c486b0c3b41c9079da416d8a30b8ee0a65e69/pr-assets/4088/mobile-before.jpg) | ![Square mobile Dock with the tools shown](https://raw.githubusercontent.com/WordPress/wordpress-playground/7c2c486b0c3b41c9079da416d8a30b8ee0a65e69/pr-assets/4088/mobile-tools-shown.jpg) | ![Square mobile Dock with the tools hidden and address row visible](https://raw.githubusercontent.com/WordPress/wordpress-playground/7c2c486b0c3b41c9079da416d8a30b8ee0a65e69/pr-assets/4088/mobile-tools-hidden.jpg) |

## Testing

At 1024px wide or narrower, check that the Dock has square corners and a visible shadow, **New** remains full-size, and the chevron hides and shows the tools without removing the address or save status.

Above 1024px, check that the Dock remains rounded and its collapse and full-width controls still work.
