### PR TITLE
[Website] Ask before reloading edited Blueprint fragments

### DIFF
--- a/packages/playground/website/src/lib/state/url/router-hooks.spec.ts
+++ b/packages/playground/website/src/lib/state/url/router-hooks.spec.ts
@@ -78,9 +78,7 @@ describe('confirmReloadWithNewBlueprint', () => {
 			win
 		);
 
-		expect(win.confirm).toHaveBeenCalledWith(
-			'Reload this page to start a new Playground with the Blueprint from the URL?'
-		);
+		expect(win.confirm).toHaveBeenCalledOnce();
 		expect(win.location.reload).toHaveBeenCalledOnce();
 		expect(win.history.replaceState).not.toHaveBeenCalled();
 	});

--- a/packages/playground/website/src/lib/state/url/router-hooks.spec.ts
+++ b/packages/playground/website/src/lib/state/url/router-hooks.spec.ts
@@ -1,4 +1,4 @@
-import { updateUrl } from './router-hooks';
+import { confirmReloadWithNewBlueprint, updateUrl } from './router-hooks';
 
 const baseUrl = 'https://example.com';
 
@@ -51,5 +51,72 @@ describe('updateUrl', () => {
 
 			expect(result).toBe(expected);
 		});
+	});
+});
+
+describe('confirmReloadWithNewBlueprint', () => {
+	function createWindow(confirmResult: boolean) {
+		return {
+			confirm: vi.fn(() => confirmResult),
+			history: {
+				replaceState: vi.fn(),
+			},
+			location: {
+				reload: vi.fn(),
+			},
+		} as unknown as Pick<Window, 'confirm' | 'history' | 'location'>;
+	}
+
+	it('asks before reloading when only the URL hash changes', () => {
+		const win = createWindow(true);
+
+		confirmReloadWithNewBlueprint(
+			{
+				oldURL: 'https://playground.test/website-server/#old',
+				newURL: 'https://playground.test/website-server/#new',
+			},
+			win
+		);
+
+		expect(win.confirm).toHaveBeenCalledWith(
+			'Reload this page to start a new Playground with the Blueprint from the URL?'
+		);
+		expect(win.location.reload).toHaveBeenCalledOnce();
+		expect(win.history.replaceState).not.toHaveBeenCalled();
+	});
+
+	it('restores the previous URL when the reload is declined', () => {
+		const win = createWindow(false);
+
+		confirmReloadWithNewBlueprint(
+			{
+				oldURL: 'https://playground.test/website-server/#old',
+				newURL: 'https://playground.test/website-server/#new',
+			},
+			win
+		);
+
+		expect(win.location.reload).not.toHaveBeenCalled();
+		expect(win.history.replaceState).toHaveBeenCalledWith(
+			null,
+			'',
+			'https://playground.test/website-server/#old'
+		);
+	});
+
+	it('ignores hash removal because there is no new blueprint fragment to load', () => {
+		const win = createWindow(true);
+
+		confirmReloadWithNewBlueprint(
+			{
+				oldURL: 'https://playground.test/website-server/#old',
+				newURL: 'https://playground.test/website-server/',
+			},
+			win
+		);
+
+		expect(win.confirm).not.toHaveBeenCalled();
+		expect(win.location.reload).not.toHaveBeenCalled();
+		expect(win.history.replaceState).not.toHaveBeenCalled();
 	});
 });

--- a/packages/playground/website/src/lib/state/url/router-hooks.spec.ts
+++ b/packages/playground/website/src/lib/state/url/router-hooks.spec.ts
@@ -1,4 +1,4 @@
-import { confirmReloadWithNewBlueprint, updateUrl } from './router-hooks';
+import { confirmReloadAfterBlueprintChange, updateUrl } from './router-hooks';
 
 const baseUrl = 'https://example.com';
 
@@ -54,7 +54,7 @@ describe('updateUrl', () => {
 	});
 });
 
-describe('confirmReloadWithNewBlueprint', () => {
+describe('confirmReloadAfterBlueprintChange', () => {
 	function createWindow(confirmResult: boolean) {
 		return {
 			confirm: vi.fn(() => confirmResult),
@@ -70,7 +70,7 @@ describe('confirmReloadWithNewBlueprint', () => {
 	it('asks before reloading when only the URL hash changes', () => {
 		const win = createWindow(true);
 
-		confirmReloadWithNewBlueprint(
+		confirmReloadAfterBlueprintChange(
 			{
 				oldURL: 'https://playground.test/website-server/#old',
 				newURL: 'https://playground.test/website-server/#new',
@@ -86,7 +86,7 @@ describe('confirmReloadWithNewBlueprint', () => {
 	it('restores the previous URL when the reload is declined', () => {
 		const win = createWindow(false);
 
-		confirmReloadWithNewBlueprint(
+		confirmReloadAfterBlueprintChange(
 			{
 				oldURL: 'https://playground.test/website-server/#old',
 				newURL: 'https://playground.test/website-server/#new',
@@ -102,10 +102,10 @@ describe('confirmReloadWithNewBlueprint', () => {
 		);
 	});
 
-	it('ignores hash removal because there is no new blueprint fragment to load', () => {
+	it('asks before reloading without a URL Blueprint when the hash is removed', () => {
 		const win = createWindow(true);
 
-		confirmReloadWithNewBlueprint(
+		confirmReloadAfterBlueprintChange(
 			{
 				oldURL: 'https://playground.test/website-server/#old',
 				newURL: 'https://playground.test/website-server/',
@@ -113,8 +113,8 @@ describe('confirmReloadWithNewBlueprint', () => {
 			win
 		);
 
-		expect(win.confirm).not.toHaveBeenCalled();
-		expect(win.location.reload).not.toHaveBeenCalled();
+		expect(win.confirm).toHaveBeenCalledOnce();
+		expect(win.location.reload).toHaveBeenCalledOnce();
 		expect(win.history.replaceState).not.toHaveBeenCalled();
 	});
 });

--- a/packages/playground/website/src/lib/state/url/router-hooks.ts
+++ b/packages/playground/website/src/lib/state/url/router-hooks.ts
@@ -11,6 +11,8 @@ export type URLComponents = {
 
 const confirmBlueprintReloadMessage =
 	'Reload this page to start a new Playground with the Blueprint from the URL?';
+const confirmNoBlueprintReloadMessage =
+	'Reload this page to start a new Playground without a Blueprint from the URL?';
 
 export function useCurrentUrl() {
 	const [url, setUrl] = useState(window.location.href);
@@ -96,18 +98,21 @@ const events = [
 	eventHashchange,
 ];
 
-export function confirmReloadWithNewBlueprint(
+export function confirmReloadAfterBlueprintChange(
 	event: Pick<HashChangeEvent, 'oldURL' | 'newURL'> &
 		Partial<Pick<Event, 'stopImmediatePropagation'>>,
 	win: Pick<Window, 'confirm' | 'history' | 'location'> = window
 ) {
 	const oldUrl = new URL(event.oldURL);
 	const newUrl = new URL(event.newURL);
-	if (!isOnlyHashChange(oldUrl, newUrl) || !newUrl.hash) {
+	if (!isOnlyHashChange(oldUrl, newUrl)) {
 		return;
 	}
 	event.stopImmediatePropagation?.();
-	if (win.confirm(confirmBlueprintReloadMessage)) {
+	const confirmationMessage = newUrl.hash
+		? confirmBlueprintReloadMessage
+		: confirmNoBlueprintReloadMessage;
+	if (win.confirm(confirmationMessage)) {
 		win.location.reload();
 	} else {
 		win.history.replaceState(null, '', oldUrl.toString());
@@ -149,9 +154,13 @@ if (
 	typeof window.addEventListener !== 'undefined' &&
 	typeof window[hashChangeConfirmPatchKey as any] === 'undefined'
 ) {
-	window.addEventListener(eventHashchange, confirmReloadWithNewBlueprint, {
-		capture: true,
-	});
+	window.addEventListener(
+		eventHashchange,
+		confirmReloadAfterBlueprintChange,
+		{
+			capture: true,
+		}
+	);
 	Object.defineProperty(window, hashChangeConfirmPatchKey, { value: true });
 }
 

--- a/packages/playground/website/src/lib/state/url/router-hooks.ts
+++ b/packages/playground/website/src/lib/state/url/router-hooks.ts
@@ -149,7 +149,9 @@ if (
 	typeof window.addEventListener !== 'undefined' &&
 	typeof window[hashChangeConfirmPatchKey as any] === 'undefined'
 ) {
-	window.addEventListener(eventHashchange, confirmReloadWithNewBlueprint);
+	window.addEventListener(eventHashchange, confirmReloadWithNewBlueprint, {
+		capture: true,
+	});
 	Object.defineProperty(window, hashChangeConfirmPatchKey, { value: true });
 }
 

--- a/packages/playground/website/src/lib/state/url/router-hooks.ts
+++ b/packages/playground/website/src/lib/state/url/router-hooks.ts
@@ -9,6 +9,9 @@ export type URLComponents = {
 	pathname?: string;
 };
 
+const confirmBlueprintReloadMessage =
+	'Reload this page to start a new Playground with the Blueprint from the URL?';
+
 export function useCurrentUrl() {
 	const [url, setUrl] = useState(window.location.href);
 	useEffect(() => {
@@ -93,6 +96,33 @@ const events = [
 	eventHashchange,
 ];
 
+export function confirmReloadWithNewBlueprint(
+	event: Pick<HashChangeEvent, 'oldURL' | 'newURL'> &
+		Partial<Pick<Event, 'stopImmediatePropagation'>>,
+	win: Pick<Window, 'confirm' | 'history' | 'location'> = window
+) {
+	const oldUrl = new URL(event.oldURL);
+	const newUrl = new URL(event.newURL);
+	if (!isOnlyHashChange(oldUrl, newUrl) || !newUrl.hash) {
+		return;
+	}
+	event.stopImmediatePropagation?.();
+	if (win.confirm(confirmBlueprintReloadMessage)) {
+		win.location.reload();
+	} else {
+		win.history.replaceState(null, '', oldUrl.toString());
+	}
+}
+
+function isOnlyHashChange(oldUrl: URL, newUrl: URL) {
+	return (
+		oldUrl.origin === newUrl.origin &&
+		oldUrl.pathname === newUrl.pathname &&
+		oldUrl.search === newUrl.search &&
+		oldUrl.hash !== newUrl.hash
+	);
+}
+
 const subscribeToLocationUpdates = (callback: () => void) => {
 	for (const event of events) {
 		window.addEventListener(event, callback);
@@ -104,6 +134,9 @@ const subscribeToLocationUpdates = (callback: () => void) => {
 	};
 };
 
+const hashChangeConfirmPatchKey = Symbol.for(
+	'playground_confirm_blueprint_hashchange'
+);
 const patchKey = Symbol.for('wouter_v3');
 
 // While History API does have `popstate` event, the only
@@ -111,6 +144,15 @@ const patchKey = Symbol.for('wouter_v3');
 // is to monkey-patch these methods.
 //
 // See https://stackoverflow.com/a/4585031
+if (
+	typeof window !== 'undefined' &&
+	typeof window.addEventListener !== 'undefined' &&
+	typeof window[hashChangeConfirmPatchKey as any] === 'undefined'
+) {
+	window.addEventListener(eventHashchange, confirmReloadWithNewBlueprint);
+	Object.defineProperty(window, hashChangeConfirmPatchKey, { value: true });
+}
+
 if (
 	typeof window !== 'undefined' &&
 	typeof window.history !== 'undefined' &&


### PR DESCRIPTION
Changing or removing a Blueprint fragment now asks whether to reload. Without a reload, the address bar can describe a different Blueprint than the running Playground.

Blueprint fragments are read when Playground boots. Before this PR, editing or removing the fragment changed the URL but did nothing to the running instance. Accepting the browser prompt now reloads the page. A replacement fragment boots its Blueprint; removing the fragment boots without a URL Blueprint. Canceling restores the previous URL.

Screencast:

https://github.com/user-attachments/assets/4e16f54e-fbe0-4dd4-867b-51065cf2021d

## Testing

Open Playground with a Blueprint fragment and replace it with another encoded Blueprint. Cancel and check that the previous URL returns. Repeat and accept to check that the new Blueprint loads. Then remove the fragment and check that accepting the prompt reloads without a URL Blueprint.
