### PR TITLE
[Website] Use outward glyph for Dock Export

### DIFF
--- a/packages/playground/website/src/components/dock/dock.tsx
+++ b/packages/playground/website/src/components/dock/dock.tsx
@@ -16,7 +16,7 @@ import { CSSTransition } from 'react-transition-group';
 import { Icon } from '@wordpress/components';
 import {
 	close,
-	download,
+	external,
 	grid,
 	list,
 	page,
@@ -128,7 +128,7 @@ const DOCK_ITEMS: DockItem[] = [
 		section: 'share',
 		label: 'Export',
 		ariaLabel: 'Export',
-		icon: <Icon icon={download} size={24} />,
+		icon: <Icon icon={external} size={24} />,
 	},
 ];
 


### PR DESCRIPTION
The Dock Export button now uses the WordPress `external` glyph, so the icon reads as opening or sending the Playground outward instead of downloading into the current browser. Export contains download and GitHub handoff actions, so the old `download` glyph made the pane read like a download-only control.

This swaps the existing `@wordpress/icons` import from `download` to `external` for the Export dock item. The label and pane behavior stay unchanged.

Before:

![Dock Export button with download icon](https://gist.githubusercontent.com/adamziel/221fdc743a154c1e378eeb9958953416/raw/45018100c3032654f12e9d3e10cabfebfe8af50d/before.png)

After:

![Dock Export button with open outward icon](https://gist.githubusercontent.com/adamziel/221fdc743a154c1e378eeb9958953416/raw/2f96cf24db084ed61e0973bdf37ba83849a08d95/after-open-outward-aligned-full-dock.png)

Tested with:

```bash
npx nx test playground-website --testFile=dock-item-button.spec.tsx
```
