### PR TITLE
[Website] Restyle the GitHub connect prompt to match the Dock

### DIFF
--- a/packages/playground/website/src/components/saved-playgrounds-panel/style.module.css
+++ b/packages/playground/website/src/components/saved-playgrounds-panel/style.module.css
@@ -991,35 +991,6 @@
 	color: var(--color-alert-red, #cc1818);
 }
 
-/* The pane's one filled primary: bring the GitHub connect CTA into the accent
-   button language (it ships as a foreign full-width #000 bar from the modal). */
-.playgrounds-pane
-	.inlineForm
-	:global(a[aria-label='Connect your GitHub account']) {
-	align-self: flex-start;
-	background: var(--accent, #3858e9);
-	border-radius: var(--radius-control, 6px);
-	color: #ffffff;
-	font-size: 14px;
-	font-weight: 600;
-	gap: 8px;
-	padding: 10px 16px;
-	transition: background 0.12s ease;
-}
-
-.playgrounds-pane
-	.inlineForm
-	:global(a[aria-label='Connect your GitHub account']:hover) {
-	background: var(--accent-hover, #2f4ad1);
-}
-
-.playgrounds-pane
-	.inlineForm
-	:global(a[aria-label='Connect your GitHub account'] svg) {
-	height: 18px;
-	width: 18px;
-}
-
 .playgrounds-pane .inlineForm :global(h3) {
 	color: var(--ink, #21201d);
 	font-size: 14px;

--- a/packages/playground/website/src/github/github-oauth-guard/index.tsx
+++ b/packages/playground/website/src/github/github-oauth-guard/index.tsx
@@ -47,7 +47,7 @@ export default function GitHubOAuthGuard({
 }: GitHubOAuthGuardProps) {
 	if (oAuthState.value.isAuthorizing) {
 		return (
-			<div>
+			<div className={css.authorizing}>
 				<Spinner />
 				<p>
 					Authorization popup opened. Continue in the popup to connect
@@ -80,7 +80,7 @@ function Authenticate({
 	});
 
 	return (
-		<div>
+		<div className={css.authenticate}>
 			<p>
 				{intro ??
 					'Importing plugins, themes, and wp-content directories directly from your public GitHub repositories.'}
@@ -95,7 +95,7 @@ function Authenticate({
 						The authentication flow opens in a popup. Your running
 						Playground will stay open.
 					</p>
-					<label style={{ cursor: 'pointer' }}>
+					<label className={css.confirm}>
 						<input
 							type="checkbox"
 							checked={exported}
@@ -106,25 +106,27 @@ function Authenticate({
 					</label>
 				</>
 			) : null}
-			<p>
-				<a
-					aria-label="Connect your GitHub account"
-					className={buttonClass}
-					href={new URL('oauth.php', window.location.href).toString()}
-					onClick={async (e) => {
-						e.preventDefault();
-						if (mayLoseProgress && !exported) {
-							return;
-						}
-						await connectToGitHub({ setError });
-					}}
-				>
-					<Icon icon={GitHubIcon} />
-					Connect your GitHub account
-				</a>
-			</p>
-			{error ? <p role="alert">{error}</p> : null}
-			<p>
+			<a
+				aria-label="Connect your GitHub account"
+				className={buttonClass}
+				href={new URL('oauth.php', window.location.href).toString()}
+				onClick={async (e) => {
+					e.preventDefault();
+					if (mayLoseProgress && !exported) {
+						return;
+					}
+					await connectToGitHub({ setError });
+				}}
+			>
+				<Icon icon={GitHubIcon} />
+				Connect your GitHub account
+			</a>
+			{error ? (
+				<p className={css.error} role="alert">
+					{error}
+				</p>
+			) : null}
+			<p className={css.note}>
 				Your access token is not stored anywhere, which means you'll
 				have to re-authenticate after every page refresh.
 			</p>

--- a/packages/playground/website/src/github/github-oauth-guard/style.module.css
+++ b/packages/playground/website/src/github/github-oauth-guard/style.module.css
@@ -1,43 +1,96 @@
+/* The unauthenticated "connect" state renders inside the dock panes and inside
+   plain modals, so every color and radius reads from the pane tokens with a
+   matching literal fallback for the modal surface.
+
+   Selectors double the root class to outrank the overlay's legacy `.section p`
+   retheme (see saved-playgrounds-panel) without relying on stylesheet order. */
 .authenticate {
+	align-items: flex-start;
 	display: flex;
 	flex-direction: column;
 	gap: 12px;
 }
 
-.note {
-	margin: 0;
-	color: #8a857b;
-	font-size: 12px;
-	line-height: 1.45;
-}
-
-.error {
-	margin: 0;
-	color: #b32d2e;
+.authenticate.authenticate p {
+	color: var(--ink-muted, #5f5b54);
 	font-size: 13px;
-	line-height: 1.45;
+	line-height: 1.5;
+	margin: 0;
+	max-width: 60ch;
 }
 
-.github-button {
-	align-self: flex-start;
-	padding: 10px 20px;
-	background-color: var(--accent, #3858e9);
-	color: #fff;
-	border: none;
-	border-radius: 6px;
-	font-size: 16px;
-	font-weight: 600;
+/* Fine print reads one step quieter than body copy. */
+.authenticate.authenticate p.note {
+	color: var(--ink-faint, #8a857b);
+	font-size: 12px;
+}
+
+.authenticate.authenticate p.error {
+	color: var(--color-alert-red, #cc1818);
+}
+
+.confirm {
+	align-items: flex-start;
+	color: var(--ink-soft, #2f2d28);
 	cursor: pointer;
-	transition: background-color 0.3s ease;
-	text-decoration: none;
 	display: flex;
-	gap: 10px;
+	font-size: 13px;
+	gap: 8px;
+	line-height: 1.5;
+}
+
+.confirm input {
+	accent-color: var(--accent, #3858e9);
+	flex-shrink: 0;
+	margin: 2px 0 0;
+}
+
+.authorizing {
 	align-items: center;
+	display: flex;
+	gap: 4px;
+}
+
+.authorizing.authorizing p {
+	color: var(--ink-muted, #5f5b54);
+	font-size: 13px;
+	line-height: 1.5;
+	margin: 0;
+}
+
+/* The one filled primary of the flow: inline width, accent fill, and the same
+   type and radius as the dock's primary buttons. */
+.github-button {
+	align-items: center;
+	background: var(--accent, #3858e9);
+	border: none;
+	border-radius: var(--radius-control, 6px);
+	color: #fff;
+	cursor: pointer;
+	display: inline-flex;
+	font-size: 14px;
+	font-weight: 600;
+	gap: 8px;
 	justify-content: center;
+	padding: 10px 16px;
+	text-decoration: none;
+	transition: background 0.12s ease;
+}
+
+.github-button svg {
+	fill: currentColor;
+	height: 18px;
+	width: 18px;
 }
 
 .github-button:hover {
-	background-color: var(--accent-hover, #2f4ad1);
+	background: var(--accent-hover, #2f4ad1);
+	color: #fff;
+}
+
+.github-button:focus-visible {
+	box-shadow: inset 0 0 0 2px rgba(255, 255, 255, 0.85);
+	outline: none;
 }
 
 .github-button.disabled {

--- a/packages/playground/website/src/github/github-oauth-guard/style.module.css
+++ b/packages/playground/website/src/github/github-oauth-guard/style.module.css
@@ -11,7 +11,8 @@
 	gap: 12px;
 }
 
-.authenticate.authenticate p {
+.authenticate.authenticate p,
+.authorizing.authorizing p {
 	color: var(--ink-muted, #5f5b54);
 	font-size: 13px;
 	line-height: 1.5;
@@ -49,13 +50,6 @@
 	align-items: center;
 	display: flex;
 	gap: 4px;
-}
-
-.authorizing.authorizing p {
-	color: var(--ink-muted, #5f5b54);
-	font-size: 13px;
-	line-height: 1.5;
-	margin: 0;
 }
 
 /* The one filled primary of the flow: inline width, accent fill, and the same


### PR DESCRIPTION
## What it does

Restyles the unauthenticated "Connect your GitHub account" state to match the Dock design language. It shows up in three places — the New Playground → From GitHub tab, Export → Export to GitHub, and the private-repo auth modal — and all three pick up the new look.

## Rationale

`GitHubOAuthGuard` still shipped its own modal-era styling: a full-width blue slab CTA, 16px type, and fine print styled like body copy. The New Playground pane tried to fix it from the outside with `a[aria-label='Connect your GitHub account']` overrides in `saved-playgrounds-panel/style.module.css`, but they missed — the anchor sat inside a `<p>`, so the pane's `align-self: flex-start` never applied and the button stayed a full-width bar.

## Implementation

Restyle the guard at the source instead of patching it per-surface:

- `Authenticate` renders a `.authenticate` flex column: 13px `--ink-muted` body copy, an inline accent CTA (14px/600, `--radius-control`, 18px GitHub mark), and the token note demoted to 12px `--ink-faint` fine print. The previously-unused `.note`/`.error` classes are now wired up, and the `mayLoseProgress` checkbox and authorizing-spinner states get the same treatment.
- Every rule reads the Dock tokens with literal fallbacks (`var(--accent, #3858e9)`), so the guard renders identically inside plain modals that don't define the pane tokens.
- Selectors double the root class (`.authenticate.authenticate p`) to outrank the overlay's legacy `.section p` retheme without depending on stylesheet injection order.
- The now-dead outside patch in `saved-playgrounds-panel/style.module.css` is removed.

## Screenshots

### New Playground → From GitHub

| Before | After |
| --- | --- |
| ![Before: New Playground GitHub tab](https://raw.githubusercontent.com/WordPress/wordpress-playground/10a963a5405c89ae0ed96b83eec4f812b62c2a23/pr-assets/4094/before/new-github.png) | ![After: New Playground GitHub tab](https://raw.githubusercontent.com/WordPress/wordpress-playground/10a963a5405c89ae0ed96b83eec4f812b62c2a23/pr-assets/4094/after/new-github.png) |

### Export → Export to GitHub

| Before | After |
| --- | --- |
| ![Before: Export to GitHub](https://raw.githubusercontent.com/WordPress/wordpress-playground/10a963a5405c89ae0ed96b83eec4f812b62c2a23/pr-assets/4094/before/export-github.png) | ![After: Export to GitHub](https://raw.githubusercontent.com/WordPress/wordpress-playground/10a963a5405c89ae0ed96b83eec4f812b62c2a23/pr-assets/4094/after/export-github.png) |

## Testing instructions

1. `npm run dev`, open **New Playground → From GitHub** while not connected to GitHub — the prompt shows an inline accent button with quiet fine print below it.
2. Open **Export → Export to GitHub** — same treatment.
3. `npx nx test playground-website --testFile=index.spec.tsx`, lint, and typecheck pass.
