### PR TITLE
[Website] Anchor the autosave nudge to the Playgrounds Dock button

### DIFF
--- a/packages/playground/website/playwright/e2e/website-ui.spec.ts
+++ b/packages/playground/website/playwright/e2e/website-ui.spec.ts
@@ -2878,7 +2878,7 @@ test.describe('Default Playground storage', () => {
 		await expect(
 			website.page
 				.getByLabel('Recent autosaved Playground')
-				.getByText('Recent autosave available', { exact: true })
+				.getByText('Recent autosave', { exact: true })
 		).toBeVisible();
 		await website.waitForNestedIframes();
 		await expect(
@@ -2926,7 +2926,7 @@ echo get_option('blogname');
 		const nudge = website.page.getByLabel('Recent autosaved Playground');
 		await expect(nudge).toBeVisible();
 		await nudge
-			.getByRole('button', { name: 'Stop showing autosave prompts' })
+			.getByRole('button', { name: 'Don’t notify me about autosaves' })
 			.click();
 		await expect(nudge).toHaveCount(0);
 		await expect(

--- a/packages/playground/website/src/components/dock/dock.tsx
+++ b/packages/playground/website/src/components/dock/dock.tsx
@@ -220,6 +220,7 @@ export function Dock({
 	const recentAutosaveNudgeVisible = useRecentAutosaveNudgeVisible();
 	const setRecentAutosaveNudgeAnchor = useSetRecentAutosaveNudgeAnchor();
 	const playgroundsButtonRef = useRef<HTMLButtonElement>(null);
+	const dockStatusRef = useRef<HTMLDivElement>(null);
 	const operationNotice = useAppSelector(
 		(state) => state.ui.dockOperationNotice
 	);
@@ -412,15 +413,18 @@ export function Dock({
 		setIsMaximizing(false);
 	}, [section, dockPaneIsOpen]);
 
-	// The autosave nudge points at the Playgrounds button, so only offer that
-	// button as an anchor while it is actually on screen. A collapsed or
-	// cornered Dock hides the tools row, and the nudge then falls back to its
-	// free-floating position instead of pointing at nothing.
+	// The autosave nudge points at the Playgrounds button, or at the save
+	// status when a collapsed Dock hides the tools row. A cornered Dock shows
+	// neither, and the nudge then falls back to its free-floating position
+	// instead of pointing at nothing.
 	useEffect(() => {
-		const playgroundsButtonVisible = !isCollapsed && cornerSide === null;
-		setRecentAutosaveNudgeAnchor(
-			playgroundsButtonVisible ? playgroundsButtonRef.current : null
-		);
+		if (cornerSide !== null) {
+			setRecentAutosaveNudgeAnchor(null);
+		} else if (isCollapsed) {
+			setRecentAutosaveNudgeAnchor(dockStatusRef.current);
+		} else {
+			setRecentAutosaveNudgeAnchor(playgroundsButtonRef.current);
+		}
 		return () => setRecentAutosaveNudgeAnchor(null);
 	}, [isCollapsed, cornerSide, setRecentAutosaveNudgeAnchor]);
 
@@ -1215,7 +1219,7 @@ export function Dock({
 								}
 							/>
 						</div>
-						<div className={css.dockStatus}>
+						<div className={css.dockStatus} ref={dockStatusRef}>
 							{playgroundTitle && (
 								<span
 									className={css.dockSiteName}

--- a/packages/playground/website/src/components/dock/dock.tsx
+++ b/packages/playground/website/src/components/dock/dock.tsx
@@ -47,7 +47,10 @@ import playgroundLogoUrl from '../../playground-logo.svg';
 import AddressBar from '../address-bar';
 import { SaveStatusIndicator } from '../browser-chrome/save-status-indicator';
 import { SiteManager } from '../site-manager';
-import { useRecentAutosaveNudgeVisible } from '../ensure-playground-site/recent-autosave-nudge-context';
+import {
+	useRecentAutosaveNudgeVisible,
+	useSetRecentAutosaveNudgeAnchor,
+} from '../ensure-playground-site/recent-autosave-nudge-context';
 import { TruncatedText } from '../truncated-text';
 import { DockCornerLauncher } from './dock-corner-launcher';
 import { DockItemButton } from './dock-item-button';
@@ -215,6 +218,8 @@ export function Dock({
 	const inlineRename = useInlineRename();
 	const canManageActiveSite = activeSite?.metadata.storage !== 'none';
 	const recentAutosaveNudgeVisible = useRecentAutosaveNudgeVisible();
+	const setRecentAutosaveNudgeAnchor = useSetRecentAutosaveNudgeAnchor();
+	const playgroundsButtonRef = useRef<HTMLButtonElement>(null);
 	const operationNotice = useAppSelector(
 		(state) => state.ui.dockOperationNotice
 	);
@@ -406,6 +411,18 @@ export function Dock({
 		setIsFolding(false);
 		setIsMaximizing(false);
 	}, [section, dockPaneIsOpen]);
+
+	// The autosave nudge points at the Playgrounds button, so only offer that
+	// button as an anchor while it is actually on screen. A collapsed or
+	// cornered Dock hides the tools row, and the nudge then falls back to its
+	// free-floating position instead of pointing at nothing.
+	useEffect(() => {
+		const playgroundsButtonVisible = !isCollapsed && cornerSide === null;
+		setRecentAutosaveNudgeAnchor(
+			playgroundsButtonVisible ? playgroundsButtonRef.current : null
+		);
+		return () => setRecentAutosaveNudgeAnchor(null);
+	}, [isCollapsed, cornerSide, setRecentAutosaveNudgeAnchor]);
 
 	// The overlay query parameter only describes New and Playgrounds. Remove it
 	// when that requested pane closes or another Dock destination replaces it.
@@ -1234,6 +1251,11 @@ export function Dock({
 						{DOCK_ITEMS.map((item, index) => (
 							<DockItemButton
 								key={item.section}
+								ref={
+									item.section === 'playgrounds'
+										? playgroundsButtonRef
+										: undefined
+								}
 								label={item.label}
 								ariaLabel={item.ariaLabel}
 								icon={item.icon}

--- a/packages/playground/website/src/components/ensure-playground-site/ensure-playground-site-is-selected.tsx
+++ b/packages/playground/website/src/components/ensure-playground-site/ensure-playground-site-is-selected.tsx
@@ -1,12 +1,14 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import classNames from 'classnames';
-import { Button, Popover } from '@wordpress/components';
+import { Button, Icon, Popover } from '@wordpress/components';
+import { close, wordpress } from '@wordpress/icons';
 import css from './restore-autosave-nudge.module.css';
 import { useCurrentUrl } from '../../lib/state/url/router-hooks';
 import { isSiteSavingDisabled } from '../../lib/state/url/router';
 import { opfsSiteStorage } from '../../lib/state/opfs/opfs-site-storage';
 import {
 	OPFSSitesLoaded,
+	getSiteRecencyTimestamp,
 	isAutosavedSite,
 	selectSiteBySlug,
 	selectSortedSites,
@@ -363,9 +365,6 @@ export function EnsurePlaygroundSiteIsSelected({
 							setIsAutosaveNudgeActionPending(false);
 						}
 					}}
-					onKeepNew={async () => {
-						await keepNewPlayground();
-					}}
 					onDismiss={async () => {
 						await keepNewPlayground();
 					}}
@@ -384,16 +383,16 @@ export function EnsurePlaygroundSiteIsSelected({
 /**
  * Shows the restore choice for a recent autosave matching the current setup URL.
  *
- * The choice concerns saved Playgrounds, so the card sits above the Dock with
- * a caret pointing at the Playgrounds button. When that button is off screen
- * (collapsed or cornered Dock), the card floats in the top-right corner.
+ * The choice concerns saved Playgrounds, so the card is anchored right above
+ * the Playgrounds Dock button with a caret pointing at it. When that button is
+ * off screen (collapsed or cornered Dock), the card floats in the top-right
+ * corner instead.
  */
 function YouHaveAutosaveNudge({
 	site,
 	error,
 	isBusy,
 	onRestore,
-	onKeepNew,
 	onDismiss,
 	onDisableNotifications,
 }: {
@@ -401,13 +400,12 @@ function YouHaveAutosaveNudge({
 	error?: string;
 	isBusy: boolean;
 	onRestore: () => Promise<void>;
-	onKeepNew: () => Promise<void>;
 	onDismiss: () => Promise<void>;
 	onDisableNotifications: () => Promise<void>;
 }) {
 	const nudgeRef = useRef<HTMLElement>(null);
 	const anchorButton = useRecentAutosaveNudgeAnchor();
-	const createdAt = new Date(site.metadata.whenCreated ?? Date.now());
+	const autosavedAt = new Date(getSiteRecencyTimestamp(site) || Date.now());
 
 	useEffect(() => {
 		const dismissOnOutsidePointer = (event: PointerEvent) => {
@@ -419,90 +417,72 @@ function YouHaveAutosaveNudge({
 		return listenForPointerDownAcrossIframes(dismissOnOutsidePointer);
 	}, [isBusy, onDismiss]);
 
-	// On desktop the Playgrounds button sits below the Dock's address row, so
-	// anchoring to the button's horizontal position combined with the Dock's
-	// top edge keeps the card above the whole Dock while the caret still
-	// points down at the button.
-	const popoverAnchor = useMemo(() => {
-		if (!anchorButton) {
-			return null;
-		}
-		const dock = anchorButton.closest('nav');
-		return {
-			getBoundingClientRect() {
-				const buttonRect = anchorButton.getBoundingClientRect();
-				const dockTop =
-					dock?.getBoundingClientRect().top ?? buttonRect.top;
-				return new window.DOMRect(
-					buttonRect.x,
-					dockTop,
-					buttonRect.width,
-					Math.max(buttonRect.bottom - dockTop, 0)
-				);
-			},
-		};
-	}, [anchorButton]);
-
 	const card = (
 		<aside
 			ref={nudgeRef}
 			className={classNames(css.nudge, {
-				[css.nudgeFloating]: !popoverAnchor,
+				[css.nudgeFloating]: !anchorButton,
 			})}
 			aria-label="Recent autosaved Playground"
 		>
-			<div className={css.copy}>
-				<div className={css.title}>Recent autosave available</div>
-				<div className={css.description}>
-					Another Playground was created {getRelativeDate(createdAt)}{' '}
-					from the same URL.
-				</div>
-				{error && (
-					<div className={css.error} role="alert">
-						{error}
+			<div className={css.header}>
+				<div className={css.eyebrow}>Recent autosave</div>
+				<Button
+					className={css.dismiss}
+					icon={close}
+					label="Dismiss and keep this Playground"
+					onClick={onDismiss}
+					disabled={isBusy}
+				/>
+			</div>
+			<div className={css.site}>
+				<span className={css.siteAvatar} aria-hidden="true">
+					<Icon icon={wordpress} size={28} />
+				</span>
+				<div className={css.siteCopy}>
+					<div className={css.siteName}>{site.metadata.name}</div>
+					<div className={css.siteMeta}>
+						Autosaved {getRelativeDate(autosavedAt)}
 					</div>
-				)}
-			</div>
-			<div className={css.actions}>
-				<div className={css.decisionActions}>
-					<Button
-						variant="primary"
-						onClick={onRestore}
-						disabled={isBusy}
-					>
-						Restore Autosave
-					</Button>
-					<Button
-						variant="tertiary"
-						onClick={onKeepNew}
-						disabled={isBusy}
-					>
-						Keep this Playground
-					</Button>
-				</div>
-				<div className={css.preferenceAction}>
-					<Button
-						variant="link"
-						className={css.disableNotifications}
-						onClick={onDisableNotifications}
-						disabled={isBusy}
-					>
-						Stop showing autosave prompts
-					</Button>
 				</div>
 			</div>
+			{error && (
+				<div className={css.error} role="alert">
+					{error}
+				</div>
+			)}
+			<Button
+				variant="primary"
+				className={css.restore}
+				onClick={onRestore}
+				disabled={isBusy}
+			>
+				Restore autosave
+			</Button>
+			<p className={css.hint}>
+				Kept in this browser as a periodic snapshot — not every change
+				is saved.
+			</p>
+			<Button
+				variant="link"
+				className={css.disableNotifications}
+				onClick={onDisableNotifications}
+				disabled={isBusy}
+			>
+				Don’t notify me about autosaves
+			</Button>
 		</aside>
 	);
 
-	if (!popoverAnchor) {
+	if (!anchorButton) {
 		return card;
 	}
 	return (
 		<Popover
 			className={css.nudgePopover}
-			anchor={popoverAnchor}
+			anchor={anchorButton}
 			placement="top"
-			offset={16}
+			offset={18}
 			shift
 			noArrow={false}
 			focusOnMount={false}

--- a/packages/playground/website/src/components/ensure-playground-site/ensure-playground-site-is-selected.tsx
+++ b/packages/playground/website/src/components/ensure-playground-site/ensure-playground-site-is-selected.tsx
@@ -101,8 +101,14 @@ export function EnsurePlaygroundSiteIsSelected({
 		() => getAutosaveFingerprintFromURL(url),
 		[url.href]
 	);
+	// An open Dock pane owns the screen (all of it on mobile), so the nudge
+	// waits for it to close instead of covering it. This also keeps Escape
+	// working for the pane: the Dock lets any open popover consume Escape
+	// first, but the nudge popover never does.
+	const dockPaneIsOpen = useAppSelector((state) => state.ui.dockPaneIsOpen);
 	const canShowAutosaveNudge =
 		youHaveAutosaveNudgeEnabled &&
+		!dockPaneIsOpen &&
 		autosaveNudge &&
 		activeSite &&
 		activeSite.slug !== autosaveNudge.site.slug &&

--- a/packages/playground/website/src/components/ensure-playground-site/ensure-playground-site-is-selected.tsx
+++ b/packages/playground/website/src/components/ensure-playground-site/ensure-playground-site-is-selected.tsx
@@ -390,9 +390,9 @@ export function EnsurePlaygroundSiteIsSelected({
  * Shows the restore choice for a recent autosave matching the current setup URL.
  *
  * The choice concerns saved Playgrounds, so the card is anchored right above
- * the Playgrounds Dock button with a caret pointing at it. When that button is
- * off screen (collapsed or cornered Dock), the card floats in the top-right
- * corner instead.
+ * the Playgrounds Dock button with a caret pointing at it. A collapsed Dock
+ * hides that button and the caret points at the save status instead; a
+ * cornered Dock shows neither and the card floats in the top-right corner.
  */
 function YouHaveAutosaveNudge({
 	site,

--- a/packages/playground/website/src/components/ensure-playground-site/ensure-playground-site-is-selected.tsx
+++ b/packages/playground/website/src/components/ensure-playground-site/ensure-playground-site-is-selected.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { Button } from '@wordpress/components';
+import classNames from 'classnames';
+import { Button, Popover } from '@wordpress/components';
 import css from './restore-autosave-nudge.module.css';
 import { useCurrentUrl } from '../../lib/state/url/router-hooks';
 import { isSiteSavingDisabled } from '../../lib/state/url/router';
@@ -34,7 +35,10 @@ import {
 } from '../../lib/state/playground-identity';
 import { getRelativeDate } from '../../lib/get-relative-date';
 import { listenForPointerDownAcrossIframes } from './listen-for-pointer-down-across-iframes';
-import { RecentAutosaveNudgeProvider } from './recent-autosave-nudge-context';
+import {
+	RecentAutosaveNudgeProvider,
+	useRecentAutosaveNudgeAnchor,
+} from './recent-autosave-nudge-context';
 
 /**
  * Ensures the redux store always has an activeSite value.
@@ -379,6 +383,10 @@ export function EnsurePlaygroundSiteIsSelected({
 
 /**
  * Shows the restore choice for a recent autosave matching the current setup URL.
+ *
+ * The choice concerns saved Playgrounds, so the card sits above the Dock with
+ * a caret pointing at the Playgrounds button. When that button is off screen
+ * (collapsed or cornered Dock), the card floats in the top-right corner.
  */
 function YouHaveAutosaveNudge({
 	site,
@@ -398,6 +406,7 @@ function YouHaveAutosaveNudge({
 	onDisableNotifications: () => Promise<void>;
 }) {
 	const nudgeRef = useRef<HTMLElement>(null);
+	const anchorButton = useRecentAutosaveNudgeAnchor();
 	const createdAt = new Date(site.metadata.whenCreated ?? Date.now());
 
 	useEffect(() => {
@@ -410,10 +419,36 @@ function YouHaveAutosaveNudge({
 		return listenForPointerDownAcrossIframes(dismissOnOutsidePointer);
 	}, [isBusy, onDismiss]);
 
-	return (
+	// On desktop the Playgrounds button sits below the Dock's address row, so
+	// anchoring to the button's horizontal position combined with the Dock's
+	// top edge keeps the card above the whole Dock while the caret still
+	// points down at the button.
+	const popoverAnchor = useMemo(() => {
+		if (!anchorButton) {
+			return null;
+		}
+		const dock = anchorButton.closest('nav');
+		return {
+			getBoundingClientRect() {
+				const buttonRect = anchorButton.getBoundingClientRect();
+				const dockTop =
+					dock?.getBoundingClientRect().top ?? buttonRect.top;
+				return new window.DOMRect(
+					buttonRect.x,
+					dockTop,
+					buttonRect.width,
+					Math.max(buttonRect.bottom - dockTop, 0)
+				);
+			},
+		};
+	}, [anchorButton]);
+
+	const card = (
 		<aside
 			ref={nudgeRef}
-			className={css.nudge}
+			className={classNames(css.nudge, {
+				[css.nudgeFloating]: !popoverAnchor,
+			})}
 			aria-label="Recent autosaved Playground"
 		>
 			<div className={css.copy}>
@@ -457,5 +492,22 @@ function YouHaveAutosaveNudge({
 				</div>
 			</div>
 		</aside>
+	);
+
+	if (!popoverAnchor) {
+		return card;
+	}
+	return (
+		<Popover
+			className={css.nudgePopover}
+			anchor={popoverAnchor}
+			placement="top"
+			offset={16}
+			shift
+			noArrow={false}
+			focusOnMount={false}
+		>
+			{card}
+		</Popover>
 	);
 }

--- a/packages/playground/website/src/components/ensure-playground-site/ensure-playground-site-is-selected.tsx
+++ b/packages/playground/website/src/components/ensure-playground-site/ensure-playground-site-is-selected.tsx
@@ -474,20 +474,24 @@ function YouHaveAutosaveNudge({
 		</aside>
 	);
 
-	if (!anchorButton) {
-		return card;
-	}
 	return (
-		<Popover
-			className={css.nudgePopover}
-			anchor={anchorButton}
-			placement="top"
-			offset={18}
-			shift
-			noArrow={false}
-			focusOnMount={false}
-		>
-			{card}
-		</Popover>
+		<>
+			<div className={css.scrim} aria-hidden="true" />
+			{anchorButton ? (
+				<Popover
+					className={css.nudgePopover}
+					anchor={anchorButton}
+					placement="top"
+					offset={18}
+					shift
+					noArrow={false}
+					focusOnMount={false}
+				>
+					{card}
+				</Popover>
+			) : (
+				card
+			)}
+		</>
 	);
 }

--- a/packages/playground/website/src/components/ensure-playground-site/recent-autosave-nudge-context.tsx
+++ b/packages/playground/website/src/components/ensure-playground-site/recent-autosave-nudge-context.tsx
@@ -1,6 +1,23 @@
-import { createContext, useContext, type ReactNode } from 'react';
+import {
+	createContext,
+	useContext,
+	useMemo,
+	useState,
+	type ReactNode,
+} from 'react';
 
-const RecentAutosaveNudgeContext = createContext(false);
+type RecentAutosaveNudgeContextValue = {
+	visible: boolean;
+	anchor: HTMLElement | null;
+	setAnchor: (anchor: HTMLElement | null) => void;
+};
+
+const RecentAutosaveNudgeContext =
+	createContext<RecentAutosaveNudgeContextValue>({
+		visible: false,
+		anchor: null,
+		setAnchor: () => {},
+	});
 RecentAutosaveNudgeContext.displayName = 'RecentAutosaveNudgeContext';
 
 export function RecentAutosaveNudgeProvider({
@@ -10,13 +27,30 @@ export function RecentAutosaveNudgeProvider({
 	children: ReactNode;
 	visible: boolean;
 }) {
+	const [anchor, setAnchor] = useState<HTMLElement | null>(null);
+	const value = useMemo(
+		() => ({ visible, anchor, setAnchor }),
+		[visible, anchor]
+	);
 	return (
-		<RecentAutosaveNudgeContext.Provider value={visible}>
+		<RecentAutosaveNudgeContext.Provider value={value}>
 			{children}
 		</RecentAutosaveNudgeContext.Provider>
 	);
 }
 
 export function useRecentAutosaveNudgeVisible(): boolean {
-	return useContext(RecentAutosaveNudgeContext);
+	return useContext(RecentAutosaveNudgeContext).visible;
+}
+
+/** The on-screen Playgrounds Dock button the nudge should point at, if any. */
+export function useRecentAutosaveNudgeAnchor(): HTMLElement | null {
+	return useContext(RecentAutosaveNudgeContext).anchor;
+}
+
+/** Lets the Dock report the Playgrounds button as the nudge anchor. */
+export function useSetRecentAutosaveNudgeAnchor(): (
+	anchor: HTMLElement | null
+) => void {
+	return useContext(RecentAutosaveNudgeContext).setAnchor;
 }

--- a/packages/playground/website/src/components/ensure-playground-site/restore-autosave-nudge.module.css
+++ b/packages/playground/website/src/components/ensure-playground-site/restore-autosave-nudge.module.css
@@ -149,7 +149,26 @@
 	text-decoration: underline !important;
 }
 
+/* On phones the sheet sits directly on page content and its 1px gutters leave
+   no room for a shadow to read, so a passive scrim provides the separation.
+   It stays below the Dock (50) so the Playgrounds button the caret points at
+   keeps full contrast, and it ignores pointer events so a tap anywhere
+   outside still dismisses the nudge. */
+.scrim {
+	display: none;
+}
+
 @media (max-width: 600px) {
+	.scrim {
+		display: block;
+		position: fixed;
+		z-index: 25;
+		inset: 0;
+		background: rgb(0 0 0 / 40%);
+		animation: scrimFadeIn 200ms ease-out;
+		pointer-events: none;
+	}
+
 	/* Phones get a compact sheet: tighter spacing, and the anchored card
 	   spans the viewport right above the Dock's bottom bar. */
 	.nudge {
@@ -166,5 +185,15 @@
 		left: 12px;
 		right: 12px;
 		width: auto;
+	}
+}
+
+@keyframes scrimFadeIn {
+	from {
+		opacity: 0;
+	}
+
+	to {
+		opacity: 1;
 	}
 }

--- a/packages/playground/website/src/components/ensure-playground-site/restore-autosave-nudge.module.css
+++ b/packages/playground/website/src/components/ensure-playground-site/restore-autosave-nudge.module.css
@@ -1,8 +1,4 @@
 .nudge {
-	position: fixed;
-	z-index: 30;
-	top: 62px;
-	right: 16px;
 	display: flex;
 	align-items: stretch;
 	flex-direction: column;
@@ -10,11 +6,39 @@
 	box-sizing: border-box;
 	width: min(400px, calc(100vw - 32px));
 	padding: 18px;
+	color: #1e1e1e;
+}
+
+/* Fallback position for when the Playgrounds Dock button is off screen and
+   the card cannot point at it. */
+.nudgeFloating {
+	position: fixed;
+	z-index: 30;
+	top: 62px;
+	right: 16px;
 	background: #fff;
 	border: 1px solid #dcdcde;
 	border-radius: 6px;
 	box-shadow: 0 8px 24px rgb(0 0 0 / 14%);
-	color: #1e1e1e;
+}
+
+/* Keep the anchored nudge above the Dock (50) but below any modal overlay. */
+.nudgePopover:global(.components-popover) {
+	z-index: 60;
+}
+
+/* The popover shell carries the card visuals so its caret can blend into the
+   card's bottom border. */
+.nudgePopover :global(.components-popover__content) {
+	width: auto;
+	background: #fff;
+	border: 1px solid #dcdcde;
+	border-radius: 6px;
+	box-shadow: 0 8px 24px rgb(0 0 0 / 14%);
+}
+
+.nudgePopover :global(.components-popover__triangle-border) {
+	stroke: #dcdcde;
 }
 
 .copy {
@@ -70,7 +94,22 @@
 }
 
 @media (max-width: 600px) {
+	/* Phones get a compact sheet: tighter spacing, and the anchored card
+	   spans the viewport right above the Dock's bottom bar. */
 	.nudge {
+		padding: 14px 16px;
+		gap: 12px;
+	}
+
+	.nudgePopover .nudge {
+		width: calc(100vw - 4px);
+	}
+
+	.preferenceAction {
+		padding-top: 10px;
+	}
+
+	.nudgeFloating {
 		top: 108px;
 		left: 12px;
 		right: 12px;

--- a/packages/playground/website/src/components/ensure-playground-site/restore-autosave-nudge.module.css
+++ b/packages/playground/website/src/components/ensure-playground-site/restore-autosave-nudge.module.css
@@ -2,10 +2,10 @@
 	display: flex;
 	align-items: stretch;
 	flex-direction: column;
-	gap: 16px;
+	gap: 14px;
 	box-sizing: border-box;
 	width: min(400px, calc(100vw - 32px));
-	padding: 18px;
+	padding: 20px;
 	color: #1e1e1e;
 }
 
@@ -17,9 +17,11 @@
 	top: 62px;
 	right: 16px;
 	background: #fff;
-	border: 1px solid #dcdcde;
-	border-radius: 6px;
-	box-shadow: 0 8px 24px rgb(0 0 0 / 14%);
+	border-radius: 12px;
+	box-shadow:
+		0 0 0 1px rgb(0 0 0 / 6%),
+		0 8px 20px rgb(0 0 0 / 18%),
+		0 24px 64px rgb(0 0 0 / 28%);
 }
 
 /* Keep the anchored nudge above the Dock (50) but below any modal overlay. */
@@ -28,85 +30,135 @@
 }
 
 /* The popover shell carries the card visuals so its caret can blend into the
-   card's bottom border. */
+   card. */
 .nudgePopover :global(.components-popover__content) {
 	width: auto;
 	background: #fff;
-	border: 1px solid #dcdcde;
-	border-radius: 6px;
-	box-shadow: 0 8px 24px rgb(0 0 0 / 14%);
+	border-radius: 12px;
+	box-shadow:
+		0 0 0 1px rgb(0 0 0 / 6%),
+		0 8px 20px rgb(0 0 0 / 18%),
+		0 24px 64px rgb(0 0 0 / 28%);
+}
+
+/* The stock caret is 14px square. The triangle path only fills the top half
+   of its box, so a 32px box draws a 32×16 caret pointing at the button. */
+.nudgePopover :global(.components-popover__arrow) {
+	width: 32px;
+	height: 32px;
+}
+
+.nudgePopover :global(.components-popover__arrow.is-top) {
+	bottom: -32px !important;
 }
 
 .nudgePopover :global(.components-popover__triangle-border) {
-	stroke: #dcdcde;
+	stroke: transparent;
 }
 
-.copy {
+.header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 8px;
+}
+
+.eyebrow {
+	color: #757575;
+	font-size: 11px;
+	font-weight: 600;
+	letter-spacing: 0.16em;
+	line-height: 16px;
+	text-transform: uppercase;
+}
+
+.dismiss:global(.components-button.has-icon) {
+	width: 28px;
+	min-width: 28px;
+	height: 28px;
+	margin: -4px -6px -4px 0;
+	padding: 0;
+	color: #646970;
+}
+
+.dismiss:global(.components-button.has-icon):hover {
+	color: #1e1e1e;
+}
+
+.site {
+	display: flex;
+	align-items: center;
+	gap: 12px;
+}
+
+.siteAvatar {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	flex-shrink: 0;
+	width: 44px;
+	height: 44px;
+	background: #f0f0f0;
+	border-radius: 12px;
+}
+
+.siteCopy {
 	min-width: 0;
 }
 
-.title {
-	font-size: 13px;
+.siteName {
+	overflow: hidden;
+	font-size: 15px;
 	font-weight: 600;
+	line-height: 20px;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.siteMeta {
+	margin-top: 2px;
+	color: #757575;
+	font-size: 13px;
 	line-height: 18px;
 }
 
-.description {
-	margin-top: 4px;
-	color: #50575e;
-	font-size: 12px;
-	line-height: 17px;
-}
-
 .error {
-	margin-top: 6px;
 	color: #b32d2e;
 	font-size: 12px;
 	line-height: 17px;
 }
 
-.actions {
-	display: flex;
-	align-items: flex-start;
-	flex-direction: column;
-	gap: 10px;
-}
-
-.decisionActions {
-	display: flex;
-	align-items: center;
-	flex-wrap: wrap;
-	gap: 10px;
-}
-
-.preferenceAction {
+.restore:global(.components-button.is-primary) {
+	justify-content: center;
 	width: 100%;
-	padding-top: 12px;
-	border-top: 1px solid #dcdcde;
+	height: 44px;
+	font-size: 14px;
+}
+
+.hint {
+	margin: 2px 0 0;
+	color: #757575;
+	font-size: 13px;
+	line-height: 19px;
 }
 
 .disableNotifications:global(.components-button.is-link) {
-	color: #646970;
-}
-
-.disableNotifications:global(.components-button.is-link):hover {
-	color: #3c434a;
+	align-self: flex-start;
+	font-size: 13px;
+	/* The global styles.css strips button underlines with !important. */
+	text-decoration: underline !important;
 }
 
 @media (max-width: 600px) {
 	/* Phones get a compact sheet: tighter spacing, and the anchored card
 	   spans the viewport right above the Dock's bottom bar. */
 	.nudge {
-		padding: 14px 16px;
 		gap: 12px;
+		padding: 16px;
 	}
 
 	.nudgePopover .nudge {
 		width: calc(100vw - 4px);
-	}
-
-	.preferenceAction {
-		padding-top: 10px;
 	}
 
 	.nudgeFloating {


### PR DESCRIPTION
Moves the "Recent autosave available" nudge from the top-right corner to a callout pointing straight at the Playgrounds Dock button — the place where autosaves actually live — and redesigns it as a compact card. The "Keep this Playground" button is gone: closing the callout with the × or clicking anywhere outside keeps the new Playground, exactly like that button did.

| | Before | After |
| --- | --- | --- |
| **Desktop** | <img src="https://raw.githubusercontent.com/WordPress/wordpress-playground/5269d8808617f527cace45b58765cf19fc0ce4a1/before-desktop.png" width="440" alt="The old nudge floating in the top-right corner of the viewport" /> | <img src="https://raw.githubusercontent.com/WordPress/wordpress-playground/5269d8808617f527cace45b58765cf19fc0ce4a1/after-desktop.png" width="440" alt="The new callout anchored above the Playgrounds Dock button with a caret pointing at it" /> |
| **Mobile** | <img src="https://raw.githubusercontent.com/WordPress/wordpress-playground/5269d8808617f527cace45b58765cf19fc0ce4a1/before-mobile.png" width="220" alt="The old nudge stretched below the top of the page" /> | <img src="https://raw.githubusercontent.com/WordPress/wordpress-playground/5269d8808617f527cace45b58765cf19fc0ce4a1/after-mobile.png" width="220" alt="The new full-width sheet above the bottom Dock bar with the page dimmed behind it" /> |

On phones the callout becomes a full-width sheet directly above the Dock bar. Its 1px gutters leave a drop shadow no room to read, so a passive scrim dims the page instead — it sits below the Dock so the Playgrounds button keeps full contrast, and taps pass through it, so tapping anywhere outside still dismisses the callout.

Screencasts:

| Screencasts |
| --- |
| <img src="https://raw.githubusercontent.com/WordPress/wordpress-playground/5269d8808617f527cace45b58765cf19fc0ce4a1/autosave-nudge-desktop.gif" width="720" alt="Desktop screencast of restoring an autosave from the callout" /> |
| <img src="https://raw.githubusercontent.com/WordPress/wordpress-playground/5269d8808617f527cace45b58765cf19fc0ce4a1/autosave-nudge-mobile.gif" width="280" alt="Mobile screencast of restoring an autosave from the sheet" /> |

## Testing

Open Playground, wait for the status to show **Autosaved**, then reload. The callout should point at the Playgrounds button. **Restore autosave** switches to the autosaved Playground; × or a click outside keeps the new one. Collapse the Dock while the page is still booting and the caret points at the save status pill instead; a cornered Dock falls back to a top-right floating card. Repeat at a phone width: a full-width sheet over a dimmed page.

The images above live on the orphan branch `adamziel/anchor-autosave-nudge-to-dock-assets` — do not merge or delete it while this PR is open.