### PR TITLE
[Website] Separate Blueprint warnings and errors and preserve rounded Dock panes

### DIFF
--- a/.nxignore
+++ b/.nxignore
@@ -17,3 +17,4 @@ packages/php-wasm/node/src/test/__test*
 # from the repo root or inside a worktree.
 .worktrees
 .claude
+.context

--- a/packages/playground/website/src/components/blueprint-editor/BlueprintBundleEditor.tsx
+++ b/packages/playground/website/src/components/blueprint-editor/BlueprintBundleEditor.tsx
@@ -16,7 +16,7 @@ import {
 	Notice,
 	Tooltip as WpTooltip,
 } from '@wordpress/components';
-import { chevronDown, download, help, link } from '@wordpress/icons';
+import { chevronDown, download, help, link, warning } from '@wordpress/icons';
 import {
 	resolveRuntimeConfiguration,
 	type BlueprintValidationResult,
@@ -1096,19 +1096,22 @@ export const BlueprintBundleEditor = forwardRef<
 						(opfsSyncStatus === 'syncing' ||
 							!siteIsUnfinishedBlueprintRun) ? (
 							<p className={styles.runHint}>
-								{isWaitingToRun ? (
-									'Run will wait for this Playground to finish saving.'
-								) : (
-									<>
-										Running this Blueprint creates a fresh
-										autosaved Playground. “
-										{site?.metadata.name}” stays in{' '}
-										{isAutosaved
-											? 'Recent autosaves'
-											: 'Saved Playgrounds'}
-										.
-									</>
-								)}
+								<Icon icon={warning} size={18} />
+								<span>
+									{isWaitingToRun ? (
+										'Run will wait for this Playground to finish saving.'
+									) : (
+										<>
+											Running this Blueprint creates a fresh
+											autosaved Playground. “
+											{site?.metadata.name}” stays in{' '}
+											{isAutosaved
+												? 'Recent autosaves'
+												: 'Saved Playgrounds'}
+											.
+										</>
+									)}
+								</span>
 							</p>
 						) : null}
 						{currentPath || code || messageContent ? (

--- a/packages/playground/website/src/components/blueprint-editor/blueprint-bundle-editor.module.css
+++ b/packages/playground/website/src/components/blueprint-editor/blueprint-bundle-editor.module.css
@@ -230,13 +230,23 @@
 }
 
 .runHint {
-	background: var(--paper-2, #ffffff);
-	border-bottom: 1px solid var(--line-subtle, #ddd);
-	color: var(--ink-muted, #50575e);
+	align-items: flex-start;
+	background: #fff8e5;
+	border-bottom: 1px solid #f0b849;
+	color: #614c00;
+	display: flex;
 	font-size: 13px;
+	gap: 8px;
 	line-height: 1.5;
 	margin: 0;
 	padding: 10px 16px;
+}
+
+.runHint svg {
+	color: #996800;
+	fill: currentColor;
+	flex: 0 0 auto;
+	margin-top: 1px;
 }
 
 .editorDocsLink {

--- a/packages/playground/website/src/components/dock/dock.tsx
+++ b/packages/playground/website/src/components/dock/dock.tsx
@@ -37,6 +37,7 @@ import {
 } from '../../lib/dock-full-width';
 import {
 	getActiveClientInfo,
+	selectActiveSiteError,
 	useActiveSite,
 	useAppDispatch,
 	useAppSelector,
@@ -192,6 +193,7 @@ export function Dock({
 	const dispatch = useAppDispatch();
 	const dockPaneIsOpen = useAppSelector((state) => state.ui.dockPaneIsOpen);
 	const activeModal = useAppSelector((state) => state.ui.activeModal);
+	const activeSiteError = useAppSelector(selectActiveSiteError);
 	const section = useAppSelector((state) => state.ui.dockPaneSection);
 	const shareExportOpen = useAppSelector((state) => state.ui.shareExportOpen);
 	const [newPlaygroundHeaderOverride, setNewPlaygroundHeaderOverride] =
@@ -1152,7 +1154,8 @@ export function Dock({
 					headerOverride={paneHeaderOverride}
 					className={classNames({
 						[css.hostPaneHidden]:
-							!dockPaneIsOpen && paneExitComplete,
+							Boolean(activeSiteError) ||
+							(!dockPaneIsOpen && paneExitComplete),
 						[css.paneSave]: section === 'save',
 						[css.paneWide]: isWideSection,
 					})}

--- a/packages/playground/website/src/components/dock/style.module.css
+++ b/packages/playground/website/src/components/dock/style.module.css
@@ -235,11 +235,12 @@
 	--accent: #3858e9;
 	--accent-hover: #2f4ad1;
 	--accent-link: #2645c9;
+	--radius-pane: 14px;
 	--radius-card: 8px;
 	--radius-control: 6px;
 
 	background: var(--paper-1);
-	border-radius: 14px;
+	border-radius: var(--radius-pane);
 	bottom: 94px;
 	/* Shadow only — a floating element doesn't also need a hard border
 	   (the doubled edge is a slop tell). A faint top highlight fakes a lit top. */
@@ -261,6 +262,13 @@
 	transform: translate(-50%, 0);
 	width: min(600px, calc(100vw - 40px));
 	z-index: 40;
+}
+
+/* Classic scrollbars paint their track over the pane's rounded edge. Keep the
+   track transparent and away from the corner curve. */
+.pane::-webkit-scrollbar-track {
+	background: transparent;
+	margin-block: var(--radius-pane);
 }
 
 .pane-editor {

--- a/packages/playground/website/src/components/dock/style.module.css
+++ b/packages/playground/website/src/components/dock/style.module.css
@@ -265,10 +265,13 @@
 }
 
 /* Classic scrollbars paint their track over the pane's rounded edge. Keep the
-   track transparent and away from the corner curve. */
+   track transparent and away from the corner curve. Physical margins, not
+   margin-block: logical properties resolve unreliably inside scrollbar
+   pseudo-elements, and this track is always vertical. */
 .pane::-webkit-scrollbar-track {
 	background: transparent;
-	margin-block: var(--radius-pane);
+	margin-bottom: var(--radius-pane);
+	margin-top: var(--radius-pane);
 }
 
 .pane-editor {


### PR DESCRIPTION
Part of #4099.

This pulls three visual fixes out of the larger failed Blueprint recovery work:

* Running a stored Blueprint now has an amber warning instead of another strip of editor chrome.
* A site error hides the retained Dock pane instead of stacking two workflows. The pane stays mounted, so dismissing an ordinary error restores its prior state.
* Classic scrollbar tracks are transparent and stop before the pane corners, so always-visible scrollbars no longer make the right edge square.

This PR does not decide where a failed Blueprint run should return. #4099 adds that explicit recovery flow.

## Stored Blueprint warning

### Desktop

| Before | After |
| --- | --- |
| <img width="440" alt="Stored Blueprint notice blending into the editor on desktop" src="https://raw.githubusercontent.com/WordPress/wordpress-playground/697642ee2c/before-warning-desktop.png"> | <img width="440" alt="Amber stored Blueprint warning on desktop" src="https://raw.githubusercontent.com/WordPress/wordpress-playground/697642ee2c/after-warning-desktop.png"> |

### Mobile

| Before | After |
| --- | --- |
| <img width="260" alt="Stored Blueprint notice blending into the editor on mobile" src="https://raw.githubusercontent.com/WordPress/wordpress-playground/697642ee2c/before-warning-narrow.png"> | <img width="260" alt="Amber stored Blueprint warning on mobile" src="https://raw.githubusercontent.com/WordPress/wordpress-playground/697642ee2c/after-warning-narrow.png"> |

## Desktop error and scrollbar fixes

| Change | Before | After |
| --- | --- | --- |
| Error owns the layer | <img width="320" alt="Runtime error stacked over the Blueprint editor" src="https://github.com/user-attachments/assets/ae34eacd-4c4a-41cb-bbd7-353086ad22ba"> | <img width="320" alt="Runtime error shown without the Blueprint pane behind it" src="https://github.com/user-attachments/assets/3fac5bdd-8ee6-4805-a0d8-76f942b960fc"> |
| Rounded pane corners | <img width="320" alt="Scrollbar track covering the rounded pane corners" src="https://github.com/user-attachments/assets/4a5de246-4a7d-4f25-8917-30c9d52bd6ec"> | <img width="320" alt="Scrollable pane retaining its rounded corners" src="https://github.com/user-attachments/assets/e9aa53f1-e185-4aa5-9757-9c50651c5eb9"> |

Error sheets are already full-screen on mobile, so the pane-layer and rounded-corner changes only affect the floating desktop Dock.

## Testing

1. Open a stored Playground's Blueprint and check that the run warning stands apart from the editor at desktop and mobile widths.
2. Run a Blueprint that fails and check that the Blueprint pane is not visible behind the error.
3. With classic scrollbars enabled, scroll a Dock pane and check that its right corners remain rounded.
