### PR TITLE
[Website] Give failed Blueprint runs an explicit recovery path

### DIFF
--- a/packages/playground/website/src/components/site-error-modal/site-error-modal.tsx
+++ b/packages/playground/website/src/components/site-error-modal/site-error-modal.tsx
@@ -4,10 +4,17 @@ import { logger } from '@php-wasm/logger';
 
 import { Modal } from '../modal';
 import css from './style.module.css';
-import { useAppDispatch } from '../../lib/state/redux/store';
+import {
+	setActiveSite,
+	useAppDispatch,
+	useAppSelector,
+} from '../../lib/state/redux/store';
 import { removeClientInfo } from '../../lib/state/redux/slice-clients';
 import {
 	clearActiveSiteError,
+	modalSlugs,
+	setDockPaneOpen,
+	setDockPaneSection,
 	type SerializedBlueprintStepErrorDetails,
 	type SerializedSiteErrorDetails,
 } from '../../lib/state/redux/slice-ui';
@@ -18,7 +25,11 @@ import type {
 	BlueprintStepError,
 } from './types';
 import { getSiteErrorView } from './get-site-error-view';
-import type { SiteInfo } from '../../lib/state/redux/slice-sites';
+import {
+	isUnfinishedBlueprintRun,
+	selectSiteBySlug,
+	type SiteInfo,
+} from '../../lib/state/redux/slice-sites';
 import { useKapaAI } from './use-kapa-ai';
 import { PlaygroundRoute, redirectTo } from '../../lib/state/url/router';
 
@@ -30,6 +41,18 @@ export function SiteErrorModal({
 }: SiteErrorModalProps) {
 	const dispatch = useAppDispatch();
 	const sitesAPI = useSitesAPI();
+	const siteSlugToReturnToIfBlueprintFails =
+		site.metadata.siteSlugToReturnToIfBlueprintFails;
+	const siteToReturnToIfBlueprintFails = useAppSelector((state) =>
+		siteSlugToReturnToIfBlueprintFails
+			? selectSiteBySlug(state, siteSlugToReturnToIfBlueprintFails)
+			: undefined
+	);
+	const isEditingBlueprint = useAppSelector(
+		(state) =>
+			state.ui.dockPaneIsOpen && state.ui.dockPaneSection === 'blueprint'
+	);
+	const activeModal = useAppSelector((state) => state.ui.activeModal);
 	const {
 		isReporting,
 		setIsReporting,
@@ -82,13 +105,94 @@ export function SiteErrorModal({
 	};
 
 	const blueprintStepError = extractBlueprintStepError(errorDetails);
-	const view = getSiteErrorView({
+	const isBlueprintRunFailure = isUnfinishedBlueprintRun(site);
+	const isSeamlessMode =
+		new URLSearchParams(document.location.search).get('mode') ===
+		'seamless';
+	const baseView = getSiteErrorView({
 		error,
 		site,
 		blueprintStepError,
 		helpers,
 		errorDetails,
 	});
+	const errorMessage =
+		typeof errorDetails === 'string' ? errorDetails : errorDetails?.message;
+	const recoveryBody =
+		error === 'initial-opfs-sync-interrupted' ? (
+			<p className={css.errorLead}>
+				This Blueprint run stopped before its WordPress files finished
+				saving.
+			</p>
+		) : error === 'site-boot-failed' && !blueprintStepError ? (
+			errorMessage ? (
+				<p className={css.errorLead}>{errorMessage}</p>
+			) : (
+				<p className={css.errorLead}>
+					The Blueprint run did not finish.
+				</p>
+			)
+		) : (
+			baseView.body
+		);
+	const returnOrStartAction = siteToReturnToIfBlueprintFails ? (
+		<Button
+			variant={isSeamlessMode ? 'primary' : 'secondary'}
+			key="return-to-source"
+			onClick={async () => {
+				dispatch(setActiveSite(siteToReturnToIfBlueprintFails.slug));
+				await discardFailedBlueprintRun();
+			}}
+		>
+			Return to your last Playground
+		</Button>
+	) : (
+		<Button
+			variant={isSeamlessMode ? 'primary' : 'secondary'}
+			key="start-new-playground"
+			onClick={async () => {
+				await discardFailedBlueprintRun();
+				helpers.reloadWithoutBlueprint();
+			}}
+		>
+			Start a new Playground
+		</Button>
+	);
+	async function discardFailedBlueprintRun() {
+		try {
+			await sitesAPI.delete(siteSlug);
+			dispatch(removeClientInfo(siteSlug));
+		} catch (error) {
+			logger.error('Failed to discard Blueprint run', error);
+		}
+	}
+	const view = isBlueprintRunFailure
+		? {
+				...baseView,
+				title:
+					error === 'site-boot-failed'
+						? 'Blueprint run failed'
+						: error === 'initial-opfs-sync-interrupted'
+							? 'Blueprint run did not finish'
+							: baseView.title,
+				body: recoveryBody,
+				actions: [
+					returnOrStartAction,
+					!isSeamlessMode ? (
+						<Button
+							variant="primary"
+							key="edit-blueprint"
+							onClick={() => {
+								dispatch(setDockPaneSection('blueprint'));
+								dispatch(setDockPaneOpen(true));
+							}}
+						>
+							Edit Blueprint
+						</Button>
+					) : null,
+				],
+			}
+		: baseView;
 
 	const detailText = formatErrorDetails(errorDetails);
 	const shouldShowKapaButton =
@@ -96,6 +200,13 @@ export function SiteErrorModal({
 		!isReporting &&
 		detailText &&
 		kapaAI.isEnabled();
+	if (
+		isBlueprintRunFailure &&
+		(isEditingBlueprint ||
+			activeModal === modalSlugs.GITHUB_PRIVATE_REPO_AUTH)
+	) {
+		return null;
+	}
 
 	return (
 		<Modal
@@ -111,8 +222,14 @@ export function SiteErrorModal({
 					</>
 				) as unknown as string
 			}
-			onRequestClose={() => dispatch(clearActiveSiteError())}
-			shouldCloseOnClickOutside
+			onRequestClose={() => {
+				if (!isBlueprintRunFailure) {
+					dispatch(clearActiveSiteError());
+				}
+			}}
+			isDismissible={!isBlueprintRunFailure}
+			shouldCloseOnClickOutside={!isBlueprintRunFailure}
+			shouldCloseOnEsc={!isBlueprintRunFailure}
 			overlayClassName={css.errorModalOverlay}
 			className={css.errorModal}
 		>

--- a/packages/playground/website/src/lib/state/redux/boot-site-client.spec.ts
+++ b/packages/playground/website/src/lib/state/redux/boot-site-client.spec.ts
@@ -278,6 +278,41 @@ describe('bootSiteClient', () => {
 		);
 	});
 
+	it('requires an explicit retry for an interrupted Blueprint run', async () => {
+		const site = createSite('blueprint-run', {
+			loadedFromStorage: true,
+			metadata: {
+				initialOpfsSyncPending: true,
+				siteSlugToReturnToIfBlueprintFails: 'source-site',
+			},
+		});
+		const state = createState(site);
+		const dispatch = createDispatch(state);
+
+		await bootSiteClient(
+			'blueprint-run',
+			document.createElement('iframe'),
+			{ signal: new AbortController().signal }
+		)(dispatch, () => state);
+
+		expect(startPlaygroundWeb).not.toHaveBeenCalled();
+		expect(
+			opfsSiteStorage!.removeWordPressFilesKeepMetadata
+		).not.toHaveBeenCalled();
+		expect(dispatch).toHaveBeenCalledWith(
+			expect.objectContaining({
+				type: 'ui/setActiveSiteError',
+				payload: expect.objectContaining({
+					error: 'initial-opfs-sync-interrupted',
+				}),
+			})
+		);
+		expect(
+			state.sites.entities['blueprint-run'].metadata
+				.siteSlugToReturnToIfBlueprintFails
+		).toBe('source-site');
+	});
+
 	it('boots stored OPFS files based on Playground metadata, not WordPress file probes', async () => {
 		const site = createSite('stored-save', { loadedFromStorage: true });
 		const state = createState(site);


### PR DESCRIPTION
Builds on #4134.

A stored Blueprint can fail before its first WordPress file copy completes. The old error dialog could be dismissed, leaving a loading screen that could never finish.

This PR makes the error dialog the recovery screen. It keeps the specific failure reason and offers two explicit actions:

- **Edit Blueprint** opens the Blueprint editor so the input can be corrected.
- **Return to your last Playground** discards the failed run and restores the Playground that launched it.

If that Playground no longer exists, the second action starts a new one instead. Seamless mode omits the editor and makes the return action primary.

The dialog cannot be closed with an X, Escape, or an outside click. Close does not secretly navigate. Private repository authentication may cover it temporarily; the recovery dialog returns when authentication closes.

Reloading an interrupted run also stops before booting WordPress again. It keeps the return target and does not delete the partial files behind the user's back.

| Desktop before | Desktop after |
| --- | --- |
| <img width="720" alt="Before: an unavailable release dialog with no route back to the Blueprint" src="https://raw.githubusercontent.com/WordPress/wordpress-playground/39e991af1c1df706f2008630cfa69032a33aefd6/after-desktop.png"> | <img width="720" alt="After: an unavailable release dialog with AI troubleshooting and explicit Blueprint recovery actions" src="https://raw.githubusercontent.com/WordPress/wordpress-playground/8964cf1261bd2761eb0ff7318b04ad35c1789487/after-desktop.png"> |

| Mobile before | Mobile after |
| --- | --- |
| <img width="390" alt="Before on mobile: an unavailable release dialog with no route back to the Blueprint" src="https://raw.githubusercontent.com/WordPress/wordpress-playground/39e991af1c1df706f2008630cfa69032a33aefd6/after-mobile.png"> | <img width="390" alt="After on mobile: an unavailable release dialog with AI troubleshooting and explicit recovery actions" src="https://raw.githubusercontent.com/WordPress/wordpress-playground/8964cf1261bd2761eb0ff7318b04ad35c1789487/after-mobile.png"> |

## Testing

1. From a stored Playground, run a Blueprint with `preferredVersions.wp` set to `999.9`.
2. Confirm the failure dialog shows the unavailable version, keeps **Troubleshoot with AI**, and cannot be dismissed.
3. Open **Edit Blueprint**, close the editor, and confirm the failure dialog returns.
4. Choose **Return to your last Playground** and confirm the original Playground opens and the failed run is absent from Recent.
5. Repeat at a mobile viewport.
