### PR TITLE
[Website] Decode JSON-encoded <php-snippet> child payloads

### DIFF
--- a/packages/docs/site/docs/main/guides/php-code-snippets.md
+++ b/packages/docs/site/docs/main/guides/php-code-snippets.md
@@ -126,6 +126,26 @@ escaping every `<` character.
 </php-snippet>
 ```
 
+A literal `</script>` still closes the child script element, even when it is
+inside a PHP string. Use JSON-encoded child payloads when the PHP source or
+expected output contains that sequence:
+
+```html
+<php-snippet name="example.php">
+	<script type="application/x-php+json">
+		"\u003C?php\necho '\u003C/script\u003E';"
+	</script>
+	<script type="text/expected-output+json">
+		"\u003C/script\u003E"
+	</script>
+</php-snippet>
+```
+
+Both payloads are parsed as JSON and must decode to strings; other JSON values
+are rejected. Encode `<` as `\u003C` so the HTML parser never sees a literal
+`</script>`. `JSON.stringify()` does not escape `<` by itself. The unencoded
+`application/x-php` and `text/expected-output` types remain supported.
+
 Very short snippets can also be written as text, as long as PHP opening tags are
 escaped:
 

--- a/packages/playground/website/playwright/e2e/php-code-snippet.spec.ts
+++ b/packages/playground/website/playwright/e2e/php-code-snippet.spec.ts
@@ -68,6 +68,82 @@ test.describe('php-code-snippet embed', () => {
 		}
 	});
 
+	test('decodes JSON-encoded child payloads', async ({ page }) => {
+		await page.goto(DEMO_URL);
+		await waitForPhpSnippetDefinition(page);
+		await page.evaluate(() => {
+			document.body.insertAdjacentHTML(
+				'beforeend',
+				String.raw`
+					<php-snippet name="json-payload.php">
+						<script type="application/x-php+json">
+							"\u003C?php\necho '\u003C/script\u003E';"
+						</script>
+						<script type="text/expected-output+json">
+							"\u003C/script\u003E"
+						</script>
+					</php-snippet>
+				`
+			);
+		});
+
+		const snippet = await waitForRenderedPhpSnippet(
+			page,
+			'php-snippet[name="json-payload.php"]'
+		);
+		await expect(snippet.locator('textarea.ta')).toHaveValue(
+			"<?php\necho '</script>';"
+		);
+		await expect(snippet.locator('.output-body')).toHaveText('</script>');
+	});
+
+	test('rejects JSON child payloads that are not strings', async ({
+		page,
+	}) => {
+		await page.goto(DEMO_URL);
+		await waitForPhpSnippetDefinition(page);
+
+		const rejected = await page.evaluate(async () => {
+			const codeSnippet = document.createElement(
+				'php-snippet'
+			) as HTMLElement & {
+				_readCode(): Promise<string>;
+			};
+			const codeScript = document.createElement('script');
+			codeScript.type = 'application/x-php+json';
+			codeScript.textContent = '{}';
+			codeSnippet.append(codeScript);
+
+			let code = false;
+			try {
+				await codeSnippet._readCode();
+			} catch (error) {
+				code = error instanceof TypeError;
+			}
+
+			const outputSnippet = document.createElement(
+				'php-snippet'
+			) as HTMLElement & {
+				_readExpectedOutput(): string | null;
+			};
+			const outputScript = document.createElement('script');
+			outputScript.type = 'text/expected-output+json';
+			outputScript.textContent = 'null';
+			outputSnippet.append(outputScript);
+
+			let output = false;
+			try {
+				outputSnippet._readExpectedOutput();
+			} catch (error) {
+				output = error instanceof TypeError;
+			}
+
+			return { code, output };
+		});
+
+		expect(rejected).toEqual({ code: true, output: true });
+	});
+
 	test('runnable snippets are editable by default unless readonly', async ({
 		page,
 	}) => {

--- a/packages/playground/website/public/php-code-snippet.js
+++ b/packages/playground/website/public/php-code-snippet.js
@@ -1061,6 +1061,23 @@ class PhpSnippet extends HTMLElement {
 	}
 }
 
+/**
+ * Reads PHP source or expected output from a child `<script>` element.
+ *
+ * Plain-text script types are dedented so authors can indent their payloads
+ * with the surrounding HTML. Script types ending in `+json` are parsed as
+ * JSON instead. JSON encoding lets authors escape `<` as `\u003C`, preventing
+ * the HTML parser from treating a payload's `</script>` sequence as the end
+ * of the child element before this function can read it.
+ *
+ * A JSON payload must decode to a string because PHP source and expected
+ * output are both text. Other JSON values are rejected rather than coerced.
+ *
+ * @param {HTMLScriptElement} script The child script containing the payload.
+ * @return {string} The dedented plain-text payload or decoded JSON string.
+ * @throws {SyntaxError} If a JSON-encoded payload contains invalid JSON.
+ * @throws {TypeError} If a JSON-encoded payload does not decode to a string.
+ */
 function readScriptPayload(script) {
 	const payload = script.textContent || '';
 	if (!script.type.endsWith('+json')) {

--- a/packages/playground/website/public/php-code-snippet.js
+++ b/packages/playground/website/public/php-code-snippet.js
@@ -1067,7 +1067,14 @@ function readScriptPayload(script) {
 		return dedentLeading(payload);
 	}
 
-	const decoded = JSON.parse(payload);
+	let decoded;
+	try {
+		decoded = JSON.parse(payload);
+	} catch (err) {
+		throw new SyntaxError(
+			`<script type="${script.type}"> contains invalid JSON: ${err.message}`
+		);
+	}
 	if (typeof decoded !== 'string') {
 		throw new TypeError(
 			`<script type="${script.type}"> JSON payload must decode to a string.`

--- a/packages/playground/website/public/php-code-snippet.js
+++ b/packages/playground/website/public/php-code-snippet.js
@@ -820,10 +820,10 @@ class PhpSnippet extends HTMLElement {
 
 	_readExpectedOutput() {
 		const script = this.querySelector(
-			'script[type="text/expected-output"]'
+			'script[type="text/expected-output"], script[type="text/expected-output+json"]'
 		);
 		if (script) {
-			return dedentLeading(script.textContent || '');
+			return readScriptPayload(script);
 		}
 		if (this.hasAttribute('expected-output')) {
 			return this.getAttribute('expected-output');
@@ -843,9 +843,9 @@ class PhpSnippet extends HTMLElement {
 			return await res.text();
 		}
 		const script = this.querySelector(
-			'script[type="application/x-php"], script[type="text/x-php"], script[type="text/php"]'
+			'script[type="application/x-php"], script[type="application/x-php+json"], script[type="text/x-php"], script[type="text/php"]'
 		);
-		if (script) return dedentLeading(script.textContent || '');
+		if (script) return readScriptPayload(script);
 		return dedentLeading(this.textContent || '');
 	}
 
@@ -1059,6 +1059,21 @@ class PhpSnippet extends HTMLElement {
 		};
 		outputBody.addEventListener('animationend', clear);
 	}
+}
+
+function readScriptPayload(script) {
+	const payload = script.textContent || '';
+	if (!script.type.endsWith('+json')) {
+		return dedentLeading(payload);
+	}
+
+	const decoded = JSON.parse(payload);
+	if (typeof decoded !== 'string') {
+		throw new TypeError(
+			`<script type="${script.type}"> JSON payload must decode to a string.`
+		);
+	}
+	return decoded;
 }
 
 function isRunShortcut(event) {


### PR DESCRIPTION
Adds opt-in JSON-encoded child payloads to `<php-snippet>` so PHP source and expected output can contain a literal `</script>`. This is additive: the existing unencoded syntax remains supported and unchanged.

### Existing syntax — still supported

```html
<php-snippet name="example.php">
	<script type="application/x-php">
		<?php echo 'Hello';
	</script>
	<script type="text/expected-output">
		Hello
	</script>
</php-snippet>
```

### New opt-in JSON syntax

```html
<php-snippet name="example.php">
	<script type="application/x-php+json">
		"\u003C?php\necho '\u003C/script\u003E';"
	</script>
	<script type="text/expected-output+json">
		"\u003C/script\u003E"
	</script>
</php-snippet>
```

The browser closes a child `<script>` when it sees `</script>`, before the component can read it. The new types parse their bodies as JSON strings, allowing `<` to be encoded as `\u003C`. Invalid JSON and non-string values are rejected.

All existing unencoded types—`application/x-php`, `text/x-php`, `text/php`, and `text/expected-output`—keep their current behavior.

## Testing

Embed both examples. Confirm the existing snippet still renders normally and the JSON snippet shows a literal `</script>` in both the editor and expected output. Replace a JSON payload with `{}` and confirm the component rejects it.
