### PR TITLE
Build PHP WASM runtimes with Sodium support

### DIFF
--- a/packages/php-wasm/compile/Makefile
+++ b/packages/php-wasm/compile/Makefile
@@ -235,6 +235,20 @@ libiconv/jspi/dist/root/lib/lib/libiconv.a: base-image libz_jspi
 	docker cp $$(docker create playground-php-wasm:libiconv):/root/install/lib ./libiconv/jspi/dist/root/lib
 	docker cp $$(docker create playground-php-wasm:libiconv):/root/install/include ./libiconv/jspi/dist/root/lib
 
+libsodium_asyncify: libsodium/asyncify/dist/root/lib/lib/libsodium.a
+libsodium/asyncify/dist/root/lib/lib/libsodium.a: base-image
+	mkdir -p ./libsodium/asyncify/dist/root/lib
+	docker build -f ./libsodium/Dockerfile -t playground-php-wasm:libsodium .
+	docker cp $$(docker create playground-php-wasm:libsodium):/root/install/lib ./libsodium/asyncify/dist/root/lib
+	docker cp $$(docker create playground-php-wasm:libsodium):/root/install/include ./libsodium/asyncify/dist/root/lib
+
+libsodium_jspi: libsodium/jspi/dist/root/lib/lib/libsodium.a
+libsodium/jspi/dist/root/lib/lib/libsodium.a: base-image
+	mkdir -p ./libsodium/jspi/dist/root/lib
+	docker build -f ./libsodium/Dockerfile -t playground-php-wasm:libsodium . --build-arg JSPI=1
+	docker cp $$(docker create playground-php-wasm:libsodium):/root/install/lib ./libsodium/jspi/dist/root/lib
+	docker cp $$(docker create playground-php-wasm:libsodium):/root/install/include ./libsodium/jspi/dist/root/lib
+
 # This didn't get a proper JSPI port because it wasn't actually used in the build.
 # It's kept here because we still will want PHP WASM to support interactive CLI and
 # a lot of work has been done to get the libncurses and libedit support where it is now.
@@ -311,8 +325,8 @@ libImageMagick/jspi/dist/root/lib/lib/libMagickCore-7.Q16HDRI.a: base-image libz
 	docker cp $$(docker create playground-php-wasm:libImageMagick):/root/install/bin ./libImageMagick/jspi/dist/root/lib
 
 all: all_jspi all_asyncify
-all_jspi: libz_jspi libzip_jspi libpng16_jspi libjpeg_jspi libwebp_jspi libaom_jspi libavif_jspi libgd_jspi libxml2_jspi libopenssl_jspi libsqlite3_jspi libiconv_jspi oniguruma_jspi libcurl_jspi libImageMagick_jspi
-all_asyncify: libz_asyncify libzip_asyncify libpng16_asyncify libjpeg_asyncify libwebp_asyncify libaom_asyncify libavif_asyncify libgd_asyncify libxml2_asyncify libopenssl_asyncify libsqlite3_asyncify libiconv_asyncify oniguruma_asyncify libcurl_asyncify libImageMagick_asyncify
+all_jspi: libz_jspi libzip_jspi libpng16_jspi libjpeg_jspi libwebp_jspi libaom_jspi libavif_jspi libgd_jspi libxml2_jspi libopenssl_jspi libsqlite3_jspi libiconv_jspi libsodium_jspi oniguruma_jspi libcurl_jspi libImageMagick_jspi
+all_asyncify: libz_asyncify libzip_asyncify libpng16_asyncify libjpeg_asyncify libwebp_asyncify libaom_asyncify libavif_asyncify libgd_asyncify libxml2_asyncify libopenssl_asyncify libsqlite3_asyncify libiconv_asyncify libsodium_asyncify oniguruma_asyncify libcurl_asyncify libImageMagick_asyncify
 
 clean:
 	rm -rf ./libz/jspi/dist
@@ -337,6 +351,8 @@ clean:
 	rm -rf ./libsqlite3/asyncify/dist
 	rm -rf ./libiconv/jspi/dist
 	rm -rf ./libiconv/asyncify/dist
+	rm -rf ./libsodium/jspi/dist
+	rm -rf ./libsodium/asyncify/dist
 	rm -rf ./oniguruma/jspi/dist
 	rm -rf ./oniguruma/asyncify/dist
 	rm -rf ./libImageMagick/jspi/dist

--- a/packages/php-wasm/compile/build.js
+++ b/packages/php-wasm/compile/build.js
@@ -106,6 +106,11 @@ const argParser = yargs(process.argv.slice(2))
 			choices: ['yes', 'no'],
 			description: 'Build with OpenSSL support',
 		},
+		WITH_SODIUM: {
+			type: 'string',
+			choices: ['yes', 'no'],
+			description: 'Build with Sodium support',
+		},
 		WITH_NODEFS: {
 			type: 'string',
 			choices: ['yes', 'no'],
@@ -202,6 +207,7 @@ const platformDefaults = {
 		WITH_MBSTRING: 'yes',
 		WITH_MBREGEX: 'yes',
 		WITH_OPENSSL: 'yes',
+		WITH_SODIUM: 'yes',
 		WITH_WS_NETWORKING_PROXY: 'yes',
 		WITH_OPCACHE: 'yes',
 		WITH_IMAGICK: 'no',
@@ -336,6 +342,8 @@ await asyncSpawn(
 		getArg('WITH_CLI_SAPI'),
 		'--build-arg',
 		getArg('WITH_OPENSSL'),
+		'--build-arg',
+		getArg('WITH_SODIUM'),
 		'--build-arg',
 		getArg('WITH_NODEFS'),
 		'--build-arg',

--- a/packages/php-wasm/compile/libsodium/Dockerfile
+++ b/packages/php-wasm/compile/libsodium/Dockerfile
@@ -1,0 +1,26 @@
+FROM playground-php-wasm:base
+
+ARG JSPI=0
+ARG LIBSODIUM_VERSION=1.0.20
+
+RUN set -euxo pipefail; \
+	wget https://download.libsodium.org/libsodium/releases/libsodium-$LIBSODIUM_VERSION.tar.gz; \
+	tar -xzf libsodium-$LIBSODIUM_VERSION.tar.gz; \
+	rm libsodium-$LIBSODIUM_VERSION.tar.gz
+
+WORKDIR /root/libsodium-$LIBSODIUM_VERSION
+
+RUN set -euxo pipefail; \
+	source /root/emsdk/emsdk_env.sh; \
+	emconfigure ./configure \
+		--build=i386-pc-linux-gnu \
+		--host=wasm32-unknown-emscripten \
+		--prefix=/root/install \
+		--disable-shared \
+		--enable-static
+
+RUN set -euxo pipefail; \
+	source /root/emsdk/emsdk_env.sh; \
+	export JSPI_FLAGS=$(if [ "$JSPI" = "1" ]; then echo "-sSUPPORT_LONGJMP=wasm -fwasm-exceptions"; fi); \
+	EMCC_FLAGS="-fPIC $JSPI_FLAGS" emmake make -j12; \
+	emmake make install

--- a/packages/php-wasm/compile/php/Dockerfile
+++ b/packages/php-wasm/compile/php/Dockerfile
@@ -47,6 +47,7 @@ COPY ./compile/libavif/ /root/builds/libavif
 COPY ./compile/libsqlite3/ /root/builds/libsqlite3
 COPY ./compile/libxml2/ /root/builds/libxml2
 COPY ./compile/libz/ /root/builds/libz
+COPY ./compile/libsodium/ /root/builds/libsodium
 COPY ./compile/oniguruma/ /root/builds/oniguruma
 COPY ./compile/libImageMagick/ /root/builds/libImageMagick
 COPY ./compile/libgd/ /root/builds/libgd
@@ -121,6 +122,7 @@ ARG WITH_CLI_SAPI
 ARG WITH_SQLITE
 ARG WITH_MYSQL
 ARG WITH_OPENSSL
+ARG WITH_SODIUM
 ARG WITH_ICONV
 ARG WITH_SOURCEMAPS
 ARG OUTPUT_DIR_ON_HOST
@@ -230,6 +232,14 @@ RUN if [ "$WITH_OPENSSL" = "yes" ]; \
 		cp -r /libs/libopenssl/* /root/lib; \
 		echo -n ' --with-openssl --with-openssl-dir=/root/lib ' >> /root/.php-configure-flags; \
 		echo -n ' /root/lib/lib/libcrypto.a /root/lib/lib/libssl.a ' >> /root/.emcc-php-wasm-sources; \
+	fi;
+
+# Sodium is bundled with PHP since 7.2 and needs an external static libsodium.
+RUN if [ "$WITH_SODIUM" = "yes" ]; then \
+		echo -n ' --with-sodium=/root/lib ' >> /root/.php-configure-flags; \
+		echo -n ' /root/lib/lib/libsodium.a ' >> /root/.emcc-php-wasm-sources; \
+	else \
+		echo -n ' --without-sodium ' >> /root/.php-configure-flags; \
 	fi;
 
 # Remove fileinfo if needed

--- a/packages/php-wasm/node/project.json
+++ b/packages/php-wasm/node/project.json
@@ -169,6 +169,7 @@
 				"testFiles": [
 					"php-imagick.spec.ts",
 					"php-soap.spec.ts",
+					"php-sodium.spec.ts",
 					"php-image-extensions.spec.ts",
 					"php-email-capture.spec.ts",
 					"php-fsockopen.spec.ts",
@@ -185,6 +186,7 @@
 				"testFiles": [
 					"php-imagick.spec.ts",
 					"php-soap.spec.ts",
+					"php-sodium.spec.ts",
 					"php-image-extensions.spec.ts",
 					"php-email-capture.spec.ts",
 					"php-fsockopen.spec.ts",

--- a/packages/php-wasm/node/src/test/php-sodium.spec.ts
+++ b/packages/php-wasm/node/src/test/php-sodium.spec.ts
@@ -1,0 +1,38 @@
+import { PHP, SupportedPHPVersions } from '@php-wasm/universal';
+import { loadNodeRuntime } from '../lib';
+import { jspi } from 'wasm-feature-detect';
+
+const runtimeMode = (await jspi()) ? 'jspi' : 'asyncify';
+const phpVersions =
+	'PHP' in process.env ? [process.env['PHP']!] : SupportedPHPVersions;
+
+describe(`Sodium extension - ${runtimeMode}`, () => {
+	describe.each(phpVersions)('PHP %s', (phpVersion) => {
+		it('loads and opens a secretbox', async () => {
+			using php = new PHP(await loadNodeRuntime(phpVersion as any));
+			const result = await php.run({
+				code: `<?php
+					$loaded = extension_loaded('sodium');
+					$hasKeyBytes = defined('SODIUM_CRYPTO_SECRETBOX_KEYBYTES');
+					$canSeal = is_callable('sodium_crypto_secretbox');
+					$canOpen = is_callable('sodium_crypto_secretbox_open');
+					$plaintext = 'missing';
+					if ($loaded && $hasKeyBytes && $canSeal && $canOpen) {
+						$key = random_bytes(SODIUM_CRYPTO_SECRETBOX_KEYBYTES);
+						$nonce = random_bytes(SODIUM_CRYPTO_SECRETBOX_NONCEBYTES);
+						$ciphertext = sodium_crypto_secretbox('secret', $nonce, $key);
+						$plaintext = sodium_crypto_secretbox_open($ciphertext, $nonce, $key);
+					}
+					echo ($loaded ? 'loaded' : 'missing') . ':';
+					echo $hasKeyBytes ? SODIUM_CRYPTO_SECRETBOX_KEYBYTES : 'missing';
+					echo ':' . ($canSeal ? 'seal' : 'no-seal');
+					echo ':' . ($canOpen ? 'open' : 'no-open');
+					echo ':' . $plaintext;
+				`,
+			});
+
+			expect(result.text).toBe('loaded:32:seal:open:secret');
+			expect(result.errors).toBeFalsy();
+		});
+	});
+});


### PR DESCRIPTION
Fixes #4105.

Downstream tracker: https://github.com/Automattic/wp-codebox/issues/1825

## Problem

PHP WASM builds do not currently compile or link libsodium, so PHP’s bundled Sodium extension is unavailable. Applications using standard Sodium constants and functions fail during bootstrap.

## Solution

- Cross-compile pinned libsodium 1.0.20 artifacts for Asyncify and JSPI.
- Include both variants in the shared dependency build and clean lifecycle.
- Enable PHP with `--with-sodium` by default and link the static archive.
- Run a Node runtime contract across supported PHP versions in both modes, proving the extension, key-size constant, secretbox APIs, and a seal/open round trip.

## How to test

1. Run `npm ci` on a fresh checkout.
2. Run `make -C packages/php-wasm/compile libsodium_asyncify libsodium_jspi`.
3. Rebuild PHP WASM Node runtimes with `npm run recompile:php:node`.
4. Run `npm exec nx -- run php-wasm-node:test-asyncify-node` and confirm `php-sodium.spec.ts` passes for every supported PHP version.
5. On a JSPI-capable Node runtime, run `npm exec nx -- run php-wasm-node:test-jspi-node` and confirm the same round-trip coverage passes.
6. Run `npm exec nx -- run php-wasm-node:lint` and `npm exec nx -- run php-wasm-node:typecheck`.

## Local verification

Passed:

- `npm exec nx -- run php-wasm-node:lint`
- `npm exec nx -- run php-wasm-node:typecheck`
- `make -C packages/php-wasm/compile -n libsodium_asyncify libsodium_jspi`
- `git diff --check`

The current published PHP WASM binaries reproduce the issue (`extension_loaded("sodium") === false`). Docker was unavailable locally, so the rebuilt-runtime tests in steps 2–5 remain the explicit readiness gate for this draft.

## Compatibility and size

- Applies to the supported PHP 7.4–8.5 recompilation targets across web/node and Asyncify/JSPI.
- PHP 5.2 remains unchanged because that PHP version does not bundle Sodium.
- Existing callers may set `WITH_SODIUM=no` to omit the extension.
- Enabling Sodium by default increases each PHP WASM binary by the statically linked libsodium code; exact compressed and uncompressed deltas should be recorded from CI build artifacts before marking ready.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with GPT-5.6 Sol
- **Used for:** Investigated the PHP-WASM compiler pipeline, drafted the libsodium integration and deterministic runtime coverage, and ran focused static verification. Chris reviewed and owns the change.