### PR TITLE
[Website] Place Dock panes above the visible collapsed row

### DIFF
--- a/packages/playground/website/src/components/dock/dock-positioning.spec.ts
+++ b/packages/playground/website/src/components/dock/dock-positioning.spec.ts
@@ -128,6 +128,26 @@ describe('Dock positioning', () => {
 		).toEqual({ bottom: '504px', left: '308px' });
 	});
 
+	it('keeps operation notices above the visible collapsed Dock row', () => {
+		expect(
+			getDockOperationToastStyle({
+				isMobile: false,
+				dockSize: { width: 800, height: 140 },
+				toolsHeight: 60,
+				isCollapsed: true,
+				dockCenter: null,
+				viewportSize: { width: 1200, height: 800 },
+				paneHeight: 0,
+				toastHeight: 62,
+				paneOpen: false,
+				isEditorSection: false,
+			})
+		).toEqual({
+			bottom: `${80 + DOCK_PANE_GAP}px`,
+			left: '600px',
+		});
+	});
+
 	it('centers operation notices when the viewport is narrower than its gaps', () => {
 		expect(
 			getDockOperationToastStyle({

--- a/packages/playground/website/src/components/dock/dock-positioning.spec.ts
+++ b/packages/playground/website/src/components/dock/dock-positioning.spec.ts
@@ -1,4 +1,5 @@
 import {
+	DOCK_DRAG_EDGE,
 	DOCK_PANE_GAP,
 	DOCK_PANE_MIN_HEIGHT,
 	getDockOperationToastStyle,
@@ -12,6 +13,8 @@ describe('Dock positioning', () => {
 			getDockPaneStyle({
 				isMobile: false,
 				dockSize: { width: 800, height: 0 },
+				toolsHeight: 60,
+				isCollapsed: false,
 				dockCenter: null,
 				viewportSize: { width: 1200, height: 800 },
 				isEditorSection: false,
@@ -40,6 +43,8 @@ describe('Dock positioning', () => {
 			getDockPaneStyle({
 				isMobile: false,
 				dockSize: { width: 800, height: 80 },
+				toolsHeight: 60,
+				isCollapsed: false,
 				dockCenter: null,
 				viewportSize: { width: 1200, height: 100 },
 				isEditorSection: false,
@@ -54,6 +59,8 @@ describe('Dock positioning', () => {
 			getDockPaneStyle({
 				isMobile: true,
 				dockSize: { width: 390, height: 72 },
+				toolsHeight: 0,
+				isCollapsed: false,
 				dockCenter: null,
 				viewportSize: { width: 390, height: 844 },
 				isEditorSection: false,
@@ -68,6 +75,8 @@ describe('Dock positioning', () => {
 			getDockPaneStyle({
 				isMobile: false,
 				dockSize: { width: 800, height: 80 },
+				toolsHeight: 60,
+				isCollapsed: false,
 				dockCenter: 100,
 				viewportSize: { width: 1200, height: 800 },
 				isEditorSection: false,
@@ -80,6 +89,25 @@ describe('Dock positioning', () => {
 			top: 'auto',
 			maxHeight: '560px',
 			height: '560px',
+		});
+	});
+
+	it('keeps desktop panes above the visible collapsed Dock row', () => {
+		expect(
+			getDockPaneStyle({
+				isMobile: false,
+				dockSize: { width: 800, height: 140 },
+				toolsHeight: 60,
+				isCollapsed: true,
+				dockCenter: null,
+				viewportSize: { width: 1200, height: 800 },
+				isEditorSection: false,
+				isFixedHeightSection: false,
+				isPlaygroundsSection: false,
+			})
+		).toMatchObject({
+			bottom: `${80 + DOCK_PANE_GAP}px`,
+			maxHeight: `${800 - 80 - DOCK_PANE_GAP - DOCK_DRAG_EDGE}px`,
 		});
 	});
 

--- a/packages/playground/website/src/components/dock/dock-positioning.ts
+++ b/packages/playground/website/src/components/dock/dock-positioning.ts
@@ -169,7 +169,7 @@ function getVisibleDockHeight({
 	dockSize: Size;
 	toolsHeight: number;
 	isCollapsed: boolean;
-}) {
+}): number {
 	// Mobile collapse removes the tools from layout, so dockSize is already the
 	// visible height. Desktop collapse translates them out without reflowing.
 	return isCollapsed && !isMobile

--- a/packages/playground/website/src/components/dock/dock-positioning.ts
+++ b/packages/playground/website/src/components/dock/dock-positioning.ts
@@ -14,6 +14,8 @@ type Size = { width: number; height: number };
 export function getDockPaneStyle({
 	isMobile,
 	dockSize,
+	toolsHeight,
+	isCollapsed,
 	dockCenter,
 	viewportSize,
 	isEditorSection,
@@ -22,6 +24,8 @@ export function getDockPaneStyle({
 }: {
 	isMobile: boolean;
 	dockSize: Size;
+	toolsHeight: number;
+	isCollapsed: boolean;
 	dockCenter: number | null;
 	viewportSize: Size;
 	isEditorSection: boolean;
@@ -37,7 +41,13 @@ export function getDockPaneStyle({
 		} as CSSProperties;
 	}
 
-	const dockTop = viewportSize.height - dockSize.height;
+	const visibleDockHeight = getVisibleDockHeight({
+		isMobile,
+		dockSize,
+		toolsHeight,
+		isCollapsed,
+	});
+	const dockTop = viewportSize.height - visibleDockHeight;
 	const center = getDockPaneCenter({
 		dockCenter,
 		viewportWidth: viewportSize.width,
@@ -52,7 +62,7 @@ export function getDockPaneStyle({
 
 	return {
 		left: `${center}px`,
-		bottom: `${dockSize.height + DOCK_PANE_GAP}px`,
+		bottom: `${visibleDockHeight + DOCK_PANE_GAP}px`,
 		top: 'auto',
 		maxHeight: `${maxHeight}px`,
 		...(isFixedHeightSection ? { height: `${stableHeight}px` } : {}),
@@ -87,12 +97,12 @@ export function getDockOperationToastStyle({
 		return undefined;
 	}
 
-	// Mobile collapse removes the tools from layout, so dockSize is already the
-	// visible height. Desktop collapse translates them out without reflowing.
-	const visibleDockHeight =
-		isCollapsed && !isMobile
-			? Math.max(0, dockSize.height - toolsHeight)
-			: dockSize.height;
+	const visibleDockHeight = getVisibleDockHeight({
+		isMobile,
+		dockSize,
+		toolsHeight,
+		isCollapsed,
+	});
 	const desiredBottom =
 		visibleDockHeight +
 		DOCK_PANE_GAP +
@@ -147,4 +157,22 @@ export function getDockPaneCenter({
 		Math.max(desiredCenter, halfPaneWidth + DOCK_DRAG_EDGE),
 		viewportWidth - halfPaneWidth - DOCK_DRAG_EDGE
 	);
+}
+
+function getVisibleDockHeight({
+	isMobile,
+	dockSize,
+	toolsHeight,
+	isCollapsed,
+}: {
+	isMobile: boolean;
+	dockSize: Size;
+	toolsHeight: number;
+	isCollapsed: boolean;
+}) {
+	// Mobile collapse removes the tools from layout, so dockSize is already the
+	// visible height. Desktop collapse translates them out without reflowing.
+	return isCollapsed && !isMobile
+		? Math.max(0, dockSize.height - toolsHeight)
+		: dockSize.height;
 }

--- a/packages/playground/website/src/components/dock/dock.tsx
+++ b/packages/playground/website/src/components/dock/dock.tsx
@@ -983,6 +983,8 @@ export function Dock({
 	const paneStyle = getDockPaneStyle({
 		isMobile,
 		dockSize,
+		toolsHeight,
+		isCollapsed,
 		dockCenter,
 		viewportSize,
 		isEditorSection,


### PR DESCRIPTION
Dock panes now use the visible Dock height when the tools row is collapsed. The Store permanently pane no longer floats above the hidden tools row.

| Breakpoint | Before | After |
| --- | --- | --- |
| Desktop | ![Before desktop screenshot of the Store permanently pane floating too far above the collapsed Dock](https://gist.githubusercontent.com/adamziel/bf121eb093fae3ebfb7c715cd0c8e396/raw/ea076eda0733d69a3c046828a477253cacf5f30d/dock-popover-before-desktop.svg) | ![After desktop screenshot of the Store permanently pane directly above the collapsed Dock](https://gist.githubusercontent.com/adamziel/bf121eb093fae3ebfb7c715cd0c8e396/raw/50a36258dbb7b7b5431ca91c1207fc0cb8e21dd6/dock-popover-after-desktop.svg) |
| Mobile | ![Before mobile screenshot of the Store permanently pane](https://gist.githubusercontent.com/adamziel/bf121eb093fae3ebfb7c715cd0c8e396/raw/9f9831e92c4876b9d42de38cac5e954581d810ee/dock-popover-before-mobile.svg) | ![After mobile screenshot of the Store permanently pane](https://gist.githubusercontent.com/adamziel/bf121eb093fae3ebfb7c715cd0c8e396/raw/a67c370a0c54d11cac3484d1bdd47b25664299aa/dock-popover-after-mobile.svg) |

## Testing

Open a Playground, collapse the Dock tools, then click the Unsaved or Autosaved status. Check that the Store permanently pane sits just above the visible Dock row on desktop and still fills the space above the mobile Dock.
