### PR TITLE
[Website] Accept Blueprints and file bytes from opener windows

### DIFF
--- a/packages/playground/website/demos/index.html
+++ b/packages/playground/website/demos/index.html
@@ -72,6 +72,11 @@
 			<a href="time-traveling.html" target="_blank">Time Travel</a>
 		</li>
 		<li>
+			<a href="opener-handshake.html" target="_blank"
+				>Opener Blueprint handshake</a
+			>
+		</li>
+		<li>
 			<a href="../wordpress.html" target="_blank"
 				>WordPress Pull Request Previewer</a
 			>

--- a/packages/playground/website/demos/opener-handshake.html
+++ b/packages/playground/website/demos/opener-handshake.html
@@ -1,0 +1,271 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<title>Playground opener Blueprint handshake</title>
+		<style>
+			* {
+				box-sizing: border-box;
+			}
+			body {
+				font-family:
+					-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+				line-height: 1.5;
+				margin: 0 auto;
+				max-width: 860px;
+				padding: 32px 20px;
+			}
+			label,
+			legend {
+				font-weight: 600;
+			}
+			input[type='text'],
+			textarea {
+				display: block;
+				font: inherit;
+				margin: 6px 0 18px;
+				padding: 8px;
+				width: 100%;
+			}
+			textarea {
+				font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+				min-height: 190px;
+			}
+			fieldset {
+				border: 1px solid #c3c4c7;
+				margin: 18px 0;
+				padding: 14px;
+			}
+			.actions {
+				display: flex;
+				gap: 8px;
+				margin: 18px 0;
+			}
+			button {
+				font: inherit;
+				padding: 8px 14px;
+			}
+			pre {
+				background: #1e1e1e;
+				color: #f0f0f0;
+				min-height: 180px;
+				overflow: auto;
+				padding: 14px;
+				white-space: pre-wrap;
+			}
+			.hint {
+				color: #50575e;
+			}
+		</style>
+	</head>
+	<body>
+		<h1>Playground opener Blueprint handshake</h1>
+		<p class="hint">
+			This page must keep the <code>window.open()</code> handle. Do not
+			add <code>noopener</code>, because the receiver requires
+			<code>window.opener</code>.
+		</p>
+
+		<label for="playground-url">Playground URL</label>
+		<input id="playground-url" type="text" />
+
+		<label for="blueprint">Blueprint JSON</label>
+		<textarea id="blueprint" spellcheck="false">
+{
+  "landingPage": "/wp-admin/",
+  "login": true,
+  "plugins": ["hello-dolly"]
+}</textarea
+		>
+
+		<label for="file">Optional local file</label>
+		<input id="file" type="file" />
+
+		<fieldset>
+			<legend>File destination</legend>
+			<label>
+				<input type="radio" name="destination" value="vfs" checked />
+				Virtual filesystem
+			</label>
+			<label>
+				<input type="radio" name="destination" value="media-library" />
+				Media Library
+			</label>
+		</fieldset>
+
+		<label for="vfs-path">VFS path</label>
+		<input
+			id="vfs-path"
+			type="text"
+			value="/wordpress/wp-content/note.txt"
+		/>
+
+		<div class="actions">
+			<button id="open" type="button">Open in Playground</button>
+			<button id="send-again" type="button" disabled>
+				Send run again
+			</button>
+		</div>
+
+		<h2>Protocol log</h2>
+		<pre id="log" aria-live="polite"></pre>
+
+		<script>
+			const PROTOCOL_VERSION = 1;
+			const playgroundUrlInput =
+				document.getElementById('playground-url');
+			const blueprintInput = document.getElementById('blueprint');
+			const fileInput = document.getElementById('file');
+			const pathInput = document.getElementById('vfs-path');
+			const openButton = document.getElementById('open');
+			const sendAgainButton = document.getElementById('send-again');
+			const logOutput = document.getElementById('log');
+
+			playgroundUrlInput.value =
+				window.location.protocol === 'file:'
+					? 'http://127.0.0.1:5400/website-server/'
+					: new URL('../', window.location.href).href;
+
+			let receiverWindow;
+			let runPayloadPromise;
+			let lastRunPayload;
+			let receiverOrigin = '*';
+			let sendingRun = false;
+			let helloInterval;
+
+			document
+				.querySelectorAll('input[name="destination"]')
+				.forEach((input) =>
+					input.addEventListener('change', () => {
+						pathInput.disabled = selectedDestination() !== 'vfs';
+					})
+				);
+
+			openButton.addEventListener('click', () => {
+				let targetUrl;
+				try {
+					targetUrl = new URL(playgroundUrlInput.value);
+					targetUrl.searchParams.set('blueprint-source', 'opener');
+				} catch (error) {
+					appendLog(`Invalid Playground URL: ${error.message}`);
+					return;
+				}
+
+				// Open synchronously so browsers treat this as a user-initiated popup.
+				receiverWindow = window.open(targetUrl.href);
+				if (!receiverWindow) {
+					appendLog('The browser blocked the Playground popup.');
+					return;
+				}
+
+				sendingRun = false;
+				lastRunPayload = undefined;
+				receiverOrigin = '*';
+				sendAgainButton.disabled = true;
+				runPayloadPromise = createRunPayload();
+				appendLog(`Opened ${targetUrl.href}`);
+				clearInterval(helloInterval);
+				helloInterval = setInterval(sendHello, 1_000);
+			});
+
+			sendAgainButton.addEventListener('click', () => {
+				if (!receiverWindow || !lastRunPayload) {
+					return;
+				}
+				receiverWindow.postMessage(lastRunPayload, receiverOrigin);
+				appendLog('sent playground-blueprint:run again');
+			});
+
+			window.addEventListener('message', (event) => {
+				if (
+					event.source !== receiverWindow ||
+					!event.data ||
+					typeof event.data.type !== 'string' ||
+					event.data.protocolVersion !== PROTOCOL_VERSION
+				) {
+					return;
+				}
+				appendLog(`received ${JSON.stringify(event.data)}`);
+				if (event.data.type === 'playground-blueprint:ready') {
+					receiverOrigin =
+						event.origin === 'null' ? '*' : event.origin;
+					void sendRun();
+				}
+			});
+
+			async function sendRun() {
+				if (sendingRun || !receiverWindow || !runPayloadPromise) {
+					return;
+				}
+				sendingRun = true;
+				try {
+					lastRunPayload = await runPayloadPromise;
+					receiverWindow.postMessage(lastRunPayload, receiverOrigin);
+					appendLog('sent playground-blueprint:run');
+					sendAgainButton.disabled = false;
+					clearInterval(helloInterval);
+				} catch (error) {
+					appendLog(`Could not create run payload: ${error.message}`);
+					sendingRun = false;
+				}
+			}
+
+			function sendHello() {
+				if (!receiverWindow || receiverWindow.closed || sendingRun) {
+					clearInterval(helloInterval);
+					return;
+				}
+				receiverWindow.postMessage(
+					{
+						type: 'playground-blueprint:hello',
+						protocolVersion: PROTOCOL_VERSION,
+					},
+					'*'
+				);
+			}
+
+			async function createRunPayload() {
+				const blueprint = JSON.parse(blueprintInput.value);
+				const selectedFile = fileInput.files[0];
+				const files = [];
+				if (selectedFile) {
+					const destination = selectedDestination();
+					if (
+						destination === 'vfs' &&
+						!pathInput.value.startsWith('/')
+					) {
+						throw new Error('The VFS path must be absolute.');
+					}
+					files.push({
+						name: selectedFile.name,
+						bytes: await selectedFile.arrayBuffer(),
+						mimeType: selectedFile.type || undefined,
+						destination,
+						...(destination === 'vfs'
+							? { path: pathInput.value }
+							: {}),
+					});
+				}
+				return {
+					type: 'playground-blueprint:run',
+					protocolVersion: PROTOCOL_VERSION,
+					blueprint,
+					files,
+				};
+			}
+
+			function selectedDestination() {
+				return document.querySelector(
+					'input[name="destination"]:checked'
+				).value;
+			}
+
+			function appendLog(message) {
+				const timestamp = new Date().toLocaleTimeString();
+				logOutput.textContent += `[${timestamp}] ${message}\n`;
+				logOutput.scrollTop = logOutput.scrollHeight;
+			}
+		</script>
+	</body>
+</html>

--- a/packages/playground/website/src/components/ensure-playground-site/ensure-playground-site-is-selected.tsx
+++ b/packages/playground/website/src/components/ensure-playground-site/ensure-playground-site-is-selected.tsx
@@ -42,6 +42,7 @@ import {
 	RecentAutosaveNudgeProvider,
 	useRecentAutosaveNudgeAnchor,
 } from './recent-autosave-nudge-context';
+import { getOpenerBlueprintReceiver } from '../../lib/opener-blueprint-protocol';
 
 /**
  * Ensures the redux store always has an activeSite value.
@@ -70,6 +71,8 @@ export function EnsurePlaygroundSiteIsSelected({
 		selectSiteBySlug(state, requestedSiteSlug!)
 	);
 	const isSavingDisabled = isSiteSavingDisabled(url);
+	const expectsOpenerBlueprint =
+		url.searchParams.get('blueprint-source') === 'opener';
 	const shouldUseTemporarySite =
 		url.searchParams.get('storage') === 'temp' ||
 		isSavingDisabled ||
@@ -168,9 +171,11 @@ export function EnsurePlaygroundSiteIsSelected({
 					);
 
 					if (shouldUseTemporarySite) {
-						await sitesAPI.createNewTemporarySite(
-							requestedSiteSlug
-						);
+						const siteCreated =
+							await tryCreateTemporarySite(requestedSiteSlug);
+						if (!siteCreated) {
+							return;
+						}
 						if (!isSavingDisabled) {
 							setNeedMissingSitePromptForSlug(requestedSiteSlug);
 						}
@@ -184,10 +189,13 @@ export function EnsurePlaygroundSiteIsSelected({
 								'Error creating saved site. Falling back to a temporary site.',
 								error
 							);
-							await sitesAPI.createNewTemporarySite(
-								requestedSiteSlug
-							);
-							setNeedMissingSitePromptForSlug(requestedSiteSlug);
+							const siteCreated =
+								await tryCreateTemporarySite(requestedSiteSlug);
+							if (siteCreated) {
+								setNeedMissingSitePromptForSlug(
+									requestedSiteSlug
+								);
+							}
 						}
 					}
 					return;
@@ -210,7 +218,7 @@ export function EnsurePlaygroundSiteIsSelected({
 			}
 
 			if (shouldUseTemporarySite) {
-				await sitesAPI.createNewTemporarySite();
+				await tryCreateTemporarySite();
 			} else {
 				// A matching autosave may already be waiting for its first OPFS
 				// sync. Keep it selected instead of creating a duplicate for the
@@ -219,6 +227,13 @@ export function EnsurePlaygroundSiteIsSelected({
 					activeSite &&
 					isAutosavedSite(activeSite) &&
 					activeSite.metadata.initialOpfsSyncPending &&
+					(!expectsOpenerBlueprint ||
+						(activeSite.metadata.originalBlueprintSource.type ===
+							'opener' &&
+							getOpenerBlueprintReceiver()?.getAcceptedRun(
+								activeSite.metadata.originalBlueprintSource
+									.runId
+							))) &&
 					getAutosaveFingerprintFromSite(activeSite) ===
 						currentSetupUrlFingerprint
 				) {
@@ -228,13 +243,17 @@ export function EnsurePlaygroundSiteIsSelected({
 				// Offer restore only when the autosave came from the same
 				// setup URL. A different setup URL should create a fresh
 				// Playground even if another autosave exists.
-				const matchingAutosave = sortedSites
-					.filter(isAutosavedSite)
-					.find(
-						(site) =>
-							getAutosaveFingerprintFromSite(site) ===
-							currentSetupUrlFingerprint
-					);
+				// An opener URL does not contain the transferred Blueprint, so it
+				// cannot identify a compatible autosave from an earlier run.
+				const matchingAutosave = expectsOpenerBlueprint
+					? undefined
+					: sortedSites
+							.filter(isAutosavedSite)
+							.find(
+								(site) =>
+									getAutosaveFingerprintFromSite(site) ===
+									currentSetupUrlFingerprint
+							);
 				if (
 					matchingAutosave &&
 					isInitialPageLoadUrl &&
@@ -248,7 +267,7 @@ export function EnsurePlaygroundSiteIsSelected({
 						site: matchingAutosave,
 						setupUrlFingerprint: currentSetupUrlFingerprint,
 					});
-					await sitesAPI.createNewTemporarySite();
+					await tryCreateTemporarySite();
 					return;
 				}
 
@@ -258,12 +277,35 @@ export function EnsurePlaygroundSiteIsSelected({
 						updateUrl: false,
 					});
 				} catch (error) {
+					if (
+						expectsOpenerBlueprint &&
+						getOpenerBlueprintReceiver()?.state === 'error'
+					) {
+						await tryCreateTemporarySite();
+						return;
+					}
 					logger.error(
 						'Error creating saved site. Falling back to a temporary site.',
 						error
 					);
-					await sitesAPI.createNewTemporarySite();
+					await tryCreateTemporarySite();
 				}
+			}
+		}
+
+		async function tryCreateTemporarySite(siteSlug?: string) {
+			try {
+				await sitesAPI.createNewTemporarySite(siteSlug);
+				return true;
+			} catch (error) {
+				if (
+					expectsOpenerBlueprint &&
+					getOpenerBlueprintReceiver()?.state === 'error'
+				) {
+					// The mock site exposes the error UI before its activation rejects.
+					return false;
+				}
+				throw error;
 			}
 		}
 

--- a/packages/playground/website/src/components/playground-viewport/index.tsx
+++ b/packages/playground/website/src/components/playground-viewport/index.tsx
@@ -19,6 +19,7 @@ import {
 import classNames from 'classnames';
 import { SiteErrorModal } from '../site-error-modal';
 import { getRuntimeBootFingerprint } from '../../lib/state/playground-identity';
+import { getOpenerBlueprintReceiver } from '../../lib/opener-blueprint-protocol';
 
 export const supportedDisplayModes = [
 	'browser-full-screen',
@@ -56,6 +57,17 @@ export const PlaygroundViewport = ({
  * as there's no risk of data loss
  */
 export const KeepAliveTemporarySitesViewport = () => {
+	const waitingForOpener = getOpenerBlueprintReceiver()?.state === 'waiting';
+	const [showOpenerHint, setShowOpenerHint] = useState(false);
+	useEffect(() => {
+		if (!waitingForOpener) {
+			setShowOpenerHint(false);
+			return;
+		}
+		const timeout = setTimeout(() => setShowOpenerHint(true), 30_000);
+		return () => clearTimeout(timeout);
+	}, [waitingForOpener]);
+
 	const temporarySites = useAppSelector(selectTemporarySites);
 	const activeSite = useActiveSite();
 	// Check if a site slug is set (even if the entity doesn't exist yet).
@@ -137,7 +149,17 @@ export const KeepAliveTemporarySitesViewport = () => {
 	if (!sitesFinishedLoading) {
 		return (
 			<div className={css.loadingViewport}>
-				<h1 className={css.loadingCaption}>Loading Playgrounds</h1>
+				<h1 className={css.loadingCaption}>
+					{waitingForOpener
+						? 'Waiting for the opener to send a Blueprint…'
+						: 'Loading Playgrounds'}
+				</h1>
+				{waitingForOpener && showOpenerHint ? (
+					<p className={css.loadingHint}>
+						Keep the opener page open and try sending the Blueprint
+						again.
+					</p>
+				) : null}
 				<div className={css.progressWrapper}>
 					<div className={css.progressBar} />
 				</div>

--- a/packages/playground/website/src/components/playground-viewport/style.module.css
+++ b/packages/playground/website/src/components/playground-viewport/style.module.css
@@ -43,6 +43,15 @@
 	text-align: center;
 }
 
+.loading-hint {
+	font-family: -apple-system, BlinkMacSystemFont, sans-serif;
+	font-size: 14px;
+	line-height: 1.5;
+	margin: 12px 0 0;
+	max-width: 520px;
+	text-align: center;
+}
+
 .progress-wrapper {
 	position: relative;
 	width: calc(100% - 48px);
@@ -77,6 +86,10 @@
 	}
 
 	.loading-caption {
+		color: #fff;
+	}
+
+	.loading-hint {
 		color: #fff;
 	}
 

--- a/packages/playground/website/src/components/saved-playgrounds-panel/index.tsx
+++ b/packages/playground/website/src/components/saved-playgrounds-panel/index.tsx
@@ -729,6 +729,9 @@ export function SavedPlaygroundsPanel({
 		if (source.type === 'inline-string') {
 			return 'inline Blueprint';
 		}
+		if (source.type === 'opener') {
+			return 'opener Blueprint';
+		}
 		if (source.type === 'opfs-site') {
 			return 'saved Playground files';
 		}

--- a/packages/playground/website/src/lib/apply-opener-blueprint-files.ts
+++ b/packages/playground/website/src/lib/apply-opener-blueprint-files.ts
@@ -1,0 +1,123 @@
+import { dirname, joinPaths, randomFilename } from '@php-wasm/util';
+import type { PlaygroundClient } from '@wp-playground/remote';
+import type { OpenerBlueprintFile } from './opener-blueprint-protocol';
+
+const IMPORT_MEDIA_FILE = `<?php
+require '/wordpress/wp-load.php';
+require_once ABSPATH . 'wp-admin/includes/image.php';
+require_once ABSPATH . 'wp-admin/includes/file.php';
+
+$source_path = getenv('PLAYGROUND_UPLOAD_PATH');
+$requested_name = getenv('PLAYGROUND_UPLOAD_NAME');
+$requested_mime_type = getenv('PLAYGROUND_UPLOAD_MIME_TYPE');
+
+if (!$source_path || !is_readable($source_path)) {
+	throw new Exception('The uploaded media file is not readable.');
+}
+
+$filename = sanitize_file_name($requested_name ? $requested_name : '');
+if (!$filename) {
+	throw new Exception('The uploaded media file needs a valid filename.');
+}
+
+$uploads = wp_upload_dir();
+if (!empty($uploads['error'])) {
+	throw new Exception($uploads['error']);
+}
+if (!wp_mkdir_p($uploads['path'])) {
+	throw new Exception('Could not create the WordPress uploads directory.');
+}
+
+$filename = wp_unique_filename($uploads['path'], $filename);
+$target_path = trailingslashit($uploads['path']) . $filename;
+if (!copy($source_path, $target_path)) {
+	throw new Exception('Could not copy the uploaded media file.');
+}
+
+$filetype = wp_check_filetype($filename, null);
+$mime_type = $requested_mime_type
+	? $requested_mime_type
+	: (!empty($filetype['type']) ? $filetype['type'] : 'application/octet-stream');
+$attachment = array(
+	'guid' => trailingslashit($uploads['url']) . $filename,
+	'post_mime_type' => $mime_type,
+	'post_title' => preg_replace('/\\.[^.]+$/', '', $filename),
+	'post_status' => 'inherit',
+);
+$attachment_id = wp_insert_attachment($attachment, $target_path, 0);
+if (is_wp_error($attachment_id)) {
+	throw new Exception($attachment_id->get_error_message());
+}
+if (!$attachment_id) {
+	throw new Exception('Could not create the WordPress media attachment.');
+}
+
+$metadata = wp_generate_attachment_metadata($attachment_id, $target_path);
+if (!is_wp_error($metadata) && !empty($metadata)) {
+	wp_update_attachment_metadata($attachment_id, $metadata);
+}
+`;
+
+export async function applyOpenerBlueprintFiles(
+	playground: PlaygroundClient,
+	files: OpenerBlueprintFile[],
+	signal: AbortSignal,
+	onFileApplied?: (completedFiles: number) => void
+): Promise<void> {
+	for (let index = 0; index < files.length; index++) {
+		if (signal.aborted) {
+			throw new Error('The Playground boot was cancelled.');
+		}
+		const file = files[index];
+		if (file.destination === 'vfs') {
+			await writeVfsFile(playground, file);
+		} else {
+			await importMediaLibraryFile(playground, file);
+		}
+		if (signal.aborted) {
+			throw new Error('The Playground boot was cancelled.');
+		}
+		onFileApplied?.(index + 1);
+	}
+}
+
+async function writeVfsFile(
+	playground: PlaygroundClient,
+	file: OpenerBlueprintFile
+): Promise<void> {
+	const parentPath = dirname(file.path!);
+	if (!(await playground.fileExists(parentPath))) {
+		await playground.mkdir(parentPath);
+	}
+	await playground.writeFile(file.path!, new Uint8Array(file.bytes));
+}
+
+async function importMediaLibraryFile(
+	playground: PlaygroundClient,
+	file: OpenerBlueprintFile
+): Promise<void> {
+	const temporaryPath = joinPaths(
+		'/tmp',
+		`playground-opener-upload-${randomFilename()}`
+	);
+	await playground.writeFile(temporaryPath, new Uint8Array(file.bytes));
+	try {
+		const result = await playground.run({
+			code: IMPORT_MEDIA_FILE,
+			env: {
+				PLAYGROUND_UPLOAD_PATH: temporaryPath,
+				PLAYGROUND_UPLOAD_NAME: file.name,
+				PLAYGROUND_UPLOAD_MIME_TYPE: file.mimeType ?? '',
+			},
+		});
+		if (result.exitCode !== 0) {
+			throw new Error(
+				result.errors || 'Could not import the Media Library file.'
+			);
+		}
+	} finally {
+		if (await playground.fileExists(temporaryPath)) {
+			await playground.unlink(temporaryPath);
+		}
+	}
+}

--- a/packages/playground/website/src/lib/opener-blueprint-protocol.spec.ts
+++ b/packages/playground/website/src/lib/opener-blueprint-protocol.spec.ts
@@ -1,0 +1,326 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from 'vitest';
+import {
+	initializeOpenerBlueprintReceiver,
+	OPENER_BLUEPRINT_MAX_FILES,
+	OPENER_BLUEPRINT_MAX_TOTAL_BYTES,
+	OpenerBlueprintReceiver,
+	validateOpenerBlueprintRun,
+} from './opener-blueprint-protocol';
+
+describe('initializeOpenerBlueprintReceiver', () => {
+	it('installs the listener only for the opener source parameter', () => {
+		const inactiveHost = createHost();
+		expect(
+			initializeOpenerBlueprintReceiver(
+				new URL('https://playground.test/'),
+				inactiveHost.host
+			)
+		).toBeUndefined();
+		expect(inactiveHost.host.addEventListener).not.toHaveBeenCalled();
+
+		const activeHost = createHost();
+		const receiver = initializeOpenerBlueprintReceiver(
+			new URL('https://playground.test/?blueprint-source=opener'),
+			activeHost.host
+		);
+
+		expect(receiver).toBeInstanceOf(OpenerBlueprintReceiver);
+		expect(activeHost.host.addEventListener).toHaveBeenCalledOnce();
+		expect(activeHost.opener.postMessage).toHaveBeenCalledWith(
+			{
+				type: 'playground-blueprint:ready',
+				protocolVersion: 1,
+			},
+			'*'
+		);
+		receiver?.dispose();
+	});
+});
+
+describe('OpenerBlueprintReceiver', () => {
+	it('filters messages by source, version, and type, and replies to hello', () => {
+		const { receiver, dispatchMessage, opener } = createReceiver();
+		opener.postMessage.mockClear();
+
+		dispatchMessage(
+			{
+				type: 'playground-blueprint:hello',
+				protocolVersion: 1,
+			},
+			'https://opener.test',
+			{ postMessage: vi.fn() }
+		);
+		dispatchMessage({
+			type: 'playground-blueprint:hello',
+			protocolVersion: 2,
+		});
+		dispatchMessage({ type: 'unknown', protocolVersion: 1 });
+		expect(opener.postMessage).not.toHaveBeenCalled();
+
+		dispatchMessage({
+			type: 'playground-blueprint:hello',
+			protocolVersion: 1,
+			extraField: true,
+		});
+		expect(opener.postMessage).toHaveBeenCalledWith(
+			{
+				type: 'playground-blueprint:ready',
+				protocolVersion: 1,
+			},
+			'*'
+		);
+		receiver.dispose();
+	});
+
+	it('accepts the first valid run and pins later messages to its origin', async () => {
+		const { receiver, dispatchMessage, opener } = createReceiver();
+		opener.postMessage.mockClear();
+		const runPromise = receiver.waitForRun();
+
+		dispatchMessage(validRunMessage(), 'https://opener.test');
+		expect(receiver.state).toBe('booting');
+		const acceptedRun = await runPromise;
+		expect(acceptedRun).toEqual({
+			blueprint: {},
+			files: [],
+			runId: expect.any(String),
+		});
+		expect(receiver.getAcceptedRun(acceptedRun.runId)).toBe(acceptedRun);
+		expect(receiver.getAcceptedRun('another-run')).toBeUndefined();
+		expect(opener.postMessage).toHaveBeenLastCalledWith(
+			{
+				type: 'playground-blueprint:accepted',
+				protocolVersion: 1,
+			},
+			'https://opener.test'
+		);
+
+		dispatchMessage(validRunMessage(), 'https://different.test');
+		expect(opener.postMessage).toHaveBeenLastCalledWith(
+			{
+				type: 'playground-blueprint:rejected',
+				protocolVersion: 1,
+				reason: 'already-running',
+			},
+			'https://opener.test'
+		);
+
+		receiver.reportProgress(140, 'Finishing');
+		expect(opener.postMessage).toHaveBeenLastCalledWith(
+			{
+				type: 'playground-blueprint:progress',
+				protocolVersion: 1,
+				value: 100,
+				caption: 'Finishing',
+			},
+			'https://opener.test'
+		);
+		receiver.reportBooted('/wp-admin/');
+		expect(receiver.state).toBe('booted');
+		expect(receiver.getAcceptedRun(acceptedRun.runId)).toBeUndefined();
+		expect(opener.postMessage).toHaveBeenLastCalledWith(
+			{
+				type: 'playground-blueprint:booted',
+				protocolVersion: 1,
+				landingPage: '/wp-admin/',
+			},
+			'https://opener.test'
+		);
+		receiver.dispose();
+	});
+
+	it('uses a wildcard target for a file opener after accepting its run', () => {
+		const { receiver, dispatchMessage, opener } = createReceiver();
+		opener.postMessage.mockClear();
+
+		dispatchMessage(validRunMessage(), 'null');
+		receiver.reportError(new Error('Boot failed'));
+
+		expect(opener.postMessage).toHaveBeenLastCalledWith(
+			{
+				type: 'playground-blueprint:error',
+				protocolVersion: 1,
+				message: 'Boot failed',
+			},
+			'*'
+		);
+		expect(receiver.state).toBe('error');
+		receiver.dispose();
+	});
+
+	it('rejects a malformed run without throwing from the message listener', async () => {
+		const { receiver, dispatchMessage, opener } = createReceiver();
+		opener.postMessage.mockClear();
+		const runPromise = receiver.waitForRun();
+
+		expect(() =>
+			dispatchMessage(
+				{
+					type: 'playground-blueprint:run',
+					protocolVersion: 1,
+					blueprint: 'not an object',
+				},
+				'https://opener.test'
+			)
+		).not.toThrow();
+		await expect(runPromise).rejects.toThrow('plain object');
+		expect(receiver.state).toBe('error');
+		expect(opener.postMessage).toHaveBeenLastCalledWith(
+			expect.objectContaining({
+				type: 'playground-blueprint:rejected',
+				protocolVersion: 1,
+			}),
+			'https://opener.test'
+		);
+
+		dispatchMessage(validRunMessage(), 'https://opener.test');
+		expect(opener.postMessage).toHaveBeenLastCalledWith(
+			{
+				type: 'playground-blueprint:rejected',
+				protocolVersion: 1,
+				reason: 'already-running',
+			},
+			'https://opener.test'
+		);
+		receiver.dispose();
+	});
+});
+
+describe('validateOpenerBlueprintRun', () => {
+	it('accepts the file count and total byte limits exactly', () => {
+		const files = Array.from({ length: OPENER_BLUEPRINT_MAX_FILES }, () =>
+			validFile()
+		);
+		Object.defineProperty(files[0].bytes, 'byteLength', {
+			value: OPENER_BLUEPRINT_MAX_TOTAL_BYTES,
+		});
+
+		expect(
+			validateOpenerBlueprintRun({ blueprint: {}, files })
+		).not.toBeInstanceOf(Error);
+	});
+
+	it('rejects more than 200 files', () => {
+		const files = Array.from(
+			{ length: OPENER_BLUEPRINT_MAX_FILES + 1 },
+			() => validFile()
+		);
+
+		expect(validateOpenerBlueprintRun({ blueprint: {}, files })).toEqual(
+			expect.any(Error)
+		);
+	});
+
+	it('rejects more than 512 MB in total', () => {
+		const file = validFile();
+		Object.defineProperty(file.bytes, 'byteLength', {
+			value: OPENER_BLUEPRINT_MAX_TOTAL_BYTES + 1,
+		});
+
+		expect(
+			validateOpenerBlueprintRun({ blueprint: {}, files: [file] })
+		).toEqual(expect.any(Error));
+	});
+
+	it.each([
+		['a non-object Blueprint', { blueprint: 'nope' }],
+		['an array Blueprint', { blueprint: [] }],
+		['a non-array files value', { blueprint: {}, files: {} }],
+		['a null files value', { blueprint: {}, files: null }],
+		[
+			'bytes other than an ArrayBuffer',
+			{
+				blueprint: {},
+				files: [
+					{
+						...validFile(),
+						bytes: new Uint8Array(),
+					},
+				],
+			},
+		],
+		[
+			'an unknown destination',
+			{
+				blueprint: {},
+				files: [{ ...validFile(), destination: 'somewhere' }],
+			},
+		],
+		[
+			'a relative VFS path',
+			{
+				blueprint: {},
+				files: [{ ...validFile(), path: 'relative.txt' }],
+			},
+		],
+		[
+			'a VFS traversal path',
+			{
+				blueprint: {},
+				files: [
+					{
+						...validFile(),
+						path: '/wordpress/../tmp/file.txt',
+					},
+				],
+			},
+		],
+	])('rejects %s', (_label, message) => {
+		expect(validateOpenerBlueprintRun(message)).toEqual(expect.any(Error));
+	});
+});
+
+function validRunMessage() {
+	return {
+		type: 'playground-blueprint:run',
+		protocolVersion: 1,
+		blueprint: {},
+	};
+}
+
+function validFile() {
+	return {
+		name: 'file.txt',
+		bytes: new ArrayBuffer(0),
+		destination: 'vfs',
+		path: '/wordpress/file.txt',
+	};
+}
+
+function createReceiver() {
+	const testHost = createHost();
+	const receiver = new OpenerBlueprintReceiver(testHost.host);
+	return { receiver, ...testHost };
+}
+
+function createHost() {
+	let messageListener: ((event: MessageEvent) => void) | undefined;
+	const opener = { postMessage: vi.fn() };
+	const host = {
+		opener,
+		addEventListener: vi.fn(
+			(_type: 'message', listener: (event: MessageEvent) => void) => {
+				messageListener = listener;
+			}
+		),
+		removeEventListener: vi.fn(),
+	};
+	return {
+		host,
+		opener,
+		dispatchMessage(
+			data: unknown,
+			origin = 'https://opener.test',
+			source: unknown = opener
+		) {
+			messageListener?.(
+				new MessageEvent('message', {
+					data,
+					origin,
+					source: source as WindowProxy,
+				})
+			);
+		},
+	};
+}

--- a/packages/playground/website/src/lib/opener-blueprint-protocol.ts
+++ b/packages/playground/website/src/lib/opener-blueprint-protocol.ts
@@ -1,0 +1,314 @@
+import { normalizePath } from '@php-wasm/util';
+
+export const OPENER_BLUEPRINT_PROTOCOL_VERSION = 1;
+export const OPENER_BLUEPRINT_MAX_FILES = 200;
+export const OPENER_BLUEPRINT_MAX_TOTAL_BYTES = 512 * 1024 * 1024;
+
+export type OpenerBlueprintFile = {
+	name: string;
+	bytes: ArrayBuffer;
+	mimeType?: string;
+	destination: 'vfs' | 'media-library';
+	path?: string;
+};
+
+export type OpenerBlueprintRun = {
+	runId: string;
+	blueprint: Record<string, unknown>;
+	files: OpenerBlueprintFile[];
+};
+
+type ValidatedOpenerBlueprintRun = Omit<OpenerBlueprintRun, 'runId'>;
+
+export type OpenerBlueprintReceiverState =
+	| 'waiting'
+	| 'booting'
+	| 'booted'
+	| 'error';
+
+type PostMessageTarget = Pick<Window, 'postMessage'>;
+
+type ReceiverWindow = {
+	opener: PostMessageTarget | null;
+	addEventListener(
+		type: 'message',
+		listener: (event: MessageEvent) => void
+	): void;
+	removeEventListener(
+		type: 'message',
+		listener: (event: MessageEvent) => void
+	): void;
+};
+
+type ProtocolMessage = {
+	type: string;
+	protocolVersion: typeof OPENER_BLUEPRINT_PROTOCOL_VERSION;
+	[key: string]: unknown;
+};
+
+let activeReceiver: OpenerBlueprintReceiver | undefined;
+
+export function initializeOpenerBlueprintReceiver(
+	url: URL = new URL(window.location.href),
+	host: ReceiverWindow = window
+): OpenerBlueprintReceiver | undefined {
+	if (url.searchParams.get('blueprint-source') !== 'opener') {
+		return undefined;
+	}
+	activeReceiver ??= new OpenerBlueprintReceiver(host);
+	return activeReceiver;
+}
+
+export function getOpenerBlueprintReceiver():
+	| OpenerBlueprintReceiver
+	| undefined {
+	return activeReceiver;
+}
+
+export class OpenerBlueprintReceiver {
+	// TODO: Consider a MessageChannel-based persistent driving API in protocol v2.
+	state: OpenerBlueprintReceiverState = 'waiting';
+	terminalError?: Error;
+
+	readonly #opener: PostMessageTarget | null;
+	readonly #host: ReceiverWindow;
+	#targetOrigin = '*';
+	#acceptedRun?: OpenerBlueprintRun;
+	#hasAcceptedRun = false;
+	#resolveRun?: (run: OpenerBlueprintRun) => void;
+	#rejectRun?: (error: Error) => void;
+
+	constructor(host: ReceiverWindow = window) {
+		this.#host = host;
+		this.#opener = host.opener;
+		host.addEventListener('message', this.#onMessage);
+		this.#post({ type: 'playground-blueprint:ready' }, '*');
+	}
+
+	waitForRun(): Promise<OpenerBlueprintRun> {
+		if (this.terminalError) {
+			return Promise.reject(this.terminalError);
+		}
+		if (this.#acceptedRun) {
+			return Promise.resolve(this.#acceptedRun);
+		}
+		if (this.#hasAcceptedRun) {
+			return Promise.reject(
+				new Error('The opener Blueprint run is no longer available.')
+			);
+		}
+		return new Promise((resolve, reject) => {
+			this.#resolveRun = resolve;
+			this.#rejectRun = reject;
+		});
+	}
+
+	getAcceptedRun(runId: string): OpenerBlueprintRun | undefined {
+		return this.#acceptedRun?.runId === runId
+			? this.#acceptedRun
+			: undefined;
+	}
+
+	reportProgress(value: number, caption?: string): void {
+		if (this.state !== 'booting') {
+			return;
+		}
+		this.#post({
+			type: 'playground-blueprint:progress',
+			value: Math.max(0, Math.min(100, value)),
+			...(caption ? { caption } : {}),
+		});
+	}
+
+	reportBooted(landingPage: string): void {
+		if (this.state !== 'booting') {
+			return;
+		}
+		this.state = 'booted';
+		this.#acceptedRun = undefined;
+		this.#post({
+			type: 'playground-blueprint:booted',
+			landingPage,
+		});
+	}
+
+	reportError(error: unknown): void {
+		if (this.state !== 'booting') {
+			return;
+		}
+		this.state = 'error';
+		this.terminalError = asError(error);
+		this.#acceptedRun = undefined;
+		this.#post({
+			type: 'playground-blueprint:error',
+			message: this.terminalError.message,
+		});
+	}
+
+	dispose(): void {
+		this.#host.removeEventListener('message', this.#onMessage);
+	}
+
+	#onMessage = (event: MessageEvent) => {
+		if (
+			!this.#opener ||
+			event.source !== (this.#opener as MessageEventSource) ||
+			!isProtocolMessage(event.data)
+		) {
+			return;
+		}
+
+		if (
+			event.data.type === 'playground-blueprint:hello' &&
+			this.state === 'waiting'
+		) {
+			this.#post({ type: 'playground-blueprint:ready' }, '*');
+			return;
+		}
+
+		if (event.data.type !== 'playground-blueprint:run') {
+			return;
+		}
+
+		if (this.state !== 'waiting') {
+			this.#post(
+				{
+					type: 'playground-blueprint:rejected',
+					reason: 'already-running',
+				},
+				this.#hasAcceptedRun
+					? this.#targetOrigin
+					: event.origin === 'null'
+						? '*'
+						: event.origin
+			);
+			return;
+		}
+
+		const validationResult = validateOpenerBlueprintRun(event.data);
+		if (validationResult instanceof Error) {
+			this.state = 'error';
+			this.terminalError = validationResult;
+			this.#post(
+				{
+					type: 'playground-blueprint:rejected',
+					reason: validationResult.message,
+				},
+				event.origin === 'null' ? '*' : event.origin
+			);
+			const rejectRun = this.#rejectRun;
+			this.#resolveRun = undefined;
+			this.#rejectRun = undefined;
+			rejectRun?.(validationResult);
+			return;
+		}
+
+		// There is intentionally no origin allowlist. As with fragment Blueprints,
+		// the PHP-WASM sandbox is the security boundary for untrusted code.
+		this.#targetOrigin = event.origin === 'null' ? '*' : event.origin;
+		const acceptedRun = {
+			...validationResult,
+			runId: crypto.randomUUID(),
+		};
+		this.#acceptedRun = acceptedRun;
+		this.#hasAcceptedRun = true;
+		this.state = 'booting';
+		this.#post({ type: 'playground-blueprint:accepted' });
+		const resolveRun = this.#resolveRun;
+		this.#resolveRun = undefined;
+		this.#rejectRun = undefined;
+		resolveRun?.(acceptedRun);
+	};
+
+	#post(
+		message: Omit<ProtocolMessage, 'protocolVersion'>,
+		targetOrigin = this.#targetOrigin
+	): void {
+		this.#opener?.postMessage(
+			{
+				...message,
+				protocolVersion: OPENER_BLUEPRINT_PROTOCOL_VERSION,
+			},
+			targetOrigin
+		);
+	}
+}
+
+export function validateOpenerBlueprintRun(
+	message: Record<string, unknown>
+): ValidatedOpenerBlueprintRun | Error {
+	if (!isPlainObject(message.blueprint)) {
+		return new Error('The Blueprint must be a plain object.');
+	}
+
+	const files = message.files === undefined ? [] : message.files;
+	if (!Array.isArray(files)) {
+		return new Error('Files must be an array.');
+	}
+	if (files.length > OPENER_BLUEPRINT_MAX_FILES) {
+		return new Error(
+			`A maximum of ${OPENER_BLUEPRINT_MAX_FILES} files may be transferred.`
+		);
+	}
+
+	let totalBytes = 0;
+	for (const file of files) {
+		if (!isPlainObject(file)) {
+			return new Error('Each file must be a plain object.');
+		}
+		if (typeof file.name !== 'string' || file.name.length === 0) {
+			return new Error('Each file must have a name.');
+		}
+		if (!(file.bytes instanceof ArrayBuffer)) {
+			return new Error('Each file must contain ArrayBuffer bytes.');
+		}
+		if (file.mimeType !== undefined && typeof file.mimeType !== 'string') {
+			return new Error('A file MIME type must be a string.');
+		}
+		if (file.destination === 'vfs') {
+			if (
+				typeof file.path !== 'string' ||
+				!file.path.startsWith('/') ||
+				normalizePath(file.path) !== file.path
+			) {
+				return new Error(
+					'Each VFS path must be absolute, normalized, and contain no ".." segments.'
+				);
+			}
+		} else if (file.destination !== 'media-library') {
+			return new Error(
+				'Each file destination must be "vfs" or "media-library".'
+			);
+		}
+
+		totalBytes += file.bytes.byteLength;
+		if (totalBytes > OPENER_BLUEPRINT_MAX_TOTAL_BYTES) {
+			return new Error('Transferred files may total at most 512 MB.');
+		}
+	}
+
+	return {
+		blueprint: message.blueprint,
+		files: files as OpenerBlueprintFile[],
+	};
+}
+
+function isProtocolMessage(value: unknown): value is ProtocolMessage {
+	return (
+		isPlainObject(value) &&
+		typeof value.type === 'string' &&
+		value.protocolVersion === OPENER_BLUEPRINT_PROTOCOL_VERSION
+	);
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+	if (typeof value !== 'object' || value === null) {
+		return false;
+	}
+	const prototype = Object.getPrototypeOf(value);
+	return prototype === Object.prototype || prototype === null;
+}
+
+function asError(error: unknown): Error {
+	return error instanceof Error ? error : new Error(String(error));
+}

--- a/packages/playground/website/src/lib/state/playground-identity.ts
+++ b/packages/playground/website/src/lib/state/playground-identity.ts
@@ -10,6 +10,7 @@ type SetupQueryParam = Exclude<keyof QueryAPIParams, NonSetupQueryParam>;
 
 const SETUP_QUERY_PARAM_KEYS = Object.keys({
 	blueprint: true,
+	'blueprint-source': true,
 	'blueprint-url': true,
 	'core-pr': true,
 	'gutenberg-branch': true,

--- a/packages/playground/website/src/lib/state/redux/boot-site-client.ts
+++ b/packages/playground/website/src/lib/state/redux/boot-site-client.ts
@@ -41,6 +41,9 @@ import {
 } from './error-utils';
 import { PHPMYADMIN_INSTALL_PATH } from '@wp-playground/tools';
 import { phpExtensionQueryArgsToExtensionsArray } from '../url/php-extension-query';
+import { ProgressTracker, type ProgressTrackerEvent } from '@php-wasm/progress';
+import { getOpenerBlueprintReceiver } from '../../opener-blueprint-protocol';
+import { applyOpenerBlueprintFiles } from '../../apply-opener-blueprint-files';
 
 const PENDING_OPFS_SITE_REMOVAL_RETRY_DELAYS_MS = [700, 1400];
 
@@ -59,10 +62,36 @@ export function bootSiteClient(
 		dispatch: PlaygroundDispatch,
 		getState: () => PlaygroundReduxState
 	) => {
+		let site = selectSiteBySlug(getState(), siteSlug);
+		const openerSource = site?.metadata.originalBlueprintSource;
+		const openerReceiver =
+			openerSource?.type === 'opener'
+				? getOpenerBlueprintReceiver()
+				: undefined;
+		const openerRun =
+			openerReceiver?.state === 'booting' &&
+			openerSource?.type === 'opener'
+				? openerReceiver.getAcceptedRun(openerSource.runId)
+				: undefined;
+		const reportOpenerBootCancelled = () => {
+			if (
+				openerSource?.type === 'opener' &&
+				openerReceiver?.getAcceptedRun(openerSource.runId)
+			) {
+				openerReceiver.reportError(
+					new Error('The Playground boot was cancelled.')
+				);
+			}
+		};
 		if (signal.aborted) {
+			reportOpenerBootCancelled();
 			return;
 		}
-		let site = selectSiteBySlug(getState(), siteSlug);
+		if (openerRun) {
+			signal.addEventListener('abort', reportOpenerBootCancelled, {
+				once: true,
+			});
+		}
 		if (!site) {
 			dispatch(
 				setActiveSiteError({
@@ -222,17 +251,38 @@ export function bootSiteClient(
 		}
 
 		let playground: PlaygroundClient | undefined = undefined;
+		let openerProgressTracker: ProgressTracker | undefined;
+		let bootProgressTracker: ProgressTracker | undefined;
+		let fileProgressTracker: ProgressTracker | undefined;
+		if (openerRun && openerReceiver) {
+			openerProgressTracker = new ProgressTracker();
+			openerProgressTracker.addEventListener(
+				'progress',
+				(event: ProgressTrackerEvent) => {
+					openerReceiver.reportProgress(
+						event.detail.progress,
+						event.detail.caption
+					);
+				}
+			);
+			if (openerRun.files.length) {
+				bootProgressTracker = openerProgressTracker.stage(0.9);
+			} else {
+				bootProgressTracker = openerProgressTracker.stage(1);
+			}
+		}
 		try {
 			const phpExtensions = phpExtensionQueryArgsToExtensionsArray(
 				site.originalUrlParams?.searchParams?.['php-extension'],
 				document.location.href
 			);
 
-			await startPlaygroundWeb({
+			const startedPlayground = await startPlaygroundWeb({
 				iframe: iframe!,
 				remoteUrl: getRemoteUrl().toString(),
 				scope: site.slug,
 				blueprint,
+				progressTracker: bootProgressTracker,
 				extensions: phpExtensions,
 				// Intercept the Playground client even if the
 				// Blueprint fails.
@@ -256,9 +306,42 @@ export function bootSiteClient(
 					},
 				],
 			});
-		} catch (e) {
+
 			if (signal.aborted) {
 				return;
+			}
+			if (openerRun && openerReceiver) {
+				if (openerRun.files.length) {
+					fileProgressTracker = openerProgressTracker?.stage(
+						0.1,
+						'Applying transferred files'
+					);
+					fileProgressTracker?.set(0);
+				}
+				await applyOpenerBlueprintFiles(
+					startedPlayground,
+					openerRun.files,
+					signal,
+					(completedFiles) => {
+						fileProgressTracker?.set(
+							(completedFiles / openerRun.files.length) * 100
+						);
+					}
+				);
+				openerReceiver.reportBooted(
+					await startedPlayground.getCurrentURL()
+				);
+				signal.removeEventListener('abort', reportOpenerBootCancelled);
+			}
+		} catch (e) {
+			if (openerRun) {
+				signal.removeEventListener('abort', reportOpenerBootCancelled);
+			}
+			if (signal.aborted) {
+				return;
+			}
+			if (openerRun) {
+				openerReceiver?.reportError(e);
 			}
 			logger.error(e);
 			logTrackingEvent('error', { source: 'bootSiteClient' });

--- a/packages/playground/website/src/lib/state/redux/slice-sites.ts
+++ b/packages/playground/website/src/lib/state/redux/slice-sites.ts
@@ -21,6 +21,7 @@ import {
 	type ResolvedBlueprint,
 	applyQueryOverrides,
 } from '../url/resolve-blueprint-from-url';
+import { getOpenerBlueprintReceiver } from '../../opener-blueprint-protocol';
 import {
 	deleteBlueprintBundle,
 	isTraversableFilesystemBackend,
@@ -541,6 +542,7 @@ export function setTemporarySiteSpec(
 			dispatch(sitesSlice.actions.setFirstTemporarySiteCreated());
 			return newSiteInfo;
 		} catch (e) {
+			reportOpenerBlueprintError(resolvedBlueprint?.source, e);
 			logger.error(
 				'Error preparing the Blueprint after it was downloaded.',
 				e
@@ -599,8 +601,13 @@ export function createStoredSite(
 			blueprint = source;
 			originalBlueprintSource = { type: 'opfs-site' };
 		}
-		const runtimeConfiguration =
-			await resolveRuntimeConfiguration(blueprint);
+		let runtimeConfiguration: RuntimeConfiguration;
+		try {
+			runtimeConfiguration = await resolveRuntimeConfiguration(blueprint);
+		} catch (error) {
+			reportOpenerBlueprintError(originalBlueprintSource, error);
+			throw error;
+		}
 		const now = Date.now();
 		const sites = selectAllSites(getState());
 		let displayName = siteName;
@@ -697,16 +704,34 @@ async function prepareResolvedBlueprint(
 	resolvedBlueprint: ResolvedBlueprint,
 	playgroundUrlWithQueryApiArgs: URL
 ) {
-	const reflection = await BlueprintReflection.create(
-		resolvedBlueprint.blueprint
-	);
-	if (reflection.getVersion() === 1) {
-		resolvedBlueprint.blueprint = await applyQueryOverrides(
-			resolvedBlueprint.blueprint as any,
-			playgroundUrlWithQueryApiArgs.searchParams
+	try {
+		const reflection = await BlueprintReflection.create(
+			resolvedBlueprint.blueprint
 		);
+		if (reflection.getVersion() === 1) {
+			resolvedBlueprint.blueprint = await applyQueryOverrides(
+				resolvedBlueprint.blueprint as any,
+				playgroundUrlWithQueryApiArgs.searchParams
+			);
+		}
+		return resolvedBlueprint;
+	} catch (error) {
+		reportOpenerBlueprintError(resolvedBlueprint.source, error);
+		throw error;
 	}
-	return resolvedBlueprint;
+}
+
+function reportOpenerBlueprintError(
+	source: BlueprintSource | undefined,
+	error: unknown
+) {
+	if (source?.type !== 'opener') {
+		return;
+	}
+	const receiver = getOpenerBlueprintReceiver();
+	if (receiver?.getAcceptedRun(source.runId)) {
+		receiver.reportError(error);
+	}
 }
 
 /**

--- a/packages/playground/website/src/lib/state/url/resolve-blueprint-from-url.ts
+++ b/packages/playground/website/src/lib/state/url/resolve-blueprint-from-url.ts
@@ -13,6 +13,7 @@ import { parseBlueprint, isMcpServerEnabled } from './router';
 import { OverlayFilesystem, InMemoryFilesystem } from '@wp-playground/storage';
 import { decodeBlueprintHash } from './decode-blueprint-hash';
 import { getDefaultPhpVersionForWordPress } from '../../wordpress-version-compatibility';
+import { getOpenerBlueprintReceiver } from '../../opener-blueprint-protocol';
 
 export { decodeBlueprintHash };
 
@@ -23,6 +24,10 @@ export type BlueprintSource =
 	  }
 	| {
 			type: 'inline-string';
+	  }
+	| {
+			type: 'opener';
+			runId: string;
 	  }
 	| {
 			type: 'none';
@@ -70,7 +75,32 @@ export async function resolveBlueprintFromURL(
 	 * If the URL has no parameters or fragment, and a default blueprint is provided,
 	 * use the default blueprint.
 	 */
-	if (
+	if (query.get('blueprint-source') === 'opener') {
+		const receiver = getOpenerBlueprintReceiver();
+		if (!receiver) {
+			throw new Error(
+				'The opener Blueprint receiver was not initialized.'
+			);
+		}
+		const { blueprint, runId } = await receiver.waitForRun();
+		if (isMcpServerEnabled()) {
+			const error = new Error(
+				`Starting a new Playground from an opener Blueprint is disabled when the MCP server
+				is active to prevent potential prompt injection vulnerabilities.
+				Please remove the "blueprint-source" query parameter to proceed or
+				disable the MCP server by removing the "mcp-port" query parameter.`
+			);
+			receiver.reportError(error);
+			throw error;
+		}
+		return {
+			blueprint: blueprint as Blueprint,
+			source: {
+				type: 'opener',
+				runId,
+			},
+		};
+	} else if (
 		window.self === window.top &&
 		!query.size &&
 		!fragment.length &&

--- a/packages/playground/website/src/lib/state/url/router.ts
+++ b/packages/playground/website/src/lib/state/url/router.ts
@@ -26,6 +26,7 @@ export interface QueryAPIParams {
 	'import-content'?: string;
 	url?: string;
 	'blueprint-url'?: string;
+	'blueprint-source'?: 'opener';
 	'page-title'?: string;
 }
 

--- a/packages/playground/website/src/main.tsx
+++ b/packages/playground/website/src/main.tsx
@@ -6,8 +6,10 @@ import { Provider } from 'react-redux';
 import store from './lib/state/redux/store';
 import { Layout } from './components/layout';
 import { EnsurePlaygroundSite } from './components/ensure-playground-site';
+import { initializeOpenerBlueprintReceiver } from './lib/opener-blueprint-protocol';
 
 collectWindowErrors(logger);
+initializeOpenerBlueprintReceiver();
 
 const root = createRoot(document.getElementById('root')!);
 root.render(

--- a/packages/playground/website/vite.config.ts
+++ b/packages/playground/website/vite.config.ts
@@ -323,6 +323,12 @@ export default defineConfig(({ command, mode }) => {
 					'peer.html': fileURLToPath(
 						new URL('./demos/peer.html', import.meta.url)
 					),
+					'opener-handshake.html': fileURLToPath(
+						new URL(
+							'./demos/opener-handshake.html',
+							import.meta.url
+						)
+					),
 					'time-traveling.html': fileURLToPath(
 						new URL('./demos/time-traveling.html', import.meta.url)
 					),


### PR DESCRIPTION
Adds an opt-in `postMessage` handshake for pages that need to open Playground with a Blueprint and local file bytes.

The receiver exists only under `?blueprint-source=opener`. It sends `playground-blueprint:ready`, accepts one version-1 `run` payload from the captured `window.opener`, then reports `accepted`, `progress`, and `booted` or `error`. Later runs are rejected.

```js
{
  type: 'playground-blueprint:run',
  protocolVersion: 1,
  blueprint,
  files: [{ name, bytes, mimeType, destination, path }]
}
```

Transferred files are applied after the normal Blueprint boot and before the first OPFS sync. VFS files create their parent directories. Media files are copied into uploads and registered through `wp_insert_attachment()` and attachment metadata generation.

The receiver pins the accepted run's origin, with `'*'` only for a `file://` opener. There is intentionally no allowlist: PHP-WASM remains the sandbox boundary, as it is for fragment Blueprints. The payload is capped at 200 files and 512 MB, and opener Blueprints remain disabled while the MCP server is active.

This introduces a new public version-1 message protocol. It does not change pages without the activation parameter. `demos/opener-handshake.html` is a self-contained reference opener that also works from `file://`.

## Open questions

- Are the message names, versioning shape, and transfer caps suitable for a public contract?
- Should opener runs remain autosaved? This prototype starts a fresh autosave instead of restoring one whose URL cannot identify the transferred bytes, but that setup URL still cannot replay the upload by itself.
- Should a later version replace window messages with a `MessageChannel` or Blueprint bundle transport?

The website unit suite, typecheck, lint, standalone build, and embedded PHP syntax check pass. The real-browser pass and screenshots are still pending because this workspace had no browser session available.

## Manual testing

1. Start the website dev server and open `/website-server/demos/opener-handshake.html`.
2. Send the default Blueprint with `note.txt` targeting `/wordpress/wp-content/note.txt`; confirm `ready → accepted → progress → booted`, the logged-in admin landing page, and the file contents.
3. Repeat with an image targeting Media Library and confirm its thumbnail appears.
4. Send the run again, then try a fresh tab with `blueprint: "nope"`; confirm `already-running` and a friendly receiver error respectively, with no console rejection.
5. Open the demo from `file://`, then open Playground once without `blueprint-source=opener`; confirm the file opener works and the plain page sends no `ready` message.
