### PR TITLE
[Website] Preserve concurrent metadata while preparing Blueprint drafts

### DIFF
--- a/packages/playground/website/src/components/blueprint-editor/SiteBlueprintBundleEditor.spec.ts
+++ b/packages/playground/website/src/components/blueprint-editor/SiteBlueprintBundleEditor.spec.ts
@@ -1,13 +1,60 @@
 // @vitest-environment jsdom
 
-import { describe, expect, it, vi } from 'vitest';
+import { act, createElement } from 'react';
+import { createRoot } from 'react-dom/client';
+import type { Root } from 'react-dom/client';
+import {
+	afterAll,
+	afterEach,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	vi,
+} from 'vitest';
 import { InMemoryFilesystemBackend } from '@wp-playground/storage';
-import { readSiteBlueprintJson } from './SiteBlueprintBundleEditor';
+import type * as BlueprintBundleStorageModule from '../../lib/state/opfs/opfs-blueprint-bundle-storage';
+import type * as SliceSitesModule from '../../lib/state/redux/slice-sites';
+import {
+	readSiteBlueprintJson,
+	SiteBlueprintBundleEditor,
+} from './SiteBlueprintBundleEditor';
+
+type SiteInfo = SliceSitesModule.SiteInfo;
+
+const mocks = vi.hoisted(() => ({
+	dispatch: vi.fn(),
+	persistBlueprintBundle: vi.fn(),
+	updateSiteMetadata: vi.fn(),
+}));
+
+vi.mock(
+	'../../lib/state/opfs/opfs-blueprint-bundle-storage',
+	async (importOriginal) => ({
+		...(await importOriginal<typeof BlueprintBundleStorageModule>()),
+		persistBlueprintBundle: mocks.persistBlueprintBundle,
+	})
+);
 
 vi.mock('../../lib/state/redux/store', () => ({
-	useAppDispatch: vi.fn(),
+	useAppDispatch: () => mocks.dispatch,
 	useAppSelector: vi.fn(),
 }));
+
+vi.mock('../../lib/state/redux/slice-sites', async (importOriginal) => ({
+	...(await importOriginal<typeof SliceSitesModule>()),
+	updateSiteMetadata: mocks.updateSiteMetadata,
+}));
+
+vi.mock('./BlueprintBundleEditor', async () => {
+	const { forwardRef } = await import('react');
+	return {
+		BlueprintBundleEditor: forwardRef(function BlueprintBundleEditorMock() {
+			return null;
+		}),
+	};
+});
 
 describe('readSiteBlueprintJson', () => {
 	it('seeds a minimal Blueprint when no declaration exists', async () => {
@@ -26,5 +73,90 @@ describe('readSiteBlueprintJson', () => {
 			'File not found: /blueprint.json'
 		);
 		expect(await backend.fileExists('/blueprint.json')).toBe(false);
+	});
+});
+
+describe('SiteBlueprintBundleEditor', () => {
+	let container: HTMLDivElement;
+	let root: Root;
+
+	beforeAll(() => {
+		vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+	});
+
+	afterAll(() => {
+		vi.unstubAllGlobals();
+	});
+
+	beforeEach(() => {
+		container = document.createElement('div');
+		document.body.append(container);
+		root = createRoot(container);
+		mocks.dispatch.mockReset();
+		mocks.persistBlueprintBundle.mockReset();
+		mocks.updateSiteMetadata.mockReset();
+	});
+
+	afterEach(() => {
+		act(() => root.unmount());
+		container.remove();
+	});
+
+	it('updates only Blueprint metadata after storing an autosaved draft', async () => {
+		const site = {
+			slug: 'autosaved-site',
+			metadata: {
+				id: 'autosaved-site',
+				name: 'Autosaved Playground',
+				storage: 'opfs',
+				persistence: 'autosave',
+				initialOpfsSyncPending: true,
+				originalBlueprint: { steps: [] },
+				originalBlueprintSource: { type: 'none' },
+				runtimeConfiguration: {
+					phpVersion: '8.3',
+					wpVersion: 'latest',
+				},
+			},
+		} as SiteInfo;
+		const persistedBackend = new InMemoryFilesystemBackend();
+		const metadataAction = { type: 'update-site-metadata' };
+		let finishPersistence!: () => void;
+		const persistence = new Promise<InMemoryFilesystemBackend>(
+			(resolve) => {
+				finishPersistence = () => resolve(persistedBackend);
+			}
+		);
+		mocks.persistBlueprintBundle.mockReturnValue(persistence);
+		mocks.updateSiteMetadata.mockReturnValue(metadataAction);
+		mocks.dispatch.mockResolvedValue(undefined);
+
+		await act(async () => {
+			root.render(createElement(SiteBlueprintBundleEditor, { site }));
+			await Promise.resolve();
+		});
+		await vi.waitFor(() =>
+			expect(mocks.persistBlueprintBundle).toHaveBeenCalledOnce()
+		);
+
+		expect(mocks.updateSiteMetadata).not.toHaveBeenCalled();
+
+		await act(async () => {
+			finishPersistence();
+			await persistence;
+		});
+		await vi.waitFor(() =>
+			expect(mocks.updateSiteMetadata).toHaveBeenCalledOnce()
+		);
+
+		expect(mocks.updateSiteMetadata).toHaveBeenCalledWith({
+			slug: site.slug,
+			changes: {
+				originalBlueprint: persistedBackend,
+				originalBlueprintSource: { type: 'opfs-site' },
+			},
+		});
+		expect(mocks.dispatch).toHaveBeenCalledOnce();
+		expect(mocks.dispatch).toHaveBeenCalledWith(metadataAction);
 	});
 });

--- a/packages/playground/website/src/components/blueprint-editor/SiteBlueprintBundleEditor.tsx
+++ b/packages/playground/website/src/components/blueprint-editor/SiteBlueprintBundleEditor.tsx
@@ -16,15 +16,12 @@ import {
 	useRef,
 	useState,
 } from 'react';
-import {
-	loadPersistedBlueprintBundle,
-	persistBlueprintBundle,
-} from '../../lib/state/opfs/opfs-blueprint-bundle-storage';
+import { persistBlueprintBundle } from '../../lib/state/opfs/opfs-blueprint-bundle-storage';
 import {
 	isAutosavedSite,
 	isExplicitlySavedSite,
 	type SiteInfo,
-	updateSite,
+	updateSiteMetadata,
 } from '../../lib/state/redux/slice-sites';
 import { useAppDispatch } from '../../lib/state/redux/store';
 import styles from './blueprint-bundle-editor.module.css';
@@ -272,20 +269,19 @@ export const SiteBlueprintBundleEditor = forwardRef<
 				// Autosaved Playgrounds keep editable Blueprint bundles beside their
 				// WordPress files. Declaration-only metadata is converted once into a
 				// per-site OPFS bundle so later edits cannot leak into another site.
-				await persistBlueprintBundle(site.slug, fs.backend);
 				const opfsFilesystem = new EventedFilesystem(
-					await loadPersistedBlueprintBundle(site.slug)
+					await persistBlueprintBundle(site.slug, fs.backend)
 				);
+				// Boot may update site metadata while the bundle is copied. Merge only
+				// the bundle fields after the copy instead of restoring the SiteInfo
+				// snapshot captured when this effect started.
 				await dispatch(
-					updateSite({
+					updateSiteMetadata({
 						slug: site.slug,
 						changes: {
-							metadata: {
-								...site.metadata,
-								originalBlueprint: opfsFilesystem.backend,
-								originalBlueprintSource: {
-									type: 'opfs-site',
-								},
+							originalBlueprint: opfsFilesystem.backend,
+							originalBlueprintSource: {
+								type: 'opfs-site',
 							},
 						},
 					})


### PR DESCRIPTION
Part of #4099.

Opening the Blueprint editor while an autosaved Playground is still copying its WordPress files into OPFS could put the Playground back into a pending state.

The editor stored its Blueprint bundle asynchronously, then wrote the entire site metadata snapshot captured before that work started. If boot cleared `initialOpfsSyncPending` in the meantime, this stale write restored it.

Update only `originalBlueprint` and `originalBlueprintSource` after storing the bundle. Boot and synchronization metadata is left alone.

## Testing

Open the Blueprint editor for a newly created autosaved Playground while its initial save completes. Reload and confirm it opens from its stored files.
