### PR TITLE
[Website] Clarify New Playground and autosave failure states

### DIFF
--- a/packages/playground/website/src/components/ensure-playground-site/ensure-playground-site-is-selected.tsx
+++ b/packages/playground/website/src/components/ensure-playground-site/ensure-playground-site-is-selected.tsx
@@ -313,24 +313,31 @@ export function EnsurePlaygroundSiteIsSelected({
 		setAutosaveNudge(undefined);
 		setAutosaveNudgeError(undefined);
 		setIsAutosaveNudgeActionPending(true);
+		// Dismissing the restore choice settles it for this page load. If keeping
+		// the new Playground fails, report that save failure separately instead of
+		// reopening a prompt about the older autosave.
+		setDeclinedYouHaveAutosaveFingerprints((fingerprints) =>
+			fingerprints.includes(dismissedNudge.setupUrlFingerprint)
+				? fingerprints
+				: [...fingerprints, dismissedNudge.setupUrlFingerprint]
+		);
 		try {
 			await sitesAPI.autosaveTemporarySite(undefined, {
 				updateUrl: false,
 				excludeFromPruning: [dismissedNudge.site.slug],
 			});
-			setDeclinedYouHaveAutosaveFingerprints((fingerprints) => [
-				...fingerprints,
-				dismissedNudge.setupUrlFingerprint,
-			]);
 			return true;
 		} catch (error) {
 			logger.error(
 				'Error autosaving the new Playground after declining restore.',
 				error
 			);
-			setAutosaveNudge(dismissedNudge);
-			setAutosaveNudgeError(
-				'Could not keep the new Playground. Please try again.'
+			dispatch(
+				setDockOperationNotice({
+					title: 'Couldn’t autosave this Playground',
+					message:
+						'It’s still open but will be lost on refresh. Your earlier autosave is unchanged.',
+				})
 			);
 			return false;
 		} finally {

--- a/packages/playground/website/src/components/saved-playgrounds-panel/index.tsx
+++ b/packages/playground/website/src/components/saved-playgrounds-panel/index.tsx
@@ -15,6 +15,7 @@ import {
 	pencil,
 	layout,
 	fullscreen,
+	offline as offlineIcon,
 } from '@wordpress/icons';
 import { Icon } from '@wordpress/icons';
 import { GitHubIcon } from '../../github/github';
@@ -1422,9 +1423,22 @@ export function SavedPlaygroundsPanel({
 					</div>
 				)}
 				{!blueprintsLoading && blueprintsError && (
-					<p className={css.emptyMessage}>
-						Unable to load Blueprints. Check your connection.
-					</p>
+					<div className={css.blueprintsError} role="alert">
+						<span
+							className={css.blueprintsErrorIcon}
+							aria-hidden="true"
+						>
+							<Icon icon={offlineIcon} size={16} />
+						</span>
+						<div>
+							<p className={css.blueprintsErrorTitle}>
+								The Blueprint gallery couldn’t load
+							</p>
+							<p className={css.blueprintsErrorMessage}>
+								Check your internet connection and try again.
+							</p>
+						</div>
+					</div>
 				)}
 				{!blueprintsLoading &&
 					!blueprintsError &&

--- a/packages/playground/website/src/components/saved-playgrounds-panel/style.module.css
+++ b/packages/playground/website/src/components/saved-playgrounds-panel/style.module.css
@@ -1361,6 +1361,51 @@
 	color: #5f5b54;
 }
 
+.playgrounds-pane .blueprintsError {
+	align-items: flex-start;
+	background: #fff8e5;
+	border: 1px solid #e6d39a;
+	border-radius: 10px;
+	color: var(--ink, #21201d);
+	display: flex;
+	gap: 12px;
+	padding: 14px 16px;
+}
+
+.playgrounds-pane .blueprintsErrorIcon {
+	align-items: center;
+	background: #f5df9d;
+	border-radius: 50%;
+	color: #6d4a00;
+	display: flex;
+	flex: none;
+	font-size: 13px;
+	font-weight: 700;
+	height: 24px;
+	justify-content: center;
+	line-height: 1;
+	width: 24px;
+}
+
+.playgrounds-pane .blueprintsErrorTitle,
+.playgrounds-pane .blueprintsErrorMessage {
+	margin: 0;
+}
+
+.playgrounds-pane .blueprintsErrorTitle {
+	color: var(--ink, #21201d);
+	font-size: 14px;
+	font-weight: 600;
+	line-height: 1.4;
+}
+
+.playgrounds-pane .blueprintsErrorMessage {
+	color: var(--ink-muted, #5f5b54);
+	font-size: 13px;
+	line-height: 1.5;
+	margin-top: 2px;
+}
+
 .playgrounds-pane .showMoreButton {
 	border-color: rgba(33, 30, 25, 0.14);
 	color: #5f5b54;

--- a/packages/playground/website/src/components/site-error-modal/get-site-error-view.spec.tsx
+++ b/packages/playground/website/src/components/site-error-modal/get-site-error-view.spec.tsx
@@ -82,6 +82,27 @@ describe('getSiteErrorView', () => {
 		expect(view.title).toBe('Blueprint could not be downloaded');
 		expect(renderToStaticMarkup(view.body)).toContain(url);
 	});
+
+	it('explains an incomplete WordPress download and offers a retry', () => {
+		const view = getSiteErrorView({
+			error: 'site-boot-failed',
+			site: createSite(),
+			helpers,
+			errorDetails: {
+				message:
+					'WordPress core bundle file-count parity check failed: extracted 1812 files, expected 1816.',
+			},
+		});
+
+		expect(view.title).toBe('WordPress download was incomplete');
+		expect(renderToStaticMarkup(view.body)).toContain(
+			'the downloaded WordPress package was missing files'
+		);
+		expect(renderToStaticMarkup(view.actions[0])).toContain(
+			'Reload and try again'
+		);
+		expect(view.hideReportButton).toBe(true);
+	});
 });
 
 function createSite(

--- a/packages/playground/website/src/components/site-error-modal/get-site-error-view.spec.tsx
+++ b/packages/playground/website/src/components/site-error-modal/get-site-error-view.spec.tsx
@@ -89,8 +89,7 @@ describe('getSiteErrorView', () => {
 			site: createSite(),
 			helpers,
 			errorDetails: {
-				message:
-					'WordPress core bundle file-count parity check failed: extracted 1812 files, expected 1816.',
+				originalErrorClassName: 'WordPressBundleFileCountMismatchError',
 			},
 		});
 

--- a/packages/playground/website/src/components/site-error-modal/get-site-error-view.tsx
+++ b/packages/playground/website/src/components/site-error-modal/get-site-error-view.tsx
@@ -699,19 +699,16 @@ function genericSiteBootFailedView({
 }
 
 function isIncompleteWordPressBundleError(errorDetails: unknown): boolean {
-	let message = '';
-	if (typeof errorDetails === 'string') {
-		message = errorDetails;
-	} else if (
-		errorDetails &&
-		typeof errorDetails === 'object' &&
-		'message' in errorDetails &&
-		typeof errorDetails.message === 'string'
-	) {
-		message = errorDetails.message;
+	if (!errorDetails || typeof errorDetails !== 'object') {
+		return false;
 	}
-	return message.includes(
-		'WordPress core bundle file-count parity check failed'
+	const error = errorDetails as {
+		name?: unknown;
+		originalErrorClassName?: unknown;
+	};
+	return (
+		error.name === 'WordPressBundleFileCountMismatchError' ||
+		error.originalErrorClassName === 'WordPressBundleFileCountMismatchError'
 	);
 }
 

--- a/packages/playground/website/src/components/site-error-modal/get-site-error-view.tsx
+++ b/packages/playground/website/src/components/site-error-modal/get-site-error-view.tsx
@@ -661,6 +661,7 @@ function resourceDownloadFailedView({
 function genericSiteBootFailedView({
 	blueprintStepError,
 	helpers,
+	errorDetails,
 }: SiteErrorViewContext): SiteErrorViewConfig {
 	// If we have a Blueprint step error, the dedicated view will have been used.
 	if (blueprintStepError) {
@@ -670,6 +671,9 @@ function genericSiteBootFailedView({
 			blueprintStepError,
 			helpers,
 		});
+	}
+	if (isIncompleteWordPressBundleError(errorDetails)) {
+		return incompleteWordPressBundleView(helpers);
 	}
 
 	return {
@@ -689,6 +693,59 @@ function genericSiteBootFailedView({
 				onClick={helpers.reloadWithoutBlueprint}
 			>
 				Reload Fresh Playground
+			</Button>,
+		],
+	};
+}
+
+function isIncompleteWordPressBundleError(errorDetails: unknown): boolean {
+	let message = '';
+	if (typeof errorDetails === 'string') {
+		message = errorDetails;
+	} else if (
+		errorDetails &&
+		typeof errorDetails === 'object' &&
+		'message' in errorDetails &&
+		typeof errorDetails.message === 'string'
+	) {
+		message = errorDetails.message;
+	}
+	return message.includes(
+		'WordPress core bundle file-count parity check failed'
+	);
+}
+
+function incompleteWordPressBundleView(
+	helpers: PresentationHelpers
+): SiteErrorViewConfig {
+	return {
+		title: 'WordPress download was incomplete',
+		isDeveloperError: false,
+		hideReportButton: true,
+		hideTroubleshootWithAiButton: true,
+		detailSummaryOverride: 'Technical details',
+		body: (
+			<>
+				<p className={css.errorLead}>
+					Playground stopped because the downloaded WordPress package
+					was missing files.
+				</p>
+				<ul className={css.errorList}>
+					<li>
+						This usually means the download was interrupted or a
+						cached copy was damaged.
+					</li>
+					<li>Reload to download WordPress again.</li>
+				</ul>
+			</>
+		),
+		actions: [
+			<Button
+				variant="primary"
+				key="reload-incomplete-wordpress"
+				onClick={helpers.reloadPage}
+			>
+				Reload and try again
 			</Button>,
 		],
 	};

--- a/packages/playground/website/src/github/preview-pr/form.tsx
+++ b/packages/playground/website/src/github/preview-pr/form.tsx
@@ -119,6 +119,7 @@ export default function PreviewPRForm({
 		cleanupRetryRef.current = () => {};
 
 		const { target: repo, ref, isBranch } = resolved;
+		const isBareWordPressPr = repo === 'wordpress' && value.trim() === ref;
 		setSubmitting(true);
 
 		// For branches, skip verification since we'll use the most recent artifact with prefix matching
@@ -141,7 +142,11 @@ export default function PreviewPRForm({
 				}
 
 				if (error === 'invalid_pr_number' || error === 'no_ci_runs') {
-					setError(`The PR ${ref} does not exist.`);
+					setError(
+						isBareWordPressPr
+							? `Couldn’t find WordPress Core PR ${ref}. If this is a Gutenberg PR, paste its full GitHub URL instead.`
+							: `The PR ${ref} does not exist.`
+					);
 				} else if (
 					error === 'artifact_not_found' ||
 					error === 'artifact_not_available'
@@ -180,7 +185,9 @@ export default function PreviewPRForm({
 					);
 				} else {
 					setError(
-						`The PR ${ref} couldn't be previewed due to an unexpected error. Please try again later or file an issue in the WordPress Playground repository.`
+						isBareWordPressPr
+							? `Playground treated ${ref} as a WordPress Core PR, but couldn’t verify it. If this is a Gutenberg PR, paste its full GitHub URL instead.`
+							: `The PR ${ref} couldn't be previewed due to an unexpected error. Please try again later or file an issue in the WordPress Playground repository.`
 					);
 					// https://github.com/WordPress/wordpress-playground/issues/new
 				}
@@ -251,12 +258,7 @@ export default function PreviewPRForm({
 
 	return (
 		<form onSubmit={handleSubmit}>
-			<div className={css.content}>
-				{submitting && (
-					<div className={css.overlay}>
-						<Spinner />
-					</div>
-				)}
+			<div>
 				<TextControl
 					disabled={submitting}
 					label={inputLabel}
@@ -274,6 +276,12 @@ export default function PreviewPRForm({
 						Gutenberg branch links work too.
 					</p>
 				)}
+				{submitting && (
+					<div className={css.loadingStatus} role="status">
+						<Spinner />
+						<span>Checking GitHub for a preview build…</span>
+					</div>
+				)}
 				{errorMsg &&
 					(inline ? (
 						<Notice status="error" isDismissible={false}>
@@ -289,8 +297,9 @@ export default function PreviewPRForm({
 						variant="primary"
 						type="submit"
 						disabled={submitting}
+						isBusy={submitting}
 					>
-						Preview
+						{submitting ? 'Checking…' : 'Preview'}
 					</Button>
 				</div>
 			) : (

--- a/packages/playground/website/src/github/preview-pr/style.module.css
+++ b/packages/playground/website/src/github/preview-pr/style.module.css
@@ -1,7 +1,3 @@
-.content {
-	position: relative;
-}
-
 /* Short note under the field explaining what input is accepted. */
 .hint {
 	margin: 8px 0 0;
@@ -17,26 +13,21 @@
 	margin-top: 12px;
 }
 
-.overlay {
-	width: 100%;
-	height: 100%;
-	position: absolute;
+.loading-status {
+	align-items: center;
+	background: var(--paper-2, #faf8f5);
+	border: 1px solid var(--line-control, rgba(33, 32, 29, 0.14));
+	border-radius: var(--radius-card, 8px);
+	color: var(--ink-muted, #5f5b54);
+	display: flex;
+	font-size: 13px;
+	gap: 10px;
+	line-height: 1.4;
+	margin-top: 12px;
+	padding: 10px 12px;
+}
 
-	&:before {
-		content: '';
-		position: absolute;
-		top: 0;
-		left: 0;
-		width: 100%;
-		height: 100%;
-		background-color: rgba(255, 255, 255, 0.75);
-	}
-
-	svg {
-		top: 50%;
-		left: 50%;
-		transform: translate(-50%, -50%);
-		padding: 0;
-		margin: 0;
-	}
+.loading-status :global(.components-spinner) {
+	flex: none;
+	margin: 0;
 }

--- a/packages/playground/website/src/lib/state/opfs/opfs-site-storage.ts
+++ b/packages/playground/website/src/lib/state/opfs/opfs-site-storage.ts
@@ -550,8 +550,9 @@ async function opfsWriteFile(path: string, content: string) {
 			);
 		};
 	});
+	let timeoutId: ReturnType<typeof setTimeout>;
 	const promiseToTimeout = new Promise<void>((resolve, reject) => {
-		setTimeout(
+		timeoutId = setTimeout(
 			() =>
 				reject(
 					new Error(
@@ -562,7 +563,10 @@ async function opfsWriteFile(path: string, content: string) {
 		);
 	});
 
-	return Promise.race<void>([promiseToWrite, promiseToTimeout]).finally(() =>
-		worker.terminate()
+	return Promise.race<void>([promiseToWrite, promiseToTimeout]).finally(
+		() => {
+			clearTimeout(timeoutId);
+			worker.terminate();
+		}
 	);
 }

--- a/packages/playground/website/src/lib/state/opfs/opfs-site-storage.ts
+++ b/packages/playground/website/src/lib/state/opfs/opfs-site-storage.ts
@@ -538,10 +538,28 @@ async function opfsWriteFile(path: string, content: string) {
 				);
 			}
 		};
-		worker.onerror = reject;
+		worker.onerror = (event) => {
+			const detail =
+				event instanceof ErrorEvent && event.message
+					? ` ${event.message}`
+					: '';
+			reject(
+				new Error(
+					`The browser storage worker failed while writing ${path} at ${metadataWorkerUrl}.${detail}`
+				)
+			);
+		};
 	});
 	const promiseToTimeout = new Promise<void>((resolve, reject) => {
-		setTimeout(() => reject(new Error('timeout')), 5000);
+		setTimeout(
+			() =>
+				reject(
+					new Error(
+						`The browser storage worker did not finish writing ${path} within 5 seconds.`
+					)
+				),
+			5000
+		);
 	});
 
 	return Promise.race<void>([promiseToWrite, promiseToTimeout]).finally(() =>

--- a/packages/playground/wordpress/src/index.ts
+++ b/packages/playground/wordpress/src/index.ts
@@ -518,10 +518,9 @@ export async function unzipWordPress(
 			options.expectedFileCount != null &&
 			stats.fileCount !== options.expectedFileCount
 		) {
-			throw new Error(
-				`WordPress core bundle file-count parity check failed: ` +
-					`extracted ${stats.fileCount} files, expected ${options.expectedFileCount}. ` +
-					`The download may be truncated or corrupt.`
+			throw new WordPressBundleFileCountMismatchError(
+				stats.fileCount,
+				options.expectedFileCount
 			);
 		}
 	} else {
@@ -610,6 +609,17 @@ export async function unzipWordPress(
 				joinPaths(php.documentRoot, '/wp-config-sample.php')
 			)
 		);
+	}
+}
+
+export class WordPressBundleFileCountMismatchError extends Error {
+	constructor(actualFileCount: number, expectedFileCount: number) {
+		super(
+			`WordPress core bundle file-count parity check failed: ` +
+				`extracted ${actualFileCount} files, expected ${expectedFileCount}. ` +
+				`The download may be truncated or corrupt.`
+		);
+		this.name = 'WordPressBundleFileCountMismatchError';
 	}
 }
 


### PR DESCRIPTION
Gives New Playground failures specific states instead of generic placeholders and crash copy.

A failed gallery request now stays inside a compact warning. Pull-request verification keeps the form readable. An incomplete WordPress bundle gets its own retry screen. A failed attempt to keep a new Playground reports the problem in the Dock without reopening the prompt for an older autosave. OPFS worker failures retain the file path and worker URL in the logged error.

## Blueprint gallery

| | Before | After |
| --- | --- | --- |
| Desktop | ![The old Blueprint gallery error in a large empty card](https://raw.githubusercontent.com/WordPress/wordpress-playground/b22f357e8499a831caf62453678d9335dea6a748/before-gallery-desktop.png) | ![The compact Blueprint gallery connection warning](https://raw.githubusercontent.com/WordPress/wordpress-playground/b22f357e8499a831caf62453678d9335dea6a748/after-gallery-desktop.png) |
| Mobile | ![The old Blueprint gallery error on mobile](https://raw.githubusercontent.com/WordPress/wordpress-playground/b22f357e8499a831caf62453678d9335dea6a748/before-gallery-mobile.png) | ![The compact Blueprint gallery warning on mobile](https://raw.githubusercontent.com/WordPress/wordpress-playground/b22f357e8499a831caf62453678d9335dea6a748/after-gallery-mobile.png) |

## Pull-request verification

| | Before | After |
| --- | --- | --- |
| Desktop | ![The old washed-out pull-request loading state](https://raw.githubusercontent.com/WordPress/wordpress-playground/b22f357e8499a831caf62453678d9335dea6a748/before-loading-desktop.png) | ![The inline pull-request build check](https://raw.githubusercontent.com/WordPress/wordpress-playground/b22f357e8499a831caf62453678d9335dea6a748/after-loading-desktop.png) |
| Mobile | ![The old washed-out pull-request loading state on mobile](https://raw.githubusercontent.com/WordPress/wordpress-playground/b22f357e8499a831caf62453678d9335dea6a748/before-loading-mobile.png) | ![The inline pull-request build check on mobile](https://raw.githubusercontent.com/WordPress/wordpress-playground/b22f357e8499a831caf62453678d9335dea6a748/after-loading-mobile.png) |

## Testing

- Block the Blueprint gallery index request and check the compact connection warning.
- Delay a pull-request build check and check that the form stays readable at desktop and mobile widths.
- Interrupt an autosave and check that the older-autosave prompt stays dismissed while the Dock reports the failure.
- Boot from an incomplete WordPress bundle and check that the retry screen explains the missing files.
