### PR TITLE
[Website] Accept ZIP drops across the page

### DIFF
--- a/packages/playground/website/playwright/e2e/opfs.spec.ts
+++ b/packages/playground/website/playwright/e2e/opfs.spec.ts
@@ -24,6 +24,48 @@ async function createTestWordPressZip(
 	return Buffer.from(zipBytes!);
 }
 
+async function dropZipFile(
+	page: Page,
+	name: string,
+	zipBuffer: Buffer,
+	verifyDragLeaveStability = true
+) {
+	const dataTransfer = await page.evaluateHandle(
+		(file) => {
+			const bytes = Uint8Array.from(atob(file.base64), (character) =>
+				character.charCodeAt(0)
+			);
+			const dataTransfer = new DataTransfer();
+			dataTransfer.items.add(
+				new File([bytes], file.name, { type: 'application/zip' })
+			);
+			return dataTransfer;
+		},
+		{ name, base64: zipBuffer.toString('base64') }
+	);
+	await expect(
+		page.getByRole('button', { name: /Drop a Playground ZIP here/ })
+	).toBeVisible();
+	await page.waitForTimeout(50);
+	const pane = page.getByRole('dialog', { name: 'New Playground pane' });
+	const paneText = await pane.innerText();
+	const pageBody = page.locator('body');
+	await pageBody.dispatchEvent('dragenter', { dataTransfer });
+	await expect(page.locator('[data-cy="zip-drop-overlay"]')).toBeVisible();
+	expect(await pane.innerText()).toBe(paneText);
+	if (verifyDragLeaveStability) {
+		await pageBody.dispatchEvent('dragleave', { dataTransfer });
+		await pageBody.dispatchEvent('dragenter', { dataTransfer });
+		await page.waitForTimeout(75);
+		await expect(
+			page.locator('[data-cy="zip-drop-overlay"]')
+		).toBeVisible();
+	}
+	await pageBody.dispatchEvent('dragover', { dataTransfer });
+	await pageBody.dispatchEvent('drop', { dataTransfer });
+	await dataTransfer.dispose();
+}
+
 async function createPluginThemeExportZip(): Promise<Buffer> {
 	const files = [
 		new File(
@@ -971,6 +1013,70 @@ test('should remove the saved site created for a failed ZIP import', async ({
 		.toEqual(storedSiteSlugsBeforeImport);
 });
 
+test('should import a ZIP dropped on the page', async ({
+	website,
+	wordpress,
+	browserName,
+}) => {
+	test.skip(
+		browserName !== 'chromium',
+		`This test relies on OPFS which isn't available in Playwright's flavor of ${browserName}.`
+	);
+
+	await website.goto(getTemporaryPlaygroundUrl());
+	const sourceSite = await getActivePlaygroundSite(website.page);
+	expect(sourceSite?.slug).toBeTruthy();
+	const sourceSiteSlug = sourceSite.slug;
+
+	await website.openDockPane('New Playground');
+	await website.page
+		.getByRole('tab', { name: 'Import zip', exact: true })
+		.click();
+
+	const marker = 'PAGE_DROP_ZIP_IMPORT_MARKER';
+	const markerPath = 'wp-content/page-drop-zip-import-marker.php';
+	const zipBuffer = await createTestWordPressZip(marker, markerPath);
+	await dropZipFile(website.page, 'page-drop-import.zip', zipBuffer);
+
+	await expect(
+		website.page.getByText('Playground imported', { exact: true })
+	).toBeVisible({ timeout: 120000 });
+	await waitForActivePlaygroundSiteSlug(
+		website.page,
+		(slug) => slug !== sourceSiteSlug
+	);
+	await openPlaygroundPath(website.page, `/${markerPath}`);
+	await expect(wordpress.locator('body')).toContainText(marker);
+});
+
+test('should show an inline error for a non-ZIP drop', async ({
+	website,
+	browserName,
+}) => {
+	test.skip(
+		browserName !== 'chromium',
+		`This test relies on OPFS which isn't available in Playwright's flavor of ${browserName}.`
+	);
+
+	await website.goto(getTemporaryPlaygroundUrl());
+	await website.openDockPane('New Playground');
+	await website.page
+		.getByRole('tab', { name: 'Import zip', exact: true })
+		.click();
+	await dropZipFile(
+		website.page,
+		'not-a-playground-export.txt',
+		Buffer.from('not a zip archive'),
+		false
+	);
+
+	await expect(
+		website.page.getByRole('alert').filter({
+			hasText: 'Choose a WordPress Playground .zip export.',
+		})
+	).toBeVisible();
+});
+
 test('should close the pane, reveal the site, and finish during a ZIP import', async ({
 	website,
 	browserName,
@@ -1205,11 +1311,6 @@ test('should create a saved site when importing ZIP while on a saved site with n
 	await website.page
 		.getByRole('tab', { name: 'Import zip', exact: true })
 		.click();
-
-	const importZipButton = website.page.getByRole('button', {
-		name: 'Choose a .zip file…',
-	});
-	await expect(importZipButton).toBeVisible();
 
 	// Create a test ZIP
 	const importedMarker = 'FRESH_IMPORT_MARKER_BBBBB';

--- a/packages/playground/website/src/components/saved-playgrounds-panel/index.tsx
+++ b/packages/playground/website/src/components/saved-playgrounds-panel/index.tsx
@@ -1,5 +1,6 @@
 import css from './style.module.css';
 import classNames from 'classnames';
+import { createPortal } from 'react-dom';
 import {
 	Spinner,
 	DropdownMenu,
@@ -170,6 +171,7 @@ export function SavedPlaygroundsPanel({
 	const playground = usePlaygroundClient();
 	const localFsAvailability = useLocalFsAvailability(playground ?? undefined);
 	const zipFileInputRef = useRef<HTMLInputElement>(null);
+	const zipDragDepthRef = useRef(0);
 	const panelRootRef = useRef<HTMLDivElement>(null);
 	const creationPanelRef = useRef<HTMLDivElement>(null);
 	const inlineRename = useInlineRename();
@@ -177,6 +179,7 @@ export function SavedPlaygroundsPanel({
 	const [searchQuery, setSearchQuery] = useState('');
 	const [showAllStoredSites, setShowAllStoredSites] = useState(false);
 	const [isImportingZip, setIsImportingZip] = useState(false);
+	const [isDraggingZip, setIsDraggingZip] = useState(false);
 	const [zipImportError, setZipImportError] = useState<string>();
 	const zipImportPendingRef = useRef(false);
 	// A mouse click can put the cursor in the newly selected form straight away.
@@ -316,47 +319,147 @@ export function SavedPlaygroundsPanel({
 		}
 	}, [panel]);
 
-	const handleImportZip = async (e: React.ChangeEvent<HTMLInputElement>) => {
-		const file = e.target.files?.[0];
-		if (!file) return;
-		if (zipImportPendingRef.current) {
-			e.target.value = '';
-			return;
-		}
-
-		zipImportPendingRef.current = true;
-		setIsImportingZip(true);
-		setZipImportError(undefined);
-		onClose();
-		try {
-			const importedSiteSlug = await sitesAPI.createNewSiteFromZip(file);
-			const importedSite = sitesAPI
-				.list()
-				.find((site) => site.slug === importedSiteSlug);
-			dispatch(
-				setDockOperationNotice({
-					status: 'success',
-					title: 'Playground imported',
-					message:
-						importedSite?.storage === 'temporary'
-							? 'Your Playground is ready. It’s available until you close this page.'
-							: 'Your Playground is ready. It’s autosaved in this browser.',
-				})
-			);
-		} catch (error) {
-			logger.error(error);
-			setZipImportError(
-				'Unable to import this file. Is it a valid WordPress Playground export?'
-			);
-			dispatch(setDockPaneOpen(true));
-		} finally {
-			zipImportPendingRef.current = false;
-			setIsImportingZip(false);
-			if (zipFileInputRef.current) {
-				zipFileInputRef.current.value = '';
-			}
+	const handleImportZip = (event: React.ChangeEvent<HTMLInputElement>) => {
+		const file = event.target.files?.[0];
+		if (file) {
+			void importZipFile(file);
 		}
 	};
+
+	const importZipFile = useCallback(
+		async (file: File) => {
+			if (zipImportPendingRef.current) {
+				if (zipFileInputRef.current) {
+					zipFileInputRef.current.value = '';
+				}
+				return;
+			}
+			if (!file.name.toLowerCase().endsWith('.zip')) {
+				setZipImportError('Choose a WordPress Playground .zip export.');
+				if (zipFileInputRef.current) {
+					zipFileInputRef.current.value = '';
+				}
+				return;
+			}
+
+			zipImportPendingRef.current = true;
+			setIsImportingZip(true);
+			setZipImportError(undefined);
+			onClose();
+			try {
+				const importedSiteSlug =
+					await sitesAPI.createNewSiteFromZip(file);
+				const importedSite = sitesAPI
+					.list()
+					.find((site) => site.slug === importedSiteSlug);
+				dispatch(
+					setDockOperationNotice({
+						status: 'success',
+						title: 'Playground imported',
+						message:
+							importedSite?.storage === 'temporary'
+								? 'Your Playground is ready. It’s available until you close this page.'
+								: 'Your Playground is ready. It’s autosaved in this browser.',
+					})
+				);
+			} catch (error) {
+				logger.error(error);
+				setZipImportError(
+					'Unable to import this file. Is it a valid WordPress Playground export?'
+				);
+				dispatch(setDockPaneOpen(true));
+			} finally {
+				zipImportPendingRef.current = false;
+				setIsImportingZip(false);
+				if (zipFileInputRef.current) {
+					zipFileInputRef.current.value = '';
+				}
+			}
+		},
+		[dispatch, onClose, sitesAPI]
+	);
+
+	useEffect(() => {
+		if (panel !== 'new' || activeCreationTab !== 'zip' || isImportingZip) {
+			return;
+		}
+		let dragLeaveTimer: number | undefined;
+
+		function handleDragEnter(event: DragEvent) {
+			if (!hasFiles(event)) {
+				return;
+			}
+			event.preventDefault();
+			cancelPendingDragLeave();
+			zipDragDepthRef.current += 1;
+			setIsDraggingZip(true);
+		}
+
+		function handleDragOver(event: DragEvent) {
+			if (!hasFiles(event)) {
+				return;
+			}
+			event.preventDefault();
+			if (event.dataTransfer) {
+				event.dataTransfer.dropEffect = 'copy';
+			}
+		}
+
+		function handleDragLeave(event: DragEvent) {
+			if (zipDragDepthRef.current === 0) {
+				return;
+			}
+			event.preventDefault();
+			zipDragDepthRef.current -= 1;
+			if (zipDragDepthRef.current === 0) {
+				dragLeaveTimer = window.setTimeout(() => {
+					dragLeaveTimer = undefined;
+					if (zipDragDepthRef.current === 0) {
+						setIsDraggingZip(false);
+					}
+				}, 50);
+			}
+		}
+
+		function handleDrop(event: DragEvent) {
+			if (!hasFiles(event)) {
+				return;
+			}
+			event.preventDefault();
+			cancelPendingDragLeave();
+			zipDragDepthRef.current = 0;
+			setIsDraggingZip(false);
+			const file = event.dataTransfer?.files[0];
+			if (file) {
+				void importZipFile(file);
+			}
+		}
+
+		function hasFiles(event: DragEvent) {
+			return event.dataTransfer?.types.includes('Files') ?? false;
+		}
+
+		function cancelPendingDragLeave() {
+			if (dragLeaveTimer !== undefined) {
+				window.clearTimeout(dragLeaveTimer);
+				dragLeaveTimer = undefined;
+			}
+		}
+
+		document.addEventListener('dragenter', handleDragEnter, true);
+		document.addEventListener('dragover', handleDragOver, true);
+		document.addEventListener('dragleave', handleDragLeave, true);
+		document.addEventListener('drop', handleDrop, true);
+		return () => {
+			document.removeEventListener('dragenter', handleDragEnter, true);
+			document.removeEventListener('dragover', handleDragOver, true);
+			document.removeEventListener('dragleave', handleDragLeave, true);
+			document.removeEventListener('drop', handleDrop, true);
+			cancelPendingDragLeave();
+			zipDragDepthRef.current = 0;
+			setIsDraggingZip(false);
+		};
+	}, [activeCreationTab, importZipFile, isImportingZip, panel]);
 
 	const {
 		data: blueprintsData,
@@ -1494,36 +1597,58 @@ export function SavedPlaygroundsPanel({
 				);
 			case 'zip':
 				return (
-					<div className={css.inlineForm}>
-						<p className={css.inlineFormHint}>
-							Import a WordPress Playground <code>.zip</code>{' '}
-							export to start a new Playground from it.
-						</p>
-						<div className={css.inlineFormActions}>
-							<Button
-								variant="primary"
+					<>
+						{isDraggingZip &&
+							createPortal(
+								<div
+									className={css.zipDropOverlay}
+									data-cy="zip-drop-overlay"
+									aria-hidden="true"
+								>
+									<span className={css.zipDropOverlayIcon}>
+										<Icon icon={upload} size={56} />
+									</span>
+									<span className={css.zipDropOverlayTitle}>
+										Drop a Playground ZIP here
+									</span>
+								</div>,
+								document.body
+							)}
+						<div className={css.inlineForm}>
+							<p className={css.inlineFormHint}>
+								Import a WordPress Playground <code>.zip</code>{' '}
+								export to start a new Playground from it.
+							</p>
+							<button
+								type="button"
+								className={css.zipDropzone}
 								data-cy="restore-from-zip"
-								isBusy={isImportingZip}
 								disabled={isImportingZip}
 								onClick={() => zipFileInputRef.current?.click()}
 							>
-								{isImportingZip
-									? 'Importing…'
-									: 'Choose a .zip file…'}
-							</Button>
+								<span className={css.zipDropzoneIcon}>
+									<Icon icon={upload} size={32} />
+								</span>
+								<span className={css.zipDropzoneTitle}>
+									Drop a Playground ZIP here
+								</span>
+								<span className={css.zipDropzoneHint}>
+									or click to choose a file
+								</span>
+							</button>
+							{zipImportError && (
+								<div
+									className={classNames(
+										css.zipImportStatus,
+										css.zipImportError
+									)}
+									role="alert"
+								>
+									{zipImportError}
+								</div>
+							)}
 						</div>
-						{zipImportError && (
-							<div
-								className={classNames(
-									css.zipImportStatus,
-									css.zipImportError
-								)}
-								role="alert"
-							>
-								{zipImportError}
-							</div>
-						)}
-					</div>
+					</>
 				);
 			default:
 				return null;
@@ -1620,7 +1745,7 @@ export function SavedPlaygroundsPanel({
 				ref={zipFileInputRef}
 				onChange={handleImportZip}
 				accept=".zip,application/zip"
-				style={{ display: 'none' }}
+				className={css.zipFileInput}
 			/>
 			{panel !== 'new' && renderYourPlaygroundsSection()}
 			{panel !== 'playgrounds' && renderNewPlaygroundSection()}

--- a/packages/playground/website/src/components/saved-playgrounds-panel/style.module.css
+++ b/packages/playground/website/src/components/saved-playgrounds-panel/style.module.css
@@ -1032,6 +1032,102 @@
 	color: var(--ink-muted, #5f5b54);
 }
 
+.playgrounds-pane .zipFileInput {
+	display: none;
+}
+
+.playgrounds-pane .zipDropzone {
+	align-items: center;
+	background: #ffffff;
+	border: 2px dashed var(--line-control, rgba(33, 32, 29, 0.22));
+	border-radius: var(--radius-card, 8px);
+	color: var(--ink-soft, #2f2d28);
+	cursor: pointer;
+	display: flex;
+	flex-direction: column;
+	gap: var(--space-2, 8px);
+	justify-content: center;
+	min-height: 190px;
+	padding: var(--space-6, 24px);
+	text-align: center;
+	transition:
+		background 0.12s ease,
+		border-color 0.12s ease,
+		box-shadow 0.12s ease;
+	width: 100%;
+}
+
+.playgrounds-pane .zipDropzone:hover:not(:disabled) {
+	background: var(--paper-2, #faf8f5);
+	border-color: var(--accent, #3858e9);
+}
+
+.zipDropOverlay {
+	align-items: center;
+	background: rgba(247, 245, 242, 0.96);
+	border: 3px dashed #3858e9;
+	border-radius: 18px;
+	box-sizing: border-box;
+	color: #21201d;
+	display: flex;
+	flex-direction: column;
+	gap: 16px;
+	inset: 12px;
+	justify-content: center;
+	pointer-events: none;
+	position: fixed;
+	z-index: 100;
+}
+
+.zipDropOverlayIcon {
+	color: #3858e9;
+	display: flex;
+}
+
+.zipDropOverlayTitle {
+	font-size: 28px;
+	font-weight: 650;
+	text-align: center;
+}
+
+@media (max-width: 600px) {
+	.zipDropOverlay {
+		inset: 8px;
+		padding: 24px;
+	}
+
+	.zipDropOverlayTitle {
+		font-size: 22px;
+	}
+}
+
+.playgrounds-pane .zipDropzone:focus-visible {
+	border-color: var(--accent, #3858e9);
+	box-shadow: 0 0 0 2px rgba(56, 88, 233, 0.35);
+	outline: none;
+}
+
+.playgrounds-pane .zipDropzone:disabled {
+	cursor: wait;
+	opacity: 0.7;
+}
+
+.playgrounds-pane .zipDropzoneIcon {
+	color: var(--accent, #3858e9);
+	display: flex;
+}
+
+.playgrounds-pane .zipDropzoneTitle {
+	color: var(--ink, #21201d);
+	font-size: 15px;
+	font-weight: 600;
+}
+
+.playgrounds-pane .zipDropzoneHint {
+	color: var(--ink-muted, #5f5b54);
+	font-size: 13px;
+}
+
 .playgrounds-pane .zipImportStatus {
 	background: var(--paper-2, #faf8f5);
 	border: 1px solid var(--line-control, rgba(33, 32, 29, 0.14));


### PR DESCRIPTION
The ZIP import tab now has a large click target. While that tab is open, dragging a file anywhere over the page shows a stable full-page drop overlay without changing a word in the panel. A non-ZIP drop stays in the panel and reports the problem inline.

The small-breakpoint screenshots document the responsive layout; touch users keep the click-to-choose path.

## Screenshots

### Desktop drag target

| Before | During drag |
| --- | --- |
| ![ZIP import before: a small file picker button](https://github.com/user-attachments/assets/0dc7eee3-5747-45b8-b15c-3e90cc6607b9) | ![ZIP import after: a page-wide drop overlay](https://github.com/user-attachments/assets/c9fed98d-e09b-4f8c-9395-c94ef6bba3eb) |

### Small-breakpoint layout

| Before | During drag |
| --- | --- |
| ![ZIP import before at the small breakpoint](https://github.com/user-attachments/assets/9a88a5b1-6466-40cc-9346-de386ca2b033) | ![ZIP import with a page-wide drop overlay at the small breakpoint](https://github.com/user-attachments/assets/60cccc71-9042-4211-a337-75a2f8309ae2) |

## Testing

1. Drag a ZIP over different parts of the page and confirm one full-page overlay appears while the panel copy remains unchanged.
2. Cross child-element boundaries and confirm the overlay does not blink.
3. Drop the ZIP and confirm the import starts.
4. Click the target and confirm the file picker still works.
5. Drop a non-ZIP file and confirm the inline message appears.
