### PR TITLE
[Website] Turn the Logs pane into a PHP error log

### DIFF
--- a/packages/playground/website/playwright/e2e/website-ui.spec.ts
+++ b/packages/playground/website/playwright/e2e/website-ui.spec.ts
@@ -927,7 +927,7 @@ test('should make every Dock tool reachable on mobile', async ({ website }) => {
 		['Site Settings', 'Site Settings pane'],
 		['Database', 'Database pane'],
 		['Files', 'Files pane'],
-		['Logs', 'Logs pane'],
+		['Logs', 'PHP error log pane'],
 		['Export', 'Export pane'],
 	] as const;
 

--- a/packages/playground/website/src/components/dock/dock-positioning.spec.ts
+++ b/packages/playground/website/src/components/dock/dock-positioning.spec.ts
@@ -18,6 +18,7 @@ describe('Dock positioning', () => {
 				dockCenter: null,
 				viewportSize: { width: 1200, height: 800 },
 				isEditorSection: false,
+				isWideSection: false,
 				isFixedHeightSection: false,
 				isPlaygroundsSection: false,
 			})
@@ -34,6 +35,7 @@ describe('Dock positioning', () => {
 				toastHeight: 62,
 				paneOpen: false,
 				isEditorSection: false,
+				isWideSection: false,
 			})
 		).toBeUndefined();
 	});
@@ -48,6 +50,7 @@ describe('Dock positioning', () => {
 				dockCenter: null,
 				viewportSize: { width: 1200, height: 100 },
 				isEditorSection: false,
+				isWideSection: false,
 				isFixedHeightSection: false,
 				isPlaygroundsSection: false,
 			})
@@ -64,6 +67,7 @@ describe('Dock positioning', () => {
 				dockCenter: null,
 				viewportSize: { width: 390, height: 844 },
 				isEditorSection: false,
+				isWideSection: false,
 				isFixedHeightSection: false,
 				isPlaygroundsSection: false,
 			})
@@ -80,6 +84,7 @@ describe('Dock positioning', () => {
 				dockCenter: 100,
 				viewportSize: { width: 1200, height: 800 },
 				isEditorSection: false,
+				isWideSection: false,
 				isFixedHeightSection: true,
 				isPlaygroundsSection: true,
 			})
@@ -102,6 +107,7 @@ describe('Dock positioning', () => {
 				dockCenter: null,
 				viewportSize: { width: 1200, height: 800 },
 				isEditorSection: false,
+				isWideSection: false,
 				isFixedHeightSection: false,
 				isPlaygroundsSection: false,
 			})
@@ -124,6 +130,7 @@ describe('Dock positioning', () => {
 				toastHeight: 62,
 				paneOpen: true,
 				isEditorSection: false,
+				isWideSection: false,
 			})
 		).toEqual({ bottom: '504px', left: '308px' });
 	});
@@ -141,6 +148,7 @@ describe('Dock positioning', () => {
 				toastHeight: 62,
 				paneOpen: false,
 				isEditorSection: false,
+				isWideSection: false,
 			})
 		).toEqual({
 			bottom: `${80 + DOCK_PANE_GAP}px`,
@@ -161,6 +169,7 @@ describe('Dock positioning', () => {
 				toastHeight: 62,
 				paneOpen: false,
 				isEditorSection: false,
+				isWideSection: false,
 			})
 		).toEqual({ bottom: '92px', left: '5px' });
 	});
@@ -171,6 +180,7 @@ describe('Dock positioning', () => {
 				dockCenter: 0,
 				viewportWidth: 1200,
 				isEditorSection: false,
+				isWideSection: false,
 			})
 		).toBe(308);
 		expect(
@@ -178,7 +188,27 @@ describe('Dock positioning', () => {
 				dockCenter: 1200,
 				viewportWidth: 1200,
 				isEditorSection: false,
+				isWideSection: false,
 			})
 		).toBe(892);
+	});
+
+	it('clamps wide pane centers by their own half width', () => {
+		expect(
+			getDockPaneCenter({
+				dockCenter: 0,
+				viewportWidth: 1200,
+				isEditorSection: false,
+				isWideSection: true,
+			})
+		).toBe(438);
+		expect(
+			getDockPaneCenter({
+				dockCenter: 1200,
+				viewportWidth: 1200,
+				isEditorSection: false,
+				isWideSection: true,
+			})
+		).toBe(762);
 	});
 });

--- a/packages/playground/website/src/components/dock/dock-positioning.ts
+++ b/packages/playground/website/src/components/dock/dock-positioning.ts
@@ -19,6 +19,7 @@ export function getDockPaneStyle({
 	dockCenter,
 	viewportSize,
 	isEditorSection,
+	isWideSection,
 	isFixedHeightSection,
 	isPlaygroundsSection,
 }: {
@@ -29,6 +30,7 @@ export function getDockPaneStyle({
 	dockCenter: number | null;
 	viewportSize: Size;
 	isEditorSection: boolean;
+	isWideSection: boolean;
 	isFixedHeightSection: boolean;
 	isPlaygroundsSection: boolean;
 }): CSSProperties | undefined {
@@ -52,6 +54,7 @@ export function getDockPaneStyle({
 		dockCenter,
 		viewportWidth: viewportSize.width,
 		isEditorSection,
+		isWideSection,
 	});
 	const availableHeight = Math.max(
 		DOCK_PANE_MIN_HEIGHT,
@@ -81,6 +84,7 @@ export function getDockOperationToastStyle({
 	toastHeight,
 	paneOpen,
 	isEditorSection,
+	isWideSection,
 }: {
 	isMobile: boolean;
 	dockSize: Size;
@@ -92,6 +96,7 @@ export function getDockOperationToastStyle({
 	toastHeight: number;
 	paneOpen: boolean;
 	isEditorSection: boolean;
+	isWideSection: boolean;
 }): CSSProperties | undefined {
 	if (!dockSize.height) {
 		return undefined;
@@ -124,6 +129,7 @@ export function getDockOperationToastStyle({
 				dockCenter,
 				viewportWidth: viewportSize.width,
 				isEditorSection,
+				isWideSection,
 			});
 	const minCenter = halfToastWidth + DOCK_PANE_GAP;
 	const maxCenter = viewportSize.width - halfToastWidth - DOCK_PANE_GAP;
@@ -143,14 +149,17 @@ export function getDockPaneCenter({
 	dockCenter,
 	viewportWidth,
 	isEditorSection,
+	isWideSection,
 }: {
 	dockCenter: number | null;
 	viewportWidth: number;
 	isEditorSection: boolean;
+	isWideSection: boolean;
 }) {
 	const desiredCenter = dockCenter ?? viewportWidth / 2;
+	// Half of the .pane / .pane-wide / .pane-editor widths in style.module.css.
 	const halfPaneWidth = Math.min(
-		isEditorSection ? 560 : 300,
+		isEditorSection ? 560 : isWideSection ? 430 : 300,
 		(viewportWidth - 2 * DOCK_DRAG_EDGE) / 2
 	);
 	return Math.min(

--- a/packages/playground/website/src/components/dock/dock.tsx
+++ b/packages/playground/website/src/components/dock/dock.tsx
@@ -206,6 +206,8 @@ export function Dock({
 	const paneTitle = paneCopy.title;
 	const isMobile = useIsMobileDock();
 	const isEditorSection = section === 'blueprint' || section === 'files';
+	// Logs hold long monospace records, so they get a wider pane.
+	const isWideSection = section === 'logs';
 	const isFixedHeightSection =
 		section === 'new' || (section === 'share' && shareExportOpen);
 	const showSharedHeader = !isEditorSection;
@@ -988,6 +990,7 @@ export function Dock({
 		dockCenter,
 		viewportSize,
 		isEditorSection,
+		isWideSection,
 		isFixedHeightSection,
 		isPlaygroundsSection: section === 'playgrounds',
 	});
@@ -1002,6 +1005,7 @@ export function Dock({
 		toastHeight: operationToastHeight,
 		paneOpen: dockPaneIsOpen,
 		isEditorSection,
+		isWideSection,
 	});
 
 	return (
@@ -1118,6 +1122,7 @@ export function Dock({
 						[css.hostPaneHidden]:
 							!dockPaneIsOpen && paneExitComplete,
 						[css.paneSave]: section === 'save',
+						[css.paneWide]: isWideSection,
 					})}
 					style={paneStyle}
 					isEditor={isEditorSection}

--- a/packages/playground/website/src/components/dock/dock.tsx
+++ b/packages/playground/website/src/components/dock/dock.tsx
@@ -167,8 +167,8 @@ const PANE_COPY: Record<
 		description: 'Browse and edit the active Playground filesystem.',
 	},
 	logs: {
-		title: 'Logs',
-		description: 'PHP and Playground runtime messages.',
+		title: 'PHP error log',
+		description: 'Errors, warnings, and notices from your site.',
 	},
 	share: {
 		title: 'Export',

--- a/packages/playground/website/src/components/dock/dock.tsx
+++ b/packages/playground/website/src/components/dock/dock.tsx
@@ -168,7 +168,7 @@ const PANE_COPY: Record<
 	},
 	logs: {
 		title: 'Logs',
-		description: 'PHP, WordPress, and Playground runtime messages.',
+		description: 'PHP and Playground runtime messages.',
 	},
 	share: {
 		title: 'Export',

--- a/packages/playground/website/src/components/dock/style.module.css
+++ b/packages/playground/website/src/components/dock/style.module.css
@@ -297,6 +297,36 @@
 	width: min(440px, calc(100vw - 40px));
 }
 
+/* Logs hold long monospace records, so they get a wider pane. Same compound
+   selector trick as .pane-compact so the mobile override below still wins.
+   Half of this width is mirrored in dock-positioning.ts.
+
+   The pane also pins its header and scrolls the tool body internally
+   (inside .tab-contents) instead of scrolling as one piece. The Logs
+   search/filter toolbar is sticky, and every ancestor between it and the
+   pane creates its own overflow context — the tool body is the only
+   scrollport the toolbar can reliably stick to. */
+.pane.pane-wide {
+	display: flex;
+	flex-direction: column;
+	overflow: hidden;
+	width: min(860px, calc(100vw - 40px));
+}
+
+.pane.pane-wide .pane-body {
+	display: flex;
+	flex-direction: column;
+	flex: 1;
+	min-height: 0;
+	overflow: hidden;
+}
+
+/* Let the tool chain shrink so the innermost overflow: auto box scrolls. */
+.pane.pane-wide .pane-body :global(.components-flex),
+.pane.pane-wide .pane-body :global(.components-flex-item) {
+	min-height: 0;
+}
+
 /* Start states. CSSTransition keeps the base (`-enter`/`-exit`) class on the
    node alongside the `-active` class for the whole transition, so the `-active`
    rules MUST come later in source order to win — otherwise the end state never
@@ -747,6 +777,7 @@
 	   inline so the panel always clears the (collapsible) bar. */
 	.pane,
 	.pane.pane-compact,
+	.pane.pane-wide,
 	.pane-editor,
 	.pane-fixed-height {
 		border-radius: 0;

--- a/packages/playground/website/src/components/log-modal/index.tsx
+++ b/packages/playground/website/src/components/log-modal/index.tsx
@@ -340,9 +340,9 @@ function LogEntryRow({
 		const observer = new ResizeObserver(measure);
 		observer.observe(message);
 		return () => observer.disconnect();
-	}, [entry.message, expanded]);
+	}, [entry.raw, expanded]);
 
-	const lineCount = entry.message.split('\n').length;
+	const lineCount = entry.raw.split('\n').length;
 	const time =
 		entry.timestamp?.match(/\d{2}:\d{2}:\d{2}/)?.[0] ?? entry.timestamp;
 
@@ -370,7 +370,7 @@ function LogEntryRow({
 					className={css.logEntryMessage}
 					data-clamped={!expanded || undefined}
 				>
-					{splitSearchHighlights(entry.message, searchTerm).map(
+					{splitSearchHighlights(entry.raw, searchTerm).map(
 						(segment, segmentIndex) =>
 							segment.highlight ? (
 								<mark key={segmentIndex}>{segment.text}</mark>

--- a/packages/playground/website/src/components/log-modal/index.tsx
+++ b/packages/playground/website/src/components/log-modal/index.tsx
@@ -383,10 +383,17 @@ function useCopyToClipboard(): [boolean, (text: string) => void] {
 	const timerRef = useRef<number>();
 	useEffect(() => () => window.clearTimeout(timerRef.current), []);
 	const copy = (text: string) => {
-		void navigator.clipboard?.writeText(text);
-		setCopied(true);
-		window.clearTimeout(timerRef.current);
-		timerRef.current = window.setTimeout(() => setCopied(false), 1600);
+		void navigator.clipboard?.writeText(text).then(
+			() => {
+				setCopied(true);
+				window.clearTimeout(timerRef.current);
+				timerRef.current = window.setTimeout(
+					() => setCopied(false),
+					1600
+				);
+			},
+			() => {}
+		);
 	};
 	return [copied, copy];
 }

--- a/packages/playground/website/src/components/log-modal/index.tsx
+++ b/packages/playground/website/src/components/log-modal/index.tsx
@@ -215,24 +215,16 @@ export function SiteLogs({ className }: { className?: string }) {
 					<div className={css.logEmptyState}>
 						<p className={css.logEmptyTitle}>Nothing logged yet</p>
 						<p className={css.logEmptyHint}>
-							This is the combined log for your Playground. Three
+							This is the combined log for your Playground. Two
 							kinds of messages land here as you use it:
 						</p>
 						<ul className={css.logLegend}>
 							<li>
 								<span className={css.logLegendTerm}>PHP</span>
 								<span className={css.logLegendDesc}>
-									fatal errors, warnings, and notices from
-									your code
-								</span>
-							</li>
-							<li>
-								<span className={css.logLegendTerm}>
-									WordPress
-								</span>
-								<span className={css.logLegendDesc}>
-									entries written to the debug log when
-									WP_DEBUG is on
+									errors, warnings, and notices from your
+									site, and anything written to the debug log
+									when WP_DEBUG is on
 								</span>
 							</li>
 							<li>

--- a/packages/playground/website/src/components/log-modal/index.tsx
+++ b/packages/playground/website/src/components/log-modal/index.tsx
@@ -1,17 +1,27 @@
-import { Fragment, useEffect, useState } from 'react';
+import {
+	Fragment,
+	useEffect,
+	useLayoutEffect,
+	useMemo,
+	useRef,
+	useState,
+} from 'react';
 import { logEventType, logger } from '@php-wasm/logger';
 
 import classNames from 'classnames';
 import css from './style.module.css';
 import { Modal } from '../modal';
-import { TextControl } from '@wordpress/components';
+import { Icon, TextControl } from '@wordpress/components';
+import { check, copySmall } from '@wordpress/icons';
 import type {
 	PlaygroundDispatch,
 	PlaygroundReduxState,
 } from '../../lib/state/redux/store';
 import { useDispatch, useSelector } from 'react-redux';
 import { setActiveModal } from '../../lib/state/redux/slice-ui';
-import { splitLogHighlights } from './log-highlights';
+import { splitSearchHighlights } from './log-highlights';
+import { parseLogs } from './log-parsing';
+import type { LogEntry, LogTier } from './log-parsing';
 
 export function LogModal(props: { description?: JSX.Element; title?: string }) {
 	const activeModal = useSelector(
@@ -31,16 +41,62 @@ export function LogModal(props: { description?: JSX.Element; title?: string }) {
 	);
 }
 
+/** Keep in sync with `-webkit-line-clamp` in style.module.css. */
+const CLAMP_LINES = 6;
+
+const TIER_FILTERS: Array<{ tier: LogTier; label: string }> = [
+	{ tier: 'error', label: 'Errors' },
+	{ tier: 'warning', label: 'Warnings' },
+	{ tier: 'info', label: 'Info' },
+];
+
 export function SiteLogs({ className }: { className?: string }) {
 	const [logs, setLogs] = useState<string[]>([]);
 	const [searchTerm, setSearchTerm] = useState('');
+	const [tierFilter, setTierFilter] = useState<LogTier | 'all'>('all');
+	const [copiedAll, copyAll] = useCopyToClipboard();
+	const contentRef = useRef<HTMLDivElement>(null);
 
-	// Keep each entry's original append-only index as its stable React key.
-	const filteredLogs = logs
-		.map((log, index) => ({ log, index }))
-		.filter(({ log }) =>
-			log.toLowerCase().includes(searchTerm.toLowerCase())
-		);
+	// A deep scroll offset makes no sense against a different result set —
+	// jump back to the newest entries whenever the filter or search changes.
+	useEffect(() => {
+		for (
+			let node = contentRef.current?.parentElement;
+			node;
+			node = node.parentElement
+		) {
+			if (node.scrollTop > 0) {
+				node.scrollTop = 0;
+			}
+		}
+	}, [tierFilter, searchTerm]);
+
+	const entries = useMemo(() => parseLogs(logs), [logs]);
+
+	// Keep each entry's original append-only position as its stable React key.
+	const searchedEntries = useMemo(() => {
+		const needle = searchTerm.toLowerCase();
+		return entries
+			.map((entry, index) => ({ entry, index }))
+			.filter(({ entry }) => entry.raw.toLowerCase().includes(needle));
+	}, [entries, searchTerm]);
+
+	const tierCounts = useMemo(() => {
+		const counts: Record<LogTier, number> = {
+			error: 0,
+			warning: 0,
+			info: 0,
+		};
+		for (const { entry } of searchedEntries) {
+			counts[entry.tier]++;
+		}
+		return counts;
+	}, [searchedEntries]);
+
+	const visibleEntries =
+		tierFilter === 'all'
+			? searchedEntries
+			: searchedEntries.filter(({ entry }) => entry.tier === tierFilter);
 
 	useEffect(() => {
 		getLogs();
@@ -55,51 +111,104 @@ export function SiteLogs({ className }: { className?: string }) {
 		setLogs(logger.getLogs());
 	}
 
-	function logList() {
-		return filteredLogs
-			.slice()
-			.reverse()
-			.map(({ log, index }) => (
-				<div className={css.logEntry} key={index}>
-					{splitLogHighlights(log).map((segment, segmentIndex) =>
-						segment.highlight ? (
-							<mark key={segmentIndex}>{segment.text}</mark>
-						) : (
-							<Fragment key={segmentIndex}>
-								{segment.text}
-							</Fragment>
-						)
-					)}
-				</div>
-			));
+	function clearFilters() {
+		setSearchTerm('');
+		setTierFilter('all');
 	}
 
 	return (
 		<div className={classNames(css.logsComponent, className)}>
 			{logs.length > 0 ? (
-				<TextControl
-					aria-label="Search"
-					placeholder="Search logs"
-					value={searchTerm}
-					onChange={setSearchTerm}
-					autoFocus={true}
-					className={css.logSearch}
-				/>
+				<div className={css.logToolbar}>
+					<TextControl
+						aria-label="Search"
+						placeholder="Search logs"
+						value={searchTerm}
+						onChange={setSearchTerm}
+						autoFocus={true}
+					/>
+					<div
+						className={css.logFilters}
+						role="group"
+						aria-label="Filter logs by severity"
+					>
+						<button
+							type="button"
+							className={css.logFilterChip}
+							aria-pressed={tierFilter === 'all'}
+							onClick={() => setTierFilter('all')}
+						>
+							All
+							<span className={css.logFilterCount}>
+								{searchedEntries.length}
+							</span>
+						</button>
+						{TIER_FILTERS.filter(
+							({ tier }) =>
+								tierCounts[tier] > 0 || tierFilter === tier
+						).map(({ tier, label }) => (
+							<button
+								key={tier}
+								type="button"
+								className={css.logFilterChip}
+								aria-pressed={tierFilter === tier}
+								onClick={() =>
+									setTierFilter(
+										tierFilter === tier ? 'all' : tier
+									)
+								}
+							>
+								{label}
+								<span className={css.logFilterCount}>
+									{tierCounts[tier]}
+								</span>
+							</button>
+						))}
+						{visibleEntries.length > 0 && (
+							<button
+								type="button"
+								className={css.logCopyAll}
+								onClick={() =>
+									copyAll(
+										visibleEntries
+											.map(({ entry }) => entry.raw)
+											.join('\n')
+									)
+								}
+							>
+								{copiedAll ? 'Copied' : 'Copy logs'}
+							</button>
+						)}
+					</div>
+				</div>
 			) : null}
-			<div className={css.logContentContainer}>
-				{filteredLogs.length > 0 ? (
-					<main className={css.logList}>{logList()}</main>
+			<div ref={contentRef} className={css.logContentContainer}>
+				{visibleEntries.length > 0 ? (
+					<ul className={css.logList}>
+						{visibleEntries
+							.slice()
+							.reverse()
+							.map(({ entry, index }) => (
+								<LogEntryRow
+									key={index}
+									entry={entry}
+									searchTerm={searchTerm}
+								/>
+							))}
+					</ul>
 				) : logs.length > 0 ? (
 					<div className={css.logEmptyPlaceholder}>
 						<p className={css.logEmptyHint}>
-							No logs match “{searchTerm}”.
+							{searchTerm
+								? `No logs match “${searchTerm}”.`
+								: 'No logs match the current filter.'}
 						</p>
 						<button
 							type="button"
 							className={css.logClearSearch}
-							onClick={() => setSearchTerm('')}
+							onClick={clearFilters}
 						>
-							Clear search
+							Clear filters
 						</button>
 					</div>
 				) : (
@@ -141,4 +250,109 @@ export function SiteLogs({ className }: { className?: string }) {
 			</div>
 		</div>
 	);
+}
+
+/** One log record: severity, source, and time above a clamped message body. */
+function LogEntryRow({
+	entry,
+	searchTerm,
+}: {
+	entry: LogEntry;
+	searchTerm: string;
+}) {
+	const [expanded, setExpanded] = useState(false);
+	const [overflowing, setOverflowing] = useState(false);
+	const messageRef = useRef<HTMLDivElement>(null);
+	const [copied, copy] = useCopyToClipboard();
+
+	// Collapsed entries clamp to a few lines. Only entries that actually
+	// overflow that clamp — measured at the live pane width — get the toggle.
+	useLayoutEffect(() => {
+		const message = messageRef.current;
+		if (!message || expanded) {
+			return;
+		}
+		const measure = () =>
+			setOverflowing(message.scrollHeight > message.clientHeight + 1);
+		measure();
+		if (typeof ResizeObserver === 'undefined') {
+			return;
+		}
+		const observer = new ResizeObserver(measure);
+		observer.observe(message);
+		return () => observer.disconnect();
+	}, [entry.message, expanded]);
+
+	const lineCount = entry.message.split('\n').length;
+	const time =
+		entry.timestamp?.match(/\d{2}:\d{2}:\d{2}/)?.[0] ?? entry.timestamp;
+
+	return (
+		<li className={css.logEntry}>
+			<div className={css.logEntryMeta}>
+				<span className={css.logBadge} data-tier={entry.tier}>
+					{entry.label}
+				</span>
+				<span className={css.logChannel}>{entry.channel}</span>
+				{entry.timestamp && (
+					<time className={css.logTimestamp} title={entry.timestamp}>
+						{time}
+					</time>
+				)}
+				<button
+					type="button"
+					className={css.logCopy}
+					aria-label="Copy log entry"
+					title="Copy log entry"
+					onClick={() => copy(entry.raw)}
+				>
+					<Icon icon={copied ? check : copySmall} size={18} />
+				</button>
+			</div>
+			<div
+				ref={messageRef}
+				className={css.logEntryMessage}
+				data-clamped={!expanded || undefined}
+			>
+				{splitSearchHighlights(entry.message, searchTerm).map(
+					(segment, segmentIndex) =>
+						segment.highlight ? (
+							<mark key={segmentIndex}>{segment.text}</mark>
+						) : (
+							<Fragment key={segmentIndex}>
+								{segment.text}
+							</Fragment>
+						)
+				)}
+			</div>
+			{(overflowing || expanded) && (
+				<button
+					type="button"
+					className={css.logEntryToggle}
+					aria-expanded={expanded}
+					onClick={() => setExpanded(!expanded)}
+				>
+					{expanded
+						? 'Show less'
+						: lineCount > CLAMP_LINES
+							? `Show all ${lineCount} lines`
+							: 'Show more'}
+				</button>
+			)}
+		</li>
+	);
+}
+
+/** Copies text and reports a short-lived "copied" flag for button feedback. */
+function useCopyToClipboard(): [boolean, (text: string) => void] {
+	const [copied, setCopied] = useState(false);
+	const timerRef = useRef<number>();
+	useEffect(() => () => window.clearTimeout(timerRef.current), []);
+	const copy = (text: string) => {
+		void navigator.clipboard?.writeText(text);
+		setCopied(true);
+		window.clearTimeout(timerRef.current);
+		timerRef.current = window.setTimeout(() => setCopied(false), 1600);
+	};
+	return [copied, copy];
 }

--- a/packages/playground/website/src/components/log-modal/index.tsx
+++ b/packages/playground/website/src/components/log-modal/index.tsx
@@ -36,7 +36,13 @@ export function LogModal(props: { description?: JSX.Element; title?: string }) {
 	return (
 		<Modal title={props.title || 'Error Logs'} onRequestClose={onClose}>
 			<div>{props.description}</div>
-			<SiteLogs key={activeModal} className={css.logsInsideModal} />
+			{/* Error reports must show everything — a WASM crash is a
+			    Playground entry, and hiding it would hide the crash itself. */}
+			<SiteLogs
+				key={activeModal}
+				className={css.logsInsideModal}
+				defaultShowPlayground
+			/>
 		</Modal>
 	);
 }
@@ -50,10 +56,19 @@ const TIER_FILTERS: Array<{ tier: LogTier; label: string }> = [
 	{ tier: 'info', label: 'Info' },
 ];
 
-export function SiteLogs({ className }: { className?: string }) {
+export function SiteLogs({
+	className,
+	defaultShowPlayground = false,
+}: {
+	className?: string;
+	defaultShowPlayground?: boolean;
+}) {
 	const [logs, setLogs] = useState<string[]>([]);
 	const [searchTerm, setSearchTerm] = useState('');
 	const [tierFilter, setTierFilter] = useState<LogTier | 'all'>('all');
+	// Playground host messages are noise for most debugging sessions, so the
+	// Dock pane hides them until the Playground chip turns them back on.
+	const [showPlayground, setShowPlayground] = useState(defaultShowPlayground);
 	const [copiedAll, copyAll] = useCopyToClipboard();
 	const contentRef = useRef<HTMLDivElement>(null);
 
@@ -69,7 +84,7 @@ export function SiteLogs({ className }: { className?: string }) {
 				node.scrollTop = 0;
 			}
 		}
-	}, [tierFilter, searchTerm]);
+	}, [tierFilter, searchTerm, showPlayground]);
 
 	const entries = useMemo(() => parseLogs(logs), [logs]);
 
@@ -81,22 +96,40 @@ export function SiteLogs({ className }: { className?: string }) {
 			.filter(({ entry }) => entry.raw.toLowerCase().includes(needle));
 	}, [entries, searchTerm]);
 
+	const playgroundCount = useMemo(
+		() =>
+			searchedEntries.filter(
+				({ entry }) => entry.channel === 'Playground'
+			).length,
+		[searchedEntries]
+	);
+
+	const channelEntries = useMemo(
+		() =>
+			showPlayground
+				? searchedEntries
+				: searchedEntries.filter(
+						({ entry }) => entry.channel !== 'Playground'
+					),
+		[searchedEntries, showPlayground]
+	);
+
 	const tierCounts = useMemo(() => {
 		const counts: Record<LogTier, number> = {
 			error: 0,
 			warning: 0,
 			info: 0,
 		};
-		for (const { entry } of searchedEntries) {
+		for (const { entry } of channelEntries) {
 			counts[entry.tier]++;
 		}
 		return counts;
-	}, [searchedEntries]);
+	}, [channelEntries]);
 
 	const visibleEntries =
 		tierFilter === 'all'
-			? searchedEntries
-			: searchedEntries.filter(({ entry }) => entry.tier === tierFilter);
+			? channelEntries
+			: channelEntries.filter(({ entry }) => entry.tier === tierFilter);
 
 	useEffect(() => {
 		getLogs();
@@ -114,6 +147,7 @@ export function SiteLogs({ className }: { className?: string }) {
 	function clearFilters() {
 		setSearchTerm('');
 		setTierFilter('all');
+		setShowPlayground(defaultShowPlayground);
 	}
 
 	return (
@@ -130,7 +164,7 @@ export function SiteLogs({ className }: { className?: string }) {
 					<div
 						className={css.logFilters}
 						role="group"
-						aria-label="Filter logs by severity"
+						aria-label="Filter logs"
 					>
 						<button
 							type="button"
@@ -140,7 +174,7 @@ export function SiteLogs({ className }: { className?: string }) {
 						>
 							All
 							<span className={css.logFilterCount}>
-								{searchedEntries.length}
+								{channelEntries.length}
 							</span>
 						</button>
 						{TIER_FILTERS.filter(
@@ -164,6 +198,28 @@ export function SiteLogs({ className }: { className?: string }) {
 								</span>
 							</button>
 						))}
+						{(playgroundCount > 0 || showPlayground) && (
+							<>
+								<span
+									className={css.logFilterDivider}
+									aria-hidden="true"
+								/>
+								<button
+									type="button"
+									className={css.logFilterChip}
+									aria-pressed={showPlayground}
+									title="Show runtime messages from the Playground app itself"
+									onClick={() =>
+										setShowPlayground(!showPlayground)
+									}
+								>
+									Playground
+									<span className={css.logFilterCount}>
+										{playgroundCount}
+									</span>
+								</button>
+							</>
+						)}
 						{visibleEntries.length > 0 && (
 							<button
 								type="button"
@@ -203,13 +259,25 @@ export function SiteLogs({ className }: { className?: string }) {
 								? `No logs match “${searchTerm}”.`
 								: 'No logs match the current filter.'}
 						</p>
-						<button
-							type="button"
-							className={css.logClearSearch}
-							onClick={clearFilters}
-						>
-							Clear filters
-						</button>
+						{(searchTerm !== '' || tierFilter !== 'all') && (
+							<button
+								type="button"
+								className={css.logClearSearch}
+								onClick={clearFilters}
+							>
+								Clear filters
+							</button>
+						)}
+						{!showPlayground && playgroundCount > 0 && (
+							<button
+								type="button"
+								className={css.logClearSearch}
+								onClick={() => setShowPlayground(true)}
+							>
+								Show {playgroundCount} Playground{' '}
+								{playgroundCount === 1 ? 'entry' : 'entries'}
+							</button>
+						)}
 					</div>
 				) : (
 					<div className={css.logEmptyState}>
@@ -254,6 +322,7 @@ function LogEntryRow({
 }) {
 	const [expanded, setExpanded] = useState(false);
 	const [overflowing, setOverflowing] = useState(false);
+	const entryRef = useRef<HTMLLIElement>(null);
 	const messageRef = useRef<HTMLDivElement>(null);
 	const [copied, copy] = useCopyToClipboard();
 
@@ -280,12 +349,14 @@ function LogEntryRow({
 		entry.timestamp?.match(/\d{2}:\d{2}:\d{2}/)?.[0] ?? entry.timestamp;
 
 	return (
-		<li className={css.logEntry}>
+		<li ref={entryRef} className={css.logEntry}>
 			<div className={css.logEntryMeta}>
+				{/* Channel first: a two-value, fixed-width column keeps both
+				    it and the variable-width severity badge aligned. */}
+				<span className={css.logChannel}>{entry.channel}</span>
 				<span className={css.logBadge} data-tier={entry.tier}>
 					{entry.label}
 				</span>
-				<span className={css.logChannel}>{entry.channel}</span>
 				{entry.timestamp && (
 					<time className={css.logTimestamp} title={entry.timestamp}>
 						{time}
@@ -322,7 +393,19 @@ function LogEntryRow({
 					type="button"
 					className={css.logEntryToggle}
 					aria-expanded={expanded}
-					onClick={() => setExpanded(!expanded)}
+					onClick={() => {
+						const next = !expanded;
+						setExpanded(next);
+						if (!next) {
+							// Collapsing shrinks the list; without this the
+							// viewport lands on whatever slid up into it.
+							requestAnimationFrame(() =>
+								entryRef.current?.scrollIntoView({
+									block: 'nearest',
+								})
+							);
+						}
+					}}
 				>
 					{expanded
 						? 'Show less'

--- a/packages/playground/website/src/components/log-modal/index.tsx
+++ b/packages/playground/website/src/components/log-modal/index.tsx
@@ -159,7 +159,7 @@ export function SiteLogs({
 						placeholder="Search logs"
 						value={searchTerm}
 						onChange={setSearchTerm}
-						autoFocus={true}
+						__nextHasNoMarginBottom
 					/>
 					<div
 						className={css.logFilters}
@@ -177,15 +177,18 @@ export function SiteLogs({
 								{channelEntries.length}
 							</span>
 						</button>
-						{TIER_FILTERS.filter(
-							({ tier }) =>
-								tierCounts[tier] > 0 || tierFilter === tier
-						).map(({ tier, label }) => (
+						{/* The chip set is fixed: empty tiers dim instead of
+						    disappearing, so the row never reshuffles. */}
+						{TIER_FILTERS.map(({ tier, label }) => (
 							<button
 								key={tier}
 								type="button"
 								className={css.logFilterChip}
 								aria-pressed={tierFilter === tier}
+								disabled={
+									tierCounts[tier] === 0 &&
+									tierFilter !== tier
+								}
 								onClick={() =>
 									setTierFilter(
 										tierFilter === tier ? 'all' : tier
@@ -198,28 +201,23 @@ export function SiteLogs({
 								</span>
 							</button>
 						))}
-						{(playgroundCount > 0 || showPlayground) && (
-							<>
-								<span
-									className={css.logFilterDivider}
-									aria-hidden="true"
-								/>
-								<button
-									type="button"
-									className={css.logFilterChip}
-									aria-pressed={showPlayground}
-									title="Show runtime messages from the Playground app itself"
-									onClick={() =>
-										setShowPlayground(!showPlayground)
-									}
-								>
-									Playground
-									<span className={css.logFilterCount}>
-										{playgroundCount}
-									</span>
-								</button>
-							</>
-						)}
+						<span
+							className={css.logFilterDivider}
+							aria-hidden="true"
+						/>
+						<button
+							type="button"
+							className={css.logFilterChip}
+							aria-pressed={showPlayground}
+							disabled={playgroundCount === 0 && !showPlayground}
+							title="Show runtime messages from the Playground app itself"
+							onClick={() => setShowPlayground(!showPlayground)}
+						>
+							Playground
+							<span className={css.logFilterCount}>
+								{playgroundCount}
+							</span>
+						</button>
 						{visibleEntries.length > 0 && (
 							<button
 								type="button"
@@ -312,7 +310,7 @@ export function SiteLogs({
 	);
 }
 
-/** One log record: severity, source, and time above a clamped message body. */
+/** One log record: a fixed severity/time rail beside a clamped message. */
 function LogEntryRow({
 	entry,
 	searchTerm,
@@ -350,11 +348,11 @@ function LogEntryRow({
 
 	return (
 		<li ref={entryRef} className={css.logEntry}>
-			<div className={css.logEntryMeta}>
-				{/* Channel first: a two-value, fixed-width column keeps both
-				    it and the variable-width severity badge aligned. */}
-				<span className={css.logChannel}>{entry.channel}</span>
-				<span className={css.logBadge} data-tier={entry.tier}>
+			{/* Severity and time live in one fixed rail so every message
+			    column aligns. PHP is the default context — only Playground
+			    rows carry a channel tag. */}
+			<div className={css.logEntryRail}>
+				<span className={css.logSeverity} data-tier={entry.tier}>
 					{entry.label}
 				</span>
 				{entry.timestamp && (
@@ -362,58 +360,63 @@ function LogEntryRow({
 						{time}
 					</time>
 				)}
-				<button
-					type="button"
-					className={css.logCopy}
-					aria-label="Copy log entry"
-					title="Copy log entry"
-					onClick={() => copy(entry.raw)}
-				>
-					<Icon icon={copied ? check : copySmall} size={18} />
-				</button>
-			</div>
-			<div
-				ref={messageRef}
-				className={css.logEntryMessage}
-				data-clamped={!expanded || undefined}
-			>
-				{splitSearchHighlights(entry.message, searchTerm).map(
-					(segment, segmentIndex) =>
-						segment.highlight ? (
-							<mark key={segmentIndex}>{segment.text}</mark>
-						) : (
-							<Fragment key={segmentIndex}>
-								{segment.text}
-							</Fragment>
-						)
+				{entry.channel === 'Playground' && (
+					<span className={css.logChannelTag}>Playground</span>
 				)}
 			</div>
-			{(overflowing || expanded) && (
-				<button
-					type="button"
-					className={css.logEntryToggle}
-					aria-expanded={expanded}
-					onClick={() => {
-						const next = !expanded;
-						setExpanded(next);
-						if (!next) {
-							// Collapsing shrinks the list; without this the
-							// viewport lands on whatever slid up into it.
-							requestAnimationFrame(() =>
-								entryRef.current?.scrollIntoView({
-									block: 'nearest',
-								})
-							);
-						}
-					}}
+			<div className={css.logEntryBody}>
+				<div
+					ref={messageRef}
+					className={css.logEntryMessage}
+					data-clamped={!expanded || undefined}
 				>
-					{expanded
-						? 'Show less'
-						: lineCount > CLAMP_LINES
-							? `Show all ${lineCount} lines`
-							: 'Show more'}
-				</button>
-			)}
+					{splitSearchHighlights(entry.message, searchTerm).map(
+						(segment, segmentIndex) =>
+							segment.highlight ? (
+								<mark key={segmentIndex}>{segment.text}</mark>
+							) : (
+								<Fragment key={segmentIndex}>
+									{segment.text}
+								</Fragment>
+							)
+					)}
+				</div>
+				{(overflowing || expanded) && (
+					<button
+						type="button"
+						className={css.logEntryToggle}
+						aria-expanded={expanded}
+						onClick={() => {
+							const next = !expanded;
+							setExpanded(next);
+							if (!next) {
+								// Collapsing shrinks the list; without this
+								// the viewport lands on whatever slid up.
+								requestAnimationFrame(() =>
+									entryRef.current?.scrollIntoView({
+										block: 'nearest',
+									})
+								);
+							}
+						}}
+					>
+						{expanded
+							? 'Show less'
+							: lineCount > CLAMP_LINES
+								? `Show all ${lineCount} lines`
+								: 'Show more'}
+					</button>
+				)}
+			</div>
+			<button
+				type="button"
+				className={css.logCopy}
+				aria-label="Copy log entry"
+				title="Copy log entry"
+				onClick={() => copy(entry.raw)}
+			>
+				<Icon icon={copied ? check : copySmall} size={18} />
+			</button>
 		</li>
 	);
 }

--- a/packages/playground/website/src/components/log-modal/index.tsx
+++ b/packages/playground/website/src/components/log-modal/index.tsx
@@ -34,15 +34,9 @@ export function LogModal(props: { description?: JSX.Element; title?: string }) {
 	}
 
 	return (
-		<Modal title={props.title || 'Error Logs'} onRequestClose={onClose}>
+		<Modal title={props.title || 'PHP error log'} onRequestClose={onClose}>
 			<div>{props.description}</div>
-			{/* Error reports must show everything — a WASM crash is a
-			    Playground entry, and hiding it would hide the crash itself. */}
-			<SiteLogs
-				key={activeModal}
-				className={css.logsInsideModal}
-				defaultShowPlayground
-			/>
+			<SiteLogs key={activeModal} className={css.logsInsideModal} />
 		</Modal>
 	);
 }
@@ -56,19 +50,10 @@ const TIER_FILTERS: Array<{ tier: LogTier; label: string }> = [
 	{ tier: 'info', label: 'Info' },
 ];
 
-export function SiteLogs({
-	className,
-	defaultShowPlayground = false,
-}: {
-	className?: string;
-	defaultShowPlayground?: boolean;
-}) {
+export function SiteLogs({ className }: { className?: string }) {
 	const [logs, setLogs] = useState<string[]>([]);
 	const [searchTerm, setSearchTerm] = useState('');
 	const [tierFilter, setTierFilter] = useState<LogTier | 'all'>('all');
-	// Playground host messages are noise for most debugging sessions, so the
-	// Dock pane hides them until the Playground chip turns them back on.
-	const [showPlayground, setShowPlayground] = useState(defaultShowPlayground);
 	const [copiedAll, copyAll] = useCopyToClipboard();
 	const contentRef = useRef<HTMLDivElement>(null);
 
@@ -84,7 +69,7 @@ export function SiteLogs({
 				node.scrollTop = 0;
 			}
 		}
-	}, [tierFilter, searchTerm, showPlayground]);
+	}, [tierFilter, searchTerm]);
 
 	const entries = useMemo(() => parseLogs(logs), [logs]);
 
@@ -96,40 +81,22 @@ export function SiteLogs({
 			.filter(({ entry }) => entry.raw.toLowerCase().includes(needle));
 	}, [entries, searchTerm]);
 
-	const playgroundCount = useMemo(
-		() =>
-			searchedEntries.filter(
-				({ entry }) => entry.channel === 'Playground'
-			).length,
-		[searchedEntries]
-	);
-
-	const channelEntries = useMemo(
-		() =>
-			showPlayground
-				? searchedEntries
-				: searchedEntries.filter(
-						({ entry }) => entry.channel !== 'Playground'
-					),
-		[searchedEntries, showPlayground]
-	);
-
 	const tierCounts = useMemo(() => {
 		const counts: Record<LogTier, number> = {
 			error: 0,
 			warning: 0,
 			info: 0,
 		};
-		for (const { entry } of channelEntries) {
+		for (const { entry } of searchedEntries) {
 			counts[entry.tier]++;
 		}
 		return counts;
-	}, [channelEntries]);
+	}, [searchedEntries]);
 
 	const visibleEntries =
 		tierFilter === 'all'
-			? channelEntries
-			: channelEntries.filter(({ entry }) => entry.tier === tierFilter);
+			? searchedEntries
+			: searchedEntries.filter(({ entry }) => entry.tier === tierFilter);
 
 	useEffect(() => {
 		getLogs();
@@ -147,7 +114,6 @@ export function SiteLogs({
 	function clearFilters() {
 		setSearchTerm('');
 		setTierFilter('all');
-		setShowPlayground(defaultShowPlayground);
 	}
 
 	return (
@@ -174,7 +140,7 @@ export function SiteLogs({
 						>
 							All
 							<span className={css.logFilterCount}>
-								{channelEntries.length}
+								{searchedEntries.length}
 							</span>
 						</button>
 						{/* The chip set is fixed: empty tiers dim instead of
@@ -201,23 +167,6 @@ export function SiteLogs({
 								</span>
 							</button>
 						))}
-						<span
-							className={css.logFilterDivider}
-							aria-hidden="true"
-						/>
-						<button
-							type="button"
-							className={css.logFilterChip}
-							aria-pressed={showPlayground}
-							disabled={playgroundCount === 0 && !showPlayground}
-							title="Show runtime messages from the Playground app itself"
-							onClick={() => setShowPlayground(!showPlayground)}
-						>
-							Playground
-							<span className={css.logFilterCount}>
-								{playgroundCount}
-							</span>
-						</button>
 						{visibleEntries.length > 0 && (
 							<button
 								type="button"
@@ -266,43 +215,14 @@ export function SiteLogs({
 								Clear filters
 							</button>
 						)}
-						{!showPlayground && playgroundCount > 0 && (
-							<button
-								type="button"
-								className={css.logClearSearch}
-								onClick={() => setShowPlayground(true)}
-							>
-								Show {playgroundCount} Playground{' '}
-								{playgroundCount === 1 ? 'entry' : 'entries'}
-							</button>
-						)}
 					</div>
 				) : (
 					<div className={css.logEmptyState}>
 						<p className={css.logEmptyTitle}>Nothing logged yet</p>
 						<p className={css.logEmptyHint}>
-							This is the combined log for your Playground. Two
-							kinds of messages land here as you use it:
+							PHP errors, warnings, and notices from your site
+							appear here as they are written to the debug log.
 						</p>
-						<ul className={css.logLegend}>
-							<li>
-								<span className={css.logLegendTerm}>PHP</span>
-								<span className={css.logLegendDesc}>
-									errors, warnings, and notices from your
-									site, and anything written to the debug log
-									when WP_DEBUG is on
-								</span>
-							</li>
-							<li>
-								<span className={css.logLegendTerm}>
-									Playground
-								</span>
-								<span className={css.logLegendDesc}>
-									runtime messages from the Playground app
-									itself
-								</span>
-							</li>
-						</ul>
 					</div>
 				)}
 			</div>
@@ -310,7 +230,7 @@ export function SiteLogs({
 	);
 }
 
-/** One log record: a fixed severity/time rail beside a clamped message. */
+/** One log record: its timestamp above a full-width, clamped message. */
 function LogEntryRow({
 	entry,
 	searchTerm,
@@ -340,45 +260,42 @@ function LogEntryRow({
 		const observer = new ResizeObserver(measure);
 		observer.observe(message);
 		return () => observer.disconnect();
-	}, [entry.raw, expanded]);
+	}, [entry.message, expanded]);
 
-	const lineCount = entry.raw.split('\n').length;
-	const time =
-		entry.timestamp?.match(/\d{2}:\d{2}:\d{2}/)?.[0] ?? entry.timestamp;
+	const lineCount = entry.message.split('\n').length;
 
 	return (
 		<li ref={entryRef} className={css.logEntry}>
-			{/* Severity and time live in one fixed rail so every message
-			    column aligns. PHP is the default context — only Playground
-			    rows carry a channel tag. */}
-			<div className={css.logEntryRail}>
-				<span className={css.logSeverity} data-tier={entry.tier}>
-					{entry.label}
-				</span>
-				{entry.timestamp && (
-					<time className={css.logTimestamp} title={entry.timestamp}>
-						{time}
-					</time>
-				)}
-				{entry.channel === 'Playground' && (
-					<span className={css.logChannelTag}>Playground</span>
-				)}
-			</div>
+			{entry.timestamp && (
+				<time className={css.logTimestamp}>{entry.timestamp}</time>
+			)}
 			<div className={css.logEntryBody}>
 				<div
 					ref={messageRef}
 					className={css.logEntryMessage}
 					data-clamped={!expanded || undefined}
 				>
-					{splitSearchHighlights(entry.raw, searchTerm).map(
-						(segment, segmentIndex) =>
-							segment.highlight ? (
-								<mark key={segmentIndex}>{segment.text}</mark>
+					{headSegments(entry, searchTerm).map(
+						(segment, segmentIndex) => {
+							const text = segment.highlight ? (
+								<mark>{segment.text}</mark>
 							) : (
-								<Fragment key={segmentIndex}>
-									{segment.text}
-								</Fragment>
-							)
+								segment.text
+							);
+							// The severity head stays part of the message; it
+							// is only tinted, never restated elsewhere.
+							return segment.head ? (
+								<span
+									key={segmentIndex}
+									className={css.logSeverityHead}
+									data-tier={entry.tier}
+								>
+									{text}
+								</span>
+							) : (
+								<Fragment key={segmentIndex}>{text}</Fragment>
+							);
+						}
 					)}
 				</div>
 				{(overflowing || expanded) && (
@@ -419,6 +336,45 @@ function LogEntryRow({
 			</button>
 		</li>
 	);
+}
+
+/**
+ * Search-highlight segments split once more at the severity-head boundary,
+ * so the head keeps its tint even when a search match crosses from the
+ * head into the message.
+ */
+function headSegments(
+	entry: LogEntry,
+	searchTerm: string
+): Array<{ text: string; highlight: boolean; head: boolean }> {
+	const segments = splitSearchHighlights(entry.message, searchTerm);
+	const pieces: Array<{ text: string; highlight: boolean; head: boolean }> =
+		[];
+	let offset = 0;
+	for (const segment of segments) {
+		const end = offset + segment.text.length;
+		if (offset < entry.headLength && end > entry.headLength) {
+			const cut = entry.headLength - offset;
+			pieces.push({
+				text: segment.text.slice(0, cut),
+				highlight: segment.highlight,
+				head: true,
+			});
+			pieces.push({
+				text: segment.text.slice(cut),
+				highlight: segment.highlight,
+				head: false,
+			});
+		} else {
+			pieces.push({
+				text: segment.text,
+				highlight: segment.highlight,
+				head: end <= entry.headLength,
+			});
+		}
+		offset = end;
+	}
+	return pieces;
 }
 
 /** Copies text and reports a short-lived "copied" flag for button feedback. */

--- a/packages/playground/website/src/components/log-modal/log-highlights.spec.ts
+++ b/packages/playground/website/src/components/log-modal/log-highlights.spec.ts
@@ -1,44 +1,36 @@
 import { describe, expect, it } from 'vitest';
-import { splitLogHighlights } from './log-highlights';
+import { splitSearchHighlights } from './log-highlights';
 
-describe('splitLogHighlights', () => {
-	it('highlights standalone Error and Fatal markers', () => {
-		expect(splitLogHighlights('PHP Fatal: boom')).toEqual([
-			{ text: 'PHP ', highlight: false },
-			{ text: 'Fatal:', highlight: true },
-			{ text: ' boom', highlight: false },
-		]);
-		expect(splitLogHighlights('Error: failed')).toEqual([
-			{ text: 'Error:', highlight: true },
-			{ text: ' failed', highlight: false },
+describe('splitSearchHighlights', () => {
+	it('returns the whole text unhighlighted for an empty term', () => {
+		expect(splitSearchHighlights('PHP Notice: hello', '')).toEqual([
+			{ text: 'PHP Notice: hello', highlight: false },
 		]);
 	});
 
-	it('does not highlight markers embedded in words or class names', () => {
-		expect(splitLogHighlights('ParseError: nope terror: nope')).toEqual([
-			{ text: 'ParseError: nope terror: nope', highlight: false },
+	it('highlights every case-insensitive occurrence', () => {
+		expect(splitSearchHighlights('Error: fatal error', 'error')).toEqual([
+			{ text: 'Error', highlight: true },
+			{ text: ': fatal ', highlight: false },
+			{ text: 'error', highlight: true },
 		]);
 	});
 
-	it('does not highlight lowercase words that resemble severity markers', () => {
-		expect(splitLogHighlights('error: nope fatal: nope')).toEqual([
-			{ text: 'error: nope fatal: nope', highlight: false },
+	it('handles adjacent matches without dropping text', () => {
+		expect(splitSearchHighlights('abab', 'ab')).toEqual([
+			{ text: 'ab', highlight: true },
+			{ text: 'ab', highlight: true },
 		]);
 	});
 
-	it('keeps punctuation before a marker in the plain segment', () => {
-		expect(splitLogHighlights('(Error: failed)')).toEqual([
-			{ text: '(', highlight: false },
-			{ text: 'Error:', highlight: true },
-			{ text: ' failed)', highlight: false },
+	it('treats regex metacharacters as plain text', () => {
+		expect(splitSearchHighlights('a.*b then ab', 'a.*b')).toEqual([
+			{ text: 'a.*b', highlight: true },
+			{ text: ' then ab', highlight: false },
 		]);
 	});
 
-	it('keeps log markup as plain text', () => {
-		expect(splitLogHighlights('<img src=x> Error: failed')).toEqual([
-			{ text: '<img src=x> ', highlight: false },
-			{ text: 'Error:', highlight: true },
-			{ text: ' failed', highlight: false },
-		]);
+	it('returns no segments for empty text with a term', () => {
+		expect(splitSearchHighlights('', 'error')).toEqual([]);
 	});
 });

--- a/packages/playground/website/src/components/log-modal/log-highlights.ts
+++ b/packages/playground/website/src/components/log-modal/log-highlights.ts
@@ -1,30 +1,36 @@
 /**
- * Splits a log line into plain-text segments, marking `Error:`/`Fatal:` tokens
- * for emphasis. Returning data instead of HTML ensures React escapes log text.
+ * Splits text into plain and highlighted segments around every
+ * case-insensitive occurrence of the search term. Returning data instead of
+ * HTML ensures React escapes log text.
  */
-export function splitLogHighlights(
-	log: string
+export function splitSearchHighlights(
+	text: string,
+	term: string
 ): Array<{ text: string; highlight: boolean }> {
+	if (!term) {
+		return [{ text, highlight: false }];
+	}
 	const segments: Array<{ text: string; highlight: boolean }> = [];
-	// Only match standalone severity markers, not names such as `ParseError:`.
-	const pattern = /Error:|Fatal:/g;
+	const haystack = text.toLowerCase();
+	const needle = term.toLowerCase();
 	let lastIndex = 0;
-	let match: RegExpExecArray | null;
-	while ((match = pattern.exec(log)) !== null) {
-		if (match.index > 0 && /\w/.test(log[match.index - 1])) {
-			continue;
-		}
-		if (match.index > lastIndex) {
+	let index = haystack.indexOf(needle);
+	while (index !== -1) {
+		if (index > lastIndex) {
 			segments.push({
-				text: log.slice(lastIndex, match.index),
+				text: text.slice(lastIndex, index),
 				highlight: false,
 			});
 		}
-		segments.push({ text: match[0], highlight: true });
-		lastIndex = pattern.lastIndex;
+		segments.push({
+			text: text.slice(index, index + term.length),
+			highlight: true,
+		});
+		lastIndex = index + term.length;
+		index = haystack.indexOf(needle, lastIndex);
 	}
-	if (lastIndex < log.length) {
-		segments.push({ text: log.slice(lastIndex), highlight: false });
+	if (lastIndex < text.length) {
+		segments.push({ text: text.slice(lastIndex), highlight: false });
 	}
 	return segments;
 }

--- a/packages/playground/website/src/components/log-modal/log-parsing.spec.ts
+++ b/packages/playground/website/src/components/log-modal/log-parsing.spec.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest';
+import { parseLogs } from './log-parsing';
+
+describe('parseLogs', () => {
+	it('splits a raw debug.log chunk into one entry per record', () => {
+		const chunk = [
+			'[20-Jul-2026 14:59:46 UTC] PHP Notice:  Function _load_textdomain_just_in_time was called incorrectly.',
+			'[20-Jul-2026 14:59:47 UTC] WordPress database error <div style="clear:both">&nbsp;</div>',
+			'<p>MySQL query:</p>',
+			"<p>REPLACE INTO `wp_options` VALUES ('blogname','BrewCommerce','on')</p>",
+		].join('\n');
+
+		const entries = parseLogs([chunk]);
+
+		expect(entries).toHaveLength(2);
+		expect(entries[0]).toMatchObject({
+			channel: 'PHP',
+			label: 'Notice',
+			tier: 'info',
+			timestamp: '20-Jul-2026 14:59:46 UTC',
+		});
+		expect(entries[0].message).toMatch(
+			/^Function _load_textdomain_just_in_time/
+		);
+		expect(entries[1]).toMatchObject({
+			channel: 'WordPress',
+			label: 'Database error',
+			tier: 'error',
+		});
+		// Continuation lines stay inside their record instead of becoming
+		// separate entries.
+		expect(entries[1].message.split('\n')).toHaveLength(3);
+		expect(entries[1].message).toContain('MySQL query');
+	});
+
+	it('keeps severity tiers for the common PHP error levels', () => {
+		const entries = parseLogs([
+			'[20-Jul-2026 14:59:46 UTC] PHP Fatal error:  Uncaught Error: boom',
+			'[20-Jul-2026 14:59:46 UTC] PHP Warning:  Undefined variable $x',
+			'[20-Jul-2026 14:59:46 UTC] PHP Deprecated:  Optional parameter',
+			'[20-Jul-2026 14:59:46 UTC] PHP User notice:  hello',
+		]);
+		expect(entries.map((entry) => entry.tier)).toEqual([
+			'error',
+			'warning',
+			'warning',
+			'info',
+		]);
+		expect(entries[0].label).toBe('Fatal error');
+		expect(entries[0].message).toBe('Uncaught Error: boom');
+		expect(entries[3].label).toBe('User notice');
+	});
+
+	it('maps formatted logger entries to their channel and severity', () => {
+		const entries = parseLogs([
+			'[20-Jul-2026 14:59:46 UTC] JavaScript error: ReferenceError: x is not defined',
+			'[20-Jul-2026 14:59:46 UTC] Wasm Crash fatal: Aborted()',
+			'[20-Jul-2026 14:59:46 UTC] PHP fatal: request aborted',
+		]);
+		expect(entries[0]).toMatchObject({
+			channel: 'Playground',
+			label: 'Error',
+			tier: 'error',
+			message: 'ReferenceError: x is not defined',
+		});
+		expect(entries[1]).toMatchObject({
+			channel: 'Playground',
+			label: 'Crash',
+			tier: 'error',
+		});
+		expect(entries[2]).toMatchObject({
+			channel: 'PHP',
+			label: 'Fatal error',
+			tier: 'error',
+		});
+	});
+
+	it('treats unrecognized stamped records as WordPress output', () => {
+		const entries = parseLogs([
+			'[20-Jul-2026 14:59:46 UTC] Cron reschedule event error for hook',
+		]);
+		expect(entries[0]).toMatchObject({
+			channel: 'WordPress',
+			label: 'Log',
+			tier: 'info',
+			timestamp: '20-Jul-2026 14:59:46 UTC',
+			message: 'Cron reschedule event error for hook',
+		});
+	});
+
+	it('keeps records without a timestamp instead of dropping them', () => {
+		const entries = parseLogs(['stray line']);
+		expect(entries).toHaveLength(1);
+		expect(entries[0]).toMatchObject({
+			timestamp: null,
+			message: 'stray line',
+		});
+	});
+
+	it('preserves the raw record text for copying', () => {
+		const record =
+			'[20-Jul-2026 14:59:46 UTC] PHP Notice:  Something happened';
+		expect(parseLogs([record])[0].raw).toBe(record);
+	});
+});

--- a/packages/playground/website/src/components/log-modal/log-parsing.spec.ts
+++ b/packages/playground/website/src/components/log-modal/log-parsing.spec.ts
@@ -15,7 +15,7 @@ describe('parseLogs', () => {
 		expect(entries).toHaveLength(2);
 		expect(entries[0]).toMatchObject({
 			channel: 'PHP',
-			label: 'Notice',
+			label: 'E_NOTICE',
 			tier: 'info',
 			timestamp: '20-Jul-2026 14:59:46 UTC',
 		});
@@ -33,12 +33,12 @@ describe('parseLogs', () => {
 		expect(entries[1].message).toContain('MySQL query');
 	});
 
-	it('keeps severity tiers for the common PHP error levels', () => {
+	it('labels PHP error levels with their error_reporting constants', () => {
 		const entries = parseLogs([
 			'[20-Jul-2026 14:59:46 UTC] PHP Fatal error:  Uncaught Error: boom',
 			'[20-Jul-2026 14:59:46 UTC] PHP Warning:  Undefined variable $x',
 			'[20-Jul-2026 14:59:46 UTC] PHP Deprecated:  Optional parameter',
-			'[20-Jul-2026 14:59:46 UTC] PHP User notice:  hello',
+			'[20-Jul-2026 14:59:46 UTC] PHP Custom notice:  hello',
 		]);
 		expect(entries.map((entry) => entry.tier)).toEqual([
 			'error',
@@ -46,9 +46,12 @@ describe('parseLogs', () => {
 			'warning',
 			'info',
 		]);
-		expect(entries[0].label).toBe('Fatal error');
+		expect(entries[0].label).toBe('E_ERROR');
 		expect(entries[0].message).toBe('Uncaught Error: boom');
-		expect(entries[3].label).toBe('User notice');
+		expect(entries[1].label).toBe('E_WARNING');
+		expect(entries[2].label).toBe('E_DEPRECATED');
+		// Heads outside PHP's own vocabulary keep their verbatim text.
+		expect(entries[3].label).toBe('Custom notice');
 	});
 
 	it('maps formatted logger entries to their channel and severity', () => {

--- a/packages/playground/website/src/components/log-modal/log-parsing.spec.ts
+++ b/packages/playground/website/src/components/log-modal/log-parsing.spec.ts
@@ -13,29 +13,26 @@ describe('parseLogs', () => {
 		const entries = parseLogs([chunk]);
 
 		expect(entries).toHaveLength(2);
+		// The stamp is lifted; the severity head stays in the text and its
+		// span is reported so the UI can tint exactly that substring.
 		expect(entries[0]).toMatchObject({
-			channel: 'PHP',
-			label: 'E_NOTICE',
 			tier: 'info',
 			timestamp: '20-Jul-2026 14:59:46 UTC',
+			message:
+				'PHP Notice:  Function _load_textdomain_just_in_time was called incorrectly.',
+			headLength: 'PHP Notice:'.length,
 		});
-		// The record text is preserved as logged — stamp and severity
-		// head included.
-		expect(entries[0].raw).toBe(
-			'[20-Jul-2026 14:59:46 UTC] PHP Notice:  Function _load_textdomain_just_in_time was called incorrectly.'
-		);
 		expect(entries[1]).toMatchObject({
-			channel: 'PHP',
-			label: 'Database error',
 			tier: 'error',
+			headLength: 'WordPress database error'.length,
 		});
 		// Continuation lines stay inside their record instead of becoming
 		// separate entries.
-		expect(entries[1].raw.split('\n')).toHaveLength(3);
-		expect(entries[1].raw).toContain('MySQL query');
+		expect(entries[1].message.split('\n')).toHaveLength(3);
+		expect(entries[1].message).toContain('MySQL query');
 	});
 
-	it('labels PHP error levels with their error_reporting constants', () => {
+	it('classifies PHP error levels into tiers', () => {
 		const entries = parseLogs([
 			'[20-Jul-2026 14:59:46 UTC] PHP Fatal error:  Uncaught Error: boom',
 			'[20-Jul-2026 14:59:46 UTC] PHP Warning:  Undefined variable $x',
@@ -48,45 +45,43 @@ describe('parseLogs', () => {
 			'warning',
 			'info',
 		]);
-		expect(entries[0].label).toBe('E_ERROR');
-		expect(entries[1].label).toBe('E_WARNING');
-		expect(entries[2].label).toBe('E_DEPRECATED');
-		// Heads outside PHP's own vocabulary keep their verbatim text.
-		expect(entries[3].label).toBe('Custom notice');
+		expect(entries[0].message).toBe(
+			'PHP Fatal error:  Uncaught Error: boom'
+		);
+		expect(entries[0].headLength).toBe('PHP Fatal error:'.length);
 	});
 
-	it('maps formatted logger entries to their channel and severity', () => {
+	it('drops Playground host records and keeps PHP ones', () => {
 		const entries = parseLogs([
 			'[20-Jul-2026 14:59:46 UTC] JavaScript error: ReferenceError: x is not defined',
 			'[20-Jul-2026 14:59:46 UTC] Wasm Crash fatal: Aborted()',
 			'[20-Jul-2026 14:59:46 UTC] PHP fatal: request aborted',
 		]);
+		expect(entries).toHaveLength(1);
 		expect(entries[0]).toMatchObject({
-			channel: 'Playground',
-			label: 'Error',
 			tier: 'error',
-		});
-		expect(entries[1]).toMatchObject({
-			channel: 'Playground',
-			label: 'Crash',
-			tier: 'error',
-		});
-		expect(entries[2]).toMatchObject({
-			channel: 'PHP',
-			label: 'Fatal error',
-			tier: 'error',
+			message: 'PHP fatal: request aborted',
+			headLength: 'PHP fatal:'.length,
 		});
 	});
 
-	it('treats unrecognized stamped records as PHP output', () => {
+	it('treats unrecognized stamped records as plain output', () => {
 		const entries = parseLogs([
 			'[20-Jul-2026 14:59:46 UTC] Cron reschedule event error for hook',
 		]);
 		expect(entries[0]).toMatchObject({
-			channel: 'PHP',
-			label: 'Log',
 			tier: 'info',
 			timestamp: '20-Jul-2026 14:59:46 UTC',
+			message: 'Cron reschedule event error for hook',
+			headLength: 0,
+		});
+	});
+
+	it('lifts the timestamp only when it matches the exact stamp format', () => {
+		const entries = parseLogs(['[20-Jul-2026 14:59:46] missing timezone']);
+		expect(entries[0]).toMatchObject({
+			timestamp: null,
+			message: '[20-Jul-2026 14:59:46] missing timezone',
 		});
 	});
 
@@ -95,11 +90,11 @@ describe('parseLogs', () => {
 		expect(entries).toHaveLength(1);
 		expect(entries[0]).toMatchObject({
 			timestamp: null,
-			raw: 'stray line',
+			message: 'stray line',
 		});
 	});
 
-	it('preserves the raw record text', () => {
+	it('preserves the raw record text for copying', () => {
 		const record =
 			'[20-Jul-2026 14:59:46 UTC] PHP Notice:  Something happened';
 		expect(parseLogs([record])[0].raw).toBe(record);

--- a/packages/playground/website/src/components/log-modal/log-parsing.spec.ts
+++ b/packages/playground/website/src/components/log-modal/log-parsing.spec.ts
@@ -19,8 +19,10 @@ describe('parseLogs', () => {
 			tier: 'info',
 			timestamp: '20-Jul-2026 14:59:46 UTC',
 		});
-		expect(entries[0].message).toMatch(
-			/^Function _load_textdomain_just_in_time/
+		// The record text is preserved as logged — stamp and severity
+		// head included.
+		expect(entries[0].raw).toBe(
+			'[20-Jul-2026 14:59:46 UTC] PHP Notice:  Function _load_textdomain_just_in_time was called incorrectly.'
 		);
 		expect(entries[1]).toMatchObject({
 			channel: 'PHP',
@@ -29,8 +31,8 @@ describe('parseLogs', () => {
 		});
 		// Continuation lines stay inside their record instead of becoming
 		// separate entries.
-		expect(entries[1].message.split('\n')).toHaveLength(3);
-		expect(entries[1].message).toContain('MySQL query');
+		expect(entries[1].raw.split('\n')).toHaveLength(3);
+		expect(entries[1].raw).toContain('MySQL query');
 	});
 
 	it('labels PHP error levels with their error_reporting constants', () => {
@@ -47,7 +49,6 @@ describe('parseLogs', () => {
 			'info',
 		]);
 		expect(entries[0].label).toBe('E_ERROR');
-		expect(entries[0].message).toBe('Uncaught Error: boom');
 		expect(entries[1].label).toBe('E_WARNING');
 		expect(entries[2].label).toBe('E_DEPRECATED');
 		// Heads outside PHP's own vocabulary keep their verbatim text.
@@ -64,7 +65,6 @@ describe('parseLogs', () => {
 			channel: 'Playground',
 			label: 'Error',
 			tier: 'error',
-			message: 'ReferenceError: x is not defined',
 		});
 		expect(entries[1]).toMatchObject({
 			channel: 'Playground',
@@ -87,7 +87,6 @@ describe('parseLogs', () => {
 			label: 'Log',
 			tier: 'info',
 			timestamp: '20-Jul-2026 14:59:46 UTC',
-			message: 'Cron reschedule event error for hook',
 		});
 	});
 
@@ -96,11 +95,11 @@ describe('parseLogs', () => {
 		expect(entries).toHaveLength(1);
 		expect(entries[0]).toMatchObject({
 			timestamp: null,
-			message: 'stray line',
+			raw: 'stray line',
 		});
 	});
 
-	it('preserves the raw record text for copying', () => {
+	it('preserves the raw record text', () => {
 		const record =
 			'[20-Jul-2026 14:59:46 UTC] PHP Notice:  Something happened';
 		expect(parseLogs([record])[0].raw).toBe(record);

--- a/packages/playground/website/src/components/log-modal/log-parsing.spec.ts
+++ b/packages/playground/website/src/components/log-modal/log-parsing.spec.ts
@@ -23,7 +23,7 @@ describe('parseLogs', () => {
 			/^Function _load_textdomain_just_in_time/
 		);
 		expect(entries[1]).toMatchObject({
-			channel: 'WordPress',
+			channel: 'PHP',
 			label: 'Database error',
 			tier: 'error',
 		});
@@ -75,12 +75,12 @@ describe('parseLogs', () => {
 		});
 	});
 
-	it('treats unrecognized stamped records as WordPress output', () => {
+	it('treats unrecognized stamped records as PHP output', () => {
 		const entries = parseLogs([
 			'[20-Jul-2026 14:59:46 UTC] Cron reschedule event error for hook',
 		]);
 		expect(entries[0]).toMatchObject({
-			channel: 'WordPress',
+			channel: 'PHP',
 			label: 'Log',
 			tier: 'info',
 			timestamp: '20-Jul-2026 14:59:46 UTC',

--- a/packages/playground/website/src/components/log-modal/log-parsing.ts
+++ b/packages/playground/website/src/components/log-modal/log-parsing.ts
@@ -14,7 +14,11 @@ export type LogEntry = {
 	raw: string;
 	/** Full stamp, e.g. `20-Jul-2026 14:59:46 UTC`, when the record has one. */
 	timestamp: string | null;
-	/** The log source: PHP, WordPress, or Playground. */
+	/**
+	 * The runtime that produced the record: PHP (the site, via debug.log)
+	 * or Playground (the JavaScript host). Finer attribution — engine vs
+	 * WordPress core vs plugin — is not recoverable from the log text.
+	 */
 	channel: string;
 	/** Badge text, e.g. `Fatal error`, `Notice`, `Database error`. */
 	label: string;
@@ -87,7 +91,7 @@ function parseLogRecord(record: string): LogEntry {
 		return {
 			raw: record,
 			timestamp,
-			channel: 'WordPress',
+			channel: 'PHP',
 			label: 'Database error',
 			tier: 'error',
 			message: message.slice(databaseMatch[0].length),
@@ -106,11 +110,11 @@ function parseLogRecord(record: string): LogEntry {
 		};
 	}
 
-	// error_log() lines from WordPress core or plugins carry no severity head.
+	// error_log() output carries no severity head, only the debug.log stamp.
 	return {
 		raw: record,
 		timestamp,
-		channel: 'WordPress',
+		channel: 'PHP',
 		label: 'Log',
 		tier: 'info',
 		message,

--- a/packages/playground/website/src/components/log-modal/log-parsing.ts
+++ b/packages/playground/website/src/components/log-modal/log-parsing.ts
@@ -1,0 +1,129 @@
+/**
+ * The logger hands the website plain strings of two shapes: single
+ * pre-formatted `[stamp] Prefix severity: message` entries, and whole
+ * PHP debug.log chunks where one string carries many records (a single
+ * WordPress database error can dump hundreds of lines). Parsing splits
+ * chunks into records and reads each record's severity so the UI can
+ * render one row per record instead of one unbounded wall of text.
+ */
+
+export type LogTier = 'error' | 'warning' | 'info';
+
+export type LogEntry = {
+	/** The unmodified record text — what copying puts on the clipboard. */
+	raw: string;
+	/** Full stamp, e.g. `20-Jul-2026 14:59:46 UTC`, when the record has one. */
+	timestamp: string | null;
+	/** The log source: PHP, WordPress, or Playground. */
+	channel: string;
+	/** Badge text, e.g. `Fatal error`, `Notice`, `Database error`. */
+	label: string;
+	tier: LogTier;
+	/** Record text without the timestamp and severity head. */
+	message: string;
+};
+
+/** Both PHP's debug.log and the JS logger stamp records as `[20-Jul-2026 …]`. */
+const RECORD_BOUNDARY = /\n(?=\[\d{1,2}-[A-Za-z]{3}-\d{4} )/;
+const TIMESTAMP_HEAD = /^\[(\d{1,2}-[A-Za-z]{3}-\d{4} [^\]]*)\]\s?/;
+
+/** Heads written by the JS logger's formatLogEntry. */
+const FORMATTED_HEAD =
+	/^(PHP|JavaScript|Wasm Crash) (fatal|error|warn|log|info|debug):\s*/;
+const FORMATTED_SEVERITIES: Record<string, { label: string; tier: LogTier }> = {
+	fatal: { label: 'Fatal error', tier: 'error' },
+	error: { label: 'Error', tier: 'error' },
+	warn: { label: 'Warning', tier: 'warning' },
+	log: { label: 'Log', tier: 'info' },
+	info: { label: 'Info', tier: 'info' },
+	debug: { label: 'Debug', tier: 'info' },
+};
+
+/**
+ * Heads PHP itself writes to debug.log. The lazy word prefix covers the
+ * compound levels — `Fatal error`, `Recoverable fatal error`, `User notice`,
+ * `Core warning`, and the like — without listing each one.
+ */
+const PHP_HEAD =
+	/^PHP ((?:\w+ )*?(?:error|warning|notice|deprecated|strict standards)):\s*/i;
+
+const DATABASE_HEAD = /^WordPress database error\s*/;
+
+export function parseLogs(rawLogs: string[]): LogEntry[] {
+	return rawLogs.flatMap((rawLog) =>
+		rawLog
+			.split(RECORD_BOUNDARY)
+			.map((record) => record.trim())
+			.filter((record) => record !== '')
+			.map(parseLogRecord)
+	);
+}
+
+function parseLogRecord(record: string): LogEntry {
+	let message = record;
+	let timestamp: string | null = null;
+	const stampMatch = message.match(TIMESTAMP_HEAD);
+	if (stampMatch) {
+		timestamp = stampMatch[1];
+		message = message.slice(stampMatch[0].length);
+	}
+
+	const formattedMatch = message.match(FORMATTED_HEAD);
+	if (formattedMatch) {
+		const severity = FORMATTED_SEVERITIES[formattedMatch[2]];
+		const isWasmCrash = formattedMatch[1] === 'Wasm Crash';
+		return {
+			raw: record,
+			timestamp,
+			channel: formattedMatch[1] === 'PHP' ? 'PHP' : 'Playground',
+			label: isWasmCrash ? 'Crash' : severity.label,
+			tier: isWasmCrash ? 'error' : severity.tier,
+			message: message.slice(formattedMatch[0].length),
+		};
+	}
+
+	const databaseMatch = message.match(DATABASE_HEAD);
+	if (databaseMatch) {
+		return {
+			raw: record,
+			timestamp,
+			channel: 'WordPress',
+			label: 'Database error',
+			tier: 'error',
+			message: message.slice(databaseMatch[0].length),
+		};
+	}
+
+	const phpMatch = message.match(PHP_HEAD);
+	if (phpMatch) {
+		return {
+			raw: record,
+			timestamp,
+			channel: 'PHP',
+			label: phpMatch[1],
+			tier: phpTier(phpMatch[1]),
+			message: message.slice(phpMatch[0].length),
+		};
+	}
+
+	// error_log() lines from WordPress core or plugins carry no severity head.
+	return {
+		raw: record,
+		timestamp,
+		channel: 'WordPress',
+		label: 'Log',
+		tier: 'info',
+		message,
+	};
+}
+
+function phpTier(label: string): LogTier {
+	const level = label.toLowerCase();
+	if (level.endsWith('error')) {
+		return 'error';
+	}
+	if (level.endsWith('warning') || level.endsWith('deprecated')) {
+		return 'warning';
+	}
+	return 'info';
+}

--- a/packages/playground/website/src/components/log-modal/log-parsing.ts
+++ b/packages/playground/website/src/components/log-modal/log-parsing.ts
@@ -3,47 +3,51 @@
  * pre-formatted `[stamp] Prefix severity: message` entries, and whole
  * PHP debug.log chunks where one string carries many records (a single
  * WordPress database error can dump hundreds of lines). Parsing splits
- * chunks into records and reads each record's severity so the UI can
- * render one row per record instead of one unbounded wall of text. That
- * is all it does — the record text itself is displayed as logged.
+ * chunks into records, lifts the leading timestamp when it matches
+ * debug.log's exact stamp format, and reads each record's severity head
+ * — which stays in the text — to classify the record. Records from the
+ * Playground host (JavaScript, Wasm crashes) are dropped: this feeds a
+ * PHP error log view.
  */
 
 export type LogTier = 'error' | 'warning' | 'info';
 
 export type LogEntry = {
-	/**
-	 * The record exactly as logged — the panel renders and copies this
-	 * text verbatim. The fields below are read-only classifications of
-	 * it; parsing never rewrites the record.
-	 */
+	/** The unmodified record text — what copying puts on the clipboard. */
 	raw: string;
-	/** Full stamp, e.g. `20-Jul-2026 14:59:46 UTC`, when the record has one. */
+	/**
+	 * The lifted stamp, e.g. `20-Jul-2026 14:59:46 UTC`, when the record
+	 * starts with debug.log's exact format. Displayed above the message.
+	 */
 	timestamp: string | null;
 	/**
-	 * The runtime that produced the record: PHP (the site, via debug.log)
-	 * or Playground (the JavaScript host). Finer attribution — engine vs
-	 * WordPress core vs plugin — is not recoverable from the log text.
+	 * The record with the lifted stamp removed and nothing else — the
+	 * `PHP Notice:` style severity head stays in place.
 	 */
-	channel: string;
-	/** Badge text, e.g. `E_WARNING`, `Database error`. */
-	label: string;
+	message: string;
+	/**
+	 * Length of the severity head at the start of `message` (0 when the
+	 * record has none). The panel tints exactly that substring.
+	 */
+	headLength: number;
 	tier: LogTier;
 };
 
 /** Both PHP's debug.log and the JS logger stamp records as `[20-Jul-2026 …]`. */
 const RECORD_BOUNDARY = /\n(?=\[\d{1,2}-[A-Za-z]{3}-\d{4} )/;
-const TIMESTAMP_HEAD = /^\[(\d{1,2}-[A-Za-z]{3}-\d{4} [^\]]*)\]\s?/;
+const TIMESTAMP_HEAD =
+	/^\[(\d{1,2}-[A-Za-z]{3}-\d{4} \d{2}:\d{2}:\d{2} [^\]]+)\]\s?/;
 
 /** Heads written by the JS logger's formatLogEntry. */
 const FORMATTED_HEAD =
 	/^(PHP|JavaScript|Wasm Crash) (fatal|error|warn|log|info|debug):\s*/;
-const FORMATTED_SEVERITIES: Record<string, { label: string; tier: LogTier }> = {
-	fatal: { label: 'Fatal error', tier: 'error' },
-	error: { label: 'Error', tier: 'error' },
-	warn: { label: 'Warning', tier: 'warning' },
-	log: { label: 'Log', tier: 'info' },
-	info: { label: 'Info', tier: 'info' },
-	debug: { label: 'Debug', tier: 'info' },
+const FORMATTED_TIERS: Record<string, LogTier> = {
+	fatal: 'error',
+	error: 'error',
+	warn: 'warning',
+	log: 'info',
+	info: 'info',
+	debug: 'info',
 };
 
 /**
@@ -54,22 +58,6 @@ const FORMATTED_SEVERITIES: Record<string, { label: string; tier: LogTier }> = {
 const PHP_HEAD =
 	/^PHP ((?:\w+ )*?(?:error|warning|notice|deprecated|strict standards)):\s*/i;
 
-/**
- * debug.log heads restored to the constant names developers configure in
- * error_reporting. PHP prints the same string for the E_USER_* and E_CORE_*
- * variants, so the base constant is as precise as the log text allows.
- * Unlisted heads keep their verbatim text.
- */
-const PHP_LEVELS: Record<string, { label: string; tier: LogTier }> = {
-	'fatal error': { label: 'E_ERROR', tier: 'error' },
-	'recoverable fatal error': { label: 'E_RECOVERABLE_ERROR', tier: 'error' },
-	'parse error': { label: 'E_PARSE', tier: 'error' },
-	warning: { label: 'E_WARNING', tier: 'warning' },
-	deprecated: { label: 'E_DEPRECATED', tier: 'warning' },
-	notice: { label: 'E_NOTICE', tier: 'info' },
-	'strict standards': { label: 'E_STRICT', tier: 'info' },
-};
-
 const DATABASE_HEAD = /^WordPress database error\s*/;
 
 export function parseLogs(rawLogs: string[]): LogEntry[] {
@@ -79,53 +67,54 @@ export function parseLogs(rawLogs: string[]): LogEntry[] {
 			.map((record) => record.trim())
 			.filter((record) => record !== '')
 			.map(parseLogRecord)
+			.filter((entry): entry is LogEntry => entry !== null)
 	);
 }
 
-function parseLogRecord(record: string): LogEntry {
-	// The heads below are matched only to classify the record; `body` is
-	// never returned. The stamp is sliced off solely so the `^`-anchored
-	// head patterns can see past it.
-	let body = record;
+function parseLogRecord(record: string): LogEntry | null {
+	let message = record;
 	let timestamp: string | null = null;
-	const stampMatch = body.match(TIMESTAMP_HEAD);
+	const stampMatch = message.match(TIMESTAMP_HEAD);
 	if (stampMatch) {
 		timestamp = stampMatch[1];
-		body = body.slice(stampMatch[0].length);
+		message = message.slice(stampMatch[0].length);
 	}
 
-	const formattedMatch = body.match(FORMATTED_HEAD);
+	const formattedMatch = message.match(FORMATTED_HEAD);
 	if (formattedMatch) {
-		const severity = FORMATTED_SEVERITIES[formattedMatch[2]];
-		const isWasmCrash = formattedMatch[1] === 'Wasm Crash';
+		// JavaScript and Wasm Crash records come from the Playground host,
+		// not from the site's PHP runtime.
+		if (formattedMatch[1] !== 'PHP') {
+			return null;
+		}
 		return {
 			raw: record,
 			timestamp,
-			channel: formattedMatch[1] === 'PHP' ? 'PHP' : 'Playground',
-			label: isWasmCrash ? 'Crash' : severity.label,
-			tier: isWasmCrash ? 'error' : severity.tier,
+			message,
+			headLength: formattedMatch[0].trimEnd().length,
+			tier: FORMATTED_TIERS[formattedMatch[2]],
 		};
 	}
 
-	if (DATABASE_HEAD.test(body)) {
+	const databaseMatch = message.match(DATABASE_HEAD);
+	if (databaseMatch) {
 		return {
 			raw: record,
 			timestamp,
-			channel: 'PHP',
-			label: 'Database error',
+			message,
+			headLength: databaseMatch[0].trimEnd().length,
 			tier: 'error',
 		};
 	}
 
-	const phpMatch = body.match(PHP_HEAD);
+	const phpMatch = message.match(PHP_HEAD);
 	if (phpMatch) {
-		const level = PHP_LEVELS[phpMatch[1].toLowerCase()];
 		return {
 			raw: record,
 			timestamp,
-			channel: 'PHP',
-			label: level?.label ?? phpMatch[1],
-			tier: level?.tier ?? phpTier(phpMatch[1]),
+			message,
+			headLength: phpMatch[0].trimEnd().length,
+			tier: phpTier(phpMatch[1]),
 		};
 	}
 
@@ -133,18 +122,18 @@ function parseLogRecord(record: string): LogEntry {
 	return {
 		raw: record,
 		timestamp,
-		channel: 'PHP',
-		label: 'Log',
+		message,
+		headLength: 0,
 		tier: 'info',
 	};
 }
 
-function phpTier(label: string): LogTier {
-	const level = label.toLowerCase();
-	if (level.endsWith('error')) {
+function phpTier(level: string): LogTier {
+	const normalized = level.toLowerCase();
+	if (normalized.endsWith('error')) {
 		return 'error';
 	}
-	if (level.endsWith('warning') || level.endsWith('deprecated')) {
+	if (normalized.endsWith('warning') || normalized.endsWith('deprecated')) {
 		return 'warning';
 	}
 	return 'info';

--- a/packages/playground/website/src/components/log-modal/log-parsing.ts
+++ b/packages/playground/website/src/components/log-modal/log-parsing.ts
@@ -45,11 +45,27 @@ const FORMATTED_SEVERITIES: Record<string, { label: string; tier: LogTier }> = {
 
 /**
  * Heads PHP itself writes to debug.log. The lazy word prefix covers the
- * compound levels — `Fatal error`, `Recoverable fatal error`, `User notice`,
- * `Core warning`, and the like — without listing each one.
+ * compound levels — `Fatal error`, `Recoverable fatal error`, and the
+ * like — without listing each one.
  */
 const PHP_HEAD =
 	/^PHP ((?:\w+ )*?(?:error|warning|notice|deprecated|strict standards)):\s*/i;
+
+/**
+ * debug.log heads restored to the constant names developers configure in
+ * error_reporting. PHP prints the same string for the E_USER_* and E_CORE_*
+ * variants, so the base constant is as precise as the log text allows.
+ * Unlisted heads keep their verbatim text.
+ */
+const PHP_LEVELS: Record<string, { label: string; tier: LogTier }> = {
+	'fatal error': { label: 'E_ERROR', tier: 'error' },
+	'recoverable fatal error': { label: 'E_RECOVERABLE_ERROR', tier: 'error' },
+	'parse error': { label: 'E_PARSE', tier: 'error' },
+	warning: { label: 'E_WARNING', tier: 'warning' },
+	deprecated: { label: 'E_DEPRECATED', tier: 'warning' },
+	notice: { label: 'E_NOTICE', tier: 'info' },
+	'strict standards': { label: 'E_STRICT', tier: 'info' },
+};
 
 const DATABASE_HEAD = /^WordPress database error\s*/;
 
@@ -100,12 +116,13 @@ function parseLogRecord(record: string): LogEntry {
 
 	const phpMatch = message.match(PHP_HEAD);
 	if (phpMatch) {
+		const level = PHP_LEVELS[phpMatch[1].toLowerCase()];
 		return {
 			raw: record,
 			timestamp,
 			channel: 'PHP',
-			label: phpMatch[1],
-			tier: phpTier(phpMatch[1]),
+			label: level?.label ?? phpMatch[1],
+			tier: level?.tier ?? phpTier(phpMatch[1]),
 			message: message.slice(phpMatch[0].length),
 		};
 	}

--- a/packages/playground/website/src/components/log-modal/log-parsing.ts
+++ b/packages/playground/website/src/components/log-modal/log-parsing.ts
@@ -13,7 +13,10 @@
 export type LogTier = 'error' | 'warning' | 'info';
 
 export type LogEntry = {
-	/** The unmodified record text — what copying puts on the clipboard. */
+	/**
+	 * The record text as logged, trimmed of surrounding whitespace —
+	 * what copying puts on the clipboard.
+	 */
 	raw: string;
 	/**
 	 * The lifted stamp, e.g. `20-Jul-2026 14:59:46 UTC`, when the record

--- a/packages/playground/website/src/components/log-modal/log-parsing.ts
+++ b/packages/playground/website/src/components/log-modal/log-parsing.ts
@@ -38,6 +38,13 @@ export type LogEntry = {
 
 /** Both PHP's debug.log and the JS logger stamp records as `[20-Jul-2026 …]`. */
 const RECORD_BOUNDARY = /\n(?=\[\d{1,2}-[A-Za-z]{3}-\d{4} )/;
+
+/**
+ * The complete stamp shape — `d-M-Y H:i:s timezone` in PHP date terms.
+ * The record boundary above needs only the date part, but lifting a
+ * stamp out of a record demands the full format, so that a line which
+ * merely opens with something date-like keeps its brackets.
+ */
 const TIMESTAMP_HEAD =
 	/^\[(\d{1,2}-[A-Za-z]{3}-\d{4} \d{2}:\d{2}:\d{2} [^\]]+)\]\s?/;
 
@@ -61,8 +68,39 @@ const FORMATTED_TIERS: Record<string, LogTier> = {
 const PHP_HEAD =
 	/^PHP ((?:\w+ )*?(?:error|warning|notice|deprecated|strict standards)):\s*/i;
 
+/** $wpdb writes database errors with this head and no PHP severity marker. */
 const DATABASE_HEAD = /^WordPress database error\s*/;
 
+/**
+ * Parses the logger's raw strings into PHP error log entries.
+ *
+ * The logger's memory buffer can be viewed as a stream of records, but
+ * it arrives as an array of strings of two shapes:
+ *
+ *  - a single pre-formatted entry written by the JS logger, e.g.
+ *    `[20-Jul-2026 14:59:46 UTC] PHP fatal: request aborted`;
+ *  - a whole PHP debug.log chunk, where one string carries many
+ *    records — a single WordPress database error can dump hundreds
+ *    of lines.
+ *
+ * Each string is split into records at every newline followed by a
+ * `[20-Jul-2026 …]` stamp. Lines that do not open a new record — the
+ * continuation lines of a multi-line message — stay attached to the
+ * record they belong to.
+ *
+ * Parsing preserves the record text. Beyond the whitespace separating
+ * records inside a chunk, nothing is removed or rewritten: the
+ * severity head (`PHP Warning:`, `WordPress database error`, …) is
+ * read in place to classify the record and remains part of the
+ * message. See parseLogRecord for the classification rules.
+ *
+ * Records produced by the Playground host itself — JavaScript errors
+ * and Wasm crashes — are dropped. This module feeds a view of the
+ * site's PHP error log, not a combined console.
+ *
+ * @param rawLogs The strings accumulated by the logger, oldest first.
+ * @returns One entry per site record, in the order they were logged.
+ */
 export function parseLogs(rawLogs: string[]): LogEntry[] {
 	return rawLogs.flatMap((rawLog) =>
 		rawLog
@@ -74,6 +112,32 @@ export function parseLogs(rawLogs: string[]): LogEntry[] {
 	);
 }
 
+/**
+ * Parses one record into a log entry, or drops it.
+ *
+ * A record is classified by the head it opens with, tried in order:
+ *
+ *  - `PHP fatal:` style heads written by the JS logger. `PHP` records
+ *    describe the site's runtime (e.g. a crashed request) and are
+ *    kept; `JavaScript` and `Wasm Crash` records describe the
+ *    Playground host and are dropped by returning `null`.
+ *  - `WordPress database error`, written by $wpdb. Always an error.
+ *  - `PHP Warning:` style heads PHP itself writes to debug.log,
+ *    including the compound levels (`Fatal error`, `Recoverable
+ *    fatal error`, …).
+ *  - Anything else — typically bare error_log() output — is kept
+ *    verbatim as an info-tier entry with no severity head.
+ *
+ * When the record opens with debug.log's exact stamp format, the
+ * stamp is lifted into `timestamp` and removed from `message`; a
+ * leading bracket of any other shape is record text and stays put.
+ * That is the only edit `message` ever receives. The severity head
+ * is measured into `headLength` so the UI can tint it, but it is
+ * never moved or rewritten.
+ *
+ * @param record One record, as split out of a logger string.
+ * @returns The parsed entry, or `null` for Playground-host records.
+ */
 function parseLogRecord(record: string): LogEntry | null {
 	let message = record;
 	let timestamp: string | null = null;
@@ -131,6 +195,16 @@ function parseLogRecord(record: string): LogEntry | null {
 	};
 }
 
+/**
+ * Maps a PHP severity level to the tier driving the filter chips and
+ * the head tint.
+ *
+ * The level is the head text between `PHP ` and the colon, so
+ * compound levels classify by their last word: `Fatal error`,
+ * `Parse error`, and `Recoverable fatal error` all end in `error`,
+ * and `User warning` ends in `warning`. Notices and strict-standards
+ * messages fall through to `info`.
+ */
 function phpTier(level: string): LogTier {
 	const normalized = level.toLowerCase();
 	if (normalized.endsWith('error')) {

--- a/packages/playground/website/src/components/log-modal/log-parsing.ts
+++ b/packages/playground/website/src/components/log-modal/log-parsing.ts
@@ -4,13 +4,18 @@
  * PHP debug.log chunks where one string carries many records (a single
  * WordPress database error can dump hundreds of lines). Parsing splits
  * chunks into records and reads each record's severity so the UI can
- * render one row per record instead of one unbounded wall of text.
+ * render one row per record instead of one unbounded wall of text. That
+ * is all it does — the record text itself is displayed as logged.
  */
 
 export type LogTier = 'error' | 'warning' | 'info';
 
 export type LogEntry = {
-	/** The unmodified record text — what copying puts on the clipboard. */
+	/**
+	 * The record exactly as logged — the panel renders and copies this
+	 * text verbatim. The fields below are read-only classifications of
+	 * it; parsing never rewrites the record.
+	 */
 	raw: string;
 	/** Full stamp, e.g. `20-Jul-2026 14:59:46 UTC`, when the record has one. */
 	timestamp: string | null;
@@ -20,11 +25,9 @@ export type LogEntry = {
 	 * WordPress core vs plugin — is not recoverable from the log text.
 	 */
 	channel: string;
-	/** Badge text, e.g. `Fatal error`, `Notice`, `Database error`. */
+	/** Badge text, e.g. `E_WARNING`, `Database error`. */
 	label: string;
 	tier: LogTier;
-	/** Record text without the timestamp and severity head. */
-	message: string;
 };
 
 /** Both PHP's debug.log and the JS logger stamp records as `[20-Jul-2026 …]`. */
@@ -80,15 +83,18 @@ export function parseLogs(rawLogs: string[]): LogEntry[] {
 }
 
 function parseLogRecord(record: string): LogEntry {
-	let message = record;
+	// The heads below are matched only to classify the record; `body` is
+	// never returned. The stamp is sliced off solely so the `^`-anchored
+	// head patterns can see past it.
+	let body = record;
 	let timestamp: string | null = null;
-	const stampMatch = message.match(TIMESTAMP_HEAD);
+	const stampMatch = body.match(TIMESTAMP_HEAD);
 	if (stampMatch) {
 		timestamp = stampMatch[1];
-		message = message.slice(stampMatch[0].length);
+		body = body.slice(stampMatch[0].length);
 	}
 
-	const formattedMatch = message.match(FORMATTED_HEAD);
+	const formattedMatch = body.match(FORMATTED_HEAD);
 	if (formattedMatch) {
 		const severity = FORMATTED_SEVERITIES[formattedMatch[2]];
 		const isWasmCrash = formattedMatch[1] === 'Wasm Crash';
@@ -98,23 +104,20 @@ function parseLogRecord(record: string): LogEntry {
 			channel: formattedMatch[1] === 'PHP' ? 'PHP' : 'Playground',
 			label: isWasmCrash ? 'Crash' : severity.label,
 			tier: isWasmCrash ? 'error' : severity.tier,
-			message: message.slice(formattedMatch[0].length),
 		};
 	}
 
-	const databaseMatch = message.match(DATABASE_HEAD);
-	if (databaseMatch) {
+	if (DATABASE_HEAD.test(body)) {
 		return {
 			raw: record,
 			timestamp,
 			channel: 'PHP',
 			label: 'Database error',
 			tier: 'error',
-			message: message.slice(databaseMatch[0].length),
 		};
 	}
 
-	const phpMatch = message.match(PHP_HEAD);
+	const phpMatch = body.match(PHP_HEAD);
 	if (phpMatch) {
 		const level = PHP_LEVELS[phpMatch[1].toLowerCase()];
 		return {
@@ -123,7 +126,6 @@ function parseLogRecord(record: string): LogEntry {
 			channel: 'PHP',
 			label: level?.label ?? phpMatch[1],
 			tier: level?.tier ?? phpTier(phpMatch[1]),
-			message: message.slice(phpMatch[0].length),
 		};
 	}
 
@@ -134,7 +136,6 @@ function parseLogRecord(record: string): LogEntry {
 		channel: 'PHP',
 		label: 'Log',
 		tier: 'info',
-		message,
 	};
 }
 

--- a/packages/playground/website/src/components/log-modal/style.module.css
+++ b/packages/playground/website/src/components/log-modal/style.module.css
@@ -1,12 +1,206 @@
 .logs-inside-modal {
-	.log__search {
-		/* Title margin bottom + log margin top */
-		margin-bottom: var(--space-4, 16px);
-	}
-
 	.logs-component {
 		padding: var(--space-4, 16px);
 	}
+}
+
+.logs-component {
+	display: flex;
+	flex-direction: column;
+	width: 100%;
+}
+
+/* The toolbar pins to the top of the scrolling pane so search and filters
+   stay reachable while long logs scroll underneath. */
+.log-toolbar {
+	background: var(--paper-1, #fff);
+	box-shadow: 0 1px 0 var(--line-subtle, rgba(33, 32, 29, 0.08));
+	padding: var(--space-2, 8px) 0 var(--space-3, 12px);
+	position: sticky;
+	top: 0;
+	z-index: 1;
+}
+
+.log-filters {
+	align-items: center;
+	display: flex;
+	flex-wrap: wrap;
+	gap: var(--space-2, 8px);
+	margin-top: var(--space-3, 12px);
+}
+
+.log-filter-chip {
+	background: none;
+	border: 1px solid var(--line-control, rgba(33, 32, 29, 0.14));
+	border-radius: 999px;
+	color: var(--ink-muted, #5f5b54);
+	cursor: pointer;
+	font-size: 12px;
+	font-weight: 500;
+	line-height: 20px;
+	padding: 0 10px;
+}
+
+.log-filter-chip:hover {
+	border-color: var(--line-hover, rgba(33, 32, 29, 0.22));
+	color: var(--ink, #21201d);
+}
+
+.log-filter-chip[aria-pressed='true'] {
+	background: var(--ink-soft, #2f2d28);
+	border-color: var(--ink-soft, #2f2d28);
+	color: var(--paper-1, #f7f5f2);
+}
+
+.log-filter-count {
+	font-variant-numeric: tabular-nums;
+	margin-left: var(--space-1, 4px);
+	opacity: 0.65;
+}
+
+.log-copy-all {
+	background: none;
+	border: 0;
+	color: var(--accent-link, #2645c9);
+	cursor: pointer;
+	font-size: 12px;
+	font-weight: 500;
+	margin-left: auto;
+	padding: 0;
+}
+
+.log-copy-all:hover {
+	text-decoration: underline;
+}
+
+.log__content-container {
+	flex-grow: 1;
+}
+
+.log-list {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+}
+
+.log-entry {
+	border-block-end: 1px solid var(--line-subtle, rgba(33, 32, 29, 0.08));
+	padding: var(--space-3, 12px) 0;
+}
+
+.log-entry:last-child {
+	border-block-end: 0;
+}
+
+.log-entry-meta {
+	align-items: center;
+	display: flex;
+	gap: var(--space-2, 8px);
+	min-height: 24px;
+}
+
+.log-badge {
+	border-radius: 999px;
+	flex-shrink: 0;
+	font-size: 11px;
+	font-weight: 600;
+	letter-spacing: 0.02em;
+	line-height: 18px;
+	padding: 0 var(--space-2, 8px);
+}
+
+.log-badge[data-tier='error'] {
+	background: #f6e0da;
+	color: #96291b;
+}
+
+.log-badge[data-tier='warning'] {
+	background: #f3e8cd;
+	color: #765311;
+}
+
+.log-badge[data-tier='info'] {
+	background: var(--paper-3, #ece8e1);
+	color: var(--ink-muted, #5f5b54);
+}
+
+.log-channel {
+	color: var(--ink-faint, #8a857b);
+	font-size: 12px;
+}
+
+.log-timestamp {
+	color: var(--ink-faint, #8a857b);
+	font-size: 12px;
+	font-variant-numeric: tabular-nums;
+	margin-left: auto;
+}
+
+.log-copy {
+	align-items: center;
+	background: none;
+	border: 0;
+	border-radius: var(--radius-control, 6px);
+	color: var(--action-icon, #4f4b45);
+	cursor: pointer;
+	display: flex;
+	height: 24px;
+	justify-content: center;
+	opacity: 0;
+	padding: 0;
+	transition: opacity 120ms ease;
+	width: 24px;
+}
+
+.log-entry:hover .log-copy,
+.log-entry:focus-within .log-copy,
+.log-copy:focus-visible {
+	opacity: 1;
+}
+
+.log-copy:hover {
+	background: var(--paper-4, #e7e2da);
+}
+
+.log-entry-message {
+	color: var(--ink-soft, #2f2d28);
+	font-family:
+		'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
+	font-size: 12px;
+	line-height: 1.6;
+	margin-top: var(--space-2, 8px);
+	overflow-wrap: anywhere;
+	white-space-collapse: preserve-breaks;
+}
+
+/* Keep the clamp line count in sync with CLAMP_LINES in index.tsx. */
+.log-entry-message[data-clamped] {
+	-webkit-box-orient: vertical;
+	-webkit-line-clamp: 6;
+	display: -webkit-box;
+	overflow: hidden;
+}
+
+.log-entry-message mark {
+	background: #f2e2ac;
+	border-radius: 3px;
+	color: var(--ink, #21201d);
+	padding: 0 2px;
+}
+
+.log-entry-toggle {
+	background: none;
+	border: 0;
+	color: var(--accent-link, #2645c9);
+	cursor: pointer;
+	font-size: 12px;
+	font-weight: 500;
+	margin-top: var(--space-1, 4px);
+	padding: 0;
+}
+
+.log-entry-toggle:hover {
+	text-decoration: underline;
 }
 
 .log__empty_placeholder {
@@ -28,38 +222,6 @@
 
 .log-clear-search:hover {
 	text-decoration: underline;
-}
-
-.logs-component {
-	display: flex;
-	flex-direction: column;
-	width: 100%;
-}
-
-.log__content-container {
-	flex-grow: 1;
-}
-
-.log__entry {
-	border-block-end: 1px solid var(--line-subtle);
-	font-family:
-		'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
-	margin: var(--space-2) 0;
-	padding: var(--space-2) 0;
-	white-space-collapse: preserve-breaks;
-	word-wrap: break-word;
-}
-
-.log__entry:has(mark) {
-	background-color: var(--paper-3);
-}
-
-.log__entry mark {
-	background-color: var(--paper-4, #e7e2da);
-	border-radius: var(--radius-control, 6px);
-	color: var(--color-alert-red, #cc1818);
-	font-weight: 600;
-	padding: 0 var(--space-1, 4px);
 }
 
 .log-empty-state {

--- a/packages/playground/website/src/components/log-modal/style.module.css
+++ b/packages/playground/website/src/components/log-modal/style.module.css
@@ -26,7 +26,7 @@
 	display: flex;
 	flex-wrap: wrap;
 	gap: var(--space-2, 8px);
-	margin-top: var(--space-3, 12px);
+	margin-top: var(--space-2, 8px);
 }
 
 .log-filter-chip {
@@ -41,15 +41,22 @@
 	padding: 0 10px;
 }
 
-.log-filter-chip:hover {
+.log-filter-chip:hover:not(:disabled) {
 	border-color: var(--line-hover, rgba(33, 32, 29, 0.22));
 	color: var(--ink, #21201d);
 }
 
+/* The active chip fills with a warm neutral instead of near-black so the
+   filter row stays quieter than the log content it controls. */
 .log-filter-chip[aria-pressed='true'] {
-	background: var(--ink-soft, #2f2d28);
-	border-color: var(--ink-soft, #2f2d28);
-	color: var(--paper-1, #f7f5f2);
+	background: var(--paper-5, #e2dcd2);
+	border-color: var(--paper-5, #e2dcd2);
+	color: var(--ink, #21201d);
+}
+
+.log-filter-chip:disabled {
+	cursor: default;
+	opacity: 0.45;
 }
 
 .log-filter-count {
@@ -92,8 +99,14 @@
 	padding: 0;
 }
 
+/* One grid for every row: a fixed rail, the message, and a copy slot. All
+   metadata aligns in the rail; the message column is the widest and darkest
+   element, so the eye lands on it. */
 .log-entry {
 	border-block-end: 1px solid var(--line-subtle, rgba(33, 32, 29, 0.08));
+	column-gap: var(--space-4, 16px);
+	display: grid;
+	grid-template-columns: 96px minmax(0, 1fr) 24px;
 	padding: var(--space-3, 12px) 0;
 }
 
@@ -101,52 +114,48 @@
 	border-block-end: 0;
 }
 
-.log-entry-meta {
-	align-items: center;
+.log-entry-rail {
 	display: flex;
-	gap: var(--space-2, 8px);
-	min-height: 24px;
+	flex-direction: column;
+	gap: 2px;
 }
 
-.log-badge {
-	border-radius: 999px;
-	flex-shrink: 0;
+.log-entry-body {
+	min-width: 0;
+}
+
+/* Severity is a small tinted word, not a filled pill — color appears only
+   where it means something. */
+.log-severity {
 	font-size: 11px;
 	font-weight: 600;
 	letter-spacing: 0.02em;
-	line-height: 18px;
-	padding: 0 var(--space-2, 8px);
+	line-height: 19px;
 }
 
-.log-badge[data-tier='error'] {
-	background: #f6e0da;
+.log-severity[data-tier='error'] {
 	color: #96291b;
 }
 
-.log-badge[data-tier='warning'] {
-	background: #f3e8cd;
+.log-severity[data-tier='warning'] {
 	color: #765311;
 }
 
-.log-badge[data-tier='info'] {
-	background: var(--paper-3, #ece8e1);
+.log-severity[data-tier='info'] {
 	color: var(--ink-muted, #5f5b54);
-}
-
-/* A fixed-width first column ("PHP" / "Playground") so the variable-width
-   severity badges after it all start at the same x and stay scannable. */
-.log-channel {
-	color: var(--ink-faint, #8a857b);
-	flex-shrink: 0;
-	font-size: 12px;
-	min-width: 72px;
 }
 
 .log-timestamp {
 	color: var(--ink-faint, #8a857b);
 	font-size: 12px;
 	font-variant-numeric: tabular-nums;
-	margin-left: auto;
+	line-height: 19px;
+}
+
+.log-channel-tag {
+	color: var(--ink-faint, #8a857b);
+	font-size: 11px;
+	line-height: 19px;
 }
 
 .log-copy {
@@ -180,8 +189,9 @@
 	font-family:
 		'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
 	font-size: 12px;
-	line-height: 1.6;
-	margin-top: var(--space-2, 8px);
+	/* Matches the 19px rail line height so the first message line and the
+	   severity word share a baseline. */
+	line-height: 19px;
 	overflow-wrap: anywhere;
 	white-space-collapse: preserve-breaks;
 }
@@ -228,6 +238,29 @@
 
 .log-entry-toggle:hover {
 	text-decoration: underline;
+}
+
+/* On narrow screens the rail folds into one line above the message. */
+@media (max-width: 600px) {
+	.log-entry {
+		display: block;
+		position: relative;
+	}
+
+	.log-entry-rail {
+		align-items: baseline;
+		flex-direction: row;
+		gap: var(--space-2, 8px);
+		margin-bottom: var(--space-1, 4px);
+		/* Keep the metadata clear of the absolutely placed copy button. */
+		padding-right: var(--space-8, 32px);
+	}
+
+	.log-copy {
+		position: absolute;
+		right: 0;
+		top: var(--space-3, 12px);
+	}
 }
 
 .log__empty_placeholder {

--- a/packages/playground/website/src/components/log-modal/style.module.css
+++ b/packages/playground/website/src/components/log-modal/style.module.css
@@ -58,6 +58,15 @@
 	opacity: 0.65;
 }
 
+/* Separates the severity chips from the Playground channel toggle — a
+   different filter dimension in the same row. */
+.log-filter-divider {
+	align-self: stretch;
+	background: var(--line-control, rgba(33, 32, 29, 0.14));
+	margin: 2px var(--space-1, 4px);
+	width: 1px;
+}
+
 .log-copy-all {
 	background: none;
 	border: 0;
@@ -124,9 +133,13 @@
 	color: var(--ink-muted, #5f5b54);
 }
 
+/* A fixed-width first column ("PHP" / "Playground") so the variable-width
+   severity badges after it all start at the same x and stay scannable. */
 .log-channel {
 	color: var(--ink-faint, #8a857b);
+	flex-shrink: 0;
 	font-size: 12px;
+	min-width: 72px;
 }
 
 .log-timestamp {
@@ -197,6 +210,20 @@
 	font-weight: 500;
 	margin-top: var(--space-1, 4px);
 	padding: 0;
+}
+
+/* While an entry is expanded, "Show less" rides the bottom of the scrollport
+   so collapsing never requires scrolling to the end of a long record. The
+   full-width opaque band masks the text passing beneath it. */
+.log-entry-toggle[aria-expanded='true'] {
+	background: var(--paper-1, #fff);
+	bottom: 0;
+	box-shadow: 0 -1px 0 var(--line-subtle, rgba(33, 32, 29, 0.08));
+	display: block;
+	padding: var(--space-2, 8px) 0;
+	position: sticky;
+	text-align: left;
+	width: 100%;
 }
 
 .log-entry-toggle:hover {

--- a/packages/playground/website/src/components/log-modal/style.module.css
+++ b/packages/playground/website/src/components/log-modal/style.module.css
@@ -65,15 +65,6 @@
 	opacity: 0.65;
 }
 
-/* Separates the severity chips from the Playground channel toggle — a
-   different filter dimension in the same row. */
-.log-filter-divider {
-	align-self: stretch;
-	background: var(--line-control, rgba(33, 32, 29, 0.14));
-	margin: 2px var(--space-1, 4px);
-	width: 1px;
-}
-
 .log-copy-all {
 	background: none;
 	border: 0;
@@ -99,14 +90,14 @@
 	padding: 0;
 }
 
-/* One grid for every row: a fixed rail, the message, and a copy slot. All
-   metadata aligns in the rail; the message column is the widest and darkest
+/* Each row is a full-width column — timestamp above, message beneath —
+   with a copy slot on the right. The message is the widest and darkest
    element, so the eye lands on it. */
 .log-entry {
 	border-block-end: 1px solid var(--line-subtle, rgba(33, 32, 29, 0.08));
 	column-gap: var(--space-4, 16px);
 	display: grid;
-	grid-template-columns: 96px minmax(0, 1fr) 24px;
+	grid-template-columns: minmax(0, 1fr) 24px;
 	padding: var(--space-3, 12px) 0;
 }
 
@@ -114,48 +105,31 @@
 	border-block-end: 0;
 }
 
-.log-entry-rail {
-	display: flex;
-	flex-direction: column;
-	gap: 2px;
-}
-
 .log-entry-body {
+	grid-column: 1;
 	min-width: 0;
-}
-
-/* Severity is a small tinted word, not a filled pill — color appears only
-   where it means something. */
-.log-severity {
-	font-size: 11px;
-	font-weight: 600;
-	letter-spacing: 0.02em;
-	line-height: 19px;
-}
-
-.log-severity[data-tier='error'] {
-	color: #96291b;
-}
-
-.log-severity[data-tier='warning'] {
-	color: #765311;
-}
-
-.log-severity[data-tier='info'] {
-	color: var(--ink-muted, #5f5b54);
 }
 
 .log-timestamp {
 	color: var(--ink-faint, #8a857b);
 	font-size: 12px;
 	font-variant-numeric: tabular-nums;
+	grid-column: 1;
 	line-height: 19px;
 }
 
-.log-channel-tag {
-	color: var(--ink-faint, #8a857b);
-	font-size: 11px;
-	line-height: 19px;
+/* The `PHP Notice:` style head is part of the record text — it only gets
+   a tint, and color appears only where it means something. */
+.log-severity-head[data-tier='error'] {
+	color: #96291b;
+}
+
+.log-severity-head[data-tier='warning'] {
+	color: #765311;
+}
+
+.log-severity-head[data-tier='info'] {
+	color: var(--ink-muted, #5f5b54);
 }
 
 .log-copy {
@@ -166,6 +140,8 @@
 	color: var(--action-icon, #4f4b45);
 	cursor: pointer;
 	display: flex;
+	grid-column: 2;
+	grid-row: 1;
 	height: 24px;
 	justify-content: center;
 	opacity: 0;
@@ -240,29 +216,6 @@
 	text-decoration: underline;
 }
 
-/* On narrow screens the rail folds into one line above the message. */
-@media (max-width: 600px) {
-	.log-entry {
-		display: block;
-		position: relative;
-	}
-
-	.log-entry-rail {
-		align-items: baseline;
-		flex-direction: row;
-		gap: var(--space-2, 8px);
-		margin-bottom: var(--space-1, 4px);
-		/* Keep the metadata clear of the absolutely placed copy button. */
-		padding-right: var(--space-8, 32px);
-	}
-
-	.log-copy {
-		position: absolute;
-		right: 0;
-		top: var(--space-3, 12px);
-	}
-}
-
 .log__empty_placeholder {
 	align-items: flex-start;
 	display: flex;
@@ -305,33 +258,4 @@
 	font-size: 13px;
 	line-height: 1.5;
 	margin: 0;
-}
-
-.log-legend {
-	display: flex;
-	flex-direction: column;
-	gap: var(--space-2);
-	list-style: none;
-	margin: var(--space-3) 0 0;
-	padding: 0;
-	width: 100%;
-}
-
-.log-legend li {
-	align-items: baseline;
-	display: grid;
-	gap: var(--space-3);
-	grid-template-columns: max-content 1fr;
-}
-
-.log-legend-term {
-	color: var(--ink);
-	font-size: 13px;
-	font-weight: 600;
-}
-
-.log-legend-desc {
-	color: var(--ink-muted);
-	font-size: 13px;
-	line-height: 1.5;
 }

--- a/packages/playground/website/src/components/log-modal/style.module.css
+++ b/packages/playground/website/src/components/log-modal/style.module.css
@@ -227,7 +227,7 @@
 .log-clear-search {
 	background: none;
 	border: 0;
-	color: var(--accent-link);
+	color: var(--accent-link, #2645c9);
 	cursor: pointer;
 	font-size: 13px;
 	padding: 0;


### PR DESCRIPTION
The Dock's Logs pane is now a PHP error log: one record per row, shown exactly as PHP wrote it. It used to render each logger string as one monospace blob — and PHP logs arrive as whole `debug.log` chunks carrying many records, so a single database error dump filled the entire panel.

|  | Before | After |
| --- | --- | --- |
| **Desktop** | ![The old Logs pane: one unbroken monospace blob](https://raw.githubusercontent.com/articles-adamziel-com/wordpress-playground/5625dc576b2baff48e490948c62daaf9e1bc86c3/logs-before-desktop.png) | ![The PHP error log pane: one record per row, timestamps above, severity heads colored in place](https://raw.githubusercontent.com/articles-adamziel-com/wordpress-playground/5625dc576b2baff48e490948c62daaf9e1bc86c3/logs-after-desktop.png) |
| **Mobile** | ![The old Logs pane on a phone](https://raw.githubusercontent.com/articles-adamziel-com/wordpress-playground/5625dc576b2baff48e490948c62daaf9e1bc86c3/logs-before-mobile.png) | ![The PHP error log pane on a phone](https://raw.githubusercontent.com/articles-adamziel-com/wordpress-playground/5625dc576b2baff48e490948c62daaf9e1bc86c3/logs-after-mobile.png) |

The pane splits chunks into records and stops there:

- The leading `[20-Jul-2026 14:59:46 UTC]` stamp moves above the record — only when it matches debug.log's exact format. Anything else stays in the text.
- The `PHP Warning:` head stays in the line and gets a color: red for errors, amber for warnings, muted for notices. No badge, no label, no rewording.
- The copy button puts the raw record on the clipboard, stamp included.

Records longer than six lines clamp behind "Show all 31 lines"; while one is expanded, "Show less" rides the bottom of the viewport so collapsing never needs a long scroll. Severity chips and text search filter the list. The pane grew from 600px to 860px.

Messages from the Playground app itself (JavaScript errors, WASM crashes) no longer show here — before, they were interleaved with the site's output. This also applies to the crash-report modal, which renders the same list.

Earlier revisions of this PR tried severity badges, then an `E_DEPRECATED`-style rail beside each message. Both restated what the line already says, and the parsing behind them kept corrupting the line itself. The same goes for a "PHP" vs "WordPress" source split: the log text doesn't say who raised what, so the panel no longer pretends to know. Preserving the line and reading severity in place is the whole design.

## Testing

Open the Logs tool in the Dock and use the site until something logs — a plugin notice or a deprecation will do. Each record should read exactly like its debug.log line, timestamp above, severity head colored. Search for a word, toggle the severity chips, expand and collapse the long record, and copy an entry: the clipboard gets the raw line, stamp included.

No public API changes; everything is inside the website package.
