### PR TITLE
[Website] Preserve selected Query API parameters when starting over after an error

### DIFF
--- a/packages/playground/website/playwright/e2e/error-handling.spec.ts
+++ b/packages/playground/website/playwright/e2e/error-handling.spec.ts
@@ -65,7 +65,7 @@ test('should show download error modal when a resource download fails', async ({
 	await expect(reloadButton).toBeVisible();
 });
 
-test('should say when the Blueprint file could not be downloaded', async ({
+test('should recover when the Blueprint file could not be downloaded', async ({
 	page,
 }) => {
 	const blueprintUrl = 'https://example.com/missing-blueprint.json';
@@ -80,10 +80,49 @@ test('should say when the Blueprint file could not be downloaded', async ({
 		} as typeof fetch;
 	}, blueprintUrl);
 
-	await page.goto(`./?blueprint-url=${encodeURIComponent(blueprintUrl)}`);
+	const retainedParams = {
+		mode: 'seamless',
+		url: '/wp-admin/',
+		'page-title': 'Recovery test',
+		mcp: 'yes',
+		'can-save': 'no',
+	};
+	const setupParams = new URLSearchParams({
+		...retainedParams,
+		storage: 'temp',
+		wp: '6.6',
+		'blueprint-url': blueprintUrl,
+	});
+	await page.goto(`./?${setupParams}`);
 
 	await expect(
 		page.getByText('Blueprint could not be downloaded')
 	).toBeVisible();
 	await expect(page.getByRole('link', { name: blueprintUrl })).toBeVisible();
+	const originalPathname = new URL(page.url()).pathname;
+
+	const documentMarker = crypto.randomUUID();
+	await page.evaluate((marker) => {
+		Reflect.set(window, 'playgroundRecoveryDocumentMarker', marker);
+	}, documentMarker);
+	await page
+		.getByRole('button', { name: 'Start without a Blueprint' })
+		.click();
+
+	await expect(page).toHaveURL(
+		(url) => !url.searchParams.has('blueprint-url')
+	);
+	const recoveredUrl = new URL(page.url());
+	for (const [name, value] of Object.entries(retainedParams)) {
+		expect(recoveredUrl.searchParams.get(name)).toBe(value);
+	}
+	expect(recoveredUrl.pathname).toBe(originalPathname);
+	expect(recoveredUrl.searchParams.has('random')).toBe(true);
+	expect(recoveredUrl.searchParams.has('storage')).toBe(false);
+	expect(recoveredUrl.searchParams.has('wp')).toBe(false);
+	expect(
+		await page.evaluate(() =>
+			Reflect.get(window, 'playgroundRecoveryDocumentMarker')
+		)
+	).toBe(documentMarker);
 });

--- a/packages/playground/website/src/components/site-error-modal/site-error-modal.tsx
+++ b/packages/playground/website/src/components/site-error-modal/site-error-modal.tsx
@@ -20,6 +20,7 @@ import type {
 import { getSiteErrorView } from './get-site-error-view';
 import type { SiteInfo } from '../../lib/state/redux/slice-sites';
 import { useKapaAI } from './use-kapa-ai';
+import { PlaygroundRoute, redirectTo } from '../../lib/state/url/router';
 
 export function SiteErrorModal({
 	error,
@@ -60,11 +61,23 @@ export function SiteErrorModal({
 			window.location.href = url.toString();
 		},
 		reloadWithoutBlueprint() {
-			const url = new URL(window.location.href);
-			url.search = '';
-			url.pathname = '/';
-			url.hash = '';
-			window.location.href = url.toString();
+			const currentUrl = new URL(window.location.href);
+			const newSiteUrl = new URL(PlaygroundRoute.newSite());
+			const paramsToKeep = [
+				'mode',
+				'url',
+				'page-title',
+				'mcp',
+				'mcp-port',
+				'can-save',
+			];
+			for (const param of paramsToKeep) {
+				const value = currentUrl.searchParams.get(param);
+				if (value !== null) {
+					newSiteUrl.searchParams.set(param, value);
+				}
+			}
+			redirectTo(newSiteUrl.toString());
 		},
 	};
 


### PR DESCRIPTION
Part of #4099.

**Start without a Blueprint** previously assigned a new `location.href`. That reloaded the entire application and discarded the current pathname and parameters used by the surrounding integration along with the failed setup.

The action now builds a fresh Playground URL through `PlaygroundRoute.newSite()`, restores `mode`, `url`, `page-title`, `mcp`, `mcp-port`, and `can-save`, and passes it to the existing in-app router. All other query parameters, the Blueprint hash, storage selection, and site route remain discarded. Saved-site routing is unchanged.

The affected action is the blue button in the lower-right corner:

![Error modal showing Start without a Blueprint](https://raw.githubusercontent.com/WordPress/wordpress-playground/39e991af1c1df706f2008630cfa69032a33aefd6/after-desktop.png)

## Testing

Trigger an error from a non-root URL containing both retained and setup parameters. Choose **Start without a Blueprint** and confirm a fresh Playground starts in place, the pathname and retained parameters remain, and the failed setup does not run again.
