### PR TITLE
[Website] Log OPFS write worker failures

### DIFF
--- a/packages/playground/website/src/lib/state/opfs/opfs-site-storage-worker-for-safari.ts
+++ b/packages/playground/website/src/lib/state/opfs/opfs-site-storage-worker-for-safari.ts
@@ -50,6 +50,5 @@ onmessage = async function (event: MessageEvent) {
 						}
 					: error,
 		});
-		throw error;
 	}
 };

--- a/packages/playground/website/src/lib/state/opfs/opfs-site-storage-worker-for-safari.ts
+++ b/packages/playground/website/src/lib/state/opfs/opfs-site-storage-worker-for-safari.ts
@@ -6,8 +6,6 @@
  *
  * This worker exists so non-worker threads can trigger writing to OPFS files.
  */
-import { logger } from '@php-wasm/logger';
-
 onmessage = async function (event: MessageEvent) {
 	const filePath: string = event.data.path;
 	const content: string = event.data.content;
@@ -40,9 +38,17 @@ onmessage = async function (event: MessageEvent) {
 			syncAccessHandle.close();
 		}
 	} catch (error) {
-		logger.error('Error in OPFS write worker.', {
+		responsePort.postMessage({
+			type: 'error',
 			path: filePath,
-			error,
+			error:
+				error instanceof Error
+					? {
+							name: error.name,
+							message: error.message,
+							stack: error.stack,
+						}
+					: error,
 		});
 		throw error;
 	}

--- a/packages/playground/website/src/lib/state/opfs/opfs-site-storage-worker-for-safari.ts
+++ b/packages/playground/website/src/lib/state/opfs/opfs-site-storage-worker-for-safari.ts
@@ -6,34 +6,44 @@
  *
  * This worker exists so non-worker threads can trigger writing to OPFS files.
  */
+import { logger } from '@php-wasm/logger';
+
 onmessage = async function (event: MessageEvent) {
 	const filePath: string = event.data.path;
 	const content: string = event.data.content;
 	const responsePort = event.ports[0];
 
-	const pathParts = filePath.split('/').filter((p) => p.length > 0);
-
-	const fileName = pathParts.pop();
-	if (fileName === undefined) {
-		throw new Error(`Invalid path: '${filePath}'`);
-	}
-
-	let parentDirHandle = await navigator.storage.getDirectory();
-	for (const part of pathParts) {
-		parentDirHandle = await parentDirHandle.getDirectoryHandle(part);
-	}
-
-	const fileHandle = await parentDirHandle.getFileHandle(fileName, {
-		create: true,
-	});
-
-	const syncAccessHandle = await fileHandle.createSyncAccessHandle();
 	try {
-		const encodedContent = new TextEncoder().encode(content);
-		syncAccessHandle.truncate(0);
-		syncAccessHandle.write(encodedContent);
-		responsePort.postMessage('done');
-	} finally {
-		syncAccessHandle.close();
+		const pathParts = filePath.split('/').filter((p) => p.length > 0);
+
+		const fileName = pathParts.pop();
+		if (fileName === undefined) {
+			throw new Error(`Invalid path: '${filePath}'`);
+		}
+
+		let parentDirHandle = await navigator.storage.getDirectory();
+		for (const part of pathParts) {
+			parentDirHandle = await parentDirHandle.getDirectoryHandle(part);
+		}
+
+		const fileHandle = await parentDirHandle.getFileHandle(fileName, {
+			create: true,
+		});
+
+		const syncAccessHandle = await fileHandle.createSyncAccessHandle();
+		try {
+			const encodedContent = new TextEncoder().encode(content);
+			syncAccessHandle.truncate(0);
+			syncAccessHandle.write(encodedContent);
+			responsePort.postMessage('done');
+		} finally {
+			syncAccessHandle.close();
+		}
+	} catch (error) {
+		logger.error('Error in OPFS write worker.', {
+			path: filePath,
+			error,
+		});
+		throw error;
 	}
 };

--- a/packages/playground/website/src/lib/state/opfs/opfs-site-storage.ts
+++ b/packages/playground/website/src/lib/state/opfs/opfs-site-storage.ts
@@ -534,7 +534,8 @@ async function opfsWriteFile(path: string, content: string) {
 				logger.error('Error in OPFS write worker.', event.data);
 				reject(
 					new Error(
-						`The browser storage worker failed while writing ${path}. See the preceding OPFS worker log for details.`
+						`The browser storage worker failed while writing ${path}. See the preceding OPFS worker log for details.`,
+						{ cause: event.data.error }
 					)
 				);
 			} else {

--- a/packages/playground/website/src/lib/state/opfs/opfs-site-storage.ts
+++ b/packages/playground/website/src/lib/state/opfs/opfs-site-storage.ts
@@ -530,6 +530,13 @@ async function opfsWriteFile(path: string, content: string) {
 		channel.port1.onmessage = function (event: MessageEvent) {
 			if (event.data === 'done') {
 				resolve();
+			} else if (event.data?.type === 'error') {
+				logger.error('Error in OPFS write worker.', event.data);
+				reject(
+					new Error(
+						`The browser storage worker failed while writing ${path}. See the preceding OPFS worker log for details.`
+					)
+				);
 			} else {
 				reject(
 					new Error(


### PR DESCRIPTION
Logs the original exception thrown inside the OPFS metadata write worker.

Before this PR, a failed browser-storage autosave could surface only as the parent `worker.onerror` wrapper while writing `/sites/.../wp-runtime.json`. That message names the file but loses the OPFS call that actually failed inside the worker.

This PR catches worker exceptions, logs the target OPFS path and original error object to the Playground logger, then rethrows. The current autosave failure flow stays unchanged; the next Chrome DevTools report should contain the missing cause.

## Testing

Trigger an OPFS write worker failure and confirm DevTools includes `Error in OPFS write worker.` with the target path and original error.
