### PR TITLE
[Website] Track Blueprint runs until their first OPFS copy succeeds

### DIFF
--- a/packages/playground/website/src/components/blueprint-editor/BlueprintBundleEditor.spec.tsx
+++ b/packages/playground/website/src/components/blueprint-editor/BlueprintBundleEditor.spec.tsx
@@ -201,7 +201,10 @@ describe('BlueprintBundleEditor Run barrier', () => {
 			sourceSite.metadata.name,
 			filesystemBackend,
 			undefined,
-			{ persistence: 'autosave' }
+			{
+				persistence: 'autosave',
+				siteSlugToReturnToIfBlueprintFails: sourceSite.slug,
+			}
 		);
 		expect(mocks.pruneAutosavedSites).toHaveBeenCalledWith({
 			excludeSlugs: [sourceSite.slug, newSite.slug],
@@ -209,6 +212,36 @@ describe('BlueprintBundleEditor Run barrier', () => {
 		expect(mocks.setDockPaneOpen).toHaveBeenCalledWith(false);
 		expect(mocks.setActiveSite).toHaveBeenCalledWith(newSite.slug);
 		expect(mocks.resolveRuntimeConfiguration).not.toHaveBeenCalled();
+	});
+
+	it('keeps the original return target when an unfinished Blueprint run is run again', async () => {
+		const failedRun = createStoredSiteInfo('autosave', 'failed-run');
+		failedRun.metadata.siteSlugToReturnToIfBlueprintFails = 'original-site';
+		const replacement = createStoredSiteInfo('autosave', 'replacement');
+		const createAction = { type: 'create-stored-site' };
+		mocks.createStoredSite.mockReturnValue(createAction);
+		mocks.pruneAutosavedSites.mockReturnValue({
+			type: 'prune-autosaves',
+		});
+		mocks.dispatch.mockImplementation((action) =>
+			action === createAction ? Promise.resolve(replacement) : action
+		);
+		const editorRef = await renderEditor({ site: failedRun });
+
+		await act(async () => editorRef.current!.runBlueprint());
+
+		expect(mocks.createStoredSite).toHaveBeenCalledWith(
+			failedRun.metadata.name,
+			filesystemBackend,
+			undefined,
+			{
+				persistence: 'autosave',
+				siteSlugToReturnToIfBlueprintFails: 'original-site',
+			}
+		);
+		expect(mocks.pruneAutosavedSites).toHaveBeenCalledWith({
+			excludeSlugs: ['original-site', replacement.slug],
+		});
 	});
 
 	it('queues Run until the source Playground finishes syncing to OPFS', async () => {

--- a/packages/playground/website/src/components/blueprint-editor/BlueprintBundleEditor.tsx
+++ b/packages/playground/website/src/components/blueprint-editor/BlueprintBundleEditor.tsx
@@ -462,18 +462,27 @@ export const BlueprintBundleEditor = forwardRef<
 			}
 			setSaveError(null);
 			if (runInNewPlayground) {
+				const siteSlugToReturnToIfBlueprintFails =
+					site.metadata.siteSlugToReturnToIfBlueprintFails ??
+					site.slug;
 				const newSite = await dispatch(
 					createStoredSite(
 						site.metadata.name,
 						filesystem.backend,
 						undefined,
-						{ persistence: 'autosave' }
+						{
+							persistence: 'autosave',
+							siteSlugToReturnToIfBlueprintFails,
+						}
 					)
 				);
 				try {
 					await dispatch(
 						pruneAutosavedSites({
-							excludeSlugs: [site.slug, newSite.slug],
+							excludeSlugs: [
+								siteSlugToReturnToIfBlueprintFails,
+								newSite.slug,
+							],
 						})
 					);
 				} catch (error) {

--- a/packages/playground/website/src/lib/state/redux/boot-site-client.spec.ts
+++ b/packages/playground/website/src/lib/state/redux/boot-site-client.spec.ts
@@ -343,6 +343,48 @@ describe('bootSiteClient', () => {
 		);
 	});
 
+	it('clears the return target after the initial OPFS copy succeeds', async () => {
+		let resolveMount = () => {};
+		const mountFinished = new Promise<void>((resolve) => {
+			resolveMount = resolve;
+		});
+		const playground = createPlaygroundClient({
+			mountOpfs: vi.fn(() => mountFinished),
+		});
+		vi.mocked(startPlaygroundWeb).mockImplementationOnce(
+			async (options: any) => {
+				options.onClientConnected(playground);
+				return playground;
+			}
+		);
+		const site = createSite('blueprint-run', {
+			metadata: {
+				initialOpfsSyncPending: true,
+				siteSlugToReturnToIfBlueprintFails: 'source-site',
+			},
+		});
+		const state = createState(site);
+		const dispatch = createDispatch(state);
+
+		await bootSiteClient(
+			'blueprint-run',
+			document.createElement('iframe'),
+			{ signal: new AbortController().signal }
+		)(dispatch, () => state);
+
+		expect(
+			state.sites.entities['blueprint-run'].metadata
+				.siteSlugToReturnToIfBlueprintFails
+		).toBe('source-site');
+		resolveMount();
+		await vi.waitFor(() =>
+			expect(
+				state.sites.entities['blueprint-run'].metadata
+					.siteSlugToReturnToIfBlueprintFails
+			).toBeUndefined()
+		);
+	});
+
 	it('classifies a worker resource-unavailable error', async () => {
 		const unavailableError = Object.assign(
 			new Error('WordPress 6.8 is not available for download.'),

--- a/packages/playground/website/src/lib/state/redux/boot-site-client.ts
+++ b/packages/playground/website/src/lib/state/redux/boot-site-client.ts
@@ -384,6 +384,8 @@ export function bootSiteClient(
 				operation: syncOperation,
 				dispatch,
 				signal,
+				siteSlugToReturnToIfBlueprintFails:
+					site.metadata.siteSlugToReturnToIfBlueprintFails,
 			});
 		} else {
 			try {
@@ -550,6 +552,7 @@ async function syncInitialOpfsFilesInBackground({
 	operation,
 	dispatch,
 	signal,
+	siteSlugToReturnToIfBlueprintFails,
 }: {
 	playground: PlaygroundClient;
 	mountDescriptor: Omit<MountDescriptor, 'initialSyncDirection'>;
@@ -557,6 +560,7 @@ async function syncInitialOpfsFilesInBackground({
 	operation: 'save' | 'autosave';
 	dispatch: PlaygroundDispatch;
 	signal: AbortSignal;
+	siteSlugToReturnToIfBlueprintFails?: string;
 }) {
 	let shouldReportProgress = true;
 	try {
@@ -589,12 +593,17 @@ async function syncInitialOpfsFilesInBackground({
 		if (signal.aborted) {
 			return;
 		}
+		// Clear the return target in the same metadata write that completes the
+		// initial copy so failed copies retain their recovery action.
 		await dispatch(
 			updateSiteMetadata({
 				slug: siteSlug,
 				changes: {
 					initialOpfsSyncPending: false,
 					whenLastUsed: Date.now(),
+					...(siteSlugToReturnToIfBlueprintFails
+						? { siteSlugToReturnToIfBlueprintFails: undefined }
+						: {}),
 				},
 			})
 		);

--- a/packages/playground/website/src/lib/state/redux/slice-sites.spec.ts
+++ b/packages/playground/website/src/lib/state/redux/slice-sites.spec.ts
@@ -366,7 +366,10 @@ describe('stored site creation', () => {
 			'Edited Blueprint',
 			editedBundle,
 			'source-site',
-			{ persistence: 'autosave' }
+			{
+				persistence: 'autosave',
+				siteSlugToReturnToIfBlueprintFails: 'source-site',
+			}
 		)(dispatch as any, getState as any);
 
 		expect(newSite.slug).toBe('source-site-2');
@@ -375,6 +378,7 @@ describe('stored site creation', () => {
 			storage: 'opfs',
 			persistence: 'autosave',
 			initialOpfsSyncPending: true,
+			siteSlugToReturnToIfBlueprintFails: 'source-site',
 			originalBlueprint: copiedBundle,
 			originalBlueprintSource: { type: 'opfs-site' },
 			runtimeConfiguration,

--- a/packages/playground/website/src/lib/state/redux/slice-sites.ts
+++ b/packages/playground/website/src/lib/state/redux/slice-sites.ts
@@ -572,6 +572,10 @@ export function createStoredSite(
 		 * Whether the stored site is an autosave or an explicit user save.
 		 */
 		persistence?: SitePersistence;
+		/**
+		 * Slug of the stored Playground to return to if this Blueprint run fails.
+		 */
+		siteSlugToReturnToIfBlueprintFails?: string;
 	} = {}
 ) {
 	return async (
@@ -640,6 +644,12 @@ export function createStoredSite(
 				persistence: options.persistence ?? 'explicit',
 				storage: 'opfs' as const,
 				initialOpfsSyncPending: true,
+				...(options.siteSlugToReturnToIfBlueprintFails
+					? {
+							siteSlugToReturnToIfBlueprintFails:
+								options.siteSlugToReturnToIfBlueprintFails,
+						}
+					: {}),
 				...(sourceSetupUrlFingerprint
 					? {
 							sourceSetupUrlFingerprint:
@@ -790,6 +800,13 @@ export interface SiteMetadata {
 	 * OPFS and clear this flag after a successful sync.
 	 */
 	initialOpfsSyncPending?: boolean;
+	/**
+	 * Slug of the stored Playground to return to if this Blueprint run fails.
+	 *
+	 * This remains set until the first MEMFS-to-OPFS copy succeeds so retries
+	 * and reloads retain the same return target.
+	 */
+	siteSlugToReturnToIfBlueprintFails?: string;
 	/**
 	 * Legacy crash-recovery marker for replacing autosaved WordPress files.
 	 *


### PR DESCRIPTION
Part of #4099.

Running a stored Blueprint creates another OPFS-backed Playground before
WordPress boots. Until its first MEMFS-to-OPFS copy succeeds, a failed run
needs to know which stored Playground it should return to.

This records that return target when the run is created, carries it through
retries, and clears it in the same metadata write that completes the first
OPFS copy. Failed and interrupted copies keep the target. Abandoned runs
remain eligible for normal autosave cleanup.

There is no UI change here. Follow-up work uses the return target to keep
unfinished runs out of Recent and offer explicit recovery.

## Testing

Run a Blueprint from a stored Playground and confirm the new Playground boots
and saves normally. Retry before its first save finishes and confirm the same
stored Playground remains the return target.
