### PR TITLE
[Website] Keep unfinished Blueprint runs out of Recent and restore suggestions

### DIFF
--- a/packages/playground/website/src/components/ensure-playground-site/ensure-playground-site-is-selected.tsx
+++ b/packages/playground/website/src/components/ensure-playground-site/ensure-playground-site-is-selected.tsx
@@ -11,6 +11,7 @@ import {
 	OPFSSitesLoaded,
 	getSiteRecencyTimestamp,
 	isAutosavedSite,
+	isRestorableAutosavedSite,
 	selectSiteBySlug,
 	selectSortedSites,
 	type SiteInfo,
@@ -229,7 +230,7 @@ export function EnsurePlaygroundSiteIsSelected({
 				// setup URL. A different setup URL should create a fresh
 				// Playground even if another autosave exists.
 				const matchingAutosave = sortedSites
-					.filter(isAutosavedSite)
+					.filter(isRestorableAutosavedSite)
 					.find(
 						(site) =>
 							getAutosaveFingerprintFromSite(site) ===

--- a/packages/playground/website/src/components/saved-playgrounds-panel/index.tsx
+++ b/packages/playground/website/src/components/saved-playgrounds-panel/index.tsx
@@ -49,6 +49,7 @@ import type { SiteLogo, SiteInfo } from '../../lib/state/redux/slice-sites';
 import {
 	isAutosavedSite,
 	isExplicitlySavedSite,
+	isRestorableAutosavedSite,
 	selectSortedSites,
 	selectTemporarySite,
 	updateSiteMetadata,
@@ -1006,7 +1007,7 @@ export function SavedPlaygroundsPanel({
 	const inactiveStoredSites = storedSites.filter(
 		(site) => site.slug !== activeSite?.slug
 	);
-	const recentSites = inactiveStoredSites.filter(isAutosavedSite);
+	const recentSites = inactiveStoredSites.filter(isRestorableAutosavedSite);
 	const savedSites = inactiveStoredSites.filter(isExplicitlySavedSite);
 
 	function formatSiteCreatedDate(site: SiteInfo) {

--- a/packages/playground/website/src/lib/state/redux/slice-sites.spec.ts
+++ b/packages/playground/website/src/lib/state/redux/slice-sites.spec.ts
@@ -2,7 +2,7 @@ import type { OriginalUrlParams } from '../original-url-params';
 import type { SiteInfo } from './slice-sites';
 import type { TraversableFilesystemBackend } from '@wp-playground/storage';
 
-describe('stored site creation', () => {
+describe('stored sites', () => {
 	let createSite: ReturnType<typeof vi.fn>;
 	let updateSiteStorage: ReturnType<typeof vi.fn>;
 	let persistBlueprintBundle: ReturnType<typeof vi.fn>;
@@ -87,6 +87,19 @@ describe('stored site creation', () => {
 		vi.doUnmock('../url/resolve-blueprint-from-url');
 		vi.doUnmock('./slice-ui');
 		vi.doUnmock('./store');
+	});
+
+	it('classifies a normal autosave but not an unfinished Blueprint run as restorable', async () => {
+		const { isRestorableAutosavedSite } = await import('./slice-sites');
+		const autosave = createSiteInfo({ slug: 'autosave' });
+		autosave.metadata.persistence = 'autosave';
+		const unfinishedRun = createSiteInfo({ slug: 'unfinished-run' });
+		unfinishedRun.metadata.persistence = 'autosave';
+		unfinishedRun.metadata.siteSlugToReturnToIfBlueprintFails =
+			'source-site';
+
+		expect(isRestorableAutosavedSite(autosave)).toBe(true);
+		expect(isRestorableAutosavedSite(unfinishedRun)).toBe(false);
 	});
 
 	it('persists setup URL params when adding a saved site', async () => {

--- a/packages/playground/website/src/lib/state/redux/slice-sites.ts
+++ b/packages/playground/website/src/lib/state/redux/slice-sites.ts
@@ -35,6 +35,7 @@ import { deriveSlugFromSiteName, getUniqueSiteSlug } from './site-slug';
 import {
 	getAutosavedSitesToPrune,
 	getSitesSortedByRecency,
+	isAutosavedSite,
 	isStoredSite,
 	isTemporarySite,
 	type AutosavedSitesPruneOptions,
@@ -363,6 +364,38 @@ export function pruneAutosavedSites(options: AutosavedSitesPruneOptions = {}) {
 			await dispatch(removeSite(site.slug));
 		}
 	};
+}
+
+/**
+ * Checks whether a stored Playground may be offered as an autosave.
+ *
+ * A Blueprint run uses autosave persistence before its initial OPFS copy
+ * succeeds. Its return target marks it unfinished, so callers withhold it from
+ * Recent and matching-setup restore suggestions until that copy succeeds.
+ *
+ * @param site The Playground whose autosave lifecycle should be checked.
+ * @returns Whether the Playground is a restorable autosave.
+ */
+export function isRestorableAutosavedSite(site: SiteInfo) {
+	return isAutosavedSite(site) && !isUnfinishedBlueprintRun(site);
+}
+
+/**
+ * Checks whether a Playground is marked as an unfinished Blueprint run.
+ *
+ * Running a stored Blueprint records the Playground to return to before boot.
+ * The return target survives a failed boot or reload and is cleared only after
+ * the first MEMFS-to-OPFS copy succeeds.
+ *
+ * This cannot be inferred from `initialOpfsSyncPending`, because every new
+ * stored Playground starts with an initial copy. The return target distinguishes
+ * the Blueprint run while that common sync flag cannot.
+ *
+ * @param site The Playground whose Blueprint run lifecycle should be checked.
+ * @returns Whether the Playground is an unfinished Blueprint run.
+ */
+export function isUnfinishedBlueprintRun(site: SiteInfo) {
+	return typeof site.metadata.siteSlugToReturnToIfBlueprintFails === 'string';
 }
 
 /**


### PR DESCRIPTION
Part of #4099.

Builds on #4126.

An unfinished stored Blueprint run is recovery state, not a normal autosave. Keep it out of Recent and setup-URL restore suggestions until its first OPFS sync succeeds and clears the return target.

Both comparisons use the same stored Playground and the same failed run, created with unavailable WordPress version `999.9`. Before this change, reloading lists the failed run under Recent autosaves. After this change, only the Playground that launched it remains visible.

### Desktop

| Before | After |
| --- | --- |
| <img width="440" alt="Failed Blueprint run listed under Recent autosaves on desktop" src="https://raw.githubusercontent.com/WordPress/wordpress-playground/dfe5d4913c/before-recent-desktop.png"> | <img width="440" alt="Failed Blueprint run omitted from Recent autosaves on desktop" src="https://raw.githubusercontent.com/WordPress/wordpress-playground/dfe5d4913c/after-recent-desktop.png"> |

### Mobile

| Before | After |
| --- | --- |
| <img width="260" alt="Failed Blueprint run listed under Recent autosaves on mobile" src="https://raw.githubusercontent.com/WordPress/wordpress-playground/dfe5d4913c/before-recent-narrow.png"> | <img width="260" alt="Failed Blueprint run omitted from Recent autosaves on mobile" src="https://raw.githubusercontent.com/WordPress/wordpress-playground/dfe5d4913c/after-recent-narrow.png"> |

## Testing

Run a stored Playground's Blueprint with an unavailable WordPress version. Reload and confirm the unfinished run is not offered in Recent or as an autosave to restore.
