### PR TITLE
[Website] Preserve Playground records when OPFS deletion fails

### DIFF
--- a/packages/playground/website/src/lib/state/redux/site-management-api-middleware.ts
+++ b/packages/playground/website/src/lib/state/redux/site-management-api-middleware.ts
@@ -501,7 +501,8 @@ export function createSitesAPI(
 		 * Deletes a saved site by slug.
 		 *
 		 * @param siteSlug The slug of the site to delete.
-		 * @throws When the site is not found or the site is temporary.
+		 * @throws When the site is not found, the site is temporary, or its
+		 * storage cannot be deleted.
 		 */
 		async delete(siteSlug: string): Promise<void> {
 			const site = selectSiteBySlug(getState(), siteSlug);

--- a/packages/playground/website/src/lib/state/redux/slice-sites.spec.ts
+++ b/packages/playground/website/src/lib/state/redux/slice-sites.spec.ts
@@ -4,6 +4,8 @@ import type { TraversableFilesystemBackend } from '@wp-playground/storage';
 
 describe('stored sites', () => {
 	let createSite: ReturnType<typeof vi.fn>;
+	let deleteSite: ReturnType<typeof vi.fn>;
+	let loggerError: ReturnType<typeof vi.fn>;
 	let updateSiteStorage: ReturnType<typeof vi.fn>;
 	let persistBlueprintBundle: ReturnType<typeof vi.fn>;
 	let deleteBlueprintBundle: ReturnType<typeof vi.fn>;
@@ -12,6 +14,8 @@ describe('stored sites', () => {
 	beforeEach(() => {
 		vi.resetModules();
 		createSite = vi.fn();
+		deleteSite = vi.fn();
+		loggerError = vi.fn();
 		updateSiteStorage = vi.fn();
 		persistBlueprintBundle = vi.fn();
 		deleteBlueprintBundle = vi.fn();
@@ -19,7 +23,7 @@ describe('stored sites', () => {
 
 		vi.doMock('@php-wasm/logger', () => ({
 			logger: {
-				error: vi.fn(),
+				error: loggerError,
 			},
 		}));
 		vi.doMock('@wp-playground/common', () => ({
@@ -49,6 +53,7 @@ describe('stored sites', () => {
 		vi.doMock('../opfs/opfs-site-storage', () => ({
 			opfsSiteStorage: {
 				create: createSite,
+				delete: deleteSite,
 				update: updateSiteStorage,
 			},
 		}));
@@ -307,6 +312,107 @@ describe('stored sites', () => {
 		).rejects.toThrow('browser storage is not available');
 
 		expect(dispatch).not.toHaveBeenCalled();
+	});
+
+	it('keeps a stored site in Redux when deleting it from OPFS fails', async () => {
+		const { removeSite, sitesSlice } = await import('./slice-sites');
+		const site = createSiteInfo();
+		let state = {
+			sites: sitesSlice.reducer(
+				undefined,
+				sitesSlice.actions.addSite(site)
+			),
+		};
+		const dispatch = vi.fn((action) => {
+			state = {
+				sites: sitesSlice.reducer(state.sites, action),
+			};
+			return action;
+		});
+		deleteSite.mockRejectedValue(new Error('Could not delete site'));
+
+		await expect(
+			removeSite(site.slug)(dispatch as any, () => state as any)
+		).rejects.toThrow('Could not delete site');
+
+		expect(state.sites.entities[site.slug]).toEqual(site);
+	});
+
+	it('keeps a stored site in Redux when browser storage is unavailable', async () => {
+		vi.doMock('../opfs/opfs-site-storage', () => ({
+			opfsSiteStorage: undefined,
+		}));
+		const { removeSite, sitesSlice } = await import('./slice-sites');
+		const site = createSiteInfo();
+		let state = {
+			sites: sitesSlice.reducer(
+				undefined,
+				sitesSlice.actions.addSite(site)
+			),
+		};
+		const dispatch = vi.fn((action) => {
+			state = {
+				sites: sitesSlice.reducer(state.sites, action),
+			};
+			return action;
+		});
+
+		await expect(
+			removeSite(site.slug)(dispatch as any, () => state as any)
+		).rejects.toThrow('browser storage is not available');
+
+		expect(state.sites.entities[site.slug]).toEqual(site);
+		expect(dispatch).not.toHaveBeenCalled();
+	});
+
+	it('continues pruning after an autosave cannot be deleted', async () => {
+		const { pruneAutosavedSites, sitesSlice } =
+			await import('./slice-sites');
+		const failedAutosave = createSiteInfo({ slug: 'failed-autosave' });
+		failedAutosave.metadata.persistence = 'autosave';
+		failedAutosave.metadata.whenCreated = 2;
+		const removableAutosave = createSiteInfo({
+			slug: 'removable-autosave',
+		});
+		removableAutosave.metadata.persistence = 'autosave';
+		removableAutosave.metadata.whenCreated = 1;
+		let state = {
+			sites: sitesSlice.reducer(
+				undefined,
+				sitesSlice.actions.addSites([failedAutosave, removableAutosave])
+			),
+		};
+		const getState = () => state as any;
+		const dispatch: ReturnType<typeof vi.fn> = vi.fn((action) => {
+			if (typeof action === 'function') {
+				return action(dispatch, getState);
+			}
+			state = {
+				sites: sitesSlice.reducer(state.sites, action),
+			};
+			return action;
+		});
+		const deletionError = new Error('Could not delete autosave');
+		deleteSite.mockImplementation(async (slug) => {
+			if (slug === failedAutosave.slug) {
+				throw deletionError;
+			}
+		});
+
+		await expect(
+			pruneAutosavedSites({ limit: 0 })(dispatch as any, getState)
+		).resolves.toBeUndefined();
+
+		expect(deleteSite).toHaveBeenCalledWith(failedAutosave.slug);
+		expect(deleteSite).toHaveBeenCalledWith(removableAutosave.slug);
+		expect(state.sites.entities[failedAutosave.slug]).toEqual(
+			failedAutosave
+		);
+		expect(state.sites.entities[removableAutosave.slug]).toBeUndefined();
+		expect(loggerError).toHaveBeenCalledWith(
+			`Failed to prune autosaved Playground "${failedAutosave.slug}"`,
+			deletionError
+		);
 	});
 
 	it('keeps setStoredSiteSpec as the setup URL compatibility alias', async () => {

--- a/packages/playground/website/src/lib/state/redux/slice-sites.ts
+++ b/packages/playground/website/src/lib/state/redux/slice-sites.ts
@@ -316,7 +316,12 @@ export function addSite(siteInfo: SiteInfo) {
 /**
  * Removes a stored site from OPFS and from the redux state.
  *
- * Temporary sites are rejected because they only exist in redux state.
+ * Temporary sites are rejected because they only exist in redux state. If
+ * deleting the OPFS data fails, the redux record remains available for retry
+ * and the storage error is rethrown.
+ *
+ * @throws When the site is temporary, browser storage is unavailable, or its
+ * OPFS data cannot be deleted.
  */
 export function removeSite(slug: string) {
 	return async (
@@ -328,11 +333,12 @@ export function removeSite(slug: string) {
 		if (siteInfo.metadata.storage === 'none') {
 			throw new Error('Cannot remove a temporary site.');
 		}
-		try {
-			await opfsSiteStorage?.delete(siteInfo.slug);
-		} catch (error: any) {
-			logger.error('Error deleting site from OPFS:', error);
+		if (!opfsSiteStorage) {
+			throw new Error(
+				'Cannot remove a saved Playground because browser storage is not available.'
+			);
 		}
+		await opfsSiteStorage.delete(siteInfo.slug);
 		dispatch(sitesSlice.actions.removeSite(siteInfo.slug));
 
 		// Select the most recently created site
@@ -349,7 +355,9 @@ export function removeSite(slug: string) {
  * Removes autosaved Playgrounds beyond the retention limit.
  *
  * Explicitly saved Playgrounds are never pruned. `excludeSlugs` protects
- * specific autosaves for the current prune pass.
+ * specific autosaves for the current prune pass. Removal is best-effort: a
+ * failed deletion remains available for retry and does not prevent later
+ * candidates from being pruned.
  */
 export function pruneAutosavedSites(options: AutosavedSitesPruneOptions = {}) {
 	return async (
@@ -361,7 +369,14 @@ export function pruneAutosavedSites(options: AutosavedSitesPruneOptions = {}) {
 			options
 		);
 		for (const site of sitesToPrune) {
-			await dispatch(removeSite(site.slug));
+			try {
+				await dispatch(removeSite(site.slug));
+			} catch (error) {
+				logger.error(
+					`Failed to prune autosaved Playground "${site.slug}"`,
+					error
+				);
+			}
 		}
 	};
 }


### PR DESCRIPTION
Part of #4099.

Builds on #4127.

A failed OPFS deletion now leaves the Playground in Redux so the deletion can be retried.

## Background

A stored Playground has files in OPFS and a record in Redux. `removeSite()` used to catch an OPFS error and then remove the Redux record anyway. It also treated missing browser storage as a successful deletion. In both cases, the Playground disappeared from the UI while its deletion had not succeeded.

## This change

`removeSite()` now checks that browser storage is available and removes the Redux record only after OPFS deletion succeeds. Otherwise the error reaches the caller and the record remains.

Autosave pruning is allowed to skip a broken site and keep going. It catches each deletion failure in the pruning loop, logs it, and tries the next candidate. This is why the `try/catch` belongs there instead of in `removeSite()`.

## Testing

There is no practical UI control for forcing these storage failures. The focused tests cover unavailable browser storage, a rejected OPFS deletion, and a prune pass where one deletion fails while the next succeeds.
