### PR TITLE
[Website] Preserve Blueprint recovery through GitHub authentication

### DIFF
--- a/packages/playground/website/src/lib/state/redux/boot-site-client.spec.ts
+++ b/packages/playground/website/src/lib/state/redux/boot-site-client.spec.ts
@@ -11,6 +11,7 @@ import { bootSiteClient } from './boot-site-client';
 import reducer, { sitesSlice, type SiteInfo } from './slice-sites';
 import type { PlaygroundReduxState } from './store';
 import { logBlueprintEvents } from '../../tracking';
+import { shouldShowGitHubAuthModal } from '../../../github/git-auth-helpers';
 
 vi.mock('@wp-playground/client', () => ({
 	startPlaygroundWeb: vi.fn(),
@@ -77,6 +78,8 @@ describe('bootSiteClient', () => {
 				return playground;
 			}
 		);
+		vi.mocked(shouldShowGitHubAuthModal).mockReset();
+		vi.mocked(shouldShowGitHubAuthModal).mockReturnValue(false);
 		vi.mocked(
 			opfsSiteStorage!.removeWordPressFilesKeepMetadata
 		).mockReset();
@@ -383,6 +386,58 @@ describe('bootSiteClient', () => {
 					.siteSlugToReturnToIfBlueprintFails
 			).toBeUndefined()
 		);
+	});
+
+	it('keeps Blueprint recovery behind private repository authentication', async () => {
+		const authenticationError = Object.assign(
+			new Error('GitHub authentication required'),
+			{
+				name: 'GitAuthenticationError',
+				repoUrl: 'https://github.com/example/private-repository',
+			}
+		);
+		vi.mocked(startPlaygroundWeb).mockRejectedValueOnce(
+			authenticationError
+		);
+		vi.mocked(shouldShowGitHubAuthModal).mockReturnValueOnce(true);
+		const site = createSite('blueprint-run', {
+			metadata: { siteSlugToReturnToIfBlueprintFails: 'source-site' },
+		});
+		const state = createState(site);
+		const dispatch = createDispatch(state);
+
+		await bootSiteClient(
+			'blueprint-run',
+			document.createElement('iframe'),
+			{ signal: new AbortController().signal }
+		)(dispatch, () => state);
+
+		const actions: Array<{ type?: string; payload?: unknown }> =
+			dispatch.mock.calls.map(
+				([action]: [unknown]) =>
+					action as { type?: string; payload?: unknown }
+			);
+		const errorIndex = actions.findIndex(
+			(action) => action.type === 'ui/setActiveSiteError'
+		);
+		const authModalIndex = actions.findIndex(
+			(action) => action.type === 'ui/setActiveModal'
+		);
+		expect(actions[errorIndex]).toEqual(
+			expect.objectContaining({
+				payload: expect.objectContaining({
+					error: 'site-boot-failed',
+					details: expect.objectContaining({
+						name: 'GitAuthenticationError',
+						message: 'GitHub authentication required',
+					}),
+				}),
+			})
+		);
+		expect(actions[authModalIndex]).toEqual(
+			expect.objectContaining({ payload: 'github-private-repo-auth' })
+		);
+		expect(errorIndex).toBeLessThan(authModalIndex);
 	});
 
 	it('classifies a worker resource-unavailable error', async () => {

--- a/packages/playground/website/src/lib/state/redux/boot-site-client.ts
+++ b/packages/playground/website/src/lib/state/redux/boot-site-client.ts
@@ -25,6 +25,7 @@ import {
 import type { PlaygroundDispatch, PlaygroundReduxState } from './store';
 import {
 	isAutosavedSite,
+	isUnfinishedBlueprintRun,
 	selectSiteBySlug,
 	updateSiteMetadata,
 } from './slice-sites';
@@ -326,6 +327,14 @@ export function bootSiteClient(
 				if (shouldShowGitHubAuthModal(repoUrl)) {
 					if (repoUrl) {
 						dispatch(setGitHubAuthRepoUrl(repoUrl));
+					}
+					if (isUnfinishedBlueprintRun(site)) {
+						dispatch(
+							setActiveSiteError({
+								error: 'site-boot-failed',
+								details: e,
+							})
+						);
 					}
 					dispatch(
 						setActiveModal(modalSlugs.GITHUB_PRIVATE_REPO_AUTH)


### PR DESCRIPTION
An unfinished Blueprint run now records a site error before asking the user to authenticate with a private GitHub repository.

A Git authentication error normally opens only the authentication modal. That works for an ordinary Playground because authentication can resume the boot. An unfinished Blueprint run must also keep its failure state. Otherwise, dismissing the authentication modal exposes the dead loader with no error to recover from.

For these runs, `bootSiteClient()` stores `site-boot-failed` before opening GitHub authentication. The authentication modal stays on top. After it closes, the site error modal is already waiting. Normal Playgrounds keep the old behavior.

Part of #4099 which will replace the generic site error actions with explicit Blueprint recovery actions.

## Testing

Run a stored Blueprint that references a private GitHub repository while signed out. Dismiss the authentication modal and confirm the site error modal appears instead of the loader.
