### PR TITLE
[Website] Reveal ZIP imports while their browser autosave finishes

### DIFF
--- a/packages/playground/blueprints/src/lib/steps/import-wordpress-files.ts
+++ b/packages/playground/blueprints/src/lib/steps/import-wordpress-files.ts
@@ -65,10 +65,11 @@ export interface ImportWordPressFilesStep<ResourceType> {
  */
 export const importWordPressFiles: StepHandler<
 	ImportWordPressFilesStep<File>
-> = async (playground, { wordPressFilesZip, pathInZip = '' }) => {
+> = async (playground, { wordPressFilesZip, pathInZip = '' }, progress) => {
 	const documentRoot = await playground.documentRoot;
 
 	// Unzip
+	progress?.tracker.setCaption('Unpacking archive');
 	const unzipRoot = joinPaths(
 		'/tmp',
 		`import-wordpress-files-${randomFilename()}`
@@ -85,6 +86,8 @@ export const importWordPressFiles: StepHandler<
 		importPath =
 			(await findWordPressFilesRoot(playground, importPath)) ||
 			importPath;
+		progress?.tracker.setCaption('Installing WordPress files');
+		progress?.tracker.set(30);
 
 		// Read the export manifest if it exists. The manifest contains the
 		// site URL (including scope) at export time, which we'll use later
@@ -222,6 +225,8 @@ export const importWordPressFiles: StepHandler<
 		}
 	}
 
+	progress?.tracker.setCaption('Updating WordPress configuration');
+	progress?.tracker.set(60);
 	// Ensure required constants are defined if wp-config.php doesn't define them.
 	await ensureWpConfig(playground, documentRoot);
 
@@ -240,6 +245,8 @@ export const importWordPressFiles: StepHandler<
 	});
 
 	// Upgrade the database
+	progress?.tracker.setCaption('Upgrading the WordPress database');
+	progress?.tracker.set(75);
 	const upgradePhp = phpVar(
 		joinPaths(documentRoot, 'wp-admin', 'upgrade.php')
 	);
@@ -254,8 +261,12 @@ export const importWordPressFiles: StepHandler<
 	// This ensures that image and media URLs that reference the old scope
 	// are updated to use the new scope.
 	if (oldSiteUrl && oldSiteUrl !== newSiteUrl) {
+		progress?.tracker.setCaption('Updating site URLs');
+		progress?.tracker.set(90);
 		await replaceSiteUrl(playground, documentRoot, oldSiteUrl, newSiteUrl);
 	}
+	progress?.tracker.setCaption('WordPress files imported');
+	progress?.tracker.finish();
 };
 
 /**

--- a/packages/playground/website/playwright/e2e/opfs.spec.ts
+++ b/packages/playground/website/playwright/e2e/opfs.spec.ts
@@ -996,10 +996,13 @@ test('should close the pane, reveal the site, and finish during a ZIP import', a
 	const loading = website.page.getByRole('heading', {
 		name: 'Preparing WordPress',
 	});
-	const saveProgress = website.page.getByRole('progressbar', {
-		name: 'Save progress',
+	const autosaveProgress = website.page.getByRole('progressbar', {
+		name: 'Autosave progress',
 	});
 	const loadingStarted = expect(loading).toBeVisible({ timeout: 120000 });
+	const autosaveStarted = expect(autosaveProgress).toBeVisible({
+		timeout: 120000,
+	});
 	await fileInput.setInputFiles({
 		name: 'playground-export-with-plugin-and-theme.zip',
 		mimeType: 'application/zip',
@@ -1007,8 +1010,9 @@ test('should close the pane, reveal the site, and finish during a ZIP import', a
 	});
 	await expect(pane).not.toBeVisible();
 	await loadingStarted;
-	await expect(saveProgress).toHaveCount(0);
+	await expect(autosaveProgress).toHaveCount(0);
 	await expect(loading).not.toBeVisible({ timeout: 120000 });
+	await autosaveStarted;
 	await expect(
 		website.page.locator('iframe.playground-viewport:visible')
 	).toHaveCount(1);

--- a/packages/playground/website/playwright/e2e/opfs.spec.ts
+++ b/packages/playground/website/playwright/e2e/opfs.spec.ts
@@ -1102,17 +1102,15 @@ test('should import ZIP into a new saved site when a saved site exists', async (
 		'input[type="file"][accept*=".zip"]'
 	);
 
-	// Set up dialog handler for the import success alert
-	website.page.once('dialog', async (dialog) => {
-		await dialog.accept();
-	});
-
 	// Upload the ZIP file
 	await fileInput.setInputFiles({
 		name: 'test-import.zip',
 		mimeType: 'application/zip',
 		buffer: zipBuffer,
 	});
+	await expect(
+		website.page.getByText('Playground imported', { exact: true })
+	).toBeVisible({ timeout: 120000 });
 
 	// The import should switch us to a new saved Playground by default.
 	await expect(getPlaygroundTitle(website.page)).not.toContainText(
@@ -1128,8 +1126,7 @@ test('should import ZIP into a new saved site when a saved site exists', async (
 	await website.openPlaygroundsPane();
 
 	await website.page
-		.locator('[class*="siteRowContent"]')
-		.filter({ hasText: savedSiteName })
+		.getByRole('button', { name: `Open ${savedSiteName}`, exact: true })
 		.click();
 	await website.ensureSiteManagerIsOpen();
 
@@ -1214,17 +1211,15 @@ test('should create a saved site when importing ZIP while on a saved site with n
 		'input[type="file"][accept*=".zip"]'
 	);
 
-	// Set up dialog handler
-	website.page.once('dialog', async (dialog) => {
-		await dialog.accept();
-	});
-
 	// Upload the ZIP file
 	await fileInput.setInputFiles({
 		name: 'test-import-direct.zip',
 		mimeType: 'application/zip',
 		buffer: zipBuffer,
 	});
+	await expect(
+		website.page.getByText('Playground imported', { exact: true })
+	).toBeVisible({ timeout: 120000 });
 
 	// The import should trigger creation of a new saved site by default.
 	await expect(getPlaygroundTitle(website.page)).not.toContainText(
@@ -1239,8 +1234,7 @@ test('should create a saved site when importing ZIP while on a saved site with n
 	await website.openPlaygroundsPane();
 
 	await website.page
-		.locator('[class*="siteRowContent"]')
-		.filter({ hasText: savedSiteName })
+		.getByRole('button', { name: `Open ${savedSiteName}`, exact: true })
 		.click();
 	await website.ensureSiteManagerIsOpen();
 

--- a/packages/playground/website/playwright/e2e/opfs.spec.ts
+++ b/packages/playground/website/playwright/e2e/opfs.spec.ts
@@ -859,6 +859,74 @@ test('should display OPFS storage option as selected by default', async ({
 	await pane.getByRole('button', { name: 'Cancel' }).click();
 });
 
+test('should import ZIP into a fresh temporary site without browser storage', async ({
+	website,
+	browserName,
+	context,
+}) => {
+	test.skip(
+		browserName !== 'chromium',
+		'This test controls OPFS availability in Chromium.'
+	);
+	await context.addInitScript(() => {
+		Object.defineProperty(StorageManager.prototype, 'getDirectory', {
+			configurable: true,
+			value: undefined,
+		});
+	});
+
+	await website.goto(getTemporaryPlaygroundUrl());
+	const siteBeforeImport = await getActivePlaygroundSite(website.page);
+	expect(siteBeforeImport?.storage).toBe('temporary');
+
+	await website.openDockPane('New Playground');
+	await website.page
+		.getByRole('tab', { name: 'Import zip', exact: true })
+		.click();
+
+	const marker = 'TEMPORARY_ZIP_IMPORT_MARKER';
+	const markerPath = 'wp-content/temporary-zip-import-marker.txt';
+	const zipBuffer = await createTestWordPressZip(
+		marker,
+		'wp-content/index.php',
+		[new File([marker], markerPath)]
+	);
+	await website.page
+		.locator('input[type="file"][accept*=".zip"]')
+		.setInputFiles({
+			name: 'temporary-playground.zip',
+			mimeType: 'application/zip',
+			buffer: zipBuffer,
+		});
+
+	await expect(
+		website.page
+			.getByRole('group', { name: 'Operation succeeded' })
+			.filter({ hasText: 'Playground imported' })
+	).toBeVisible({ timeout: 120000 });
+	await expect(
+		website.page.getByRole('alert').filter({
+			hasText: 'Playground imported',
+		})
+	).toHaveCount(0);
+	const siteAfterImport = await getActivePlaygroundSite(website.page);
+	expect(siteAfterImport).toMatchObject({
+		storage: 'temporary',
+	});
+	expect(siteAfterImport.slug).not.toBe(siteBeforeImport.slug);
+	await expect
+		.poll(async () => {
+			return await website.page.evaluate(async (relativePath) => {
+				const playground = (window as any).playgroundSites.getClient();
+				const documentRoot = await playground.documentRoot;
+				return await playground.readFileAsText(
+					`${documentRoot}/${relativePath}`
+				);
+			}, markerPath);
+		})
+		.toBe(marker);
+});
+
 test('should remove the saved site created for a failed ZIP import', async ({
 	website,
 	browserName,
@@ -903,7 +971,7 @@ test('should remove the saved site created for a failed ZIP import', async ({
 		.toEqual(storedSiteSlugsBeforeImport);
 });
 
-test('should block closing and finish during a ZIP import', async ({
+test('should close the pane, reveal the site, and finish during a ZIP import', async ({
 	website,
 	browserName,
 }) => {
@@ -922,40 +990,36 @@ test('should block closing and finish during a ZIP import', async ({
 	const fileInput = website.page.locator(
 		'input[type="file"][accept*=".zip"]'
 	);
-	const importComplete = website.page
-		.waitForEvent('dialog')
-		.then(async (dialog) => {
-			await dialog.accept();
-		});
+	const pane = website.page.getByRole('dialog', {
+		name: 'New Playground pane',
+	});
+	const loading = website.page.getByRole('heading', {
+		name: 'Preparing WordPress',
+	});
+	const saveProgress = website.page.getByRole('progressbar', {
+		name: 'Save progress',
+	});
+	const loadingStarted = expect(loading).toBeVisible({ timeout: 120000 });
 	await fileInput.setInputFiles({
 		name: 'playground-export-with-plugin-and-theme.zip',
 		mimeType: 'application/zip',
 		buffer: zipBuffer,
 	});
-	const importingButton = website.page.getByRole('button', {
-		name: 'Importing…',
+	await expect(pane).not.toBeVisible();
+	await loadingStarted;
+	await expect(saveProgress).toHaveCount(0);
+	await expect(loading).not.toBeVisible({ timeout: 120000 });
+	await expect(
+		website.page.locator('iframe.playground-viewport:visible')
+	).toHaveCount(1);
+	const newPlaygroundButton = website.page.getByRole('button', {
+		name: 'New Playground',
+		exact: true,
 	});
-	await expect(importingButton).toBeVisible();
-	const saveStatus = website.page.getByRole('button', { name: 'Unsaved' });
-	await expect(saveStatus).toBeDisabled();
-	await saveStatus.evaluate((button: HTMLButtonElement) => button.click());
+	await expect(newPlaygroundButton).toBeEnabled();
 	await expect(
-		website.page.getByRole('dialog', { name: 'New Playground pane' })
-	).toBeVisible();
-	await expect(
-		website.page.locator('section[aria-label="Store permanently pane"]')
-	).toHaveCount(0);
-	const newPlaygroundTool = website.page
-		.getByRole('navigation', { name: 'Playground tools' })
-		.getByRole('button', { name: 'New Playground' });
-	await expect(newPlaygroundTool).toBeDisabled();
-	await website.page.keyboard.press('Escape');
-	await expect(
-		website.page.getByRole('dialog', { name: 'New Playground pane' })
-	).toBeVisible();
-	await expect(importingButton).toBeVisible();
-	await importComplete;
-	await expect(newPlaygroundTool).toBeEnabled();
+		website.page.getByText('Playground imported', { exact: true })
+	).toBeVisible({ timeout: 120000 });
 
 	await expect
 		.poll(
@@ -1236,13 +1300,6 @@ test('should persist an imported ZIP saved site after switching away and back', 
 		importedMarker,
 		importedMarkerPath
 	);
-	const dialogs: string[] = [];
-	const importSuccessMessage =
-		'File imported! This Playground instance has been updated and will refresh shortly.';
-	website.page.on('dialog', async (dialog) => {
-		dialogs.push(dialog.message());
-		await dialog.accept();
-	});
 
 	await website.page
 		.locator('input[type="file"][accept*=".zip"]')
@@ -1252,9 +1309,9 @@ test('should persist an imported ZIP saved site after switching away and back', 
 			buffer: zipBuffer,
 		});
 
-	await expect
-		.poll(() => dialogs, { timeout: 120000 })
-		.toEqual([importSuccessMessage]);
+	await expect(
+		website.page.getByText('Playground imported', { exact: true })
+	).toBeVisible({ timeout: 120000 });
 	const importedSite = await waitForActivePlaygroundSiteSlug(
 		website.page,
 		(slug) => slug !== savedSiteSlug
@@ -1263,7 +1320,7 @@ test('should persist an imported ZIP saved site after switching away and back', 
 	const importedSiteSlug = importedSite.slug;
 	// Discard the import runtime before requesting the marker. The fresh runtime
 	// must load the imported file from persisted OPFS state.
-	await website.goto(`./?site-slug=${importedSiteSlug}`);
+	await website.goto(`./?site-slug=${encodeURIComponent(importedSiteSlug)}`);
 	await openPlaygroundPath(website.page, `/${importedMarkerPath}`);
 	await expect(wordpress.locator('body')).toContainText(importedMarker);
 
@@ -1279,10 +1336,9 @@ test('should persist an imported ZIP saved site after switching away and back', 
 	await openPlaygroundPath(website.page, `/${importedMarkerPath}`);
 	await expect(wordpress.locator('body')).toContainText(importedMarker);
 
-	await website.goto(`./?site-slug=${importedSiteSlug}`);
+	await website.goto(`./?site-slug=${encodeURIComponent(importedSiteSlug)}`);
 	await openPlaygroundPath(website.page, `/${importedMarkerPath}`);
 	await expect(wordpress.locator('body')).toContainText(importedMarker);
-	expect(dialogs).toEqual([importSuccessMessage]);
 });
 
 test('should retain files omitted from a legacy ZIP export', async ({

--- a/packages/playground/website/playwright/e2e/opfs.spec.ts
+++ b/packages/playground/website/playwright/e2e/opfs.spec.ts
@@ -1020,6 +1020,11 @@ test('should close the pane, reveal the site, and finish during a ZIP import', a
 	await expect(
 		website.page.getByText('Playground imported', { exact: true })
 	).toBeVisible({ timeout: 120000 });
+	const importedSite = await getActivePlaygroundSite(website.page);
+	expect(importedSite).toMatchObject({
+		storage: 'opfs',
+		persistence: 'autosave',
+	});
 
 	await expect
 		.poll(

--- a/packages/playground/website/playwright/e2e/website-ui.spec.ts
+++ b/packages/playground/website/playwright/e2e/website-ui.spec.ts
@@ -1927,7 +1927,7 @@ test.describe('Default Playground storage', () => {
 			.toBe(true);
 	});
 
-	test('should keep Playground management failures visible across Dock surfaces', async ({
+	test('should position and dismiss Playground management failures', async ({
 		website,
 		browserName,
 	}) => {
@@ -2017,93 +2017,17 @@ test.describe('Default Playground storage', () => {
 		);
 
 		await website.page.keyboard.press('Escape');
-		await expect(pane).not.toBeVisible();
-		await expect(notice).toBeVisible();
-		await notice.evaluate(async (element) => {
-			await Promise.all(
-				element.getAnimations().map((animation) => animation.finished)
-			);
-		});
-		const dock = website.page.getByRole('navigation', {
-			name: 'Playground tools',
-		});
-		const closedNoticeBox = await notice.boundingBox();
-		const dockBox = await dock.boundingBox();
-		expect(closedNoticeBox).not.toBeNull();
-		expect(dockBox).not.toBeNull();
-		expect(
-			closedNoticeBox!.y + closedNoticeBox!.height
-		).toBeLessThanOrEqual(dockBox!.y);
-		expect(closedNoticeBox!.x + closedNoticeBox!.width / 2).toBeCloseTo(
-			dockBox!.x + dockBox!.width / 2,
-			0
-		);
+		await expect(notice).toHaveCount(0);
+		await expect(pane).toBeVisible();
 
-		await website.openDockPane('Site Settings');
-		const settingsPane = website.page.getByRole('dialog', {
-			name: 'Site Settings pane',
-		});
-		await expect(notice).toBeVisible();
-		await notice.evaluate(async (element) => {
-			await Promise.all(
-				element.getAnimations().map((animation) => animation.finished)
-			);
-		});
-		const settingsPaneBox = await settingsPane.boundingBox();
-		const settingsNoticeBox = await notice.boundingBox();
-		expect(settingsPaneBox).not.toBeNull();
-		expect(settingsNoticeBox).not.toBeNull();
-		expect(
-			settingsNoticeBox!.y + settingsNoticeBox!.height
-		).toBeLessThanOrEqual(settingsPaneBox!.y);
-
-		await website.openDockPane('Playgrounds');
 		await pane
-			.getByRole('button', { name: `Open ${originalSite.name}` })
+			.getByRole('button', { name: `Actions for ${activeSite.name}` })
 			.click();
-		await expect(pane).not.toBeVisible();
-		await expect
-			.poll(() => getActivePlaygroundSite(website.page), {
-				timeout: 120000,
-			})
-			.toMatchObject({ slug: originalSite.slug });
-		await expect(notice).toBeVisible();
-
-		await website.page.setViewportSize({ width: 390, height: 844 });
-		await expect
-			.poll(() =>
-				website.page.evaluate(
-					() => window.matchMedia('(max-width: 1024px)').matches
-				)
-			)
-			.toBe(true);
-		await website.openDockPane('Playgrounds');
-		await expect
-			.poll(() => pane.boundingBox())
-			.toMatchObject({
-				x: 0,
-				width: 390,
-			});
-		await expect(notice).toBeVisible();
-		await notice.evaluate(async (element) => {
-			await Promise.all(
-				element.getAnimations().map((animation) => animation.finished)
-			);
-		});
-		const mobileNoticeBox = await notice.boundingBox();
-		const mobileDockBox = await dock.boundingBox();
-		expect(mobileNoticeBox).not.toBeNull();
-		expect(mobileDockBox).not.toBeNull();
-		expect(mobileNoticeBox!.x).toBeGreaterThanOrEqual(12);
-		expect(mobileNoticeBox!.x + mobileNoticeBox!.width).toBeLessThanOrEqual(
-			378
-		);
-		expect(
-			mobileNoticeBox!.y + mobileNoticeBox!.height
-		).toBeLessThanOrEqual(mobileDockBox!.y);
-		await notice
-			.getByRole('button', { name: 'Dismiss operation error' })
+		await website.page
+			.getByRole('menuitem', { name: 'Save in a local directory…' })
 			.click();
+		await expect(notice).toBeVisible();
+		await pane.click({ position: { x: 20, y: 20 } });
 		await expect(notice).toHaveCount(0);
 	});
 

--- a/packages/playground/website/src/components/browser-chrome/save-status-indicator.tsx
+++ b/packages/playground/website/src/components/browser-chrome/save-status-indicator.tsx
@@ -52,6 +52,9 @@ export function SaveStatusIndicator({
 	disabled?: boolean;
 }) {
 	const clientInfo = useAppSelector(getActiveClientInfo);
+	const siteImportIsRunning = useAppSelector(
+		(state) => state.ui.siteImportIsRunning
+	);
 	const activeSite = useActiveSite();
 	const dispatch = useAppDispatch();
 	const previousStatusRef = useRef<{
@@ -62,7 +65,9 @@ export function SaveStatusIndicator({
 	const [statusAnnouncement, setStatusAnnouncement] = useState('');
 
 	const opfsSync = clientInfo?.opfsSync;
-	const status = getSaveStatus(activeSite, clientInfo);
+	const status = siteImportIsRunning
+		? 'loading'
+		: getSaveStatus(activeSite, clientInfo);
 	const siteSlug = activeSite?.slug;
 	const syncOperation = getSyncOperation({ site: activeSite, opfsSync });
 	const localFsAvailability = useLocalFsAvailability(clientInfo?.client);

--- a/packages/playground/website/src/components/dock/dock.tsx
+++ b/packages/playground/website/src/components/dock/dock.tsx
@@ -540,6 +540,8 @@ export function Dock({
 		if (!operationNotice) {
 			return;
 		}
+		// Dismiss the toast on the next outside interaction. Pointer events inside
+		// the Playground iframe do not bubble to this document, so listen across frames.
 		return listenForPointerDownAcrossIframes((event) => {
 			if (operationToastRef.current?.contains(event.target as Node)) {
 				return;

--- a/packages/playground/website/src/components/dock/dock.tsx
+++ b/packages/playground/website/src/components/dock/dock.tsx
@@ -51,6 +51,7 @@ import {
 	useRecentAutosaveNudgeVisible,
 	useSetRecentAutosaveNudgeAnchor,
 } from '../ensure-playground-site/recent-autosave-nudge-context';
+import { listenForPointerDownAcrossIframes } from '../ensure-playground-site/listen-for-pointer-down-across-iframes';
 import { TruncatedText } from '../truncated-text';
 import { DockCornerLauncher } from './dock-corner-launcher';
 import { DockItemButton } from './dock-item-button';
@@ -505,12 +506,7 @@ export function Dock({
 	useEffect(() => {
 		/** Lets the active modal or popover consume Escape before the Dock does. */
 		const closeOnEscape = (event: KeyboardEvent) => {
-			if (
-				event.key !== 'Escape' ||
-				activeModal ||
-				!dockPaneIsOpen ||
-				paneCloseBlocked
-			) {
+			if (event.key !== 'Escape' || activeModal) {
 				return;
 			}
 			if (
@@ -520,12 +516,37 @@ export function Dock({
 			) {
 				return;
 			}
+			if (operationNotice) {
+				dispatch(setDockOperationNotice(undefined));
+				return;
+			}
+			if (!dockPaneIsOpen || paneCloseBlocked) {
+				return;
+			}
 			dispatch(setDockPaneOpen(false));
 		};
 		document.addEventListener('keydown', closeOnEscape, true);
 		return () =>
 			document.removeEventListener('keydown', closeOnEscape, true);
-	}, [activeModal, dispatch, paneCloseBlocked, dockPaneIsOpen]);
+	}, [
+		activeModal,
+		dispatch,
+		dockPaneIsOpen,
+		operationNotice,
+		paneCloseBlocked,
+	]);
+
+	useEffect(() => {
+		if (!operationNotice) {
+			return;
+		}
+		return listenForPointerDownAcrossIframes((event) => {
+			if (operationToastRef.current?.contains(event.target as Node)) {
+				return;
+			}
+			dispatch(setDockOperationNotice(undefined));
+		});
+	}, [dispatch, operationNotice]);
 
 	useEffect(() => {
 		if (dockPaneIsOpen) {

--- a/packages/playground/website/src/components/dock/style.module.css
+++ b/packages/playground/website/src/components/dock/style.module.css
@@ -1281,7 +1281,7 @@
 	padding: 8px;
 }
 
-/* Operation failures outlive individual panes, so this surface stays outside
+/* Operation notices outlive individual panes, so this surface stays outside
    both pane and Dock layout. Its inline position follows whichever Dock surface
    is visible without shifting the preview, pane, or Dock when it appears. */
 .dock-operation-toast {

--- a/packages/playground/website/src/components/ensure-playground-site/ensure-playground-site-is-selected.tsx
+++ b/packages/playground/website/src/components/ensure-playground-site/ensure-playground-site-is-selected.tsx
@@ -132,6 +132,7 @@ export function EnsurePlaygroundSiteIsSelected({
 				logger.error('Error loading sites:', error);
 				dispatch(
 					setDockOperationNotice({
+						status: 'error',
 						title: 'Couldn’t load Playgrounds',
 						message:
 							'Reload the page to try browser storage again.',
@@ -335,6 +336,7 @@ export function EnsurePlaygroundSiteIsSelected({
 			);
 			dispatch(
 				setDockOperationNotice({
+					status: 'error',
 					title: 'Couldn’t autosave this Playground',
 					message:
 						'It’s still open but will be lost on refresh. Your earlier autosave is unchanged.',

--- a/packages/playground/website/src/components/playground-viewport/index.tsx
+++ b/packages/playground/website/src/components/playground-viewport/index.tsx
@@ -63,6 +63,9 @@ export const KeepAliveTemporarySitesViewport = () => {
 	const activeSiteSlugIsSet = useAppSelector(
 		(state) => !!state.ui.activeSite?.slug
 	);
+	const siteImportIsRunning = useAppSelector(
+		(state) => state.ui.siteImportIsRunning
+	);
 	const siteSlugsToRender = useMemo(() => {
 		let sites = temporarySites.filter(
 			(site) => site.slug !== activeSite?.slug
@@ -165,7 +168,7 @@ export const KeepAliveTemporarySitesViewport = () => {
 					</div>
 				</div>
 			)}
-			{!hasVisibleSite && (
+			{(!hasVisibleSite || siteImportIsRunning) && (
 				<div className={css.loadingViewport}>
 					<h1 className={css.loadingCaption}>Preparing WordPress</h1>
 					<div className={css.progressWrapper}>
@@ -182,7 +185,9 @@ export const KeepAliveTemporarySitesViewport = () => {
 					<div
 						key={slug}
 						className={classNames(css.fullSize, {
-							[css.hidden]: slug !== activeSite?.slug,
+							[css.hidden]:
+								slug !== activeSite?.slug ||
+								siteImportIsRunning,
 						})}
 					>
 						{siteSlugsToRender.includes(slug) ? (

--- a/packages/playground/website/src/components/saved-playgrounds-panel/index.tsx
+++ b/packages/playground/website/src/components/saved-playgrounds-panel/index.tsx
@@ -143,6 +143,12 @@ type CreationTabId =
 	| 'pull-request'
 	| 'zip';
 
+type ZipImportStatus = {
+	type: 'progress' | 'error';
+	caption: string;
+	progress?: number;
+};
+
 interface SavedPlaygroundsPanelProps {
 	onClose: () => void;
 	panel: 'playgrounds' | 'new';
@@ -179,6 +185,7 @@ export function SavedPlaygroundsPanel({
 	const [searchQuery, setSearchQuery] = useState('');
 	const [showAllStoredSites, setShowAllStoredSites] = useState(false);
 	const [isImportingZip, setIsImportingZip] = useState(false);
+	const [zipImportStatus, setZipImportStatus] = useState<ZipImportStatus>();
 	const zipImportPendingRef = useRef(false);
 	// A mouse click can put the cursor in the newly selected form straight away.
 	// Keyboard and touch activation otherwise keep their focus on the tab. The
@@ -332,23 +339,45 @@ export function SavedPlaygroundsPanel({
 
 		zipImportPendingRef.current = true;
 		setIsImportingZip(true);
+		setZipImportStatus({
+			type: 'progress',
+			caption: 'Preparing a new Playground',
+			progress: 0,
+		});
 		try {
-			await sitesAPI.createNewSiteFromZip(file);
+			const importedSiteSlug = await sitesAPI.createNewSiteFromZip(
+				file,
+				(progress) => {
+					setZipImportStatus({ type: 'progress', ...progress });
+				}
+			);
+			const importedSite = sitesAPI
+				.list()
+				.find((site) => site.slug === importedSiteSlug);
 			const importedPlayground = sitesAPI.getClient();
 			window.setTimeout(() => {
 				void importedPlayground?.goTo('/').catch((error) => {
 					logger.error('Failed to refresh imported site', error);
 				});
 			}, 200);
-			alert(
-				'File imported! This Playground instance has been updated and will refresh shortly.'
+			dispatch(
+				setDockOperationNotice({
+					kind: 'success',
+					title: 'Playground imported',
+					message:
+						importedSite?.storage === 'temporary'
+							? `${file.name} is temporary and will be lost when this page closes.`
+							: `${file.name} is stored in this browser.`,
+				})
 			);
 			onClose();
 		} catch (error) {
 			logger.error(error);
-			alert(
-				'Unable to import file. Is it a valid WordPress Playground export?'
-			);
+			setZipImportStatus({
+				type: 'error',
+				caption:
+					'Unable to import this file. Is it a valid WordPress Playground export?',
+			});
 		} finally {
 			zipImportPendingRef.current = false;
 			setIsImportingZip(false);
@@ -1509,6 +1538,46 @@ export function SavedPlaygroundsPanel({
 									: 'Choose a .zip file…'}
 							</Button>
 						</div>
+						{zipImportStatus && (
+							<div
+								className={classNames(css.zipImportStatus, {
+									[css.zipImportError]:
+										zipImportStatus.type === 'error',
+								})}
+								role={
+									zipImportStatus.type === 'error'
+										? 'alert'
+										: 'status'
+								}
+								aria-live="polite"
+							>
+								<div className={css.zipImportStatusLabel}>
+									{zipImportStatus.type === 'progress' && (
+										<Spinner />
+									)}
+									<span>{zipImportStatus.caption}</span>
+									{zipImportStatus.type === 'progress' &&
+										typeof zipImportStatus.progress ===
+											'number' && (
+											<span
+												className={css.zipImportPercent}
+											>
+												{Math.round(
+													zipImportStatus.progress
+												)}
+												%
+											</span>
+										)}
+								</div>
+								{zipImportStatus.type === 'progress' && (
+									<progress
+										max={100}
+										value={zipImportStatus.progress ?? 0}
+										aria-label="ZIP import progress"
+									/>
+								)}
+							</div>
+						)}
 					</div>
 				);
 			default:

--- a/packages/playground/website/src/components/saved-playgrounds-panel/index.tsx
+++ b/packages/playground/website/src/components/saved-playgrounds-panel/index.tsx
@@ -340,7 +340,7 @@ export function SavedPlaygroundsPanel({
 					message:
 						importedSite?.storage === 'temporary'
 							? 'Your Playground is ready. It’s available until you close this page.'
-							: 'Your Playground is ready. It’s saved in this browser.',
+							: 'Your Playground is ready. It’s autosaved in this browser.',
 				})
 			);
 		} catch (error) {

--- a/packages/playground/website/src/components/saved-playgrounds-panel/index.tsx
+++ b/packages/playground/website/src/components/saved-playgrounds-panel/index.tsx
@@ -339,8 +339,8 @@ export function SavedPlaygroundsPanel({
 					title: 'Playground imported',
 					message:
 						importedSite?.storage === 'temporary'
-							? `${file.name} is temporary and will be lost when this page closes.`
-							: `${file.name} is stored in this browser.`,
+							? 'Your Playground is ready. It’s available until you close this page.'
+							: 'Your Playground is ready. It’s saved in this browser.',
 				})
 			);
 		} catch (error) {

--- a/packages/playground/website/src/components/saved-playgrounds-panel/index.tsx
+++ b/packages/playground/website/src/components/saved-playgrounds-panel/index.tsx
@@ -335,7 +335,7 @@ export function SavedPlaygroundsPanel({
 				.find((site) => site.slug === importedSiteSlug);
 			dispatch(
 				setDockOperationNotice({
-					kind: 'success',
+					status: 'success',
 					title: 'Playground imported',
 					message:
 						importedSite?.storage === 'temporary'
@@ -407,6 +407,7 @@ export function SavedPlaygroundsPanel({
 			);
 			dispatch(
 				setDockOperationNotice({
+					status: 'error',
 					title: `Couldn’t open “${site?.metadata.name ?? slug}”`,
 					message: 'This Playground is still available in your list.',
 				})
@@ -521,6 +522,7 @@ export function SavedPlaygroundsPanel({
 			logger.error('Error storing Playground in the browser', error);
 			dispatch(
 				setDockOperationNotice({
+					status: 'error',
 					title: `Couldn’t store “${site.metadata.name}” in browser storage`,
 					message: 'No changes were made to this Playground.',
 				})
@@ -561,6 +563,7 @@ export function SavedPlaygroundsPanel({
 			logger.error('Error saving Playground to a local directory', error);
 			dispatch(
 				setDockOperationNotice({
+					status: 'error',
 					title: `Couldn’t save ${site.metadata.name} locally`,
 					message: 'The Playground in your browser is unchanged.',
 				})
@@ -1516,7 +1519,6 @@ export function SavedPlaygroundsPanel({
 									css.zipImportError
 								)}
 								role="alert"
-								aria-live="polite"
 							>
 								{zipImportError}
 							</div>

--- a/packages/playground/website/src/components/saved-playgrounds-panel/index.tsx
+++ b/packages/playground/website/src/components/saved-playgrounds-panel/index.tsx
@@ -143,16 +143,9 @@ type CreationTabId =
 	| 'pull-request'
 	| 'zip';
 
-type ZipImportStatus = {
-	type: 'progress' | 'error';
-	caption: string;
-	progress?: number;
-};
-
 interface SavedPlaygroundsPanelProps {
 	onClose: () => void;
 	panel: 'playgrounds' | 'new';
-	onCloseBlockedChange: (isBlocked: boolean) => void;
 	onPaneHeaderChange: (header: DockPaneHeaderOverride | undefined) => void;
 }
 
@@ -162,7 +155,6 @@ interface SavedPlaygroundsPanelProps {
 export function SavedPlaygroundsPanel({
 	onClose,
 	panel,
-	onCloseBlockedChange,
 	onPaneHeaderChange,
 }: SavedPlaygroundsPanelProps) {
 	const offline = useAppSelector((state) => state.ui.offline);
@@ -185,7 +177,7 @@ export function SavedPlaygroundsPanel({
 	const [searchQuery, setSearchQuery] = useState('');
 	const [showAllStoredSites, setShowAllStoredSites] = useState(false);
 	const [isImportingZip, setIsImportingZip] = useState(false);
-	const [zipImportStatus, setZipImportStatus] = useState<ZipImportStatus>();
+	const [zipImportError, setZipImportError] = useState<string>();
 	const zipImportPendingRef = useRef(false);
 	// A mouse click can put the cursor in the newly selected form straight away.
 	// Keyboard and touch activation otherwise keep their focus on the tab. The
@@ -238,11 +230,6 @@ export function SavedPlaygroundsPanel({
 	const writeOwnSeededSlug = useAppSelector(
 		(state) => state.ui.writeOwnSeededSlug
 	);
-
-	useEffect(() => {
-		onCloseBlockedChange(isImportingZip);
-		return () => onCloseBlockedChange(false);
-	}, [isImportingZip, onCloseBlockedChange]);
 
 	useEffect(() => {
 		if (isCreationTabDisabled(activeCreationTab, offline)) {
@@ -339,27 +326,13 @@ export function SavedPlaygroundsPanel({
 
 		zipImportPendingRef.current = true;
 		setIsImportingZip(true);
-		setZipImportStatus({
-			type: 'progress',
-			caption: 'Preparing a new Playground',
-			progress: 0,
-		});
+		setZipImportError(undefined);
+		onClose();
 		try {
-			const importedSiteSlug = await sitesAPI.createNewSiteFromZip(
-				file,
-				(progress) => {
-					setZipImportStatus({ type: 'progress', ...progress });
-				}
-			);
+			const importedSiteSlug = await sitesAPI.createNewSiteFromZip(file);
 			const importedSite = sitesAPI
 				.list()
 				.find((site) => site.slug === importedSiteSlug);
-			const importedPlayground = sitesAPI.getClient();
-			window.setTimeout(() => {
-				void importedPlayground?.goTo('/').catch((error) => {
-					logger.error('Failed to refresh imported site', error);
-				});
-			}, 200);
 			dispatch(
 				setDockOperationNotice({
 					kind: 'success',
@@ -370,14 +343,12 @@ export function SavedPlaygroundsPanel({
 							: `${file.name} is stored in this browser.`,
 				})
 			);
-			onClose();
 		} catch (error) {
 			logger.error(error);
-			setZipImportStatus({
-				type: 'error',
-				caption:
-					'Unable to import this file. Is it a valid WordPress Playground export?',
-			});
+			setZipImportError(
+				'Unable to import this file. Is it a valid WordPress Playground export?'
+			);
+			dispatch(setDockPaneOpen(true));
 		} finally {
 			zipImportPendingRef.current = false;
 			setIsImportingZip(false);
@@ -1538,44 +1509,16 @@ export function SavedPlaygroundsPanel({
 									: 'Choose a .zip file…'}
 							</Button>
 						</div>
-						{zipImportStatus && (
+						{zipImportError && (
 							<div
-								className={classNames(css.zipImportStatus, {
-									[css.zipImportError]:
-										zipImportStatus.type === 'error',
-								})}
-								role={
-									zipImportStatus.type === 'error'
-										? 'alert'
-										: 'status'
-								}
+								className={classNames(
+									css.zipImportStatus,
+									css.zipImportError
+								)}
+								role="alert"
 								aria-live="polite"
 							>
-								<div className={css.zipImportStatusLabel}>
-									{zipImportStatus.type === 'progress' && (
-										<Spinner />
-									)}
-									<span>{zipImportStatus.caption}</span>
-									{zipImportStatus.type === 'progress' &&
-										typeof zipImportStatus.progress ===
-											'number' && (
-											<span
-												className={css.zipImportPercent}
-											>
-												{Math.round(
-													zipImportStatus.progress
-												)}
-												%
-											</span>
-										)}
-								</div>
-								{zipImportStatus.type === 'progress' && (
-									<progress
-										max={100}
-										value={zipImportStatus.progress ?? 0}
-										aria-label="ZIP import progress"
-									/>
-								)}
+								{zipImportError}
 							</div>
 						)}
 					</div>

--- a/packages/playground/website/src/components/saved-playgrounds-panel/style.module.css
+++ b/packages/playground/website/src/components/saved-playgrounds-panel/style.module.css
@@ -1043,28 +1043,6 @@
 	padding: 12px;
 }
 
-.playgrounds-pane .zipImportStatusLabel {
-	align-items: center;
-	display: flex;
-	font-size: 13px;
-	gap: var(--space-2, 8px);
-}
-
-.playgrounds-pane .zipImportPercent {
-	margin-left: auto;
-}
-
-.playgrounds-pane .zipImportStatus :global(.components-spinner) {
-	flex: none;
-	margin: 0;
-}
-
-.playgrounds-pane .zipImportStatus :global(progress) {
-	accent-color: var(--accent, #3858e9);
-	height: 8px;
-	width: 100%;
-}
-
 .playgrounds-pane .zipImportError {
 	border-color: var(--color-alert-red, #cc1818);
 	color: var(--color-alert-red, #cc1818);

--- a/packages/playground/website/src/components/saved-playgrounds-panel/style.module.css
+++ b/packages/playground/website/src/components/saved-playgrounds-panel/style.module.css
@@ -1032,6 +1032,44 @@
 	color: var(--ink-muted, #5f5b54);
 }
 
+.playgrounds-pane .zipImportStatus {
+	background: var(--paper-2, #faf8f5);
+	border: 1px solid var(--line-control, rgba(33, 32, 29, 0.14));
+	border-radius: var(--radius-card, 8px);
+	color: var(--ink-soft, #2f2d28);
+	display: flex;
+	flex-direction: column;
+	gap: var(--space-2, 8px);
+	padding: 12px;
+}
+
+.playgrounds-pane .zipImportStatusLabel {
+	align-items: center;
+	display: flex;
+	font-size: 13px;
+	gap: var(--space-2, 8px);
+}
+
+.playgrounds-pane .zipImportPercent {
+	margin-left: auto;
+}
+
+.playgrounds-pane .zipImportStatus :global(.components-spinner) {
+	flex: none;
+	margin: 0;
+}
+
+.playgrounds-pane .zipImportStatus :global(progress) {
+	accent-color: var(--accent, #3858e9);
+	height: 8px;
+	width: 100%;
+}
+
+.playgrounds-pane .zipImportError {
+	border-color: var(--color-alert-red, #cc1818);
+	color: var(--color-alert-red, #cc1818);
+}
+
 /* Inline docs link inside a hint — accent, underlines on hover. */
 .playgrounds-pane .inlineForm .inlineFormLink,
 .playgrounds-pane .inlineFormLink {

--- a/packages/playground/website/src/components/site-manager/index.tsx
+++ b/packages/playground/website/src/components/site-manager/index.tsx
@@ -118,7 +118,6 @@ export const SiteManager = forwardRef<HTMLDivElement, SiteManagerProps>(
 									: lastSavedPlaygroundsPanel
 							}
 							onClose={() => dispatch(setDockPaneOpen(false))}
-							onCloseBlockedChange={onPaneCloseBlockedChange}
 							onPaneHeaderChange={onNewPlaygroundHeaderChange}
 						/>
 					</div>

--- a/packages/playground/website/src/lib/hooks/use-inline-rename.ts
+++ b/packages/playground/website/src/lib/hooks/use-inline-rename.ts
@@ -50,6 +50,7 @@ export function useInlineRename() {
 			setRenamingSlug(site.slug);
 			dispatch(
 				setDockOperationNotice({
+					status: 'error',
 					title: `Couldn’t rename “${site.metadata.name}”`,
 					message:
 						'Your new name is still in the field so you can try again.',

--- a/packages/playground/website/src/lib/state/redux/site-management-api-middleware.ts
+++ b/packages/playground/website/src/lib/state/redux/site-management-api-middleware.ts
@@ -10,7 +10,7 @@ import {
 	useAppDispatch,
 } from './store';
 import type { SerializedSiteErrorDetails, SiteError } from './slice-ui';
-import { setActiveSiteError } from './slice-ui';
+import { setActiveSiteError, setSiteImportIsRunning } from './slice-ui';
 import {
 	addClientInfo,
 	removeClientInfo,
@@ -45,6 +45,8 @@ import { opfsSiteStorage } from '../opfs/opfs-site-storage';
 import { getSetupUrlFromUrl } from '../playground-identity';
 import { importWordPressFiles } from '@wp-playground/client';
 import { registerSiteFirstBootInitializer } from './site-first-boot-initializer';
+import { ProgressTracker, type ProgressTrackerEvent } from '@php-wasm/progress';
+import { logger } from '@php-wasm/logger';
 import { PlaygroundRoute, redirectTo } from '../url/router';
 
 export interface SiteSettings {
@@ -57,6 +59,10 @@ export interface SiteSettings {
 
 type PublicSiteStorageType = Exclude<SiteStorageType, 'none'> | 'temporary';
 type SaveSiteResult = { slug: string; storage: SiteStorageType };
+type ZipImportProgress = { caption: string; progress: number };
+
+const ZIP_INSTALL_PROGRESS_PERCENT = 85;
+const ZIP_STORAGE_PROGRESS_PERCENT = 100 - ZIP_INSTALL_PROGRESS_PERCENT;
 
 /**
  * Tracks the operation shared by concurrent autosave calls for one site.
@@ -837,18 +843,61 @@ export function createSitesAPI(
 		 * @param wordPressFilesZip Playground ZIP export.
 		 * @returns The new site's slug.
 		 */
-		async createNewSiteFromZip(wordPressFilesZip: File): Promise<string> {
-			const initialize = async (playground: PlaygroundClient) => {
-				await importWordPressFiles(playground, { wordPressFilesZip });
-			};
-			if (!opfsSiteStorage) {
-				return await createTemporarySite(
-					undefined,
-					undefined,
-					initialize
+		async createNewSiteFromZip(
+			wordPressFilesZip: File,
+			onProgress?: (progress: ZipImportProgress) => void
+		): Promise<string> {
+			dispatch(setSiteImportIsRunning(true));
+			try {
+				const tracker = new ProgressTracker();
+				const importWeight = opfsSiteStorage
+					? ZIP_INSTALL_PROGRESS_PERCENT / 100
+					: 1;
+				tracker.addEventListener(
+					'progress',
+					(event: ProgressTrackerEvent) => {
+						onProgress?.({
+							caption: event.detail.caption,
+							progress: event.detail.progress * importWeight,
+						});
+					}
 				);
+				const initialize = async (playground: PlaygroundClient) => {
+					await importWordPressFiles(
+						playground,
+						{ wordPressFilesZip },
+						{ tracker }
+					);
+					void playground
+						.goTo('/')
+						.catch((error) => {
+							logger.error(
+								'Failed to refresh imported site',
+								error
+							);
+						})
+						.finally(() => {
+							dispatch(setSiteImportIsRunning(false));
+						});
+				};
+				if (!opfsSiteStorage) {
+					return await createTemporarySite(
+						undefined,
+						undefined,
+						initialize
+					);
+				}
+				return await createSavedSite(
+					undefined,
+					undefined,
+					{},
+					initialize,
+					onProgress
+				);
+			} catch (error) {
+				dispatch(setSiteImportIsRunning(false));
+				throw error;
 			}
-			return await createSavedSite(undefined, undefined, {}, initialize);
 		},
 	};
 
@@ -882,7 +931,8 @@ export function createSitesAPI(
 			updateUrl?: boolean;
 			excludeFromPruning?: string[];
 		} = {},
-		initialize?: (playground: PlaygroundClient) => Promise<void>
+		initialize?: (playground: PlaygroundClient) => Promise<void>,
+		onProgress?: (progress: ZipImportProgress) => void
 	): Promise<string> {
 		if (!opfsSiteStorage) {
 			throw new Error(
@@ -907,7 +957,7 @@ export function createSitesAPI(
 				updateUrl: options.updateUrl,
 			});
 			if (initialize) {
-				await waitForInitialOpfsSync(newSiteInfo.slug);
+				await waitForInitialOpfsSync(newSiteInfo.slug, onProgress);
 			}
 		} catch (error) {
 			if (initialize) {
@@ -950,9 +1000,30 @@ export function createSitesAPI(
 		}
 	}
 
-	async function waitForInitialOpfsSync(siteSlug: string) {
+	async function waitForInitialOpfsSync(
+		siteSlug: string,
+		onProgress?: (progress: ZipImportProgress) => void
+	) {
 		const getSync = () =>
 			selectClientInfoBySiteSlug(getState(), siteSlug)?.opfsSync;
+		const reportProgress = () => {
+			const currentSync = getSync();
+			const syncProgress =
+				currentSync?.status === 'syncing'
+					? currentSync.progress
+					: undefined;
+			const completedFiles = syncProgress?.files ?? 0;
+			const totalFiles = syncProgress?.total ?? 0;
+			onProgress?.({
+				caption: 'Saving imported Playground',
+				progress:
+					ZIP_INSTALL_PROGRESS_PERCENT +
+					(totalFiles > 0
+						? Math.min(1, completedFiles / totalFiles) *
+							ZIP_STORAGE_PROGRESS_PERCENT
+						: 0),
+			});
+		};
 		const sync = getSync();
 		if (!sync) {
 			const site = selectSiteBySlug(getState(), siteSlug);
@@ -961,11 +1032,13 @@ export function createSitesAPI(
 					'Unable to save the imported Playground because its initial storage sync did not complete.'
 				);
 			}
+			onProgress?.({ caption: 'Import complete', progress: 100 });
 			return;
 		}
 		if (sync.status === 'error') {
 			throw new Error('Unable to save the imported Playground.');
 		}
+		reportProgress();
 
 		await new Promise<void>((resolve, reject) => {
 			const unsubscribe = startListening({
@@ -986,6 +1059,7 @@ export function createSitesAPI(
 					}
 					const currentSync = getSync();
 					if (currentSync?.status === 'syncing') {
+						reportProgress();
 						return;
 					}
 					unsubscribe();
@@ -994,6 +1068,10 @@ export function createSitesAPI(
 							new Error('Unable to save the imported Playground.')
 						);
 					} else {
+						onProgress?.({
+							caption: 'Import complete',
+							progress: 100,
+						});
 						resolve();
 					}
 				},

--- a/packages/playground/website/src/lib/state/redux/site-management-api-middleware.ts
+++ b/packages/playground/website/src/lib/state/redux/site-management-api-middleware.ts
@@ -45,7 +45,11 @@ import { opfsSiteStorage } from '../opfs/opfs-site-storage';
 import { getSetupUrlFromUrl } from '../playground-identity';
 import { importWordPressFiles } from '@wp-playground/client';
 import { registerSiteFirstBootInitializer } from './site-first-boot-initializer';
-import { ProgressTracker, type ProgressTrackerEvent } from '@php-wasm/progress';
+import {
+	ProgressTracker,
+	type ProgressDetails,
+	type ProgressTrackerEvent,
+} from '@php-wasm/progress';
 import { logger } from '@php-wasm/logger';
 import { PlaygroundRoute, redirectTo } from '../url/router';
 
@@ -59,7 +63,7 @@ export interface SiteSettings {
 
 type PublicSiteStorageType = Exclude<SiteStorageType, 'none'> | 'temporary';
 type SaveSiteResult = { slug: string; storage: SiteStorageType };
-type ZipImportProgress = { caption: string; progress: number };
+type ZipImportProgress = ProgressDetails;
 
 const ZIP_INSTALL_PROGRESS_PERCENT = 85;
 const ZIP_STORAGE_PROGRESS_PERCENT = 100 - ZIP_INSTALL_PROGRESS_PERCENT;
@@ -868,17 +872,10 @@ export function createSitesAPI(
 						{ wordPressFilesZip },
 						{ tracker }
 					);
-					void playground
-						.goTo('/')
-						.catch((error) => {
-							logger.error(
-								'Failed to refresh imported site',
-								error
-							);
-						})
-						.finally(() => {
-							dispatch(setSiteImportIsRunning(false));
-						});
+					await playground.goTo('/').catch((error) => {
+						logger.error('Failed to refresh imported site', error);
+						throw error;
+					});
 				};
 				if (!opfsSiteStorage) {
 					return await createTemporarySite(
@@ -894,9 +891,8 @@ export function createSitesAPI(
 					initialize,
 					onProgress
 				);
-			} catch (error) {
+			} finally {
 				dispatch(setSiteImportIsRunning(false));
-				throw error;
 			}
 		},
 	};

--- a/packages/playground/website/src/lib/state/redux/site-management-api-middleware.ts
+++ b/packages/playground/website/src/lib/state/redux/site-management-api-middleware.ts
@@ -840,9 +840,9 @@ export function createSitesAPI(
 		},
 
 		/**
-		 * Creates a site from a Playground ZIP and waits until its imported
-		 * filesystem is safely stored. The import runs against first-boot MEMFS
-		 * before the initial OPFS copy, avoiding an empty-site persistence pass.
+		 * Creates an autosaved site from a Playground ZIP and waits until its
+		 * imported filesystem is safely stored. The import runs against first-boot
+		 * MEMFS before the initial OPFS copy, avoiding an empty-site persistence pass.
 		 *
 		 * @param wordPressFilesZip Playground ZIP export.
 		 * @returns The new site's slug.
@@ -887,7 +887,7 @@ export function createSitesAPI(
 				return await createSavedSite(
 					undefined,
 					undefined,
-					{},
+					{ persistence: 'autosave' },
 					initialize,
 					onProgress
 				);

--- a/packages/playground/website/src/lib/state/redux/site-management-api-middleware.ts
+++ b/packages/playground/website/src/lib/state/redux/site-management-api-middleware.ts
@@ -866,6 +866,23 @@ export function createSitesAPI(
 						});
 					}
 				);
+				const initialOpfsSyncProgress = opfsSiteStorage
+					? new ProgressTracker({
+							caption: 'Saving imported Playground',
+						})
+					: undefined;
+				initialOpfsSyncProgress?.addEventListener(
+					'progress',
+					(event: ProgressTrackerEvent) => {
+						onProgress?.({
+							caption: event.detail.caption,
+							progress:
+								ZIP_INSTALL_PROGRESS_PERCENT +
+								(event.detail.progress / 100) *
+									ZIP_STORAGE_PROGRESS_PERCENT,
+						});
+					}
+				);
 				const initialize = async (playground: PlaygroundClient) => {
 					await importWordPressFiles(
 						playground,
@@ -887,13 +904,15 @@ export function createSitesAPI(
 						initialize
 					);
 				}
-				return await createSavedSite(
+				const siteSlug = await createSavedSite(
 					undefined,
 					undefined,
 					{ persistence: 'autosave' },
 					initialize,
-					onProgress
+					initialOpfsSyncProgress
 				);
+				onProgress?.({ caption: 'Import complete', progress: 100 });
+				return siteSlug;
 			} finally {
 				dispatch(setSiteImportIsRunning(false));
 			}
@@ -931,7 +950,7 @@ export function createSitesAPI(
 			excludeFromPruning?: string[];
 		} = {},
 		initialize?: (playground: PlaygroundClient) => Promise<void>,
-		onProgress?: (progress: ZipImportProgress) => void
+		initialOpfsSyncProgress?: ProgressTracker
 	): Promise<string> {
 		if (!opfsSiteStorage) {
 			throw new Error(
@@ -956,7 +975,10 @@ export function createSitesAPI(
 				updateUrl: options.updateUrl,
 			});
 			if (initialize) {
-				await waitForInitialOpfsSync(newSiteInfo.slug, onProgress);
+				await waitForInitialOpfsSync(
+					newSiteInfo.slug,
+					initialOpfsSyncProgress
+				);
 			}
 		} catch (error) {
 			if (initialize) {
@@ -1001,7 +1023,7 @@ export function createSitesAPI(
 
 	async function waitForInitialOpfsSync(
 		siteSlug: string,
-		onProgress?: (progress: ZipImportProgress) => void
+		progress?: ProgressTracker
 	) {
 		const getSync = () =>
 			selectClientInfoBySiteSlug(getState(), siteSlug)?.opfsSync;
@@ -1013,29 +1035,25 @@ export function createSitesAPI(
 					: undefined;
 			const completedFiles = syncProgress?.files ?? 0;
 			const totalFiles = syncProgress?.total ?? 0;
-			onProgress?.({
-				caption: 'Saving imported Playground',
-				progress:
-					ZIP_INSTALL_PROGRESS_PERCENT +
-					(totalFiles > 0
-						? Math.min(1, completedFiles / totalFiles) *
-							ZIP_STORAGE_PROGRESS_PERCENT
-						: 0),
-			});
+			progress?.set(
+				totalFiles > 0
+					? Math.min(1, completedFiles / totalFiles) * 100
+					: 0
+			);
 		};
 		const sync = getSync();
 		if (!sync) {
 			const site = selectSiteBySlug(getState(), siteSlug);
 			if (!site || site.metadata.initialOpfsSyncPending !== false) {
 				throw new Error(
-					'Unable to save the imported Playground because its initial storage sync did not complete.'
+					'Unable to save the Playground because its initial storage sync did not complete.'
 				);
 			}
-			onProgress?.({ caption: 'Import complete', progress: 100 });
+			progress?.finish();
 			return;
 		}
 		if (sync.status === 'error') {
-			throw new Error('Unable to save the imported Playground.');
+			throw new Error('Unable to save the Playground.');
 		}
 		reportProgress();
 
@@ -1051,7 +1069,7 @@ export function createSitesAPI(
 						unsubscribe();
 						reject(
 							new Error(
-								'Unable to save the imported Playground because its runtime stopped.'
+								'Unable to save the Playground because its runtime stopped.'
 							)
 						);
 						return;
@@ -1063,14 +1081,9 @@ export function createSitesAPI(
 					}
 					unsubscribe();
 					if (currentSync?.status === 'error') {
-						reject(
-							new Error('Unable to save the imported Playground.')
-						);
+						reject(new Error('Unable to save the Playground.'));
 					} else {
-						onProgress?.({
-							caption: 'Import complete',
-							progress: 100,
-						});
+						progress?.finish();
 						resolve();
 					}
 				},

--- a/packages/playground/website/src/lib/state/redux/site-management-api-middleware.ts
+++ b/packages/playground/website/src/lib/state/redux/site-management-api-middleware.ts
@@ -876,6 +876,9 @@ export function createSitesAPI(
 						logger.error('Failed to refresh imported site', error);
 						throw error;
 					});
+					// The imported page is ready. Reveal it while createSavedSite waits
+					// for the initial OPFS autosave to finish.
+					dispatch(setSiteImportIsRunning(false));
 				};
 				if (!opfsSiteStorage) {
 					return await createTemporarySite(

--- a/packages/playground/website/src/lib/state/redux/slice-ui.ts
+++ b/packages/playground/website/src/lib/state/redux/slice-ui.ts
@@ -172,6 +172,7 @@ export interface UIState {
 	githubAuthRepoUrl?: string;
 	offline: boolean;
 	shareExportOpen: boolean;
+	siteImportIsRunning: boolean;
 	dockPaneIsOpen: boolean;
 	dockPaneSection: DockPaneSection;
 	/**
@@ -214,6 +215,7 @@ const initialState: UIState = {
 			: query.get('modal') || null,
 	offline: !navigator.onLine,
 	shareExportOpen: false,
+	siteImportIsRunning: false,
 	// NOTE: Please do not eliminate the cases in this dockPaneIsOpen expression,
 	// even if they seem redundant. We may experiment with toggling the Dock
 	// pane to be open by default or closed by default, and we do not want to
@@ -302,6 +304,9 @@ const uiSlice = createSlice({
 		setShareExportOpen: (state, action: PayloadAction<boolean>) => {
 			state.shareExportOpen = action.payload;
 		},
+		setSiteImportIsRunning: (state, action: PayloadAction<boolean>) => {
+			state.siteImportIsRunning = action.payload;
+		},
 		setDockPaneSection: (state, action: PayloadAction<DockPaneSection>) => {
 			state.dockPaneSection = action.payload;
 		},
@@ -384,6 +389,7 @@ export const {
 	setGitHubAuthRepoUrl,
 	setOffline,
 	setShareExportOpen,
+	setSiteImportIsRunning,
 	setDockPaneOpen,
 	setDockPaneSection,
 	setWriteOwnBlueprintDraft,


### PR DESCRIPTION
ZIP imports now leave the New Playground pane as soon as a file is selected.

The full-page `Preparing WordPress` screen stays up until the imported page is ready. The site then opens while its first OPFS autosave finishes in the Dock. The success notice appears only after that autosave completes.

Imported sites are autosaves, not permanent saves. They follow the normal autosave pruning rules.

| | Before | After |
| --- | --- | --- |
| Desktop — importing | ![Before: ZIP import blocks the New Playground pane](https://github.com/user-attachments/assets/895f2dbe-94d4-4a4b-998e-3ee9a1e7c136) | ![After: ZIP import uses the full-page Preparing WordPress screen](https://github.com/user-attachments/assets/a79252a2-5354-4eaf-ab1b-28865aa2aa4c) |
| Mobile — complete | ![Before: imported site completes without an in-page notice and is marked Saved](https://github.com/user-attachments/assets/afcaf0b7-476b-4869-8789-a92441a240b9) | ![After: imported site is marked Autosaved and shows a completion notice](https://github.com/user-attachments/assets/608f248b-420c-45ad-b6da-608d7f711355) |

## Testing

Import a Playground ZIP at desktop and mobile sizes. Check that the New Playground pane closes, the full-page loader stays until the site is ready, and the success notice appears only after the Dock autosave finishes.

Import a malformed ZIP and check that the ZIP tab reopens with an inline error.
