### PR TITLE
[Website] Add front-page thumbnails to saved Playgrounds

### DIFF
--- a/packages/playground/website/playwright/e2e/website-ui.spec.ts
+++ b/packages/playground/website/playwright/e2e/website-ui.spec.ts
@@ -2859,6 +2859,58 @@ test.describe('Default Playground storage', () => {
 		).toBe(true);
 	});
 
+	test('should persist a front-page thumbnail for a saved Playground', async ({
+		website,
+		browserName,
+	}) => {
+		test.skip(browserName !== 'chromium', 'This test requires OPFS.');
+
+		await website.goto(getUniqueSavedPlaygroundSetupUrl('thumbnail'));
+		await expect(
+			website.page.getByRole('button', { name: 'Autosaved' })
+		).toBeVisible({ timeout: 120000 });
+		const activeSite = await getActivePlaygroundSite(website.page);
+
+		await website.page
+			.getByRole('button', { name: 'Your Playgrounds' })
+			.click();
+		const thumbnail = website.page.locator(
+			`[data-playground-row="${activeSite.slug}"] [data-site-thumbnail]`
+		);
+		await expect(thumbnail).toHaveAttribute(
+			'src',
+			/^data:image\/(webp|jpeg);base64,/
+		);
+
+		const storedThumbnail = await website.page.evaluate(
+			async (siteSlug) => {
+				const root = await navigator.storage.getDirectory();
+				const sites = await root.getDirectoryHandle('sites');
+				const site = await sites.getDirectoryHandle(
+					`site-${encodeURIComponent(siteSlug)}`
+				);
+				const metadata = await site.getFileHandle('wp-runtime.json');
+				return JSON.parse(await (await metadata.getFile()).text())
+					.thumbnail;
+			},
+			activeSite.slug
+		);
+		expect(storedThumbnail.mime).toMatch(/^image\/(webp|jpeg)$/);
+		expect(storedThumbnail.data.length).toBeGreaterThan(0);
+
+		await website.goto(
+			`./?site-slug=${encodeURIComponent(activeSite.slug)}`
+		);
+		await website.waitForNestedIframes();
+		await website.page
+			.getByRole('button', { name: 'Your Playgrounds' })
+			.click();
+		await expect(thumbnail).toHaveAttribute(
+			'src',
+			`data:${storedThumbnail.mime};base64,${storedThumbnail.data}`
+		);
+	});
+
 	test('should persist WordPress changes after refreshing the default Playground', async ({
 		website,
 		browserName,

--- a/packages/playground/website/src/components/saved-playgrounds-panel/index.tsx
+++ b/packages/playground/website/src/components/saved-playgrounds-panel/index.tsx
@@ -1068,7 +1068,7 @@ export function SavedPlaygroundsPanel({
 				})}
 			>
 				<div className={css.siteRowContent} {...rowButtonProps}>
-					{renderSitePreview(site)}
+					<SitePreview site={site} />
 					<div className={css.siteRowInfo}>
 						{renderSiteRowName(site)}
 						{meta && (
@@ -1092,7 +1092,7 @@ export function SavedPlaygroundsPanel({
 				className={classNames(css.siteRow, css.currentSiteRow)}
 			>
 				<div className={css.siteRowContent}>
-					{renderSitePreview(site)}
+					<SitePreview site={site} />
 					<div className={css.siteRowInfo}>
 						<span className={css.currentSiteNameLine}>
 							{renderSiteRowName(site)}
@@ -1120,40 +1120,6 @@ export function SavedPlaygroundsPanel({
 				{renderRowActions(site)}
 			</div>
 		);
-	}
-
-	function renderSitePreview(site: SiteInfo) {
-		return (
-			<div
-				className={classNames(css.siteRowPreview, {
-					[css.siteRowPreviewFallback]: !site.metadata.thumbnail,
-				})}
-			>
-				{site.metadata.thumbnail ? (
-					<img
-						className={css.siteRowThumbnail}
-						src={getSiteImageDataURL(site.metadata.thumbnail)}
-						alt=""
-						data-site-thumbnail
-					/>
-				) : (
-					<div className={css.siteRowLogo}>
-						{site.metadata.logo ? (
-							<img
-								src={getSiteImageDataURL(site.metadata.logo)}
-								alt=""
-							/>
-						) : (
-							<WordPressIcon />
-						)}
-					</div>
-				)}
-			</div>
-		);
-	}
-
-	function getSiteImageDataURL(image: SiteImage) {
-		return `data:${image.mime};base64,${image.data}`;
 	}
 
 	function renderSiteGroup(title: string, sites: SiteInfo[]) {
@@ -1631,6 +1597,40 @@ export function SavedPlaygroundsPanel({
 			{panel !== 'playgrounds' && renderNewPlaygroundSection()}
 		</div>
 	);
+}
+
+function SitePreview({ site }: { site: SiteInfo }) {
+	return (
+		<div
+			className={classNames(css.siteRowPreview, {
+				[css.siteRowPreviewFallback]: !site.metadata.thumbnail,
+			})}
+		>
+			{site.metadata.thumbnail ? (
+				<img
+					className={css.siteRowThumbnail}
+					src={getSiteImageDataURL(site.metadata.thumbnail)}
+					alt=""
+					data-site-thumbnail
+				/>
+			) : (
+				<div className={css.siteRowLogo}>
+					{site.metadata.logo ? (
+						<img
+							src={getSiteImageDataURL(site.metadata.logo)}
+							alt=""
+						/>
+					) : (
+						<WordPressIcon />
+					)}
+				</div>
+			)}
+		</div>
+	);
+}
+
+function getSiteImageDataURL(image: SiteImage) {
+	return `data:${image.mime};base64,${image.data}`;
 }
 
 function PullRequestIcon() {

--- a/packages/playground/website/src/components/saved-playgrounds-panel/index.tsx
+++ b/packages/playground/website/src/components/saved-playgrounds-panel/index.tsx
@@ -1062,6 +1062,9 @@ export function SavedPlaygroundsPanel({
 				data-playground-row={site.slug}
 				className={classNames(css.siteRow, {
 					[css.siteRowSelected]: isSelected,
+					[css.siteRowWithThumbnail]: Boolean(
+						site.metadata.thumbnail
+					),
 				})}
 			>
 				<div className={css.siteRowContent} {...rowButtonProps}>
@@ -1086,7 +1089,11 @@ export function SavedPlaygroundsPanel({
 		return (
 			<div
 				data-playground-row={site.slug}
-				className={classNames(css.siteRow, css.currentSiteRow)}
+				className={classNames(css.siteRow, css.currentSiteRow, {
+					[css.siteRowWithThumbnail]: Boolean(
+						site.metadata.thumbnail
+					),
+				})}
 			>
 				<div className={css.siteRowContent}>
 					{renderSitePreview(site)}

--- a/packages/playground/website/src/components/saved-playgrounds-panel/index.tsx
+++ b/packages/playground/website/src/components/saved-playgrounds-panel/index.tsx
@@ -567,8 +567,8 @@ export function SavedPlaygroundsPanel({
 		}
 	};
 
-	// The save state lives in the row's status chip, so the meta line stays clean
-	// (just the date, or the location for local-directory Playgrounds).
+	// The save state lives in the row's status chip, so the meta line stays focused
+	// on runtime/date details or the local-directory location.
 	const getStoredSiteDetails = (site: SiteInfo) => {
 		if (site.metadata.storage === 'none') {
 			return 'Not saved to browser storage';
@@ -576,7 +576,10 @@ export function SavedPlaygroundsPanel({
 		if (site.metadata.storage === 'local-fs') {
 			return 'Local directory';
 		}
-		return formatSiteCreatedDate(site) ?? '';
+		const createdDate = formatSiteCreatedDate(site);
+		return isAutosavedSite(site)
+			? [getRuntimeLabel(site), createdDate].filter(Boolean).join(' · ')
+			: (createdDate ?? '');
 	};
 
 	const getCurrentSiteDetails = (site: SiteInfo) => {
@@ -1062,9 +1065,6 @@ export function SavedPlaygroundsPanel({
 				data-playground-row={site.slug}
 				className={classNames(css.siteRow, {
 					[css.siteRowSelected]: isSelected,
-					[css.siteRowWithThumbnail]: Boolean(
-						site.metadata.thumbnail
-					),
 				})}
 			>
 				<div className={css.siteRowContent} {...rowButtonProps}>
@@ -1089,11 +1089,7 @@ export function SavedPlaygroundsPanel({
 		return (
 			<div
 				data-playground-row={site.slug}
-				className={classNames(css.siteRow, css.currentSiteRow, {
-					[css.siteRowWithThumbnail]: Boolean(
-						site.metadata.thumbnail
-					),
-				})}
+				className={classNames(css.siteRow, css.currentSiteRow)}
 			>
 				<div className={css.siteRowContent}>
 					{renderSitePreview(site)}
@@ -1128,7 +1124,11 @@ export function SavedPlaygroundsPanel({
 
 	function renderSitePreview(site: SiteInfo) {
 		return (
-			<div className={css.siteRowPreview}>
+			<div
+				className={classNames(css.siteRowPreview, {
+					[css.siteRowPreviewFallback]: !site.metadata.thumbnail,
+				})}
+			>
 				{site.metadata.thumbnail ? (
 					<img
 						className={css.siteRowThumbnail}

--- a/packages/playground/website/src/components/saved-playgrounds-panel/index.tsx
+++ b/packages/playground/website/src/components/saved-playgrounds-panel/index.tsx
@@ -43,7 +43,7 @@ import {
 	useAppDispatch,
 	getActiveClientInfo,
 } from '../../lib/state/redux/store';
-import type { SiteLogo, SiteInfo } from '../../lib/state/redux/slice-sites';
+import type { SiteImage, SiteInfo } from '../../lib/state/redux/slice-sites';
 import {
 	isAutosavedSite,
 	isExplicitlySavedSite,
@@ -411,10 +411,6 @@ export function SavedPlaygroundsPanel({
 				})
 			);
 		});
-	};
-
-	const getLogoDataURL = (logo: SiteLogo): string => {
-		return `data:${logo.mime};base64,${logo.data}`;
 	};
 
 	const handleDeleteSite = (site: SiteInfo, closeMenu: () => void) => {
@@ -1069,16 +1065,7 @@ export function SavedPlaygroundsPanel({
 				})}
 			>
 				<div className={css.siteRowContent} {...rowButtonProps}>
-					<div className={css.siteRowLogo}>
-						{site.metadata.logo ? (
-							<img
-								src={getLogoDataURL(site.metadata.logo)}
-								alt=""
-							/>
-						) : (
-							<WordPressIcon />
-						)}
-					</div>
+					{renderSitePreview(site)}
 					<div className={css.siteRowInfo}>
 						{renderSiteRowName(site)}
 						{meta && (
@@ -1102,16 +1089,7 @@ export function SavedPlaygroundsPanel({
 				className={classNames(css.siteRow, css.currentSiteRow)}
 			>
 				<div className={css.siteRowContent}>
-					<div className={css.siteRowLogo}>
-						{site.metadata.logo ? (
-							<img
-								src={getLogoDataURL(site.metadata.logo)}
-								alt=""
-							/>
-						) : (
-							<WordPressIcon />
-						)}
-					</div>
+					{renderSitePreview(site)}
 					<div className={css.siteRowInfo}>
 						<span className={css.currentSiteNameLine}>
 							{renderSiteRowName(site)}
@@ -1139,6 +1117,36 @@ export function SavedPlaygroundsPanel({
 				{renderRowActions(site)}
 			</div>
 		);
+	}
+
+	function renderSitePreview(site: SiteInfo) {
+		return (
+			<div className={css.siteRowPreview}>
+				{site.metadata.thumbnail ? (
+					<img
+						className={css.siteRowThumbnail}
+						src={getSiteImageDataURL(site.metadata.thumbnail)}
+						alt=""
+						data-site-thumbnail
+					/>
+				) : (
+					<div className={css.siteRowLogo}>
+						{site.metadata.logo ? (
+							<img
+								src={getSiteImageDataURL(site.metadata.logo)}
+								alt=""
+							/>
+						) : (
+							<WordPressIcon />
+						)}
+					</div>
+				)}
+			</div>
+		);
+	}
+
+	function getSiteImageDataURL(image: SiteImage) {
+		return `data:${image.mime};base64,${image.data}`;
 	}
 
 	function renderSiteGroup(title: string, sites: SiteInfo[]) {

--- a/packages/playground/website/src/components/saved-playgrounds-panel/style.module.css
+++ b/packages/playground/website/src/components/saved-playgrounds-panel/style.module.css
@@ -1113,8 +1113,8 @@
 .playgrounds-pane .siteRowPreview {
 	align-items: center;
 	display: flex;
-	flex: 0 0 64px;
-	height: 48px;
+	flex: 0 0 128px;
+	height: 96px;
 	justify-content: center;
 }
 
@@ -1122,14 +1122,15 @@
 	background: var(--paper-3);
 	border: 1px solid var(--line-subtle);
 	border-radius: 6px;
-	height: 48px;
+	height: 96px;
 	object-fit: cover;
 	object-position: top;
-	width: 64px;
+	width: 128px;
 }
 
-/* Denser rows: the 50px gallery logo and 20px name drove the row height, so
-   trim both to fit more Playgrounds in view without scrolling. */
+/* Without a thumbnail, the 50px gallery logo and 20px name drove the row
+   height. Keep that fallback compact; thumbnail rows intentionally use the
+   larger 96px preview. */
 /* Neutral logo chips — a blue-tinted box on every row added up to a lot of
    accent; a quiet paper chip keeps the rows calm and lets the accent be rare. */
 .playgrounds-pane .siteRowLogo {

--- a/packages/playground/website/src/components/saved-playgrounds-panel/style.module.css
+++ b/packages/playground/website/src/components/saved-playgrounds-panel/style.module.css
@@ -1128,36 +1128,39 @@
 	width: 128px;
 }
 
-/* On phones, put the name above the preview. Keeping the thumbnail beside the
-   secondary details preserves a compact list without squeezing the primary
-   label into the narrow strip between the preview and the actions menu. */
+.playgrounds-pane .siteRowPreviewFallback {
+	background: var(--paper-2);
+	border: 1px solid var(--line-subtle);
+	border-radius: 6px;
+}
+
+/* On phones, align the name and details with the top of the preview. Let the
+   name use three lines before truncating so the larger thumbnail does not reduce
+   it to a single short fragment. */
 @media (max-width: 480px) {
-	.playgrounds-pane .siteRowWithThumbnail .siteRowContent {
-		flex-wrap: wrap;
-		gap: 8px 12px;
+	.playgrounds-pane .siteRow {
+		align-items: flex-start;
 	}
 
-	.playgrounds-pane .siteRowWithThumbnail .siteRowInfo {
-		display: contents;
+	.playgrounds-pane .siteRowContent {
+		align-items: flex-start;
+		gap: 8px;
 	}
 
-	.playgrounds-pane .siteRowWithThumbnail .siteRowName,
-	.playgrounds-pane .siteRowWithThumbnail .siteRowNameInput,
-	.playgrounds-pane .siteRowWithThumbnail .currentSiteNameLine {
-		flex-basis: 100%;
-		order: -1;
+	.playgrounds-pane .siteRowName {
+		-webkit-box-orient: vertical;
+		-webkit-line-clamp: 3;
+		display: -webkit-box;
+		line-height: 1.25;
+		white-space: normal;
 	}
 
-	.playgrounds-pane .siteRowWithThumbnail .siteRowDate,
-	.playgrounds-pane .siteRowWithThumbnail .siteRowSaving {
-		flex: 1;
-		min-width: 0;
+	.playgrounds-pane .siteRowActions {
+		padding-top: 8px;
+		padding-right: 0;
 	}
 }
 
-/* Without a thumbnail, the 50px gallery logo and 20px name drove the row
-   height. Keep that fallback compact; thumbnail rows intentionally use the
-   larger 96px preview. */
 /* Neutral logo chips — a blue-tinted box on every row added up to a lot of
    accent; a quiet paper chip keeps the rows calm and lets the accent be rare. */
 .playgrounds-pane .siteRowLogo {
@@ -1165,6 +1168,10 @@
 	color: var(--ink-soft);
 	height: 38px;
 	width: 38px;
+}
+
+.playgrounds-pane .siteRowPreviewFallback .siteRowLogo {
+	background: transparent;
 }
 
 .playgrounds-pane .siteRowLogo svg {

--- a/packages/playground/website/src/components/saved-playgrounds-panel/style.module.css
+++ b/packages/playground/website/src/components/saved-playgrounds-panel/style.module.css
@@ -1128,6 +1128,33 @@
 	width: 128px;
 }
 
+/* On phones, put the name above the preview. Keeping the thumbnail beside the
+   secondary details preserves a compact list without squeezing the primary
+   label into the narrow strip between the preview and the actions menu. */
+@media (max-width: 480px) {
+	.playgrounds-pane .siteRowWithThumbnail .siteRowContent {
+		flex-wrap: wrap;
+		gap: 8px 12px;
+	}
+
+	.playgrounds-pane .siteRowWithThumbnail .siteRowInfo {
+		display: contents;
+	}
+
+	.playgrounds-pane .siteRowWithThumbnail .siteRowName,
+	.playgrounds-pane .siteRowWithThumbnail .siteRowNameInput,
+	.playgrounds-pane .siteRowWithThumbnail .currentSiteNameLine {
+		flex-basis: 100%;
+		order: -1;
+	}
+
+	.playgrounds-pane .siteRowWithThumbnail .siteRowDate,
+	.playgrounds-pane .siteRowWithThumbnail .siteRowSaving {
+		flex: 1;
+		min-width: 0;
+	}
+}
+
 /* Without a thumbnail, the 50px gallery logo and 20px name drove the row
    height. Keep that fallback compact; thumbnail rows intentionally use the
    larger 96px preview. */

--- a/packages/playground/website/src/components/saved-playgrounds-panel/style.module.css
+++ b/packages/playground/website/src/components/saved-playgrounds-panel/style.module.css
@@ -1110,6 +1110,24 @@
 	padding: 8px var(--space-2);
 }
 
+.playgrounds-pane .siteRowPreview {
+	align-items: center;
+	display: flex;
+	flex: 0 0 64px;
+	height: 48px;
+	justify-content: center;
+}
+
+.playgrounds-pane .siteRowThumbnail {
+	background: var(--paper-3);
+	border: 1px solid var(--line-subtle);
+	border-radius: 6px;
+	height: 48px;
+	object-fit: cover;
+	object-position: top;
+	width: 64px;
+}
+
 /* Denser rows: the 50px gallery logo and 20px name drove the row height, so
    trim both to fit more Playgrounds in view without scrolling. */
 /* Neutral logo chips — a blue-tinted box on every row added up to a lot of

--- a/packages/playground/website/src/lib/state/opfs/opfs-site-storage.spec.ts
+++ b/packages/playground/website/src/lib/state/opfs/opfs-site-storage.spec.ts
@@ -128,6 +128,19 @@ describe('opfsSiteStorage', () => {
 		});
 	});
 
+	it('stores the saved Playground thumbnail in site metadata', async () => {
+		const thumbnail = {
+			mime: 'image/webp',
+			data: 'thumbnail-bytes',
+		};
+
+		await storage.create('stored-site', createSiteMetadata({ thumbnail }));
+
+		await expect(storage.read('stored-site')).resolves.toMatchObject({
+			metadata: { thumbnail },
+		});
+	});
+
 	it('updates setup URL params alongside site metadata', async () => {
 		await storage.create('stored-site', createSiteMetadata(), {
 			searchParams: { language: 'en_US' },

--- a/packages/playground/website/src/lib/state/redux/boot-site-client.spec.ts
+++ b/packages/playground/website/src/lib/state/redux/boot-site-client.spec.ts
@@ -64,6 +64,7 @@ vi.mock('../opfs/opfs-site-storage', () => ({
 vi.mock('@php-wasm/logger', () => ({
 	logger: {
 		error: vi.fn(),
+		warn: vi.fn(),
 	},
 }));
 

--- a/packages/playground/website/src/lib/state/redux/boot-site-client.ts
+++ b/packages/playground/website/src/lib/state/redux/boot-site-client.ts
@@ -43,6 +43,7 @@ import {
 import { PHPMYADMIN_INSTALL_PATH } from '@wp-playground/tools';
 import { phpExtensionQueryArgsToExtensionsArray } from '../url/php-extension-query';
 import { runSiteFirstBootInitializer } from './site-first-boot-initializer';
+import { captureAndPersistSiteThumbnail } from './capture-site-thumbnail';
 
 const PENDING_OPFS_SITE_REMOVAL_RETRY_DELAYS_MS = [700, 1400];
 
@@ -418,6 +419,18 @@ export function bootSiteClient(
 				signal,
 				siteSlugToReturnToIfBlueprintFails:
 					site.metadata.siteSlugToReturnToIfBlueprintFails,
+			}).then(() => {
+				const storedSite = selectSiteBySlug(getState(), site.slug);
+				if (
+					!signal.aborted &&
+					storedSite?.metadata.initialOpfsSyncPending === false
+				) {
+					void captureAndPersistSiteThumbnail({
+						playground: connectedPlayground,
+						siteSlug: site.slug,
+						dispatch,
+					});
+				}
 			});
 		} else {
 			try {
@@ -450,6 +463,13 @@ export function bootSiteClient(
 						},
 					})
 				);
+			}
+			if (site.metadata.storage !== 'none') {
+				void captureAndPersistSiteThumbnail({
+					playground: connectedPlayground,
+					siteSlug: site.slug,
+					dispatch,
+				});
 			}
 		}
 

--- a/packages/playground/website/src/lib/state/redux/capture-site-thumbnail.ts
+++ b/packages/playground/website/src/lib/state/redux/capture-site-thumbnail.ts
@@ -1,0 +1,30 @@
+import { logger } from '@php-wasm/logger';
+import type { PlaygroundClient } from '@wp-playground/client';
+import type { PlaygroundDispatch } from './store';
+import { updateSiteMetadata } from './slice-sites';
+
+/**
+ * Captures and stores a thumbnail without making thumbnail failure fail the
+ * save or boot operation that made the Playground available.
+ */
+export async function captureAndPersistSiteThumbnail({
+	playground,
+	siteSlug,
+	dispatch,
+}: {
+	playground: PlaygroundClient;
+	siteSlug: string;
+	dispatch: PlaygroundDispatch;
+}) {
+	try {
+		const thumbnail = await playground.captureSiteThumbnail();
+		await dispatch(
+			updateSiteMetadata({
+				slug: siteSlug,
+				changes: { thumbnail },
+			})
+		);
+	} catch (error) {
+		logger.warn('Could not update saved Playground thumbnail', error);
+	}
+}

--- a/packages/playground/website/src/lib/state/redux/persist-temporary-site.spec.ts
+++ b/packages/playground/website/src/lib/state/redux/persist-temporary-site.spec.ts
@@ -40,6 +40,7 @@ const mocks = vi.hoisted(() => ({
 vi.mock('@php-wasm/logger', () => ({
 	logger: {
 		error: vi.fn(),
+		warn: vi.fn(),
 	},
 }));
 

--- a/packages/playground/website/src/lib/state/redux/persist-temporary-site.ts
+++ b/packages/playground/website/src/lib/state/redux/persist-temporary-site.ts
@@ -28,6 +28,7 @@ import { PlaygroundRoute, redirectTo } from '../url/router';
 import type { SiteStorageType } from './slice-sites';
 import { setActiveModal } from './slice-ui';
 import { getSetupUrlFromSite } from '../playground-identity';
+import { captureAndPersistSiteThumbnail } from './capture-site-thumbnail';
 
 /**
  * Copies the running Playground into a durable storage backend.
@@ -297,6 +298,11 @@ export function persistTemporarySite(
 					},
 				})
 			);
+			void captureAndPersistSiteThumbnail({
+				playground,
+				siteSlug,
+				dispatch,
+			});
 		} catch (error) {
 			if (
 				storageType === 'local-fs' &&

--- a/packages/playground/website/src/lib/state/redux/slice-sites.ts
+++ b/packages/playground/website/src/lib/state/redux/slice-sites.ts
@@ -837,13 +837,20 @@ function parseSearchParams(searchParams: URLSearchParams) {
 export const SiteStorageTypes = ['opfs', 'local-fs', 'none'] as const;
 export type SiteStorageType = (typeof SiteStorageTypes)[number];
 
-/**
- * The site logo data.
- */
-export type SiteLogo = {
+export type SiteImage = {
 	mime: string;
 	data: string;
 };
+
+/**
+ * The site logo data.
+ */
+export type SiteLogo = SiteImage;
+
+/**
+ * A compact front-page image used to identify a saved Playground.
+ */
+export type SiteThumbnail = SiteImage;
 
 // TODO: Create a schema for this as the design matures
 /**
@@ -854,6 +861,7 @@ export interface SiteMetadata {
 	id: string;
 	name: string;
 	logo?: SiteLogo;
+	thumbnail?: SiteThumbnail;
 
 	// TODO: The designs show keeping admin username and password. Why do we want that?
 	whenCreated?: number;


### PR DESCRIPTION
Saved Playgrounds now show a 128×96 image of their front page instead of all sharing the same WordPress mark. When no image is available, the WordPress mark uses the same subtle 4:3 frame.

The website calls `captureSiteThumbnail()` from #4142 after saving and stores the result in the existing site metadata. A capture failure does not block saving or booting. Recent autosaves also keep their WordPress and PHP versions.

On phones, names and details align with the top of the preview and names may use three lines.

| Desktop before | Desktop after |
| --- | --- |
| ![Saved Playgrounds list using the WordPress mark](https://raw.githubusercontent.com/articles-adamziel-com/wordpress-playground/saved-playground-thumbnail-pr-assets/pr-assets/saved-playground-thumbnails/before-desktop.png) | ![Saved Playgrounds list using a front-page thumbnail](https://raw.githubusercontent.com/articles-adamziel-com/wordpress-playground/saved-playground-thumbnail-pr-assets/pr-assets/saved-playground-thumbnails/after-desktop.png?v=235f4269) |

| Mobile before | Mobile after |
| --- | --- |
| ![Mobile saved Playgrounds list using the WordPress mark](https://raw.githubusercontent.com/articles-adamziel-com/wordpress-playground/saved-playground-thumbnail-pr-assets/pr-assets/saved-playground-thumbnails/before-mobile.png) | ![Mobile saved Playgrounds list with top-aligned details and a framed fallback](https://raw.githubusercontent.com/articles-adamziel-com/wordpress-playground/saved-playground-thumbnail-pr-assets/pr-assets/saved-playground-thumbnails/after-mobile.png?v=235f4269) |

## Testing

Save a Playground, open **Your Playgrounds**, and check that its front-page thumbnail appears. Start another Playground and check that the previous entry keeps its WordPress and PHP versions under **Recent autosaves**. Reload the saved Playground and check that its thumbnail remains.
