### PR TITLE
[Website] Replace failed Blueprint runs before pruning autosaves

### DIFF
--- a/packages/playground/website/src/components/blueprint-editor/BlueprintBundleEditor.spec.tsx
+++ b/packages/playground/website/src/components/blueprint-editor/BlueprintBundleEditor.spec.tsx
@@ -25,6 +25,7 @@ const mocks = vi.hoisted(() => ({
 	fileExplorerProps: undefined as Record<string, unknown> | undefined,
 	loggerError: vi.fn(),
 	pruneAutosavedSites: vi.fn(),
+	removeSite: vi.fn(),
 	resolveRuntimeConfiguration: vi.fn(),
 	setActiveSite: vi.fn(),
 	setDockPaneOpen: vi.fn(),
@@ -73,6 +74,7 @@ vi.mock('../../lib/state/redux/slice-sites', async (importOriginal) => ({
 	...(await importOriginal<typeof SliceSitesModule>()),
 	createStoredSite: mocks.createStoredSite,
 	pruneAutosavedSites: mocks.pruneAutosavedSites,
+	removeSite: mocks.removeSite,
 	updateSite: mocks.updateSite,
 }));
 
@@ -123,6 +125,7 @@ describe('BlueprintBundleEditor Run barrier', () => {
 		mocks.dispatch.mockReset();
 		mocks.loggerError.mockReset();
 		mocks.pruneAutosavedSites.mockReset();
+		mocks.removeSite.mockReset();
 		mocks.resolveRuntimeConfiguration.mockReset();
 		mocks.setActiveSite.mockReset();
 		mocks.setActiveSite.mockImplementation((slug) => ({
@@ -214,15 +217,18 @@ describe('BlueprintBundleEditor Run barrier', () => {
 		expect(mocks.resolveRuntimeConfiguration).not.toHaveBeenCalled();
 	});
 
-	it('keeps the original return target when an unfinished Blueprint run is run again', async () => {
+	it('keeps the return target and removes the failed run before pruning on retry', async () => {
 		const failedRun = createStoredSiteInfo('autosave', 'failed-run');
 		failedRun.metadata.siteSlugToReturnToIfBlueprintFails = 'original-site';
 		const replacement = createStoredSiteInfo('autosave', 'replacement');
 		const createAction = { type: 'create-stored-site' };
+		const activateAction = { type: 'activate-replacement' };
+		const removeAction = { type: 'remove-site' };
+		const pruneAction = { type: 'prune-autosaves' };
 		mocks.createStoredSite.mockReturnValue(createAction);
-		mocks.pruneAutosavedSites.mockReturnValue({
-			type: 'prune-autosaves',
-		});
+		mocks.setActiveSite.mockReturnValue(activateAction);
+		mocks.removeSite.mockReturnValue(removeAction);
+		mocks.pruneAutosavedSites.mockReturnValue(pruneAction);
 		mocks.dispatch.mockImplementation((action) =>
 			action === createAction ? Promise.resolve(replacement) : action
 		);
@@ -242,6 +248,49 @@ describe('BlueprintBundleEditor Run barrier', () => {
 		expect(mocks.pruneAutosavedSites).toHaveBeenCalledWith({
 			excludeSlugs: ['original-site', replacement.slug],
 		});
+		expect(mocks.removeSite).toHaveBeenCalledWith(failedRun.slug);
+		const dispatchedActions = mocks.dispatch.mock.calls.map(
+			([action]) => action
+		);
+		expect(dispatchedActions).toContain(removeAction);
+		expect(dispatchedActions).toContain(pruneAction);
+		expect(dispatchedActions.indexOf(activateAction)).toBeLessThan(
+			dispatchedActions.indexOf(removeAction)
+		);
+		expect(dispatchedActions.indexOf(removeAction)).toBeLessThan(
+			dispatchedActions.indexOf(pruneAction)
+		);
+	});
+
+	it('does not prune autosaves when the failed run cannot be discarded', async () => {
+		const failedRun = createStoredSiteInfo('autosave', 'failed-run');
+		failedRun.metadata.siteSlugToReturnToIfBlueprintFails = 'original-site';
+		const replacement = createStoredSiteInfo('autosave', 'replacement');
+		const createAction = { type: 'create-stored-site' };
+		const removeAction = { type: 'remove-site' };
+		const pruneAction = { type: 'prune-autosaves' };
+		const deletionError = new Error('Could not delete failed run');
+		mocks.createStoredSite.mockReturnValue(createAction);
+		mocks.removeSite.mockReturnValue(removeAction);
+		mocks.pruneAutosavedSites.mockReturnValue(pruneAction);
+		mocks.dispatch.mockImplementation((action) => {
+			if (action === createAction) {
+				return Promise.resolve(replacement);
+			}
+			if (action === removeAction) {
+				return Promise.reject(deletionError);
+			}
+			return action;
+		});
+		const editorRef = await renderEditor({ site: failedRun });
+
+		await act(async () => editorRef.current!.runBlueprint());
+
+		expect(mocks.pruneAutosavedSites).not.toHaveBeenCalled();
+		expect(mocks.loggerError).toHaveBeenCalledWith(
+			'Failed to discard Blueprint run',
+			deletionError
+		);
 	});
 
 	it('queues Run until the source Playground finishes syncing to OPFS', async () => {
@@ -409,36 +458,6 @@ describe('BlueprintBundleEditor Run barrier', () => {
 
 		expect(mocks.createStoredSite).toHaveBeenCalledTimes(2);
 		expect(mocks.setActiveSite).toHaveBeenCalledWith(newSite.slug);
-	});
-
-	it('keeps a committed Playground when autosave pruning fails', async () => {
-		const sourceSite = createStoredSiteInfo('autosave');
-		const newSite = createStoredSiteInfo('autosave', 'blueprint-copy');
-		const createAction = { type: 'create-stored-site' };
-		const pruneAction = { type: 'prune-autosaves' };
-		mocks.createStoredSite.mockReturnValue(createAction);
-		mocks.pruneAutosavedSites.mockReturnValue(pruneAction);
-		mocks.dispatch.mockImplementation((action) => {
-			if (action === createAction) {
-				return Promise.resolve(newSite);
-			}
-			if (action === pruneAction) {
-				return Promise.reject(new Error('Could not prune'));
-			}
-			return action;
-		});
-		const editorRef = await renderEditor({ site: sourceSite });
-
-		await act(async () => editorRef.current!.runBlueprint());
-
-		expect(mocks.setActiveSite).toHaveBeenCalledWith(newSite.slug);
-		expect(container.textContent).not.toContain(
-			'Could not create Playground. Try again.'
-		);
-		expect(mocks.loggerError).toHaveBeenCalledWith(
-			'Failed to prune autosaved Playgrounds',
-			expect.any(Error)
-		);
 	});
 
 	it('shows that stored Blueprints run in a fresh Playground', async () => {

--- a/packages/playground/website/src/components/blueprint-editor/BlueprintBundleEditor.tsx
+++ b/packages/playground/website/src/components/blueprint-editor/BlueprintBundleEditor.tsx
@@ -60,8 +60,10 @@ import { removeClientInfo } from '../../lib/state/redux/slice-clients';
 import {
 	createStoredSite,
 	isAutosavedSite,
+	isUnfinishedBlueprintRun,
 	isStoredSite,
 	pruneAutosavedSites,
+	removeSite,
 	type SiteInfo,
 	updateSite,
 } from '../../lib/state/redux/slice-sites';
@@ -328,6 +330,8 @@ export const BlueprintBundleEditor = forwardRef<
 	const hasValidationErrors =
 		validationResult !== null && !validationResult.valid;
 	const storedSiteSlug = site && isStoredSite(site) ? site.slug : undefined;
+	const siteIsUnfinishedBlueprintRun =
+		!!site && isUnfinishedBlueprintRun(site);
 	// initialOpfsSyncPending can remain set after a failed boot. Queue only while
 	// the live client reports a copy; cancel on an explicit sync error.
 	const opfsSyncStatus = useAppSelector((state) => {
@@ -476,26 +480,26 @@ export const BlueprintBundleEditor = forwardRef<
 						}
 					)
 				);
-				try {
-					await dispatch(
-						pruneAutosavedSites({
-							excludeSlugs: [
-								siteSlugToReturnToIfBlueprintFails,
-								newSite.slug,
-							],
-						})
-					);
-				} catch (error) {
-					// The new Playground is already committed. Retention cleanup is
-					// housekeeping and must not turn a successful run into a retry
-					// that creates a duplicate Playground.
-					logger.error(
-						'Failed to prune autosaved Playgrounds',
-						error
-					);
-				}
 				dispatch(setDockPaneOpen(false));
 				dispatch(setActiveSite(newSite.slug));
+				if (siteIsUnfinishedBlueprintRun) {
+					try {
+						await dispatch(removeSite(site.slug));
+					} catch (error) {
+						logger.error('Failed to discard Blueprint run', error);
+						// Pruning while the failed run still counts toward the limit
+						// could discard an unrelated Playground.
+						return;
+					}
+				}
+				await dispatch(
+					pruneAutosavedSites({
+						excludeSlugs: [
+							siteSlugToReturnToIfBlueprintFails,
+							newSite.slug,
+						],
+					})
+				);
 				return;
 			}
 			const runtimeConfiguration = await resolveRuntimeConfiguration(
@@ -537,6 +541,7 @@ export const BlueprintBundleEditor = forwardRef<
 		dispatch,
 		filesystem,
 		hasValidationErrors,
+		siteIsUnfinishedBlueprintRun,
 		opfsSyncStatus,
 		readOnly,
 		saveFile,
@@ -1071,7 +1076,10 @@ export const BlueprintBundleEditor = forwardRef<
 								</Notice>
 							</div>
 						) : null}
-						{isStored ? (
+						{isStored &&
+						site &&
+						(opfsSyncStatus === 'syncing' ||
+							!siteIsUnfinishedBlueprintRun) ? (
 							<p className={styles.runHint}>
 								{isWaitingToRun ? (
 									'Run will wait for this Playground to finish saving.'


### PR DESCRIPTION
Part of #4099.

Builds on #4129.

Retrying an unfinished Blueprint run now replaces the failed Playground before autosave pruning begins.

The retry keeps the original Playground as its return target, creates and activates the replacement, and then removes the failed run. Only after that succeeds does it prune old autosaves. If the failed run cannot be removed, pruning stops instead of deleting an unrelated Playground to make room.

Autosave pruning already handles its own deletion failures, so the Blueprint editor no longer wraps it in a second `try/catch`. The editor also stops claiming that the failed run will remain in Recent after retry.

## Testing

From a stored Playground, run a Blueprint with `preferredVersions.wp` set to `999.9`. Open the failed run in the Blueprint editor, change the version to `latest`, and run it again. Confirm the replacement opens, the original Playground remains, and the failed run is absent from Recent.
