### PR TITLE
[Website] Make desktop address suggestions clickable and input-width

### DIFF
--- a/packages/playground/website/playwright/e2e/website-ui.spec.ts
+++ b/packages/playground/website/playwright/e2e/website-ui.spec.ts
@@ -229,6 +229,21 @@ test('should correctly load /wp-admin without the trailing slash', async ({
 	);
 });
 
+test('should navigate from the address bar suggestions', async ({
+	website,
+}) => {
+	await website.goto('./?storage=temp');
+	const dock = website.page.getByRole('navigation', {
+		name: 'Playground tools',
+	});
+	const address = dock.getByRole('combobox');
+
+	await address.click();
+	await website.page.getByRole('option', { name: /Dashboard/ }).click();
+
+	await expect(address).toHaveValue('/wp-admin/');
+});
+
 test('should route tools through one Dock pane', async ({ website }) => {
 	await website.goto('./?storage=temp');
 	const dock = website.page.getByRole('navigation', {

--- a/packages/playground/website/src/components/address-bar/index.tsx
+++ b/packages/playground/website/src/components/address-bar/index.tsx
@@ -70,6 +70,7 @@ const quickNavItems: QuickNavItem[] = [
 interface AddressBarProps {
 	url?: string;
 	onUpdate?: (url: string) => void;
+	isMobile?: boolean;
 	/**
 	 * Renders the bar inert (e.g. while the Playground is still booting and
 	 * there is no client to navigate yet) instead of hiding it, so the Dock
@@ -78,9 +79,16 @@ interface AddressBarProps {
 	disabled?: boolean;
 }
 
+/**
+ * Renders the Dock's URL input and quick-navigation list.
+ *
+ * The desktop popover follows the full input width while mobile keeps its
+ * compact presentation.
+ */
 export default function AddressBar({
 	url,
 	onUpdate,
+	isMobile = false,
 	disabled = false,
 }: AddressBarProps) {
 	const inputRef = useRef<HTMLInputElement>(null);
@@ -112,24 +120,33 @@ export default function AddressBar({
 		}
 	}, [disabled, url]);
 
-	// Update listbox width when it opens and track resize.
+	// Match the full input width on desktop while preserving the compact mobile
+	// sizing, and keep both widths in sync when the input resizes.
 	useEffect(() => {
 		if (!isOpen || !inputRef.current) {
 			return;
 		}
-		setMenuWidth(inputRef.current.offsetWidth);
+		setMenuWidth(
+			isMobile
+				? inputRef.current.offsetWidth
+				: inputRef.current.getBoundingClientRect().width
+		);
 		if (typeof ResizeObserver === 'undefined') {
 			return;
 		}
 
 		const resizeObserver = new ResizeObserver((entries) => {
 			for (const entry of entries) {
-				setMenuWidth(entry.contentRect.width);
+				setMenuWidth(
+					isMobile
+						? entry.contentRect.width
+						: entry.target.getBoundingClientRect().width
+				);
 			}
 		});
 		resizeObserver.observe(inputRef.current);
 		return () => resizeObserver.disconnect();
-	}, [isOpen]);
+	}, [isMobile, isOpen]);
 
 	function closeSuggestions() {
 		setIsOpen(false);
@@ -262,6 +279,7 @@ export default function AddressBar({
 				{isOpen && (
 					<Popover
 						placement="top-start"
+						offset={isMobile ? undefined : 8}
 						onClose={closeSuggestions}
 						anchor={inputRef.current}
 						noArrow={true}

--- a/packages/playground/website/src/components/dock/dock.tsx
+++ b/packages/playground/website/src/components/dock/dock.tsx
@@ -574,12 +574,12 @@ export function Dock({
 	// already fixed to an edge and keep their native control interactions.
 	const canDrag = !isMobile && !isFullWidth;
 
-	/** Reports whether a target is a real Dock control. */
-	const isInteractiveTarget = (target: EventTarget | null) =>
+	/** Reports whether a target belongs to a Dock control, including a portal. */
+	const isDockControlTarget = (target: EventTarget | null) =>
 		target instanceof Element &&
 		Boolean(
 			target.closest(
-				'button, a, input, textarea, select, [role="menu"], [role="menuitem"]'
+				'button, a, input, textarea, select, [role="menu"], [role="menuitem"], [role="listbox"]'
 			)
 		);
 
@@ -609,20 +609,12 @@ export function Dock({
 	// Controls keep native press, selection, and motor-tolerance behavior. The
 	// surrounding Dock chrome remains a large drag handle without turning a small
 	// pointer wobble on a button into an accidental Dock move.
-	const isNativePressTarget = (target: EventTarget | null) =>
-		target instanceof Element &&
-		Boolean(
-			target.closest(
-				'button, input, textarea, select, a, [role="menu"], [role="menuitem"]'
-			)
-		);
-
 	/** Arms a whole-surface horizontal drag and swallows clicks after real drags. */
 	const handleDockPointerDown = (event: ReactPointerEvent<HTMLElement>) => {
 		if (
 			!canDrag ||
 			event.button !== 0 ||
-			isNativePressTarget(event.target)
+			isDockControlTarget(event.target)
 		) {
 			return;
 		}
@@ -756,7 +748,7 @@ export function Dock({
 			return;
 		}
 		setDockSheen(
-			isInteractiveTarget(event.target) ? 0.12 : 1,
+			isDockControlTarget(event.target) ? 0.12 : 1,
 			event.clientX
 		);
 	};
@@ -1217,6 +1209,7 @@ export function Dock({
 						<div className={css.dockAddress}>
 							<AddressBar
 								url={clientInfo?.url}
+								isMobile={isMobile}
 								disabled={!clientInfo}
 								onUpdate={
 									clientInfo


### PR DESCRIPTION
## Motivation for the change, related issues

Desktop address suggestions could not be clicked because their portaled listbox reached the floating Dock's pointer handler and was captured as a drag surface.

## Implementation details

The Dock now treats the listbox as a control, so suggestion clicks retain their native pointer sequence. The desktop popover also follows the full URL input width and sits 8px above it. Mobile keeps its existing compact width and position.

### Desktop

| Before | After |
| --- | --- |
| ![Narrow address suggestion popover touching the URL input](https://gist.githubusercontent.com/adamziel/c3cbb328e6cdc90e1eb3246875dbe758/raw/d8e665552b9d72f2d2450098a9b0bb41459054e3/desktop-before.svg) | ![Address suggestion popover matching the URL input with a small gap](https://gist.githubusercontent.com/adamziel/c3cbb328e6cdc90e1eb3246875dbe758/raw/bd3585919ff9055cb34ca091ab74ebc16d996769/desktop-after.svg) |

### Mobile (unchanged)

| Before | After |
| --- | --- |
| ![Compact mobile address suggestion popover](https://gist.githubusercontent.com/adamziel/c3cbb328e6cdc90e1eb3246875dbe758/raw/d2186d7b7971d606de9643a721cfb7406fa8803e/mobile-before.svg) | ![Unchanged compact mobile address suggestion popover](https://gist.githubusercontent.com/adamziel/c3cbb328e6cdc90e1eb3246875dbe758/raw/d2186d7b7971d606de9643a721cfb7406fa8803e/mobile-after.svg) |

## Testing Instructions (or ideally a Blueprint)

On desktop, focus the URL input and click Dashboard. Confirm WordPress navigates to `/wp-admin/`, the popover matches the input width, and a small gap separates them. Resize to mobile and confirm the compact popover layout still behaves as before.
