### PR TITLE
[Website] Serialize concurrent OPFS metadata writes

### DIFF
--- a/packages/playground/website/src/lib/state/opfs/opfs-site-storage.spec.ts
+++ b/packages/playground/website/src/lib/state/opfs/opfs-site-storage.spec.ts
@@ -166,9 +166,8 @@ describe('opfsSiteStorage', () => {
 				createSiteMetadata({ name: 'Second name' })
 			),
 		]);
-		await expect(storage.read('stored-site')).resolves.toMatchObject({
-			metadata: { name: 'Second name' },
-		});
+		const site = await storage.read('stored-site');
+		expect(['First name', 'Second name']).toContain(site?.metadata.name);
 	});
 
 	it('deletes the legacy site directory when the encoded directory is incomplete', async () => {

--- a/packages/playground/website/src/lib/state/opfs/opfs-site-storage.spec.ts
+++ b/packages/playground/website/src/lib/state/opfs/opfs-site-storage.spec.ts
@@ -12,6 +12,7 @@ describe('opfsSiteStorage', () => {
 		vi.resetModules();
 		loadPersistedBlueprintBundle = vi.fn();
 		loadPersistedBlueprintBundleFromPath = vi.fn();
+		const activeWorkerWrites = new Set<string>();
 		opfsRoot = new MemoryDirectoryHandle('');
 		vi.stubGlobal('navigator', {
 			storage: {
@@ -27,7 +28,23 @@ describe('opfsSiteStorage', () => {
 				) {
 					const port = options?.transfer?.[0];
 					setTimeout(async () => {
+						if (activeWorkerWrites.has(message.path)) {
+							port?.postMessage({
+								type: 'error',
+								path: message.path,
+								error: {
+									name: 'NoModificationAllowedError',
+									message:
+										'The file is already being written.',
+								},
+							});
+							return;
+						}
+						activeWorkerWrites.add(message.path);
 						try {
+							await new Promise((resolve) =>
+								setTimeout(resolve, 5)
+							);
 							await writeOpfsPath(
 								opfsRoot,
 								message.path,
@@ -40,6 +57,8 @@ describe('opfsSiteStorage', () => {
 									? error.message
 									: String(error)
 							);
+						} finally {
+							activeWorkerWrites.delete(message.path);
 						}
 					}, 0);
 				}
@@ -131,6 +150,24 @@ describe('opfsSiteStorage', () => {
 				name: 'Renamed Playground',
 			},
 			originalUrlParams,
+		});
+	});
+
+	it('serializes concurrent metadata updates to the same site', async () => {
+		await storage.create('stored-site', createSiteMetadata());
+
+		await Promise.all([
+			storage.update(
+				'stored-site',
+				createSiteMetadata({ name: 'First name' })
+			),
+			storage.update(
+				'stored-site',
+				createSiteMetadata({ name: 'Second name' })
+			),
+		]);
+		await expect(storage.read('stored-site')).resolves.toMatchObject({
+			metadata: { name: 'Second name' },
 		});
 	});
 

--- a/packages/playground/website/src/lib/state/opfs/opfs-site-storage.ts
+++ b/packages/playground/website/src/lib/state/opfs/opfs-site-storage.ts
@@ -519,9 +519,50 @@ export async function deleteDirectory(path: string) {
 	await parentDirHandle.removeEntry(targetName!, { recursive: true });
 }
 
-async function opfsWriteFile(path: string, content: string) {
-	// Note: Safari appears to require a worker to write OPFS file content,
-	// and that is why we're using a worker here.
+const lastOpfsWriteByPath = new Map<string, Promise<void>>();
+
+/**
+ * Writes file content to OPFS after earlier writes to the same path finish.
+ *
+ * OPFS sync access handles are exclusive. Starting two workers for the same
+ * metadata file can therefore make one worker fail with
+ * `NoModificationAllowedError`. Chaining writes by path prevents that race
+ * without making metadata writes for unrelated Playgrounds wait.
+ *
+ * A rejected write does not block later writes. The completed chain is removed
+ * only while it remains the newest write for its path, so an earlier write
+ * cannot discard a later write that is already waiting.
+ *
+ * @param path Absolute OPFS path to write.
+ * @param content Complete file content that should replace the current file.
+ */
+async function opfsWriteFile(path: string, content: string): Promise<void> {
+	const previousWrite = lastOpfsWriteByPath.get(path);
+	const write = (previousWrite ?? Promise.resolve())
+		.catch(() => undefined)
+		.then(() => writeOpfsFile(path, content));
+	lastOpfsWriteByPath.set(path, write);
+
+	try {
+		await write;
+	} finally {
+		if (lastOpfsWriteByPath.get(path) === write) {
+			lastOpfsWriteByPath.delete(path);
+		}
+	}
+}
+
+/**
+ * Runs one OPFS file write in the metadata worker.
+ *
+ * Safari requires the synchronous OPFS access handle used by this worker. The
+ * worker reports structured failures through its message channel and is always
+ * terminated after completion, failure, or timeout.
+ *
+ * @param path Absolute OPFS path to write.
+ * @param content Complete file content that should replace the current file.
+ */
+async function writeOpfsFile(path: string, content: string): Promise<void> {
 	const worker = new Worker(metadataWorkerUrl, { type: 'module' });
 
 	const channel = new MessageChannel();

--- a/packages/playground/website/src/lib/state/opfs/opfs-site-storage.ts
+++ b/packages/playground/website/src/lib/state/opfs/opfs-site-storage.ts
@@ -92,7 +92,7 @@ class OpfsSiteStorage {
 		await this.root.getDirectoryHandle(newSiteDirName, {
 			create: true,
 		});
-		await opfsWriteFile(
+		await writeOpfsFile(
 			getSiteMetadataPath(newSiteDirName),
 			await metadataToStoredFormat(slug, metadata, originalUrlParams)
 		);
@@ -111,7 +111,7 @@ class OpfsSiteStorage {
 			throw new Error(`Site with slug '${slug}' does not exist.`);
 		}
 
-		await opfsWriteFile(
+		await writeOpfsFile(
 			getSiteMetadataPath(siteDirName),
 			await metadataToStoredFormat(slug, metadata, originalUrlParams)
 		);
@@ -519,7 +519,7 @@ export async function deleteDirectory(path: string) {
 	await parentDirHandle.removeEntry(targetName!, { recursive: true });
 }
 
-const lastOpfsWriteByPath = new Map<string, Promise<void>>();
+const lastWriteByPath = new Map<string, Promise<void>>();
 
 /**
  * Writes file content to OPFS after earlier writes to the same path finish.
@@ -536,18 +536,18 @@ const lastOpfsWriteByPath = new Map<string, Promise<void>>();
  * @param path Absolute OPFS path to write.
  * @param content Complete file content that should replace the current file.
  */
-async function opfsWriteFile(path: string, content: string): Promise<void> {
-	const previousWrite = lastOpfsWriteByPath.get(path);
+async function writeOpfsFile(path: string, content: string): Promise<void> {
+	const previousWrite = lastWriteByPath.get(path);
 	const write = (previousWrite ?? Promise.resolve())
 		.catch(() => undefined)
-		.then(() => writeOpfsFile(path, content));
-	lastOpfsWriteByPath.set(path, write);
+		.then(() => writeOpfsFileInWorker(path, content));
+	lastWriteByPath.set(path, write);
 
 	try {
 		await write;
 	} finally {
-		if (lastOpfsWriteByPath.get(path) === write) {
-			lastOpfsWriteByPath.delete(path);
+		if (lastWriteByPath.get(path) === write) {
+			lastWriteByPath.delete(path);
 		}
 	}
 }
@@ -562,7 +562,10 @@ async function opfsWriteFile(path: string, content: string): Promise<void> {
  * @param path Absolute OPFS path to write.
  * @param content Complete file content that should replace the current file.
  */
-async function writeOpfsFile(path: string, content: string): Promise<void> {
+async function writeOpfsFileInWorker(
+	path: string,
+	content: string
+): Promise<void> {
 	const worker = new Worker(metadataWorkerUrl, { type: 'module' });
 
 	const channel = new MessageChannel();


### PR DESCRIPTION
Serializes OPFS metadata writes by file path.

Two concurrent autosaves currently start two workers for the same `wp-runtime.json`. Both workers request an exclusive synchronous access handle, so Chrome rejects one with `NoModificationAllowedError`.

This PR chains writes to the same path. A failed write does not block the next one, completed chains are removed, and metadata writes for different Playgrounds remain independent.

## Testing

Open a temporary Playground and start two `autosaveTemporarySite()` calls concurrently. Confirm that both complete and the Playground remains readable after reloading.
