### PR TITLE
[Website] Validate plugin proxy redirect destinations

### DIFF
--- a/packages/playground/website/playwright/e2e/plugin-proxy-test-router.php
+++ b/packages/playground/website/playwright/e2e/plugin-proxy-test-router.php
@@ -1,0 +1,33 @@
+<?php
+
+// This test needs a PHP request router because it verifies the HTTP headers
+// emitted by PHP's header() function, not just the helper's array bookkeeping.
+// The test-only route invokes sendBufferedResponseHeaders() with controlled
+// upstream, allowlist, and default-header inputs. Returning false for every
+// other URL lets the built-in server handle ordinary proxy requests.
+if (
+	parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH)
+	!== '/__test-default-response-headers'
+) {
+	return false;
+}
+
+// plugin-proxy.php has no import-only entry point. Requiring it also dispatches
+// this test-only request, which dies with a 400 invalid-query response. Buffer
+// that response and replace it from a shutdown callback after the helper has
+// been defined.
+$allow_content_type = isset($_GET['allow-content-type']);
+ob_start();
+register_shutdown_function(function () use ($allow_content_type) {
+	ob_clean();
+	header_remove();
+	http_response_code(200);
+	sendBufferedResponseHeaders(
+		[['content-type', "Content-Type: application/octet-stream\r\n"]],
+		$allow_content_type ? ['content-type'] : ['content-length'],
+		['Content-Type: application/zip']
+	);
+	echo 'body';
+});
+
+require __DIR__ . '/../../public/plugin-proxy.php';

--- a/packages/playground/website/playwright/e2e/plugin-proxy.spec.ts
+++ b/packages/playground/website/playwright/e2e/plugin-proxy.spec.ts
@@ -1,0 +1,345 @@
+import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
+import { once } from 'node:events';
+import {
+	createServer,
+	type IncomingMessage,
+	type Server,
+	type ServerResponse,
+} from 'node:http';
+import { expect, test } from '@playwright/test';
+import { joinPaths } from '@php-wasm/util';
+
+/**
+ * Stable contract: URL mode follows allowed redirects, but rejects an off-list
+ * redirect before the destination receives a request.
+ * Plausible regression: automatic cURL redirects are re-enabled for URL mode.
+ * Independent path: these tests call the real endpoint and record requests
+ * received by a separate in-process HTTP server.
+ */
+
+test.describe.configure({ mode: 'serial' });
+test.skip(
+	({ browserName }) => browserName !== 'chromium',
+	'This server-side endpoint behavior only needs one Playwright project.'
+);
+
+const pluginProxyDocumentRoot = joinPaths(__dirname, '../../public');
+
+let requestDestinations: string[] = [];
+let pluginProxyUrl = '';
+let upstreamServer: Server | undefined;
+let pluginProxyServer: PhpServer | undefined;
+
+test.beforeAll(async () => {
+	upstreamServer = createServer(routeUpstreamRequest);
+	const upstreamPort = await listenOnAvailablePort(upstreamServer);
+
+	const pluginProxyPort = await getAvailablePort();
+	pluginProxyUrl = `http://127.0.0.1:${pluginProxyPort}/plugin-proxy.php`;
+	pluginProxyServer = startPhpServer(
+		[
+			'-d',
+			'display_errors=0',
+			'-S',
+			`127.0.0.1:${pluginProxyPort}`,
+			'-t',
+			pluginProxyDocumentRoot,
+		],
+		{
+			http_proxy: `http://127.0.0.1:${upstreamPort}`,
+			HTTP_PROXY: '',
+			https_proxy: '',
+			HTTPS_PROXY: '',
+			all_proxy: '',
+			ALL_PROXY: '',
+			no_proxy: '',
+			NO_PROXY: '',
+		}
+	);
+	await waitForPhpServer(pluginProxyServer, pluginProxyUrl);
+});
+
+test.beforeEach(async () => {
+	requestDestinations = [];
+});
+
+test.afterAll(async () => {
+	await Promise.all([
+		stopPhpServer(pluginProxyServer),
+		stopHttpServer(upstreamServer),
+	]);
+});
+
+test('rejects a direct off-allowlist URL without fetching it', async ({
+	request,
+}) => {
+	const response = await request.get(
+		urlForTarget('http://example.com/direct')
+	);
+
+	expect(response.status()).toBe(403);
+	expect(await response.text()).toBe(
+		'Error: The specified URL is not allowed.'
+	);
+	expect(requestDestinations).toEqual([]);
+});
+
+test('follows absolute and relative redirects within the allowlist', async ({
+	request,
+}) => {
+	const response = await request.get(
+		urlForTarget('http://wordpress.org/redirect-chain?original=query')
+	);
+
+	expect(response.status()).toBe(200);
+	expect(await response.json()).toEqual({
+		host: 'w.org',
+		method: 'GET',
+		body: '',
+		query: { source: 'relative', token: 'kept' },
+	});
+	expect(requestDestinations).toEqual([
+		'wordpress.org /redirect-chain',
+		'w.org /redirect-relative',
+		'w.org /final',
+	]);
+});
+
+test('rejects an off-allowlist redirect before fetching it', async ({
+	request,
+}) => {
+	const response = await request.get(
+		urlForTarget('http://wordpress.org/redirect-to-blocked')
+	);
+
+	expect(response.status()).toBe(403);
+	expect(requestDestinations).toEqual(['wordpress.org /redirect-to-blocked']);
+});
+
+test('preserves cURL POST redirect behavior', async ({ request }) => {
+	const response302 = await request.post(
+		urlForTarget('http://wordpress.org/redirect-post-302'),
+		{
+			data: 'payload=discarded',
+			headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+		}
+	);
+	expect(await response302.json()).toEqual({
+		host: 'wordpress.org',
+		method: 'GET',
+		body: '',
+		query: {},
+	});
+
+	const response307 = await request.post(
+		urlForTarget('http://wordpress.org/redirect-post-307'),
+		{
+			data: 'payload=preserved',
+			headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+		}
+	);
+	expect(await response307.json()).toEqual({
+		host: 'wordpress.org',
+		method: 'POST',
+		body: 'payload=preserved',
+		query: {},
+	});
+});
+
+test('bounds redirect loops', async ({ request }) => {
+	const response = await request.get(
+		urlForTarget('http://wordpress.org/loop')
+	);
+
+	expect(response.status()).toBe(400);
+	expect(await response.json()).toEqual({ error: 'Too many redirects' });
+});
+
+function urlForTarget(targetUrl: string) {
+	const url = new URL(pluginProxyUrl);
+	url.searchParams.set('url', targetUrl);
+	return url.href;
+}
+
+function routeUpstreamRequest(
+	request: IncomingMessage,
+	response: ServerResponse
+) {
+	handleUpstreamRequest(request, response).catch((error) => {
+		if (!response.headersSent) {
+			response.statusCode = 500;
+		}
+		response.end(error instanceof Error ? error.message : String(error));
+	});
+}
+
+async function handleUpstreamRequest(
+	request: IncomingMessage,
+	response: ServerResponse
+) {
+	const requestUrl = new URL(
+		request.url || '/',
+		`http://${request.headers.host || '127.0.0.1'}`
+	);
+	const host = requestUrl.hostname;
+	const path = requestUrl.pathname;
+	const body = await readRequestBody(request);
+	requestDestinations.push(`${host} ${path}`);
+
+	switch (path) {
+		case '/redirect-chain':
+			response.writeHead(302, {
+				Location: 'http://w.org/redirect-relative?step=2',
+			});
+			response.end('first intermediate response');
+			return;
+
+		case '/redirect-relative':
+			response.writeHead(302, {
+				Location: '/final?source=relative&token=kept',
+			});
+			response.end('second intermediate response');
+			return;
+
+		case '/redirect-to-blocked':
+			response.writeHead(302, {
+				Location: 'http://example.com/blocked',
+			});
+			response.end('blocked intermediate response');
+			return;
+
+		case '/redirect-post-302':
+			response.writeHead(302, { Location: '/echo-request' });
+			response.end();
+			return;
+
+		case '/redirect-post-307':
+			response.writeHead(307, { Location: '/echo-request' });
+			response.end();
+			return;
+
+		case '/loop':
+			response.writeHead(302, { Location: '/loop' });
+			response.end();
+			return;
+
+		case '/final':
+		case '/echo-request':
+			response.setHeader('Content-Type', 'application/json');
+			response.end(
+				JSON.stringify({
+					host,
+					method: request.method || 'GET',
+					body,
+					query: Object.fromEntries(requestUrl.searchParams),
+				})
+			);
+			return;
+
+		default:
+			response.statusCode = 404;
+			response.end('Not Found');
+	}
+}
+
+async function readRequestBody(request: IncomingMessage) {
+	const chunks: Buffer[] = [];
+	for await (const chunk of request) {
+		chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+	}
+	return Buffer.concat(chunks).toString();
+}
+
+function startPhpServer(args: string[], environment: Record<string, string>) {
+	const child = spawn('php', args, {
+		env: { ...process.env, ...environment },
+		stdio: 'pipe',
+	});
+	const server: PhpServer = { process: child, output: '' };
+	child.stdin.end();
+	child.stdout.on('data', (chunk) => {
+		server.output += chunk.toString();
+	});
+	child.stderr.on('data', (chunk) => {
+		server.output += chunk.toString();
+	});
+	child.on('error', (error) => {
+		server.spawnError = error;
+	});
+	return server;
+}
+
+async function waitForPhpServer(server: PhpServer, url: string) {
+	const deadline = Date.now() + 10_000;
+	while (Date.now() < deadline) {
+		if (server.spawnError) {
+			throw server.spawnError;
+		}
+		if (hasPhpServerExited(server)) {
+			throw new Error(`PHP server exited early:\n${server.output}`);
+		}
+		try {
+			await fetch(url, { signal: AbortSignal.timeout(500) });
+			return;
+		} catch {
+			await sleep(50);
+		}
+	}
+	throw new Error(`Timed out waiting for PHP server:\n${server.output}`);
+}
+
+async function stopPhpServer(server: PhpServer | undefined) {
+	if (!server || hasPhpServerExited(server)) {
+		return;
+	}
+	const exited = once(server.process, 'exit');
+	server.process.kill();
+	await Promise.race([exited, sleep(1000)]);
+	if (!hasPhpServerExited(server)) {
+		const killed = once(server.process, 'exit');
+		server.process.kill('SIGKILL');
+		await killed;
+	}
+}
+
+async function stopHttpServer(server: Server | undefined) {
+	if (!server?.listening) {
+		return;
+	}
+	await new Promise<void>((resolve, reject) => {
+		server.close((error) => (error ? reject(error) : resolve()));
+	});
+}
+
+function hasPhpServerExited(server: PhpServer) {
+	return (
+		server.process.exitCode !== null || server.process.signalCode !== null
+	);
+}
+
+async function getAvailablePort(): Promise<number> {
+	const server = createServer();
+	const port = await listenOnAvailablePort(server);
+	await stopHttpServer(server);
+	return port;
+}
+
+async function listenOnAvailablePort(server: Server): Promise<number> {
+	server.listen(0, '127.0.0.1');
+	await once(server, 'listening');
+	const address = server.address();
+	if (!address || typeof address === 'string') {
+		throw new Error('Could not allocate port');
+	}
+	return address.port;
+}
+
+async function sleep(milliseconds: number) {
+	await new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+type PhpServer = {
+	process: ChildProcessWithoutNullStreams;
+	output: string;
+	spawnError?: Error;
+};

--- a/packages/playground/website/playwright/e2e/plugin-proxy.spec.ts
+++ b/packages/playground/website/playwright/e2e/plugin-proxy.spec.ts
@@ -24,6 +24,7 @@ test.skip(
 );
 
 const pluginProxyDocumentRoot = joinPaths(__dirname, '../../public');
+const pluginProxyRouter = joinPaths(__dirname, 'plugin-proxy-test-router.php');
 
 let requestDestinations: string[] = [];
 let pluginProxyUrl = '';
@@ -44,6 +45,7 @@ test.beforeAll(async () => {
 			`127.0.0.1:${pluginProxyPort}`,
 			'-t',
 			pluginProxyDocumentRoot,
+			pluginProxyRouter,
 		],
 		{
 			http_proxy: `http://127.0.0.1:${upstreamPort}`,
@@ -82,6 +84,38 @@ test('rejects a direct off-allowlist URL without fetching it', async ({
 		'Error: The specified URL is not allowed.'
 	);
 	expect(requestDestinations).toEqual([]);
+});
+
+/**
+ * Stable contract: Forward an upstream Content-Type when it is allowed. When it
+ * is filtered out, send the configured default Content-Type instead.
+ *
+ * Plausible regressions: A filtered header could prevent the default from being
+ * sent, or the default could overwrite an allowed upstream header.
+ *
+ * Independent code path: The PHP fixture calls the production header helper.
+ * The test checks the Content-Type on the HTTP response returned to the client.
+ */
+test('uses a default header only when the matching upstream header is filtered', async ({
+	request,
+}) => {
+	const filteredResponse = await request.get(
+		urlForDefaultResponseHeaders({ allowContentType: false })
+	);
+
+	expect(filteredResponse.status()).toBe(200);
+	expect(filteredResponse.headers()['content-type']).toBe('application/zip');
+	expect(await filteredResponse.text()).toBe('body');
+
+	const allowedResponse = await request.get(
+		urlForDefaultResponseHeaders({ allowContentType: true })
+	);
+
+	expect(allowedResponse.status()).toBe(200);
+	expect(allowedResponse.headers()['content-type']).toBe(
+		'application/octet-stream'
+	);
+	expect(await allowedResponse.text()).toBe('body');
 });
 
 test('follows absolute and relative redirects within the allowlist', async ({
@@ -200,6 +234,25 @@ function urlForTarget(targetUrl: string) {
 	return url.href;
 }
 
+function urlForDefaultResponseHeaders({
+	allowContentType,
+}: {
+	allowContentType: boolean;
+}) {
+	const url = new URL('/__test-default-response-headers', pluginProxyUrl);
+	if (allowContentType) {
+		url.searchParams.set('allow-content-type', '1');
+	}
+	return url.href;
+}
+
+/**
+ * This in-process router is the plugin proxy's fake upstream service. The PHP
+ * cURL client reaches it through the http_proxy environment variable, allowing
+ * the tests to control redirects and echoed requests without external network
+ * calls. Running it in this process also lets each destination be recorded
+ * directly in requestDestinations for assertions.
+ */
 function routeUpstreamRequest(
 	request: IncomingMessage,
 	response: ServerResponse

--- a/packages/playground/website/playwright/e2e/plugin-proxy.spec.ts
+++ b/packages/playground/website/playwright/e2e/plugin-proxy.spec.ts
@@ -108,8 +108,9 @@ test('follows absolute and relative redirects within the allowlist', async ({
 test('rejects an off-allowlist redirect before fetching it', async ({
 	request,
 }) => {
-	const response = await request.get(
-		urlForTarget('http://wordpress.org/redirect-to-blocked')
+	const response = await request.fetch(
+		urlForTarget('http://wordpress.org/redirect-to-blocked'),
+		{ method: 'PATCH', data: 'payload=blocked' }
 	);
 
 	expect(response.status()).toBe(403);
@@ -118,7 +119,7 @@ test('rejects an off-allowlist redirect before fetching it', async ({
 
 test('preserves cURL POST redirect behavior', async ({ request }) => {
 	const response302 = await request.post(
-		urlForTarget('http://wordpress.org/redirect-post-302'),
+		urlForTarget('http://wordpress.org/redirect-302'),
 		{
 			data: 'payload=discarded',
 			headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
@@ -132,7 +133,7 @@ test('preserves cURL POST redirect behavior', async ({ request }) => {
 	});
 
 	const response307 = await request.post(
-		urlForTarget('http://wordpress.org/redirect-post-307'),
+		urlForTarget('http://wordpress.org/redirect-307'),
 		{
 			data: 'payload=preserved',
 			headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
@@ -146,6 +147,43 @@ test('preserves cURL POST redirect behavior', async ({ request }) => {
 	});
 });
 
+test('forwards other methods with cURL redirect behavior', async ({
+	request,
+}) => {
+	const response302 = await request.fetch(
+		urlForTarget('http://wordpress.org/redirect-302'),
+		{ method: 'PATCH', data: 'payload=patch' }
+	);
+	expect(await response302.json()).toEqual({
+		host: 'wordpress.org',
+		method: 'PATCH',
+		body: 'payload=patch',
+		query: {},
+	});
+
+	const response303 = await request.fetch(
+		urlForTarget('http://wordpress.org/redirect-303'),
+		{ method: 'PUT', data: 'payload=discarded' }
+	);
+	expect(await response303.json()).toEqual({
+		host: 'wordpress.org',
+		method: 'GET',
+		body: '',
+		query: {},
+	});
+
+	const response307 = await request.fetch(
+		urlForTarget('http://wordpress.org/redirect-307'),
+		{ method: 'DELETE', data: 'payload=delete' }
+	);
+	expect(await response307.json()).toEqual({
+		host: 'wordpress.org',
+		method: 'DELETE',
+		body: 'payload=delete',
+		query: {},
+	});
+});
+
 test('bounds redirect loops', async ({ request }) => {
 	const response = await request.get(
 		urlForTarget('http://wordpress.org/loop')
@@ -153,6 +191,7 @@ test('bounds redirect loops', async ({ request }) => {
 
 	expect(response.status()).toBe(400);
 	expect(await response.json()).toEqual({ error: 'Too many redirects' });
+	expect(requestDestinations).toHaveLength(31);
 });
 
 function urlForTarget(targetUrl: string) {
@@ -208,12 +247,17 @@ async function handleUpstreamRequest(
 			response.end('blocked intermediate response');
 			return;
 
-		case '/redirect-post-302':
+		case '/redirect-302':
 			response.writeHead(302, { Location: '/echo-request' });
 			response.end();
 			return;
 
-		case '/redirect-post-307':
+		case '/redirect-303':
+			response.writeHead(303, { Location: '/echo-request' });
+			response.end();
+			return;
+
+		case '/redirect-307':
 			response.writeHead(307, { Location: '/echo-request' });
 			response.end();
 			return;

--- a/packages/playground/website/public/plugin-proxy.php
+++ b/packages/playground/website/public/plugin-proxy.php
@@ -469,12 +469,12 @@ function sendBufferedResponseHeaders($response_headers, $allowed_response_header
 {
 	$seen_headers = [];
 	foreach ($response_headers as [$header_name, $header_line]) {
-		$seen_headers[$header_name] = true;
 		$header_allowed = (
 			NULL === $allowed_response_headers
 			|| in_array($header_name, $allowed_response_headers, true)
 		) && $header_name !== 'transfer-encoding';
 		if ($header_allowed) {
+			$seen_headers[$header_name] = true;
 			header($header_line);
 		}
 	}
@@ -520,7 +520,6 @@ $downloader = new PluginDownloader(
 if (!array_key_exists('url', $_GET)) {
 	header('Access-Control-Allow-Origin: *');
 }
-$pluginResponse;
 try {
 	/** @deprecated Plugins and themes downloads are no longer needed now that WordPress.org serves
 	 *              the proper CORS headers. This code will be removed in one of the next releases.

--- a/packages/playground/website/public/plugin-proxy.php
+++ b/packages/playground/website/public/plugin-proxy.php
@@ -83,7 +83,7 @@ class PluginDownloader
 				'date',
 				'age',
 				'vary',
-				'cache-Control'
+				'cache-control'
 			], [
 				'Content-Type: application/zip',
 				'Content-Disposition: attachment; filename="plugin.zip"',
@@ -178,7 +178,7 @@ class PluginDownloader
 				'date',
 				'age',
 				'vary',
-				'cache-Control'
+				'cache-control'
 			);
 			$artifact_res = $this->gitHubRequest($zip_download_api_endpoint, false, false);
 			ob_end_flush();
@@ -259,7 +259,7 @@ class PluginDownloader
 				'date',
 				'age',
 				'vary',
-				'cache-Control'
+				'cache-control'
 			], [
 				'Content-Type: application/zip',
 				'Content-Disposition: attachment; filename="plugin.zip"',

--- a/packages/playground/website/public/plugin-proxy.php
+++ b/packages/playground/website/public/plugin-proxy.php
@@ -53,6 +53,7 @@ class PullRequestApiException extends ApiException
 		return $this->pullRequestOpenedAt;
 	}
 }
+class UrlNotAllowedException extends ApiException {}
 class PluginDownloader
 {
 
@@ -302,7 +303,60 @@ class PluginDownloader
 		];
 	}
 }
-function streamHttpResponse($url, $request_method = 'GET', $request_headers = [], $request_body = null, $allowed_response_headers = [], $default_response_headers = [])
+
+function streamHttpResponse($url, $request_method = 'GET', $request_headers = [], $request_body = null, $allowed_response_headers = [], $default_response_headers = [], $allowed_hosts = null)
+{
+	$redirect_count = 0;
+	$follow_location = $allowed_hosts === null;
+	while (true) {
+		// An allowlist opts into manual redirects so every outbound URL is checked first.
+		if (
+			!$follow_location
+			&& !isPluginProxyUrlAllowed($url, $allowed_hosts)
+		) {
+			throw new UrlNotAllowedException('URL is not allowed');
+		}
+
+		$info = streamHttpResponseOnce(
+			$url,
+			$request_method,
+			$request_headers,
+			$request_body,
+			$allowed_response_headers,
+			$default_response_headers,
+			$follow_location
+		);
+
+		if ($follow_location || empty($info['redirect_url'])) {
+			return $info;
+		}
+
+		// Match modern libcurl's default redirect limit.
+		if ($redirect_count >= 30) {
+			throw new ApiException('Too many redirects');
+		}
+
+		// Match libcurl's default redirect behavior for POST requests.
+		if (
+			$request_method === 'POST'
+			&& in_array($info['http_code'], [301, 302, 303], true)
+		) {
+			$request_method = 'GET';
+			$request_body = null;
+		}
+
+		$url = $info['redirect_url'];
+		$redirect_count++;
+	}
+}
+
+function isPluginProxyUrlAllowed($candidate_url, $allowed_hosts)
+{
+	$host = is_string($candidate_url) ? parse_url($candidate_url, PHP_URL_HOST) : null;
+	return is_string($host) && in_array($host, $allowed_hosts, true);
+}
+
+function streamHttpResponseOnce($url, $request_method, $request_headers, $request_body, $allowed_response_headers, $default_response_headers, $follow_location)
 {
 	$ch = curl_init($url);
 	curl_setopt_array(
@@ -311,7 +365,7 @@ function streamHttpResponse($url, $request_method = 'GET', $request_headers = []
 			CURLOPT_RETURNTRANSFER => true,
 			CURLOPT_CONNECTTIMEOUT => 30,
 			CURLOPT_FAILONERROR => true,
-			CURLOPT_FOLLOWLOCATION => true,
+			CURLOPT_FOLLOWLOCATION => $follow_location,
 		]
 	);
 
@@ -326,39 +380,68 @@ function streamHttpResponse($url, $request_method = 'GET', $request_headers = []
 		curl_setopt($ch, CURLOPT_HTTPHEADER, $request_headers);
 	}
 
-	$seen_headers = [];
+	// Hold each header block until we know whether it describes an intermediate redirect.
+	$response_status = 0;
+	$response_headers = [];
+	$has_location_header = false;
+	$is_redirect_response = false;
 	curl_setopt(
 		$ch,
 		CURLOPT_HEADERFUNCTION,
-		function ($curl, $header_line) use ($seen_headers, $allowed_response_headers) {
-			if (strpos($header_line, ':') === false) {
-				return strlen($header_line);
+		function ($curl, $header_line) use (
+			&$response_status,
+			&$response_headers,
+			&$has_location_header,
+			&$is_redirect_response,
+			$allowed_response_headers,
+			$default_response_headers
+		) {
+			$header_length = strlen($header_line);
+			if (preg_match('/^HTTP\/\S+\s+(\d{3})/', $header_line, $matches)) {
+				$response_status = (int)$matches[1];
+				$response_headers = [];
+				$has_location_header = false;
+				$is_redirect_response = false;
+				return $header_length;
 			}
-			$header_name = strtolower(substr($header_line, 0, strpos($header_line, ':')));
-			$seen_headers[$header_name] = true;
-			$illegal_headers = ['transfer-encoding'];
-			$header_allowed = (
-				NULL === $allowed_response_headers || in_array($header_name, $allowed_response_headers)
-			) && !in_array($header_name, $illegal_headers);
-			if ($header_allowed) {
-				header($header_line);
+
+			if (trim($header_line) === '') {
+				if ($response_status < 100 || $response_status >= 200) {
+					$is_redirect_response = (
+						$response_status >= 300
+						&& $response_status < 400
+						&& $has_location_header
+					);
+					if (!$is_redirect_response) {
+						sendBufferedResponseHeaders(
+							$response_headers,
+							$allowed_response_headers,
+							$default_response_headers
+						);
+					}
+				}
+				return $header_length;
 			}
-			return strlen($header_line);
+
+			$separator_position = strpos($header_line, ':');
+			if ($separator_position === false) {
+				return $header_length;
+			}
+
+			$header_name = strtolower(substr($header_line, 0, $separator_position));
+			$response_headers[] = [$header_name, $header_line];
+			if ($header_name === 'location') {
+				$has_location_header = true;
+			}
+			return $header_length;
 		}
 	);
-	$extra_headers_sent = false;
 	curl_setopt(
 		$ch,
 		CURLOPT_WRITEFUNCTION,
-		function ($curl, $body) use (&$extra_headers_sent, $default_response_headers) {
-			if (!$extra_headers_sent) {
-				foreach ($default_response_headers as $header_line) {
-					$header_name = strtolower(substr($header_line, 0, strpos($header_line, ':')));
-					if (!isset($seen_headers[$header_name])) {
-						header($header_line);
-					}
-				}
-				$extra_headers_sent = true;
+		function ($curl, $body) use (&$is_redirect_response) {
+			if ($is_redirect_response) {
+				return strlen($body);
 			}
 			echo $body;
 			flush();
@@ -367,12 +450,36 @@ function streamHttpResponse($url, $request_method = 'GET', $request_headers = []
 	);
 	$response = curl_exec($ch);
 	$info = curl_getinfo($ch);
+	closeCurlHandle($ch);
+	if (!$follow_location && $is_redirect_response && empty($info['redirect_url'])) {
+		throw new ApiException('Invalid redirect');
+	}
 	if ($response === false && isset($info['http_code']) && $info['http_code'] === 429) {
-		closeCurlHandle($ch);
 		throw new RateLimitedException('Rate limited');
 	}
-	closeCurlHandle($ch);
 	return $info;
+}
+
+function sendBufferedResponseHeaders($response_headers, $allowed_response_headers, $default_response_headers)
+{
+	$seen_headers = [];
+	foreach ($response_headers as [$header_name, $header_line]) {
+		$seen_headers[$header_name] = true;
+		$header_allowed = (
+			NULL === $allowed_response_headers
+			|| in_array($header_name, $allowed_response_headers, true)
+		) && $header_name !== 'transfer-encoding';
+		if ($header_allowed) {
+			header($header_line);
+		}
+	}
+
+	foreach ($default_response_headers as $header_line) {
+		$header_name = strtolower(substr($header_line, 0, strpos($header_line, ':')));
+		if (!isset($seen_headers[$header_name])) {
+			header($header_line);
+		}
+	}
 }
 
 function closeCurlHandle($ch)
@@ -523,12 +630,6 @@ try {
 		// but only if the URL is allowlisted.
 		$url = $_GET['url'];
 		$allowed_domains = ['api.wordpress.org', 'w.org', 'wordpress.org', 's.w.org'];
-		$parsed_url = parse_url($url);
-		if (!in_array($parsed_url['host'], $allowed_domains)) {
-			http_response_code(403);
-			echo "Error: The specified URL is not allowed.";
-			exit;
-		}
 
 		/**
 		 * Pass through the request headers we got from WordPress via fetch(),
@@ -570,12 +671,18 @@ try {
 			$_SERVER['REQUEST_METHOD'],
 			get_request_headers(),
 			file_get_contents('php://input'),
-			null
+			null,
+			[],
+			$allowed_domains
 		);
 	} else {
 		throw new ApiException('Invalid query parameters');
 	}
 } catch (ApiException $e) {
+	if ($e instanceof UrlNotAllowedException) {
+		http_response_code(403);
+		die("Error: The specified URL is not allowed.");
+	}
 	http_response_code($e instanceof RateLimitedException ? 429 : 400);
 	if (!headers_sent()) {
 		header('Content-Type: application/json');

--- a/packages/playground/website/public/plugin-proxy.php
+++ b/packages/playground/website/public/plugin-proxy.php
@@ -306,12 +306,13 @@ class PluginDownloader
 
 function streamHttpResponse($url, $request_method = 'GET', $request_headers = [], $request_body = null, $allowed_response_headers = [], $default_response_headers = [], $allowed_hosts = null)
 {
-	$redirect_count = 0;
-	$follow_location = $allowed_hosts === null;
-	while (true) {
-		// An allowlist opts into manual redirects so every outbound URL is checked first.
+	// Make the initial request, then manually follow up to libcurl's default 30 redirects.
+	// See https://curl.se/libcurl/c/CURLOPT_MAXREDIRS.html
+	$max_redirects = 30;
+	for ($redirect_count = 0; $redirect_count <= $max_redirects; $redirect_count++) {
+		// When supplied, the allowlist applies to every outbound URL.
 		if (
-			!$follow_location
+			$allowed_hosts !== null
 			&& !isPluginProxyUrlAllowed($url, $allowed_hosts)
 		) {
 			throw new UrlNotAllowedException('URL is not allowed');
@@ -323,31 +324,31 @@ function streamHttpResponse($url, $request_method = 'GET', $request_headers = []
 			$request_headers,
 			$request_body,
 			$allowed_response_headers,
-			$default_response_headers,
-			$follow_location
+			$default_response_headers
 		);
 
-		if ($follow_location || empty($info['redirect_url'])) {
+		if (empty($info['redirect_url'])) {
 			return $info;
 		}
 
-		// Match modern libcurl's default redirect limit.
-		if ($redirect_count >= 30) {
-			throw new ApiException('Too many redirects');
-		}
-
-		// Match libcurl's default redirect behavior for POST requests.
-		if (
+		// Match libcurl's default method behavior across redirects.
+		// See https://curl.se/libcurl/c/CURLOPT_FOLLOWLOCATION.html
+		$redirect_uses_get = (
+			$info['http_code'] === 303
+			&& $request_method !== 'HEAD'
+		) || (
 			$request_method === 'POST'
-			&& in_array($info['http_code'], [301, 302, 303], true)
-		) {
+			&& in_array($info['http_code'], [301, 302], true)
+		);
+		if ($redirect_uses_get) {
 			$request_method = 'GET';
 			$request_body = null;
 		}
 
 		$url = $info['redirect_url'];
-		$redirect_count++;
 	}
+
+	throw new ApiException('Too many redirects');
 }
 
 function isPluginProxyUrlAllowed($candidate_url, $allowed_hosts)
@@ -356,7 +357,7 @@ function isPluginProxyUrlAllowed($candidate_url, $allowed_hosts)
 	return is_string($host) && in_array($host, $allowed_hosts, true);
 }
 
-function streamHttpResponseOnce($url, $request_method, $request_headers, $request_body, $allowed_response_headers, $default_response_headers, $follow_location)
+function streamHttpResponseOnce($url, $request_method, $request_headers, $request_body, $allowed_response_headers, $default_response_headers)
 {
 	$ch = curl_init($url);
 	curl_setopt_array(
@@ -365,7 +366,6 @@ function streamHttpResponseOnce($url, $request_method, $request_headers, $reques
 			CURLOPT_RETURNTRANSFER => true,
 			CURLOPT_CONNECTTIMEOUT => 30,
 			CURLOPT_FAILONERROR => true,
-			CURLOPT_FOLLOWLOCATION => $follow_location,
 		]
 	);
 
@@ -374,6 +374,11 @@ function streamHttpResponseOnce($url, $request_method, $request_headers, $reques
 		curl_setopt($ch, CURLOPT_POSTFIELDS, $request_body);
 	} else if ($request_method === 'HEAD') {
 		curl_setopt($ch, CURLOPT_NOBODY, true);
+	} else if ($request_method !== 'GET') {
+		if ($request_body !== null && $request_body !== '') {
+			curl_setopt($ch, CURLOPT_POSTFIELDS, $request_body);
+		}
+		curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $request_method);
 	}
 
 	if (count($request_headers)) {
@@ -451,7 +456,7 @@ function streamHttpResponseOnce($url, $request_method, $request_headers, $reques
 	$response = curl_exec($ch);
 	$info = curl_getinfo($ch);
 	closeCurlHandle($ch);
-	if (!$follow_location && $is_redirect_response && empty($info['redirect_url'])) {
+	if ($is_redirect_response && empty($info['redirect_url'])) {
 		throw new ApiException('Invalid redirect');
 	}
 	if ($response === false && isset($info['http_code']) && $info['http_code'] === 429) {


### PR DESCRIPTION
## Motivation for the change, related issues

The proxy's `url` mode accepts a URL and limits requests to a short list of host names. A redirect points to another URL, so checking only the first URL does not apply that rule to the rest of the redirect chain.

Redirects still need to work because downloads commonly use them. For `url` mode, the proxy should check each destination before contacting it and stop if any destination is outside the allowed-host list.

The proxy also supplies default response headers for several download routes. If an upstream header is filtered out, it has not been sent and should not prevent a configured default header from being used. In addition, parsed header names are lowercase, so response-header allowlists must use lowercase names too.

## Implementation details

`streamHttpResponse()` now handles all redirects in one bounded PHP loop. cURL makes one request at a time and reports the next redirect URL. When a caller supplies an allowed-host list, PHP checks the hostname before making each request.

Internal download routes use the same redirect loop without the four-host list because their starting URLs are selected by application code and use different download hosts.

The loop follows cURL's redirect behavior:

- It follows up to 30 redirects.
- A POST becomes a GET after a 301 or 302 response.
- A 303 response changes every method except HEAD to GET.
- A 307 or 308 response keeps the original method and body.
- Other methods, including PUT, PATCH, and DELETE, are forwarded correctly.

PHP briefly buffers each response's headers so it can tell whether the response is an intermediate redirect. Intermediate redirect bodies are discarded. The final response body continues streaming to the caller and is never buffered in full.

Response headers are now recorded as present only after they pass the response-header allowlist and are forwarded. This means a filtered upstream header no longer suppresses a configured default header. The `Cache-Control` entries in the response-header allowlists are also stored as lowercase `cache-control`, matching the parsed header names.

## Testing Instructions (or ideally a Blueprint)

Run the focused endpoint tests:

```bash
npm exec nx -- run playground-website:e2e:playwright -- --project=chromium plugin-proxy.spec.ts
```

Run PHP syntax and website lint checks:

```bash
php -l packages/playground/website/public/plugin-proxy.php
php -l packages/playground/website/playwright/e2e/plugin-proxy-test-router.php
npm exec nx -- lint playground-website --skipNxCache
```

The Playwright suite starts the real PHP endpoint and an in-process Node HTTP proxy. The Node server creates controlled redirect chains and records every requested destination, so the tests can prove that rejected destinations are not contacted. A small PHP test router verifies the headers emitted by PHP's `header()` function. The tests do not make external requests.

The seven focused tests cover:

1. Rejecting a direct URL outside the allowed-host list.
2. Using a default response header only when the matching upstream header is filtered.
3. Following absolute and relative redirects within the allowed-host list.
4. Rejecting a redirect before contacting a destination outside the list.
5. Preserving POST behavior across 302 and 307 responses.
6. Preserving PUT, PATCH, and DELETE behavior across 302, 303, and 307 responses.
7. Stopping after the 30-redirect limit.
