### PR TITLE
[Website] Share concurrent OPFS autosave operations

### DIFF
--- a/packages/playground/website/playwright/e2e/sites-api.spec.ts
+++ b/packages/playground/website/playwright/e2e/sites-api.spec.ts
@@ -86,7 +86,7 @@ test('playgroundSites.autosaveTemporarySite() persists without disrupting the ta
 	expect(result.sameUrl).toBe(true);
 });
 
-test('autosaveTemporarySite() joins finalization after persistence finishes', async ({
+test('a concurrent autosave waits for pruning after persistence finishes', async ({
 	website,
 	browserName,
 }) => {
@@ -99,6 +99,8 @@ test('autosaveTemporarySite() joins finalization after persistence finishes', as
 	await website.page.waitForFunction(() =>
 		Boolean((window as any).playgroundSites?.getClient())
 	);
+	// Seed more autosaved sites than the retention limit so the next autosave
+	// must remove an older site before it can finish.
 	await website.page.evaluate(async () => {
 		const opfsRoot = await navigator.storage.getDirectory();
 		const sitesRoot = await opfsRoot.getDirectoryHandle('sites', {
@@ -154,6 +156,8 @@ test('autosaveTemporarySite() joins finalization after persistence finishes', as
 		});
 		const directoryHandlePrototype = FileSystemDirectoryHandle.prototype;
 		const removeEntry = directoryHandlePrototype.removeEntry;
+		// Pause pruning after the current site has been persisted. This exposes the
+		// interval where its storage is already OPFS but its autosave is still active.
 		directoryHandlePrototype.removeEntry = async function (name, options) {
 			if (name.startsWith('site-autosave-timing-')) {
 				notifyDeletionStarted();
@@ -165,6 +169,8 @@ test('autosaveTemporarySite() joins finalization after persistence finishes', as
 		try {
 			const firstSave = api.autosaveTemporarySite(siteSlug);
 			await deletionStarted;
+			// A second request for the same site must wait for the complete shared
+			// autosave instead of returning early based on the updated storage alone.
 			const secondSave = api.autosaveTemporarySite(siteSlug);
 			let secondSaveFinished = false;
 			void secondSave.finally(() => {
@@ -172,6 +178,7 @@ test('autosaveTemporarySite() joins finalization after persistence finishes', as
 			});
 			await new Promise((resolve) => setTimeout(resolve));
 			const secondSaveFinishedBeforePruning = secondSaveFinished;
+			// Let pruning finish so both calls can resolve with the shared result.
 			finishDeletion();
 			const [firstResult, secondResult] = await Promise.all([
 				firstSave,

--- a/packages/playground/website/playwright/e2e/sites-api.spec.ts
+++ b/packages/playground/website/playwright/e2e/sites-api.spec.ts
@@ -86,6 +86,116 @@ test('playgroundSites.autosaveTemporarySite() persists without disrupting the ta
 	expect(result.sameUrl).toBe(true);
 });
 
+test('autosaveTemporarySite() joins finalization after persistence finishes', async ({
+	website,
+	browserName,
+}) => {
+	test.skip(
+		browserName !== 'chromium',
+		`This test relies on OPFS which isn't available in Playwright's flavor of ${browserName}.`
+	);
+
+	await website.goto('./?storage=temp');
+	await website.page.waitForFunction(() =>
+		Boolean((window as any).playgroundSites?.getClient())
+	);
+	await website.page.evaluate(async () => {
+		const opfsRoot = await navigator.storage.getDirectory();
+		const sitesRoot = await opfsRoot.getDirectoryHandle('sites', {
+			create: true,
+		});
+		for (let index = 0; index < 6; index++) {
+			const slug = `autosave-timing-${index}`;
+			const siteDirectory = await sitesRoot.getDirectoryHandle(
+				`site-${slug}`,
+				{ create: true }
+			);
+			const metadataFile = await siteDirectory.getFileHandle(
+				'wp-runtime.json',
+				{ create: true }
+			);
+			const writable = await metadataFile.createWritable();
+			await writable.write(
+				JSON.stringify({
+					slug,
+					id: slug,
+					name: `Autosave timing ${index}`,
+					storage: 'opfs',
+					persistence: 'autosave',
+					whenCreated: index + 1,
+					whenLastUsed: index + 1,
+					runtimeConfiguration: {
+						phpVersion: '8.3',
+						wpVersion: 'latest',
+						intl: false,
+						networking: true,
+						extraLibraries: [],
+						constants: {},
+					},
+					originalBlueprint: {},
+					originalBlueprintSource: { type: 'none' },
+				})
+			);
+			await writable.close();
+		}
+	});
+	await website.goto('./?storage=temp&autosave-timing=1');
+
+	const result = await website.page.evaluate(async () => {
+		const api = (window as any).playgroundSites;
+		const siteSlug = api.list().find((site: any) => site.isActive).slug;
+		let notifyDeletionStarted!: () => void;
+		const deletionStarted = new Promise<void>((resolve) => {
+			notifyDeletionStarted = resolve;
+		});
+		let finishDeletion!: () => void;
+		const deletionCanFinish = new Promise<void>((resolve) => {
+			finishDeletion = resolve;
+		});
+		const directoryHandlePrototype = FileSystemDirectoryHandle.prototype;
+		const removeEntry = directoryHandlePrototype.removeEntry;
+		directoryHandlePrototype.removeEntry = async function (name, options) {
+			if (name.startsWith('site-autosave-timing-')) {
+				notifyDeletionStarted();
+				await deletionCanFinish;
+			}
+			return await removeEntry.call(this, name, options);
+		};
+
+		try {
+			const firstSave = api.autosaveTemporarySite(siteSlug);
+			await deletionStarted;
+			const secondSave = api.autosaveTemporarySite(siteSlug);
+			let secondSaveFinished = false;
+			void secondSave.finally(() => {
+				secondSaveFinished = true;
+			});
+			await new Promise((resolve) => setTimeout(resolve));
+			const secondSaveFinishedBeforePruning = secondSaveFinished;
+			finishDeletion();
+			const [firstResult, secondResult] = await Promise.all([
+				firstSave,
+				secondSave,
+			]);
+			return {
+				firstResult,
+				secondResult,
+				secondSaveFinishedBeforePruning,
+			};
+		} finally {
+			finishDeletion();
+			directoryHandlePrototype.removeEntry = removeEntry;
+		}
+	});
+
+	expect(result.secondSaveFinishedBeforePruning).toBe(false);
+	expect(result.secondResult).toEqual(result.firstResult);
+	expect(result.firstResult).toEqual({
+		slug: expect.any(String),
+		storage: 'opfs',
+	});
+});
+
 test('playgroundSites.createNewSavedSite() creates unique slugs for repeated Blueprint titles', async ({
 	website,
 	browserName,

--- a/packages/playground/website/src/lib/state/redux/site-management-api-middleware.spec.ts
+++ b/packages/playground/website/src/lib/state/redux/site-management-api-middleware.spec.ts
@@ -1,0 +1,91 @@
+// @vitest-environment jsdom
+
+import type { PlaygroundDispatch, PlaygroundReduxState } from './store';
+import type { SiteInfo } from './slice-sites';
+import { createSitesAPI } from './site-management-api-middleware';
+
+const mocks = vi.hoisted(() => ({
+	persistTemporarySite: vi.fn(),
+}));
+
+vi.mock('./persist-temporary-site', () => ({
+	persistTemporarySite: mocks.persistTemporarySite,
+}));
+
+vi.mock('./store', () => ({
+	selectActiveSite: (state: PlaygroundReduxState) =>
+		state.ui.activeSite?.slug
+			? state.sites.entities[state.ui.activeSite.slug]
+			: undefined,
+	selectActiveSiteError: vi.fn(),
+	selectActiveSiteErrorDetails: vi.fn(),
+	setActiveSite: vi.fn(),
+	useAppDispatch: vi.fn(),
+}));
+
+describe('createSitesAPI', () => {
+	it('shares an autosave already running for the same site', async () => {
+		const site = createTemporarySite();
+		const state = createState(site);
+		let finishPersistence!: () => void;
+		const persistenceCanFinish = new Promise<void>((resolve) => {
+			finishPersistence = resolve;
+		});
+		const persist = vi.fn(async () => {
+			await persistenceCanFinish;
+			site.metadata.storage = 'opfs';
+		});
+		mocks.persistTemporarySite.mockReturnValue(persist);
+		const dispatch = vi.fn((action) => {
+			if (action === persist) {
+				return persist();
+			}
+			return Promise.resolve();
+		}) as unknown as PlaygroundDispatch;
+		const api = createSitesAPI(() => state, dispatch);
+
+		const firstAutosave = api.autosaveTemporarySite(site.slug);
+		const secondAutosave = api.autosaveTemporarySite(site.slug);
+
+		expect(mocks.persistTemporarySite).toHaveBeenCalledTimes(1);
+		finishPersistence();
+		await expect(
+			Promise.all([firstAutosave, secondAutosave])
+		).resolves.toEqual([
+			{ slug: site.slug, storage: 'opfs' },
+			{ slug: site.slug, storage: 'opfs' },
+		]);
+	});
+});
+
+function createState(site: SiteInfo): PlaygroundReduxState {
+	return {
+		ui: { activeSite: { slug: site.slug } },
+		sites: {
+			ids: [site.slug],
+			entities: { [site.slug]: site },
+		},
+	} as PlaygroundReduxState;
+}
+
+function createTemporarySite(): SiteInfo {
+	return {
+		slug: 'test-site',
+		metadata: {
+			id: 'test-site',
+			name: 'Test Playground',
+			storage: 'none',
+			whenCreated: 0,
+			runtimeConfiguration: {
+				phpVersion: '8.3',
+				wpVersion: 'latest',
+				intl: false,
+				networking: true,
+				extraLibraries: [],
+				constants: {},
+			},
+			originalBlueprint: {},
+			originalBlueprintSource: { type: 'none' },
+		},
+	};
+}

--- a/packages/playground/website/src/lib/state/redux/site-management-api-middleware.spec.ts
+++ b/packages/playground/website/src/lib/state/redux/site-management-api-middleware.spec.ts
@@ -112,8 +112,8 @@ describe('createSitesAPI', () => {
 		await Promise.resolve();
 
 		expect(secondAutosaveFinished).toBe(false);
-		expect(mocks.pruneAutosavedSites).toHaveBeenCalledWith({
-			excludeSlugs: [site.slug, 'late-exclusion'],
+		expect(mocks.pruneAutosavedSites).toHaveBeenNthCalledWith(1, {
+			excludeSlugs: [site.slug],
 		});
 		expect(pushState).not.toHaveBeenCalled();
 		finishPruning();
@@ -123,6 +123,9 @@ describe('createSitesAPI', () => {
 			{ slug: site.slug, storage: 'opfs' },
 			{ slug: site.slug, storage: 'opfs' },
 		]);
+		expect(mocks.pruneAutosavedSites).toHaveBeenNthCalledWith(2, {
+			excludeSlugs: [site.slug, 'late-exclusion'],
+		});
 		expect(pushState).toHaveBeenCalledTimes(1);
 	});
 

--- a/packages/playground/website/src/lib/state/redux/site-management-api-middleware.spec.ts
+++ b/packages/playground/website/src/lib/state/redux/site-management-api-middleware.spec.ts
@@ -35,6 +35,9 @@ describe('createSitesAPI', () => {
 		vi.clearAllMocks();
 		mocks.pruneAutosavedSites.mockImplementation(() => vi.fn());
 	});
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
 
 	it('shares an autosave between API instances for the same store', async () => {
 		const site = createTemporarySite();
@@ -89,13 +92,19 @@ describe('createSitesAPI', () => {
 			action === prune ? pruningCanFinish : Promise.resolve()
 		);
 		const api = createSitesAPI(() => state, dispatch);
+		const pushState = vi
+			.spyOn(window.history, 'pushState')
+			.mockImplementation(() => undefined);
 
 		const firstAutosave = api.autosaveTemporarySite(site.slug);
 		finishPersistence();
 		await vi.waitFor(() =>
 			expect(mocks.pruneAutosavedSites).toHaveBeenCalledTimes(1)
 		);
-		const secondAutosave = api.autosaveTemporarySite(site.slug);
+		const secondAutosave = api.autosaveTemporarySite(site.slug, {
+			updateUrl: true,
+			excludeFromPruning: ['late-exclusion'],
+		});
 		let secondAutosaveFinished = false;
 		void secondAutosave.then(() => {
 			secondAutosaveFinished = true;
@@ -103,6 +112,10 @@ describe('createSitesAPI', () => {
 		await Promise.resolve();
 
 		expect(secondAutosaveFinished).toBe(false);
+		expect(mocks.pruneAutosavedSites).toHaveBeenCalledWith({
+			excludeSlugs: [site.slug, 'late-exclusion'],
+		});
+		expect(pushState).not.toHaveBeenCalled();
 		finishPruning();
 		await expect(
 			Promise.all([firstAutosave, secondAutosave])
@@ -110,6 +123,7 @@ describe('createSitesAPI', () => {
 			{ slug: site.slug, storage: 'opfs' },
 			{ slug: site.slug, storage: 'opfs' },
 		]);
+		expect(pushState).toHaveBeenCalledTimes(1);
 	});
 
 	it('applies each concurrent caller’s routing and pruning options', async () => {

--- a/packages/playground/website/src/lib/state/redux/site-management-api-middleware.spec.ts
+++ b/packages/playground/website/src/lib/state/redux/site-management-api-middleware.spec.ts
@@ -114,6 +114,7 @@ describe('createSitesAPI', () => {
 		expect(secondAutosaveFinished).toBe(false);
 		expect(mocks.pruneAutosavedSites).toHaveBeenNthCalledWith(1, {
 			excludeSlugs: [site.slug],
+			signal: expect.any(AbortSignal),
 		});
 		expect(pushState).not.toHaveBeenCalled();
 		finishPruning();
@@ -125,6 +126,7 @@ describe('createSitesAPI', () => {
 		]);
 		expect(mocks.pruneAutosavedSites).toHaveBeenNthCalledWith(2, {
 			excludeSlugs: [site.slug, 'late-exclusion'],
+			signal: expect.any(AbortSignal),
 		});
 		expect(pushState).toHaveBeenCalledTimes(1);
 	});
@@ -170,8 +172,69 @@ describe('createSitesAPI', () => {
 		expect(mocks.pruneAutosavedSites).toHaveBeenCalledOnce();
 		expect(mocks.pruneAutosavedSites).toHaveBeenCalledWith({
 			excludeSlugs: [site.slug, 'first-exclusion', 'second-exclusion'],
+			signal: expect.any(AbortSignal),
 		});
 		expect(pushState).toHaveBeenCalledTimes(1);
+	});
+
+	it('coordinates pruning exclusions across site slugs', async () => {
+		const firstSite = createTemporarySite('first-site');
+		const secondSite = createTemporarySite('second-site');
+		const state = createState(firstSite, secondSite);
+		let finishPersistence!: () => void;
+		const persistenceCanFinish = new Promise<void>((resolve) => {
+			finishPersistence = resolve;
+		});
+		mocks.persistTemporarySite.mockImplementation(
+			(siteSlug: string) => async () => {
+				await persistenceCanFinish;
+				state.sites.entities[siteSlug]!.metadata.storage = 'opfs';
+			}
+		);
+		let finishFirstPrune!: () => void;
+		const firstPruneCanFinish = new Promise<void>((resolve) => {
+			finishFirstPrune = resolve;
+		});
+		let pruneRuns = 0;
+		mocks.pruneAutosavedSites.mockImplementation(() => async () => {
+			pruneRuns++;
+			if (pruneRuns === 1) {
+				await firstPruneCanFinish;
+			}
+		});
+		const dispatch = vi.fn((action: unknown) => {
+			if (typeof action === 'function') {
+				return action(dispatch, () => state);
+			}
+			return action;
+		}) as unknown as PlaygroundDispatch;
+		const api = createSitesAPI(() => state, dispatch);
+
+		const firstAutosave = api.autosaveTemporarySite(firstSite.slug, {
+			excludeFromPruning: ['first-protected-site'],
+		});
+		const secondAutosave = api.autosaveTemporarySite(secondSite.slug, {
+			excludeFromPruning: ['second-protected-site'],
+		});
+		finishPersistence();
+
+		await vi.waitFor(() =>
+			expect(mocks.pruneAutosavedSites).toHaveBeenCalledTimes(1)
+		);
+		expect(mocks.pruneAutosavedSites).toHaveBeenNthCalledWith(1, {
+			excludeSlugs: [
+				firstSite.slug,
+				'first-protected-site',
+				secondSite.slug,
+				'second-protected-site',
+			],
+			signal: expect.any(AbortSignal),
+		});
+		expect(pruneRuns).toBe(1);
+
+		finishFirstPrune();
+		await Promise.all([firstAutosave, secondAutosave]);
+		expect(pruneRuns).toBe(1);
 	});
 });
 
@@ -188,21 +251,23 @@ function createDispatch(
 	}) as unknown as PlaygroundDispatch;
 }
 
-function createState(site: SiteInfo): PlaygroundReduxState {
+function createState(...sites: SiteInfo[]): PlaygroundReduxState {
 	return {
-		ui: { activeSite: { slug: site.slug } },
+		ui: { activeSite: { slug: sites[0].slug } },
 		sites: {
-			ids: [site.slug],
-			entities: { [site.slug]: site },
+			ids: sites.map((site) => site.slug),
+			entities: Object.fromEntries(
+				sites.map((site) => [site.slug, site])
+			),
 		},
 	} as PlaygroundReduxState;
 }
 
-function createTemporarySite(): SiteInfo {
+function createTemporarySite(slug = 'test-site'): SiteInfo {
 	return {
-		slug: 'test-site',
+		slug,
 		metadata: {
-			id: 'test-site',
+			id: slug,
 			name: 'Test Playground',
 			storage: 'none',
 			whenCreated: 0,

--- a/packages/playground/website/src/lib/state/redux/site-management-api-middleware.spec.ts
+++ b/packages/playground/website/src/lib/state/redux/site-management-api-middleware.spec.ts
@@ -1,15 +1,22 @@
 // @vitest-environment jsdom
 
 import type { PlaygroundDispatch, PlaygroundReduxState } from './store';
+import type * as SliceSitesModule from './slice-sites';
 import type { SiteInfo } from './slice-sites';
 import { createSitesAPI } from './site-management-api-middleware';
 
 const mocks = vi.hoisted(() => ({
 	persistTemporarySite: vi.fn(),
+	pruneAutosavedSites: vi.fn(),
 }));
 
 vi.mock('./persist-temporary-site', () => ({
 	persistTemporarySite: mocks.persistTemporarySite,
+}));
+
+vi.mock('./slice-sites', async (importOriginal) => ({
+	...(await importOriginal<typeof SliceSitesModule>()),
+	pruneAutosavedSites: mocks.pruneAutosavedSites,
 }));
 
 vi.mock('./store', () => ({
@@ -24,7 +31,12 @@ vi.mock('./store', () => ({
 }));
 
 describe('createSitesAPI', () => {
-	it('shares an autosave already running for the same site', async () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mocks.pruneAutosavedSites.mockImplementation(() => vi.fn());
+	});
+
+	it('shares an autosave between API instances for the same store', async () => {
 		const site = createTemporarySite();
 		const state = createState(site);
 		let finishPersistence!: () => void;
@@ -36,18 +48,16 @@ describe('createSitesAPI', () => {
 			site.metadata.storage = 'opfs';
 		});
 		mocks.persistTemporarySite.mockReturnValue(persist);
-		const dispatch = vi.fn((action) => {
-			if (action === persist) {
-				return persist();
-			}
-			return Promise.resolve();
-		}) as unknown as PlaygroundDispatch;
-		const api = createSitesAPI(() => state, dispatch);
+		const dispatch = createDispatch(persist);
+		const firstApi = createSitesAPI(() => state, dispatch);
+		const secondApi = createSitesAPI(() => state, dispatch);
 
-		const firstAutosave = api.autosaveTemporarySite(site.slug);
-		const secondAutosave = api.autosaveTemporarySite(site.slug);
+		const firstAutosave = firstApi.autosaveTemporarySite(site.slug);
+		const secondAutosave = secondApi.autosaveTemporarySite(site.slug);
 
-		expect(mocks.persistTemporarySite).toHaveBeenCalledTimes(1);
+		await vi.waitFor(() =>
+			expect(mocks.persistTemporarySite).toHaveBeenCalledTimes(1)
+		);
 		finishPersistence();
 		await expect(
 			Promise.all([firstAutosave, secondAutosave])
@@ -56,7 +66,110 @@ describe('createSitesAPI', () => {
 			{ slug: site.slug, storage: 'opfs' },
 		]);
 	});
+
+	it('waits for finalization when persistence has already updated storage', async () => {
+		const site = createTemporarySite();
+		const state = createState(site);
+		let finishPersistence!: () => void;
+		const persistenceCanFinish = new Promise<void>((resolve) => {
+			finishPersistence = resolve;
+		});
+		const persist = vi.fn(async () => {
+			await persistenceCanFinish;
+			site.metadata.storage = 'opfs';
+		});
+		mocks.persistTemporarySite.mockReturnValue(persist);
+		let finishPruning!: () => void;
+		const pruningCanFinish = new Promise<void>((resolve) => {
+			finishPruning = resolve;
+		});
+		const prune = vi.fn();
+		mocks.pruneAutosavedSites.mockReturnValue(prune);
+		const dispatch = createDispatch(persist, (action) =>
+			action === prune ? pruningCanFinish : Promise.resolve()
+		);
+		const api = createSitesAPI(() => state, dispatch);
+
+		const firstAutosave = api.autosaveTemporarySite(site.slug);
+		finishPersistence();
+		await vi.waitFor(() =>
+			expect(mocks.pruneAutosavedSites).toHaveBeenCalledTimes(1)
+		);
+		const secondAutosave = api.autosaveTemporarySite(site.slug);
+		let secondAutosaveFinished = false;
+		void secondAutosave.then(() => {
+			secondAutosaveFinished = true;
+		});
+		await Promise.resolve();
+
+		expect(secondAutosaveFinished).toBe(false);
+		finishPruning();
+		await expect(
+			Promise.all([firstAutosave, secondAutosave])
+		).resolves.toEqual([
+			{ slug: site.slug, storage: 'opfs' },
+			{ slug: site.slug, storage: 'opfs' },
+		]);
+	});
+
+	it('applies each concurrent caller’s routing and pruning options', async () => {
+		const site = createTemporarySite();
+		const state = createState(site);
+		let finishPersistence!: () => void;
+		const persistenceCanFinish = new Promise<void>((resolve) => {
+			finishPersistence = resolve;
+		});
+		const persist = vi.fn(async () => {
+			await persistenceCanFinish;
+			site.metadata.storage = 'opfs';
+		});
+		mocks.persistTemporarySite.mockReturnValue(persist);
+		const dispatch = createDispatch(persist);
+		const api = createSitesAPI(() => state, dispatch);
+		const pushState = vi
+			.spyOn(window.history, 'pushState')
+			.mockImplementation(() => undefined);
+
+		const firstAutosave = api.autosaveTemporarySite(site.slug, {
+			excludeFromPruning: ['first-exclusion'],
+		});
+		const secondAutosave = api.autosaveTemporarySite(site.slug, {
+			updateUrl: true,
+			excludeFromPruning: ['second-exclusion'],
+		});
+		finishPersistence();
+		await Promise.all([firstAutosave, secondAutosave]);
+
+		expect(mocks.persistTemporarySite).toHaveBeenCalledTimes(1);
+		expect(mocks.persistTemporarySite).toHaveBeenCalledWith(
+			site.slug,
+			'opfs',
+			{
+				skipRenameModal: true,
+				persistence: 'autosave',
+				updateUrl: false,
+			}
+		);
+		expect(mocks.pruneAutosavedSites).toHaveBeenCalledOnce();
+		expect(mocks.pruneAutosavedSites).toHaveBeenCalledWith({
+			excludeSlugs: [site.slug, 'first-exclusion', 'second-exclusion'],
+		});
+		expect(pushState).toHaveBeenCalledTimes(1);
+	});
 });
+
+function createDispatch(
+	persist: () => Promise<void>,
+	dispatchOther: (action: unknown) => Promise<unknown> = () =>
+		Promise.resolve()
+): PlaygroundDispatch {
+	return vi.fn((action) => {
+		if (action === persist) {
+			return persist();
+		}
+		return dispatchOther(action);
+	}) as unknown as PlaygroundDispatch;
+}
 
 function createState(site: SiteInfo): PlaygroundReduxState {
 	return {

--- a/packages/playground/website/src/lib/state/redux/site-management-api-middleware.ts
+++ b/packages/playground/website/src/lib/state/redux/site-management-api-middleware.ts
@@ -50,8 +50,10 @@ type PublicSiteStorageType = Exclude<SiteStorageType, 'none'> | 'temporary';
 type SaveSiteResult = { slug: string; storage: SiteStorageType };
 type AutosaveInProgress = {
 	promise: Promise<SaveSiteResult>;
-	excludeFromPruning: Set<string>;
-	urlUpdateRequested: boolean;
+	requests: {
+		excludeFromPruning: Set<string>;
+		urlUpdateRequested: boolean;
+	};
 };
 
 // The window API and React hooks create separate API objects for the same Redux
@@ -95,10 +97,11 @@ export function createSitesAPI(
 	getState: () => PlaygroundReduxState,
 	dispatch: PlaygroundDispatch
 ) {
-	let autosavesInProgressBySiteSlug =
+	const existingAutosavesInProgress =
 		autosavesInProgressByDispatch.get(dispatch);
-	if (!autosavesInProgressBySiteSlug) {
-		autosavesInProgressBySiteSlug = new Map();
+	const autosavesInProgressBySiteSlug =
+		existingAutosavesInProgress ?? new Map<string, AutosaveInProgress>();
+	if (!existingAutosavesInProgress) {
 		autosavesInProgressByDispatch.set(
 			dispatch,
 			autosavesInProgressBySiteSlug
@@ -308,68 +311,13 @@ export function createSitesAPI(
 				if (site.metadata.storage !== 'none') {
 					return { slug: site.slug, storage: site.metadata.storage };
 				}
-				const promise = Promise.resolve()
-					.then(async () => {
-						const currentAutosave = autosaveInProgress!;
-						await dispatch(
-							persistTemporarySite(site.slug, 'opfs', {
-								skipRenameModal: true,
-								persistence: 'autosave',
-								updateUrl: false,
-							})
-						);
-						const updatedSite = selectSiteBySlug(
-							getState(),
-							site.slug
-						);
-						const storage = updatedSite?.metadata.storage;
-						if (storage !== 'opfs' && storage !== 'local-fs') {
-							throw new Error(
-								`Site ${site.slug} was not persisted (storage: ${storage}).`
-							);
-						}
-						let urlWasUpdated = false;
-						let prunedExclusionCount = 0;
-						do {
-							if (
-								currentAutosave.urlUpdateRequested &&
-								!urlWasUpdated
-							) {
-								redirectTo(PlaygroundRoute.site(updatedSite));
-								urlWasUpdated = true;
-							}
-							const excludeSlugs = [
-								...currentAutosave.excludeFromPruning,
-							];
-							await dispatch(
-								pruneAutosavedSites({ excludeSlugs })
-							);
-							prunedExclusionCount = excludeSlugs.length;
-						} while (
-							prunedExclusionCount !==
-							currentAutosave.excludeFromPruning.size
-						);
-						if (
-							currentAutosave.urlUpdateRequested &&
-							!urlWasUpdated
-						) {
-							redirectTo(PlaygroundRoute.site(updatedSite));
-						}
-						return { slug: site.slug, storage };
-					})
-					.finally(() => {
-						const currentAutosave = autosaveInProgress!;
-						if (
-							autosavesInProgressBySiteSlug.get(site.slug) ===
-							currentAutosave
-						) {
-							autosavesInProgressBySiteSlug.delete(site.slug);
-						}
-					});
-				autosaveInProgress = {
-					promise,
+				const requests: AutosaveInProgress['requests'] = {
 					excludeFromPruning: new Set([site.slug]),
 					urlUpdateRequested: false,
+				};
+				autosaveInProgress = {
+					promise: runSharedAutosave(site, requests),
+					requests,
 				};
 				autosavesInProgressBySiteSlug.set(
 					site.slug,
@@ -378,11 +326,85 @@ export function createSitesAPI(
 			}
 
 			for (const excludedSlug of options.excludeFromPruning ?? []) {
-				autosaveInProgress.excludeFromPruning.add(excludedSlug);
+				autosaveInProgress.requests.excludeFromPruning.add(
+					excludedSlug
+				);
 			}
-			autosaveInProgress.urlUpdateRequested ||=
+			autosaveInProgress.requests.urlUpdateRequested ||=
 				options.updateUrl ?? false;
 			return await autosaveInProgress.promise;
+
+			/**
+			 * Persists one site and finalizes every request that joins before it
+			 * completes.
+			 *
+			 * Persistence is shared because concurrent filesystem copies target the
+			 * same OPFS destination and race its mount and metadata work. Routing and
+			 * pruning stay outside that copy so later callers can still contribute their
+			 * requested side effects.
+			 */
+			async function runSharedAutosave(
+				siteToAutosave: SiteInfo,
+				requests: AutosaveInProgress['requests']
+			): Promise<SaveSiteResult> {
+				// Let the caller publish this promise in the per-store map before any
+				// persistence work can dispatch actions that start another autosave.
+				await Promise.resolve();
+
+				try {
+					await dispatch(
+						persistTemporarySite(siteToAutosave.slug, 'opfs', {
+							skipRenameModal: true,
+							persistence: 'autosave',
+							// Routing is decided after all concurrent callers have joined.
+							updateUrl: false,
+						})
+					);
+					const updatedSite = selectSiteBySlug(
+						getState(),
+						siteToAutosave.slug
+					);
+					const storage = updatedSite?.metadata.storage;
+					if (storage !== 'opfs' && storage !== 'local-fs') {
+						throw new Error(
+							`Site ${siteToAutosave.slug} was not persisted (storage: ${storage}).`
+						);
+					}
+
+					let urlWasUpdated = false;
+					let prunedExclusionCount = 0;
+					do {
+						if (requests.urlUpdateRequested && !urlWasUpdated) {
+							redirectTo(PlaygroundRoute.site(updatedSite));
+							urlWasUpdated = true;
+						}
+						// Never expose the mutable request set to the pruning thunk. If a
+						// caller joins while this snapshot is in use, run another pass.
+						const excludeSlugs = [...requests.excludeFromPruning];
+						await dispatch(pruneAutosavedSites({ excludeSlugs }));
+						prunedExclusionCount = excludeSlugs.length;
+					} while (
+						prunedExclusionCount !==
+						requests.excludeFromPruning.size
+					);
+					if (requests.urlUpdateRequested && !urlWasUpdated) {
+						// The URL request arrived while the final prune pass was pending.
+						redirectTo(PlaygroundRoute.site(updatedSite));
+					}
+					return { slug: siteToAutosave.slug, storage };
+				} finally {
+					// Only remove the entry owned by this workflow. A replacement for the
+					// same slug must remain registered.
+					if (
+						autosavesInProgressBySiteSlug.get(siteToAutosave.slug)
+							?.requests === requests
+					) {
+						autosavesInProgressBySiteSlug.delete(
+							siteToAutosave.slug
+						);
+					}
+				}
+			}
 		},
 
 		/**

--- a/packages/playground/website/src/lib/state/redux/site-management-api-middleware.ts
+++ b/packages/playground/website/src/lib/state/redux/site-management-api-middleware.ts
@@ -82,6 +82,10 @@ export function createSitesAPI(
 	getState: () => PlaygroundReduxState,
 	dispatch: PlaygroundDispatch
 ) {
+	const autosavesInProgressBySiteSlug = new Map<
+		string,
+		Promise<SaveSiteResult>
+	>();
 	const api = {
 		/**
 		 * Lists all known sites.
@@ -257,7 +261,9 @@ export function createSitesAPI(
 		 * Autosaves a temporary Playground into browser storage.
 		 *
 		 * Autosave keeps the current browser URL unchanged unless the caller
-		 * asks to route to the new stored site.
+		 * asks to route to the new stored site. Concurrent requests for one site
+		 * share the same persistence operation so they cannot race the filesystem
+		 * copy, metadata update, or autosave pruning.
 		 *
 		 * @param siteSlug Optional slug. Uses the active site when omitted.
 		 * @param options Optional URL update and pruning behavior.
@@ -279,29 +285,47 @@ export function createSitesAPI(
 			if (site.metadata.storage !== 'none') {
 				return { slug: site.slug, storage: site.metadata.storage };
 			}
-			await dispatch(
-				persistTemporarySite(site.slug, 'opfs', {
-					skipRenameModal: true,
-					persistence: 'autosave',
-					updateUrl: options.updateUrl ?? false,
-				})
+			const autosaveInProgress = autosavesInProgressBySiteSlug.get(
+				site.slug
 			);
-			await dispatch(
-				pruneAutosavedSites({
-					excludeSlugs: [
-						site.slug,
-						...(options.excludeFromPruning ?? []),
-					],
-				})
-			);
-			const updatedSite = selectSiteBySlug(getState(), site.slug);
-			const storage = updatedSite?.metadata.storage;
-			if (storage !== 'opfs' && storage !== 'local-fs') {
-				throw new Error(
-					`Site ${site.slug} was not persisted (storage: ${storage}).`
-				);
+			if (autosaveInProgress) {
+				return await autosaveInProgress;
 			}
-			return { slug: site.slug, storage };
+
+			const autosave = (async () => {
+				await dispatch(
+					persistTemporarySite(site.slug, 'opfs', {
+						skipRenameModal: true,
+						persistence: 'autosave',
+						updateUrl: options.updateUrl ?? false,
+					})
+				);
+				await dispatch(
+					pruneAutosavedSites({
+						excludeSlugs: [
+							site.slug,
+							...(options.excludeFromPruning ?? []),
+						],
+					})
+				);
+				const updatedSite = selectSiteBySlug(getState(), site.slug);
+				const storage = updatedSite?.metadata.storage;
+				if (storage !== 'opfs' && storage !== 'local-fs') {
+					throw new Error(
+						`Site ${site.slug} was not persisted (storage: ${storage}).`
+					);
+				}
+				return { slug: site.slug, storage };
+			})();
+			autosavesInProgressBySiteSlug.set(site.slug, autosave);
+
+			try {
+				return await autosave;
+			} finally {
+				if (autosavesInProgressBySiteSlug.get(site.slug) === autosave) {
+					autosavesInProgressBySiteSlug.delete(site.slug);
+				}
+			}
 		},
 
 		/**

--- a/packages/playground/website/src/lib/state/redux/site-management-api-middleware.ts
+++ b/packages/playground/website/src/lib/state/redux/site-management-api-middleware.ts
@@ -36,6 +36,7 @@ import type { PlaygroundClient } from '@wp-playground/remote';
 import type { AllPHPVersion } from '@php-wasm/universal';
 import { opfsSiteStorage } from '../opfs/opfs-site-storage';
 import { getSetupUrlFromUrl } from '../playground-identity';
+import { PlaygroundRoute, redirectTo } from '../url/router';
 
 export interface SiteSettings {
 	phpVersion?: AllPHPVersion;
@@ -47,6 +48,18 @@ export interface SiteSettings {
 
 type PublicSiteStorageType = Exclude<SiteStorageType, 'none'> | 'temporary';
 type SaveSiteResult = { slug: string; storage: SiteStorageType };
+type AutosaveInProgress = {
+	promise: Promise<SaveSiteResult>;
+	excludeFromPruning: Set<string>;
+	urlUpdateRequested: boolean;
+};
+
+// The window API and React hooks create separate API objects for the same Redux
+// store. Key by dispatch so those objects share autosaves without mixing stores.
+const autosavesInProgressByDispatch = new WeakMap<
+	PlaygroundDispatch,
+	Map<string, AutosaveInProgress>
+>();
 
 /**
  * API for listing, renaming, saving, and opening Playground
@@ -82,10 +95,15 @@ export function createSitesAPI(
 	getState: () => PlaygroundReduxState,
 	dispatch: PlaygroundDispatch
 ) {
-	const autosavesInProgressBySiteSlug = new Map<
-		string,
-		Promise<SaveSiteResult>
-	>();
+	let autosavesInProgressBySiteSlug =
+		autosavesInProgressByDispatch.get(dispatch);
+	if (!autosavesInProgressBySiteSlug) {
+		autosavesInProgressBySiteSlug = new Map();
+		autosavesInProgressByDispatch.set(
+			dispatch,
+			autosavesInProgressBySiteSlug
+		);
+	}
 	const api = {
 		/**
 		 * Lists all known sites.
@@ -261,9 +279,10 @@ export function createSitesAPI(
 		 * Autosaves a temporary Playground into browser storage.
 		 *
 		 * Autosave keeps the current browser URL unchanged unless the caller
-		 * asks to route to the new stored site. Concurrent requests for one site
-		 * share the same persistence operation so they cannot race the filesystem
-		 * copy, metadata update, or autosave pruning.
+		 * asks to route to the new stored site. Concurrent requests that begin while
+		 * one site is temporary share the filesystem copy and metadata update.
+		 * Routing runs when any caller requests it, and pruning uses their combined
+		 * exclusions.
 		 *
 		 * @param siteSlug Optional slug. Uses the active site when omitted.
 		 * @param options Optional URL update and pruning behavior.
@@ -282,50 +301,74 @@ export function createSitesAPI(
 			if (!site) {
 				throw new Error('No site selected');
 			}
-			if (site.metadata.storage !== 'none') {
-				return { slug: site.slug, storage: site.metadata.storage };
-			}
-			const autosaveInProgress = autosavesInProgressBySiteSlug.get(
+			let autosaveInProgress = autosavesInProgressBySiteSlug.get(
 				site.slug
 			);
-			if (autosaveInProgress) {
-				return await autosaveInProgress;
+			if (!autosaveInProgress) {
+				if (site.metadata.storage !== 'none') {
+					return { slug: site.slug, storage: site.metadata.storage };
+				}
+				const promise = Promise.resolve()
+					.then(async () => {
+						const currentAutosave = autosaveInProgress!;
+						await dispatch(
+							persistTemporarySite(site.slug, 'opfs', {
+								skipRenameModal: true,
+								persistence: 'autosave',
+								updateUrl: false,
+							})
+						);
+						const updatedSite = selectSiteBySlug(
+							getState(),
+							site.slug
+						);
+						const storage = updatedSite?.metadata.storage;
+						if (storage !== 'opfs' && storage !== 'local-fs') {
+							throw new Error(
+								`Site ${site.slug} was not persisted (storage: ${storage}).`
+							);
+						}
+						if (currentAutosave.urlUpdateRequested) {
+							redirectTo(PlaygroundRoute.site(updatedSite));
+						}
+						await dispatch(
+							pruneAutosavedSites({
+								excludeSlugs: [
+									site.slug,
+									...currentAutosave.excludeFromPruning,
+								],
+							})
+						);
+						return { slug: site.slug, storage };
+					})
+					.finally(() => {
+						const currentAutosave = autosaveInProgress!;
+						if (
+							autosavesInProgressBySiteSlug.get(site.slug) ===
+							currentAutosave
+						) {
+							autosavesInProgressBySiteSlug.delete(site.slug);
+						}
+					});
+				autosaveInProgress = {
+					promise,
+					excludeFromPruning: new Set(),
+					urlUpdateRequested: false,
+				};
+				autosavesInProgressBySiteSlug.set(
+					site.slug,
+					autosaveInProgress
+				);
 			}
 
-			const autosave = (async () => {
-				await dispatch(
-					persistTemporarySite(site.slug, 'opfs', {
-						skipRenameModal: true,
-						persistence: 'autosave',
-						updateUrl: options.updateUrl ?? false,
-					})
-				);
-				await dispatch(
-					pruneAutosavedSites({
-						excludeSlugs: [
-							site.slug,
-							...(options.excludeFromPruning ?? []),
-						],
-					})
-				);
-				const updatedSite = selectSiteBySlug(getState(), site.slug);
-				const storage = updatedSite?.metadata.storage;
-				if (storage !== 'opfs' && storage !== 'local-fs') {
-					throw new Error(
-						`Site ${site.slug} was not persisted (storage: ${storage}).`
-					);
+			if (site.metadata.storage === 'none') {
+				for (const excludedSlug of options.excludeFromPruning ?? []) {
+					autosaveInProgress.excludeFromPruning.add(excludedSlug);
 				}
-				return { slug: site.slug, storage };
-			})();
-			autosavesInProgressBySiteSlug.set(site.slug, autosave);
-
-			try {
-				return await autosave;
-			} finally {
-				if (autosavesInProgressBySiteSlug.get(site.slug) === autosave) {
-					autosavesInProgressBySiteSlug.delete(site.slug);
-				}
+				autosaveInProgress.urlUpdateRequested ||=
+					options.updateUrl ?? false;
 			}
+			return await autosaveInProgress.promise;
 		},
 
 		/**

--- a/packages/playground/website/src/lib/state/redux/site-management-api-middleware.ts
+++ b/packages/playground/website/src/lib/state/redux/site-management-api-middleware.ts
@@ -97,16 +97,10 @@ export function createSitesAPI(
 	getState: () => PlaygroundReduxState,
 	dispatch: PlaygroundDispatch
 ) {
-	const existingAutosavesInProgress =
-		autosavesInProgressByDispatch.get(dispatch);
 	const autosavesInProgressBySiteSlug =
-		existingAutosavesInProgress ?? new Map<string, AutosaveInProgress>();
-	if (!existingAutosavesInProgress) {
-		autosavesInProgressByDispatch.set(
-			dispatch,
-			autosavesInProgressBySiteSlug
-		);
-	}
+		autosavesInProgressByDispatch.get(dispatch) ??
+		new Map<string, AutosaveInProgress>();
+	autosavesInProgressByDispatch.set(dispatch, autosavesInProgressBySiteSlug);
 	const api = {
 		/**
 		 * Lists all known sites.

--- a/packages/playground/website/src/lib/state/redux/site-management-api-middleware.ts
+++ b/packages/playground/website/src/lib/state/redux/site-management-api-middleware.ts
@@ -50,7 +50,7 @@ type PublicSiteStorageType = Exclude<SiteStorageType, 'none'> | 'temporary';
 type SaveSiteResult = { slug: string; storage: SiteStorageType };
 type AutosaveInProgress = {
 	promise: Promise<SaveSiteResult>;
-	excludeFromPruning: Set<string>;
+	excludeFromPruning: string[];
 	urlUpdateRequested: boolean;
 };
 
@@ -279,10 +279,9 @@ export function createSitesAPI(
 		 * Autosaves a temporary Playground into browser storage.
 		 *
 		 * Autosave keeps the current browser URL unchanged unless the caller
-		 * asks to route to the new stored site. Concurrent requests that begin while
-		 * one site is temporary share the filesystem copy and metadata update.
-		 * Routing runs when any caller requests it, and pruning uses their combined
-		 * exclusions.
+		 * asks to route to the new stored site. Concurrent requests for one site
+		 * share the filesystem copy and metadata update. Routing runs when any caller
+		 * requests it, and pruning checks their combined exclusions as it proceeds.
 		 *
 		 * @param siteSlug Optional slug. Uses the active site when omitted.
 		 * @param options Optional URL update and pruning behavior.
@@ -328,17 +327,23 @@ export function createSitesAPI(
 								`Site ${site.slug} was not persisted (storage: ${storage}).`
 							);
 						}
+						let urlWasUpdated = false;
 						if (currentAutosave.urlUpdateRequested) {
 							redirectTo(PlaygroundRoute.site(updatedSite));
+							urlWasUpdated = true;
 						}
 						await dispatch(
 							pruneAutosavedSites({
-								excludeSlugs: [
-									site.slug,
-									...currentAutosave.excludeFromPruning,
-								],
+								excludeSlugs:
+									currentAutosave.excludeFromPruning,
 							})
 						);
+						if (
+							currentAutosave.urlUpdateRequested &&
+							!urlWasUpdated
+						) {
+							redirectTo(PlaygroundRoute.site(updatedSite));
+						}
 						return { slug: site.slug, storage };
 					})
 					.finally(() => {
@@ -352,7 +357,7 @@ export function createSitesAPI(
 					});
 				autosaveInProgress = {
 					promise,
-					excludeFromPruning: new Set(),
+					excludeFromPruning: [site.slug],
 					urlUpdateRequested: false,
 				};
 				autosavesInProgressBySiteSlug.set(
@@ -361,13 +366,17 @@ export function createSitesAPI(
 				);
 			}
 
-			if (site.metadata.storage === 'none') {
-				for (const excludedSlug of options.excludeFromPruning ?? []) {
-					autosaveInProgress.excludeFromPruning.add(excludedSlug);
+			for (const excludedSlug of options.excludeFromPruning ?? []) {
+				if (
+					!autosaveInProgress.excludeFromPruning.includes(
+						excludedSlug
+					)
+				) {
+					autosaveInProgress.excludeFromPruning.push(excludedSlug);
 				}
-				autosaveInProgress.urlUpdateRequested ||=
-					options.updateUrl ?? false;
 			}
+			autosaveInProgress.urlUpdateRequested ||=
+				options.updateUrl ?? false;
 			return await autosaveInProgress.promise;
 		},
 

--- a/packages/playground/website/src/lib/state/redux/site-management-api-middleware.ts
+++ b/packages/playground/website/src/lib/state/redux/site-management-api-middleware.ts
@@ -400,7 +400,7 @@ export function createSitesAPI(
 						siteToAutosave.slug
 					);
 					const storage = updatedSite?.metadata.storage;
-					if (storage !== 'opfs' && storage !== 'local-fs') {
+					if (!updatedSite || !isStoredSite(updatedSite)) {
 						throw new Error(
 							`Site ${siteToAutosave.slug} was not persisted (storage: ${storage}).`
 						);

--- a/packages/playground/website/src/lib/state/redux/site-management-api-middleware.ts
+++ b/packages/playground/website/src/lib/state/redux/site-management-api-middleware.ts
@@ -25,6 +25,7 @@ import {
 	deriveSiteNameFromSlug,
 	getSitePublicPersistence,
 	isAutosavedSite,
+	isStoredSite,
 	type SiteInfo,
 	type SitePersistence,
 	type SiteStorageType,
@@ -308,7 +309,7 @@ export function createSitesAPI(
 			// and await the same persistence and pruning work.
 			if (!autosaveInProgress) {
 				// With no shared autosave left to finalize, a stored site needs no work.
-				if (site.metadata.storage !== 'none') {
+				if (isStoredSite(site)) {
 					return { slug: site.slug, storage: site.metadata.storage };
 				}
 				// Always protect the site being saved from pruning. Caller-specific

--- a/packages/playground/website/src/lib/state/redux/site-management-api-middleware.ts
+++ b/packages/playground/website/src/lib/state/redux/site-management-api-middleware.ts
@@ -50,7 +50,7 @@ type PublicSiteStorageType = Exclude<SiteStorageType, 'none'> | 'temporary';
 type SaveSiteResult = { slug: string; storage: SiteStorageType };
 type AutosaveInProgress = {
 	promise: Promise<SaveSiteResult>;
-	excludeFromPruning: string[];
+	excludeFromPruning: Set<string>;
 	urlUpdateRequested: boolean;
 };
 
@@ -281,7 +281,8 @@ export function createSitesAPI(
 		 * Autosave keeps the current browser URL unchanged unless the caller
 		 * asks to route to the new stored site. Concurrent requests for one site
 		 * share the filesystem copy and metadata update. Routing runs when any caller
-		 * requests it, and pruning checks their combined exclusions as it proceeds.
+		 * requests it. Pruning repeats with a new immutable exclusion snapshot when a
+		 * caller joins during the current prune pass.
 		 *
 		 * @param siteSlug Optional slug. Uses the active site when omitted.
 		 * @param options Optional URL update and pruning behavior.
@@ -328,15 +329,25 @@ export function createSitesAPI(
 							);
 						}
 						let urlWasUpdated = false;
-						if (currentAutosave.urlUpdateRequested) {
-							redirectTo(PlaygroundRoute.site(updatedSite));
-							urlWasUpdated = true;
-						}
-						await dispatch(
-							pruneAutosavedSites({
-								excludeSlugs:
-									currentAutosave.excludeFromPruning,
-							})
+						let prunedExclusionCount = 0;
+						do {
+							if (
+								currentAutosave.urlUpdateRequested &&
+								!urlWasUpdated
+							) {
+								redirectTo(PlaygroundRoute.site(updatedSite));
+								urlWasUpdated = true;
+							}
+							const excludeSlugs = [
+								...currentAutosave.excludeFromPruning,
+							];
+							await dispatch(
+								pruneAutosavedSites({ excludeSlugs })
+							);
+							prunedExclusionCount = excludeSlugs.length;
+						} while (
+							prunedExclusionCount !==
+							currentAutosave.excludeFromPruning.size
 						);
 						if (
 							currentAutosave.urlUpdateRequested &&
@@ -357,7 +368,7 @@ export function createSitesAPI(
 					});
 				autosaveInProgress = {
 					promise,
-					excludeFromPruning: [site.slug],
+					excludeFromPruning: new Set([site.slug]),
 					urlUpdateRequested: false,
 				};
 				autosavesInProgressBySiteSlug.set(
@@ -367,13 +378,7 @@ export function createSitesAPI(
 			}
 
 			for (const excludedSlug of options.excludeFromPruning ?? []) {
-				if (
-					!autosaveInProgress.excludeFromPruning.includes(
-						excludedSlug
-					)
-				) {
-					autosaveInProgress.excludeFromPruning.push(excludedSlug);
-				}
+				autosaveInProgress.excludeFromPruning.add(excludedSlug);
 			}
 			autosaveInProgress.urlUpdateRequested ||=
 				options.updateUrl ?? false;

--- a/packages/playground/website/src/lib/state/redux/site-management-api-middleware.ts
+++ b/packages/playground/website/src/lib/state/redux/site-management-api-middleware.ts
@@ -97,10 +97,12 @@ export function createSitesAPI(
 	getState: () => PlaygroundReduxState,
 	dispatch: PlaygroundDispatch
 ) {
-	const autosavesInProgressBySiteSlug =
-		autosavesInProgressByDispatch.get(dispatch) ??
-		new Map<string, AutosaveInProgress>();
-	autosavesInProgressByDispatch.set(dispatch, autosavesInProgressBySiteSlug);
+	let autosavesForStore = autosavesInProgressByDispatch.get(dispatch);
+	if (!autosavesForStore) {
+		autosavesForStore = new Map();
+		autosavesInProgressByDispatch.set(dispatch, autosavesForStore);
+	}
+	const autosavesInProgressBySiteSlug = autosavesForStore;
 	const api = {
 		/**
 		 * Lists all known sites.
@@ -301,10 +303,17 @@ export function createSitesAPI(
 			let autosaveInProgress = autosavesInProgressBySiteSlug.get(
 				site.slug
 			);
+			// The first caller starts and registers the shared autosave. Callers that
+			// arrive while it is running skip this branch, add their options below,
+			// and await the same persistence and pruning work.
 			if (!autosaveInProgress) {
+				// With no shared autosave left to finalize, a stored site needs no work.
 				if (site.metadata.storage !== 'none') {
 					return { slug: site.slug, storage: site.metadata.storage };
 				}
+				// Always protect the site being saved from pruning. Caller-specific
+				// exclusions and routing requests are merged below for both the first
+				// caller and any callers that join later.
 				const requests: AutosaveInProgress['requests'] = {
 					excludeFromPruning: new Set([site.slug]),
 					urlUpdateRequested: false,

--- a/packages/playground/website/src/lib/state/redux/site-management-api-middleware.ts
+++ b/packages/playground/website/src/lib/state/redux/site-management-api-middleware.ts
@@ -52,16 +52,22 @@ type SaveSiteResult = { slug: string; storage: SiteStorageType };
 type AutosaveInProgress = {
 	promise: Promise<SaveSiteResult>;
 	requests: {
-		excludeFromPruning: Set<string>;
 		urlUpdateRequested: boolean;
 	};
 };
+type AutosaveCoordinator = {
+	autosavesBySiteSlug: Map<string, AutosaveInProgress>;
+	activePruningExclusions: Set<ReadonlySet<string>>;
+	pruneInProgress?: Promise<void>;
+	activePruneAbortController?: AbortController;
+};
 
 // The window API and React hooks create separate API objects for the same Redux
-// store. Key by dispatch so those objects share autosaves without mixing stores.
-const autosavesInProgressByDispatch = new WeakMap<
+// store. Key by dispatch so those objects share per-site persistence and one
+// store-wide pruning operation without mixing stores.
+const autosaveCoordinatorsByDispatch = new WeakMap<
 	PlaygroundDispatch,
-	Map<string, AutosaveInProgress>
+	AutosaveCoordinator
 >();
 
 /**
@@ -98,12 +104,16 @@ export function createSitesAPI(
 	getState: () => PlaygroundReduxState,
 	dispatch: PlaygroundDispatch
 ) {
-	let autosavesForStore = autosavesInProgressByDispatch.get(dispatch);
-	if (!autosavesForStore) {
-		autosavesForStore = new Map();
-		autosavesInProgressByDispatch.set(dispatch, autosavesForStore);
+	let autosaveCoordinator = autosaveCoordinatorsByDispatch.get(dispatch);
+	if (!autosaveCoordinator) {
+		autosaveCoordinator = {
+			autosavesBySiteSlug: new Map(),
+			activePruningExclusions: new Set(),
+		};
+		autosaveCoordinatorsByDispatch.set(dispatch, autosaveCoordinator);
 	}
-	const autosavesInProgressBySiteSlug = autosavesForStore;
+	const coordinator = autosaveCoordinator;
+	const autosavesInProgressBySiteSlug = coordinator.autosavesBySiteSlug;
 	const api = {
 		/**
 		 * Lists all known sites.
@@ -281,8 +291,8 @@ export function createSitesAPI(
 		 * Autosave keeps the current browser URL unchanged unless the caller
 		 * asks to route to the new stored site. Concurrent requests for one site
 		 * share the filesystem copy and metadata update. Routing runs when any caller
-		 * requests it. Pruning repeats with a new immutable exclusion snapshot when a
-		 * caller joins during the current prune pass.
+		 * requests it. Pruning is serialized across the store and protects the slugs
+		 * requested by every concurrent autosave.
 		 *
 		 * @param siteSlug Optional slug. Uses the active site when omitted.
 		 * @param options Optional URL update and pruning behavior.
@@ -304,48 +314,52 @@ export function createSitesAPI(
 			let autosaveInProgress = autosavesInProgressBySiteSlug.get(
 				site.slug
 			);
-			// The first caller starts and registers the shared autosave. Callers that
-			// arrive while it is running skip this branch, add their options below,
-			// and await the same persistence and pruning work.
-			if (!autosaveInProgress) {
-				// With no shared autosave left to finalize, a stored site needs no work.
-				if (isStoredSite(site)) {
-					return { slug: site.slug, storage: site.metadata.storage };
-				}
-				// Always protect the site being saved from pruning. Caller-specific
-				// exclusions and routing requests are merged below for both the first
-				// caller and any callers that join later.
-				const requests: AutosaveInProgress['requests'] = {
-					excludeFromPruning: new Set([site.slug]),
-					urlUpdateRequested: false,
-				};
-				autosaveInProgress = {
-					promise: runSharedAutosave(site, requests),
-					requests,
-				};
-				autosavesInProgressBySiteSlug.set(
-					site.slug,
-					autosaveInProgress
-				);
+			// With no shared autosave left to finalize, a stored site needs no work.
+			if (!autosaveInProgress && isStoredSite(site)) {
+				return { slug: site.slug, storage: site.metadata.storage };
 			}
 
-			for (const excludedSlug of options.excludeFromPruning ?? []) {
-				autosaveInProgress.requests.excludeFromPruning.add(
-					excludedSlug
-				);
+			// Pruning is store-wide, so register this caller's exclusions with the
+			// store coordinator rather than the per-site persistence operation.
+			const pruningExclusions = new Set([
+				site.slug,
+				...(options.excludeFromPruning ?? []),
+			]);
+			coordinator.activePruningExclusions.add(pruningExclusions);
+			// Stop between deletions and restart with a new immutable snapshot.
+			coordinator.activePruneAbortController?.abort();
+
+			try {
+				// The first caller starts and registers the shared persistence work.
+				// Later callers contribute routing and await that same operation.
+				if (!autosaveInProgress) {
+					const requests: AutosaveInProgress['requests'] = {
+						urlUpdateRequested: false,
+					};
+					autosaveInProgress = {
+						promise: runSharedAutosave(site, requests),
+						requests,
+					};
+					autosavesInProgressBySiteSlug.set(
+						site.slug,
+						autosaveInProgress
+					);
+				}
+
+				autosaveInProgress.requests.urlUpdateRequested ||=
+					options.updateUrl ?? false;
+				return await autosaveInProgress.promise;
+			} finally {
+				coordinator.activePruningExclusions.delete(pruningExclusions);
 			}
-			autosaveInProgress.requests.urlUpdateRequested ||=
-				options.updateUrl ?? false;
-			return await autosaveInProgress.promise;
 
 			/**
 			 * Persists one site and finalizes every request that joins before it
 			 * completes.
 			 *
 			 * Persistence is shared because concurrent filesystem copies target the
-			 * same OPFS destination and race its mount and metadata work. Routing and
-			 * pruning stay outside that copy so later callers can still contribute their
-			 * requested side effects.
+			 * same OPFS destination and race its mount and metadata work. Routing remains
+			 * attached to that site, while pruning is coordinated across the store.
 			 */
 			async function runSharedAutosave(
 				siteToAutosave: SiteInfo,
@@ -376,23 +390,13 @@ export function createSitesAPI(
 					}
 
 					let urlWasUpdated = false;
-					let prunedExclusionCount = 0;
-					do {
-						if (requests.urlUpdateRequested && !urlWasUpdated) {
-							redirectTo(PlaygroundRoute.site(updatedSite));
-							urlWasUpdated = true;
-						}
-						// Never expose the mutable request set to the pruning thunk. If a
-						// caller joins while this snapshot is in use, run another pass.
-						const excludeSlugs = [...requests.excludeFromPruning];
-						await dispatch(pruneAutosavedSites({ excludeSlugs }));
-						prunedExclusionCount = excludeSlugs.length;
-					} while (
-						prunedExclusionCount !==
-						requests.excludeFromPruning.size
-					);
+					if (requests.urlUpdateRequested) {
+						redirectTo(PlaygroundRoute.site(updatedSite));
+						urlWasUpdated = true;
+					}
+					await runStoreWidePruning();
 					if (requests.urlUpdateRequested && !urlWasUpdated) {
-						// The URL request arrived while the final prune pass was pending.
+						// The URL request arrived while pruning was pending.
 						redirectTo(PlaygroundRoute.site(updatedSite));
 					}
 					return { slug: siteToAutosave.slug, storage };
@@ -408,6 +412,66 @@ export function createSitesAPI(
 						);
 					}
 				}
+			}
+
+			/**
+			 * Shares one store-wide prune between concurrent autosaves. A caller that
+			 * arrives during a pass aborts it between deletions; the pass then restarts
+			 * with a fresh snapshot containing every active caller's exclusions.
+			 */
+			async function runStoreWidePruning(): Promise<void> {
+				let pruning = coordinator.pruneInProgress;
+				if (!pruning) {
+					pruning = runPruningPasses();
+					coordinator.pruneInProgress = pruning;
+				}
+				await pruning;
+
+				async function runPruningPasses(): Promise<void> {
+					// Publish the promise before pruning can dispatch more autosave work.
+					await Promise.resolve();
+					try {
+						let passWasAborted: boolean;
+						do {
+							const abortController = new AbortController();
+							coordinator.activePruneAbortController =
+								abortController;
+							try {
+								await dispatch(
+									pruneAutosavedSites({
+										excludeSlugs: [
+											...getActivePruningExclusions(),
+										],
+										signal: abortController.signal,
+									})
+								);
+							} finally {
+								if (
+									coordinator.activePruneAbortController ===
+									abortController
+								) {
+									coordinator.activePruneAbortController =
+										undefined;
+								}
+							}
+							passWasAborted = abortController.signal.aborted;
+						} while (passWasAborted);
+					} finally {
+						if (coordinator.pruneInProgress === pruning) {
+							coordinator.pruneInProgress = undefined;
+						}
+					}
+				}
+			}
+
+			function getActivePruningExclusions(): Set<string> {
+				const slugs = new Set<string>();
+				for (const exclusions of coordinator.activePruningExclusions) {
+					for (const slug of exclusions) {
+						slugs.add(slug);
+					}
+				}
+				return slugs;
 			}
 		},
 

--- a/packages/playground/website/src/lib/state/redux/site-management-api-middleware.ts
+++ b/packages/playground/website/src/lib/state/redux/site-management-api-middleware.ts
@@ -49,12 +49,28 @@ export interface SiteSettings {
 
 type PublicSiteStorageType = Exclude<SiteStorageType, 'none'> | 'temporary';
 type SaveSiteResult = { slug: string; storage: SiteStorageType };
+
+/**
+ * Tracks the operation shared by concurrent autosave calls for one site.
+ *
+ * The promise covers persistence, routing, and pruning. Routing requests remain
+ * mutable until the operation completes because a later caller may require a
+ * URL update while awaiting the same promise.
+ */
 type AutosaveInProgress = {
 	promise: Promise<SaveSiteResult>;
 	requests: {
 		urlUpdateRequested: boolean;
 	};
 };
+
+/**
+ * Coordinates autosaves created for one Redux store.
+ *
+ * Filesystem persistence is shared by site slug. Pruning reads the store's
+ * complete site list, so active calls contribute exclusions to one shared
+ * pruning operation.
+ */
 type AutosaveCoordinator = {
 	autosavesBySiteSlug: Map<string, AutosaveInProgress>;
 	activePruningExclusions: Set<ReadonlySet<string>>;
@@ -314,24 +330,26 @@ export function createSitesAPI(
 			let autosaveInProgress = autosavesInProgressBySiteSlug.get(
 				site.slug
 			);
-			// With no shared autosave left to finalize, a stored site needs no work.
+			// A stored site with no autosave in progress has no work left to complete.
 			if (!autosaveInProgress && isStoredSite(site)) {
 				return { slug: site.slug, storage: site.metadata.storage };
 			}
 
-			// Pruning is store-wide, so register this caller's exclusions with the
-			// store coordinator rather than the per-site persistence operation.
+			// Each pruning pass considers every autosaved site in the Redux store.
+			// Keep this call's exclusions visible to the shared pass until it finishes.
 			const pruningExclusions = new Set([
 				site.slug,
 				...(options.excludeFromPruning ?? []),
 			]);
 			coordinator.activePruningExclusions.add(pruningExclusions);
-			// Stop between deletions and restart with a new immutable snapshot.
+			// A running pass selected its candidates from an older snapshot. Stop it
+			// before its next deletion so the new exclusions can be applied.
 			coordinator.activePruneAbortController?.abort();
 
 			try {
-				// The first caller starts and registers the shared persistence work.
-				// Later callers contribute routing and await that same operation.
+				// Only one filesystem copy may target a site's OPFS destination.
+				// Concurrent autosaveTemporarySite() invocations for that slug share the
+				// copy and combine whether the stored site's URL must be opened.
 				if (!autosaveInProgress) {
 					const requests: AutosaveInProgress['requests'] = {
 						urlUpdateRequested: false,
@@ -354,19 +372,18 @@ export function createSitesAPI(
 			}
 
 			/**
-			 * Persists one site and finalizes every request that joins before it
-			 * completes.
+			 * Persists one site and completes its shared routing and pruning work.
 			 *
-			 * Persistence is shared because concurrent filesystem copies target the
-			 * same OPFS destination and race its mount and metadata work. Routing remains
-			 * attached to that site, while pruning is coordinated across the store.
+			 * Concurrent filesystem copies would target the same OPFS destination and
+			 * race its mount and metadata updates. Routing remains specific to this site;
+			 * pruning joins the operation shared by the Redux store.
 			 */
 			async function runSharedAutosave(
 				siteToAutosave: SiteInfo,
 				requests: AutosaveInProgress['requests']
 			): Promise<SaveSiteResult> {
-				// Let the caller publish this promise in the per-store map before any
-				// persistence work can dispatch actions that start another autosave.
+				// The promise must be present in the per-site map before persistence can
+				// dispatch actions that start another autosave.
 				await Promise.resolve();
 
 				try {
@@ -374,7 +391,7 @@ export function createSitesAPI(
 						persistTemporarySite(siteToAutosave.slug, 'opfs', {
 							skipRenameModal: true,
 							persistence: 'autosave',
-							// Routing is decided after all concurrent callers have joined.
+							// The shared operation combines routing requests separately.
 							updateUrl: false,
 						})
 					);
@@ -415,9 +432,11 @@ export function createSitesAPI(
 			}
 
 			/**
-			 * Shares one store-wide prune between concurrent autosaves. A caller that
-			 * arrives during a pass aborts it between deletions; the pass then restarts
-			 * with a fresh snapshot containing every active caller's exclusions.
+			 * Runs the pruning operation shared by active autosaves in this Redux store.
+			 *
+			 * Each pass receives an immutable exclusion snapshot. Registering another
+			 * autosave aborts an active pass between deletions, then the loop starts a
+			 * replacement pass containing all exclusions that are still active.
 			 */
 			async function runStoreWidePruning(): Promise<void> {
 				let pruning = coordinator.pruneInProgress;
@@ -428,7 +447,8 @@ export function createSitesAPI(
 				await pruning;
 
 				async function runPruningPasses(): Promise<void> {
-					// Publish the promise before pruning can dispatch more autosave work.
+					// The shared promise must be published before pruning can dispatch work
+					// that starts another autosave.
 					await Promise.resolve();
 					try {
 						let passWasAborted: boolean;
@@ -464,6 +484,9 @@ export function createSitesAPI(
 				}
 			}
 
+			/**
+			 * Returns the union of exclusions owned by active autosave calls.
+			 */
 			function getActivePruningExclusions(): Set<string> {
 				const slugs = new Set<string>();
 				for (const exclusions of coordinator.activePruningExclusions) {

--- a/packages/playground/website/src/lib/state/redux/slice-sites.spec.ts
+++ b/packages/playground/website/src/lib/state/redux/slice-sites.spec.ts
@@ -415,61 +415,6 @@ describe('stored sites', () => {
 		);
 	});
 
-	it('honors exclusions added while a prune pass is running', async () => {
-		const { pruneAutosavedSites, sitesSlice } =
-			await import('./slice-sites');
-		const firstAutosave = createSiteInfo({ slug: 'first-autosave' });
-		firstAutosave.metadata.persistence = 'autosave';
-		firstAutosave.metadata.whenCreated = 2;
-		const excludedAutosave = createSiteInfo({
-			slug: 'excluded-autosave',
-		});
-		excludedAutosave.metadata.persistence = 'autosave';
-		excludedAutosave.metadata.whenCreated = 1;
-		let state = {
-			sites: sitesSlice.reducer(
-				undefined,
-				sitesSlice.actions.addSites([firstAutosave, excludedAutosave])
-			),
-		};
-		const getState = () => state as any;
-		const dispatch: ReturnType<typeof vi.fn> = vi.fn((action) => {
-			if (typeof action === 'function') {
-				return action(dispatch, getState);
-			}
-			state = {
-				sites: sitesSlice.reducer(state.sites, action),
-			};
-			return action;
-		});
-		let finishFirstDeletion!: () => void;
-		const firstDeletionCanFinish = new Promise<void>((resolve) => {
-			finishFirstDeletion = resolve;
-		});
-		deleteSite.mockImplementation(async (slug) => {
-			if (slug === firstAutosave.slug) {
-				await firstDeletionCanFinish;
-			}
-		});
-		const excludeSlugs: string[] = [];
-
-		const pruning = pruneAutosavedSites({ limit: 0, excludeSlugs })(
-			dispatch as any,
-			getState
-		);
-		await vi.waitFor(() =>
-			expect(deleteSite).toHaveBeenCalledWith(firstAutosave.slug)
-		);
-		excludeSlugs.push(excludedAutosave.slug);
-		finishFirstDeletion();
-		await pruning;
-
-		expect(deleteSite).not.toHaveBeenCalledWith(excludedAutosave.slug);
-		expect(state.sites.entities[excludedAutosave.slug]).toEqual(
-			excludedAutosave
-		);
-	});
-
 	it('keeps setStoredSiteSpec as the setup URL compatibility alias', async () => {
 		resolveRuntimeConfiguration.mockRejectedValue(
 			new Error('Invalid setup')

--- a/packages/playground/website/src/lib/state/redux/slice-sites.spec.ts
+++ b/packages/playground/website/src/lib/state/redux/slice-sites.spec.ts
@@ -415,6 +415,62 @@ describe('stored sites', () => {
 		);
 	});
 
+	it('stops an aborted prune before deleting the next autosave', async () => {
+		const { pruneAutosavedSites, sitesSlice } =
+			await import('./slice-sites');
+		const firstAutosave = createSiteInfo({ slug: 'first-autosave' });
+		firstAutosave.metadata.persistence = 'autosave';
+		firstAutosave.metadata.whenCreated = 2;
+		const protectedAutosave = createSiteInfo({
+			slug: 'protected-autosave',
+		});
+		protectedAutosave.metadata.persistence = 'autosave';
+		protectedAutosave.metadata.whenCreated = 1;
+		let state = {
+			sites: sitesSlice.reducer(
+				undefined,
+				sitesSlice.actions.addSites([firstAutosave, protectedAutosave])
+			),
+		};
+		const getState = () => state as any;
+		const dispatch: ReturnType<typeof vi.fn> = vi.fn((action) => {
+			if (typeof action === 'function') {
+				return action(dispatch, getState);
+			}
+			state = {
+				sites: sitesSlice.reducer(state.sites, action),
+			};
+			return action;
+		});
+		let finishFirstDeletion!: () => void;
+		const firstDeletionCanFinish = new Promise<void>((resolve) => {
+			finishFirstDeletion = resolve;
+		});
+		deleteSite.mockImplementation(async (slug) => {
+			if (slug === firstAutosave.slug) {
+				await firstDeletionCanFinish;
+			}
+		});
+		const abortController = new AbortController();
+
+		const pruning = pruneAutosavedSites({
+			limit: 0,
+			signal: abortController.signal,
+		})(dispatch as any, getState);
+		await vi.waitFor(() =>
+			expect(deleteSite).toHaveBeenCalledWith(firstAutosave.slug)
+		);
+		abortController.abort();
+		finishFirstDeletion();
+		await pruning;
+
+		expect(deleteSite).not.toHaveBeenCalledWith(protectedAutosave.slug);
+		expect(state.sites.entities[firstAutosave.slug]).toBeUndefined();
+		expect(state.sites.entities[protectedAutosave.slug]).toEqual(
+			protectedAutosave
+		);
+	});
+
 	it('keeps setStoredSiteSpec as the setup URL compatibility alias', async () => {
 		resolveRuntimeConfiguration.mockRejectedValue(
 			new Error('Invalid setup')

--- a/packages/playground/website/src/lib/state/redux/slice-sites.spec.ts
+++ b/packages/playground/website/src/lib/state/redux/slice-sites.spec.ts
@@ -415,6 +415,61 @@ describe('stored sites', () => {
 		);
 	});
 
+	it('honors exclusions added while a prune pass is running', async () => {
+		const { pruneAutosavedSites, sitesSlice } =
+			await import('./slice-sites');
+		const firstAutosave = createSiteInfo({ slug: 'first-autosave' });
+		firstAutosave.metadata.persistence = 'autosave';
+		firstAutosave.metadata.whenCreated = 2;
+		const excludedAutosave = createSiteInfo({
+			slug: 'excluded-autosave',
+		});
+		excludedAutosave.metadata.persistence = 'autosave';
+		excludedAutosave.metadata.whenCreated = 1;
+		let state = {
+			sites: sitesSlice.reducer(
+				undefined,
+				sitesSlice.actions.addSites([firstAutosave, excludedAutosave])
+			),
+		};
+		const getState = () => state as any;
+		const dispatch: ReturnType<typeof vi.fn> = vi.fn((action) => {
+			if (typeof action === 'function') {
+				return action(dispatch, getState);
+			}
+			state = {
+				sites: sitesSlice.reducer(state.sites, action),
+			};
+			return action;
+		});
+		let finishFirstDeletion!: () => void;
+		const firstDeletionCanFinish = new Promise<void>((resolve) => {
+			finishFirstDeletion = resolve;
+		});
+		deleteSite.mockImplementation(async (slug) => {
+			if (slug === firstAutosave.slug) {
+				await firstDeletionCanFinish;
+			}
+		});
+		const excludeSlugs: string[] = [];
+
+		const pruning = pruneAutosavedSites({ limit: 0, excludeSlugs })(
+			dispatch as any,
+			getState
+		);
+		await vi.waitFor(() =>
+			expect(deleteSite).toHaveBeenCalledWith(firstAutosave.slug)
+		);
+		excludeSlugs.push(excludedAutosave.slug);
+		finishFirstDeletion();
+		await pruning;
+
+		expect(deleteSite).not.toHaveBeenCalledWith(excludedAutosave.slug);
+		expect(state.sites.entities[excludedAutosave.slug]).toEqual(
+			excludedAutosave
+		);
+	});
+
 	it('keeps setStoredSiteSpec as the setup URL compatibility alias', async () => {
 		resolveRuntimeConfiguration.mockRejectedValue(
 			new Error('Invalid setup')

--- a/packages/playground/website/src/lib/state/redux/slice-sites.ts
+++ b/packages/playground/website/src/lib/state/redux/slice-sites.ts
@@ -357,8 +357,8 @@ export function removeSite(slug: string) {
  * Explicitly saved Playgrounds are never pruned. `excludeSlugs` protects
  * specific autosaves for the current prune pass. Removal is best-effort: a
  * failed deletion remains available for retry and does not prevent later
- * candidates from being pruned. An aborted pass stops before its next deletion
- * so its caller can restart with updated exclusions.
+ * candidates from being pruned. `signal` invalidates the pass between deletions
+ * when its exclusion snapshot is no longer current.
  */
 export function pruneAutosavedSites(
 	options: AutosavedSitesPruneOptions & { signal?: AbortSignal } = {}
@@ -372,6 +372,8 @@ export function pruneAutosavedSites(
 			options
 		);
 		for (const site of sitesToPrune) {
+			// The candidate list belongs to the exclusion snapshot supplied when this
+			// pass started. Do not delete another site after that snapshot is invalidated.
 			if (options.signal?.aborted) {
 				return;
 			}

--- a/packages/playground/website/src/lib/state/redux/slice-sites.ts
+++ b/packages/playground/website/src/lib/state/redux/slice-sites.ts
@@ -369,11 +369,6 @@ export function pruneAutosavedSites(options: AutosavedSitesPruneOptions = {}) {
 			options
 		);
 		for (const site of sitesToPrune) {
-			// Another caller can add an exclusion while an autosave's prune pass
-			// is waiting for an earlier deletion to finish.
-			if (options.excludeSlugs?.includes(site.slug)) {
-				continue;
-			}
 			try {
 				await dispatch(removeSite(site.slug));
 			} catch (error) {

--- a/packages/playground/website/src/lib/state/redux/slice-sites.ts
+++ b/packages/playground/website/src/lib/state/redux/slice-sites.ts
@@ -357,9 +357,12 @@ export function removeSite(slug: string) {
  * Explicitly saved Playgrounds are never pruned. `excludeSlugs` protects
  * specific autosaves for the current prune pass. Removal is best-effort: a
  * failed deletion remains available for retry and does not prevent later
- * candidates from being pruned.
+ * candidates from being pruned. An aborted pass stops before its next deletion
+ * so its caller can restart with updated exclusions.
  */
-export function pruneAutosavedSites(options: AutosavedSitesPruneOptions = {}) {
+export function pruneAutosavedSites(
+	options: AutosavedSitesPruneOptions & { signal?: AbortSignal } = {}
+) {
 	return async (
 		dispatch: PlaygroundDispatch,
 		getState: () => PlaygroundReduxState
@@ -369,6 +372,9 @@ export function pruneAutosavedSites(options: AutosavedSitesPruneOptions = {}) {
 			options
 		);
 		for (const site of sitesToPrune) {
+			if (options.signal?.aborted) {
+				return;
+			}
 			try {
 				await dispatch(removeSite(site.slug));
 			} catch (error) {

--- a/packages/playground/website/src/lib/state/redux/slice-sites.ts
+++ b/packages/playground/website/src/lib/state/redux/slice-sites.ts
@@ -369,6 +369,11 @@ export function pruneAutosavedSites(options: AutosavedSitesPruneOptions = {}) {
 			options
 		);
 		for (const site of sitesToPrune) {
+			// Another caller can add an exclusion while an autosave's prune pass
+			// is waiting for an earlier deletion to finish.
+			if (options.excludeSlugs?.includes(site.slug)) {
+				continue;
+			}
 			try {
 				await dispatch(removeSite(site.slug));
 			} catch (error) {


### PR DESCRIPTION
Shares one in-flight autosave operation between concurrent callers for the same Playground.

Before this PR, duplicate `autosaveTemporarySite()` calls ran the entire persistence pipeline twice: creating the pending OPFS record, copying the filesystem, updating metadata, and pruning old autosaves. PR #4136 serializes the final metadata writes; this follow-up prevents the duplicate pipeline in the first place.

The in-flight entry is removed after success or failure, so a later call can retry normally.

## Testing

Start two autosaves for one temporary Playground at the same time. Confirm both callers complete with the same stored Playground and only one persistence operation runs.
