### PR TITLE
[Website] Expose front-page thumbnail capture through PlaygroundClient

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,7 @@
 				"fs-extra": "11.1.1",
 				"ini": "4.1.2",
 				"jsonc-parser": "3.3.1",
+				"modern-screenshot": "4.7.0",
 				"octokit": "3.1.2",
 				"pako": "1.0.10",
 				"react": "18.3.1",
@@ -40705,6 +40706,12 @@
 			"resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
 			"integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
 			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/modern-screenshot": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/modern-screenshot/-/modern-screenshot-4.7.0.tgz",
+			"integrity": "sha512-9YxN+ddPSMMlhylOv25VHzXrl9u67QRxoh7+SEewGtgUw7t6hHTrjptSDJUSne9oG4Xk/h2cwG15nIt4Hc9ujg==",
 			"license": "MIT"
 		},
 		"node_modules/modify-values": {

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
 		"fs-extra": "11.1.1",
 		"ini": "4.1.2",
 		"jsonc-parser": "3.3.1",
+		"modern-screenshot": "4.7.0",
 		"octokit": "3.1.2",
 		"pako": "1.0.10",
 		"react": "18.3.1",

--- a/packages/playground/client/src/index.ts
+++ b/packages/playground/client/src/index.ts
@@ -26,7 +26,7 @@ export {
 	LatestSupportedPHPVersion,
 } from '@php-wasm/universal';
 export { phpVar, phpVars } from '@php-wasm/util';
-export type { PlaygroundClient, MountDescriptor };
+export type { PlaygroundClient, MountDescriptor, SiteThumbnail };
 
 import {
 	BlueprintReflection,
@@ -41,7 +41,11 @@ import type {
 } from '@wp-playground/blueprints';
 import type { WordPressInstallMode } from '@wp-playground/wordpress';
 import { ProgressTracker } from '@php-wasm/progress';
-import type { MountDescriptor, PlaygroundClient } from '@wp-playground/remote';
+import type {
+	MountDescriptor,
+	PlaygroundClient,
+	SiteThumbnail,
+} from '@wp-playground/remote';
 import type { PathAlias } from '@php-wasm/universal';
 import type { PHPWebExtension } from '@php-wasm/web';
 import { additionalRemoteOrigins } from './additional-remote-origins';

--- a/packages/playground/remote/service-worker.ts
+++ b/packages/playground/remote/service-worker.ts
@@ -221,16 +221,37 @@ self.addEventListener('fetch', (event) => {
 		return;
 	}
 
+	// Vite's /@fs/ modules remain app assets when a scoped WordPress document
+	// imports them during development. Sending them through WordPress turns the
+	// module graph into scoped 404 responses.
 	const isReservedUrl =
 		url.pathname.startsWith('/plugin-proxy') ||
 		url.pathname.startsWith('/client/index.js') ||
-		url.pathname.startsWith('/relay/');
+		url.pathname.startsWith('/relay/') ||
+		url.pathname.startsWith('/@fs/');
 	if (isReservedUrl) {
 		return;
 	}
 
 	if (url.pathname === '/feature-detect/document-isolation-policy.html') {
 		return event.respondWith(documentIsolationPolicyHtml());
+	}
+
+	// The thumbnail renderer and its resource worker are Playground assets loaded
+	// from inside a scoped WordPress document. Serve them as app assets instead of
+	// redirecting them into that site's virtual URL namespace, where WordPress
+	// would return a 404.
+	if (
+		(url.pathname.includes('/capture-site-thumbnail') &&
+			url.searchParams.has('playground-site-thumbnail-module')) ||
+		(event.request.destination === 'worker' &&
+			url.searchParams.has('playground-site-thumbnail-worker'))
+	) {
+		return event.respondWith(
+			shouldCacheUrl(url)
+				? cacheFirstFetch(event.request)
+				: fetch(event.request)
+		);
 	}
 
 	if (isURLScoped(url)) {

--- a/packages/playground/remote/service-worker.ts
+++ b/packages/playground/remote/service-worker.ts
@@ -237,21 +237,20 @@ self.addEventListener('fetch', (event) => {
 		return event.respondWith(documentIsolationPolicyHtml());
 	}
 
-	// The thumbnail renderer and its resource worker are Playground assets loaded
-	// from inside a scoped WordPress document. Serve them as app assets instead of
-	// redirecting them into that site's virtual URL namespace, where WordPress
-	// would return a 404.
+	// The renderer is bundled from
+	// `packages/playground/remote/src/lib/capture-site-thumbnail.ts`; it imports its
+	// resource worker from `modern-screenshot/worker`. Vite serves the source path
+	// in development and emits a hashed root-level filename in builds. Both assets
+	// load from inside a scoped WordPress document, so keep them out of that site's
+	// virtual URL namespace, where WordPress would return a 404.
 	const isSiteThumbnailModule =
 		url.searchParams.has('playground-site-thumbnail-module') &&
-		(/^\/capture-site-thumbnail-[A-Za-z0-9_-]+\.js$/.test(url.pathname) ||
-			(url.pathname === '/src/lib/capture-site-thumbnail.ts' &&
-				url.searchParams.has('worker_file') &&
-				url.searchParams.get('type') === 'module'));
-	if (
-		isSiteThumbnailModule ||
-		(event.request.destination === 'worker' &&
-			url.searchParams.has('playground-site-thumbnail-worker'))
-	) {
+		(url.pathname === '/src/lib/capture-site-thumbnail.ts' ||
+			/^\/capture-site-thumbnail-[A-Za-z0-9_-]+\.js$/.test(url.pathname));
+	const isSiteThumbnailWorker =
+		event.request.destination === 'worker' &&
+		url.searchParams.has('playground-site-thumbnail-worker');
+	if (isSiteThumbnailModule || isSiteThumbnailWorker) {
 		return event.respondWith(
 			shouldCacheUrl(url)
 				? cacheFirstFetch(event.request)

--- a/packages/playground/remote/service-worker.ts
+++ b/packages/playground/remote/service-worker.ts
@@ -237,12 +237,12 @@ self.addEventListener('fetch', (event) => {
 		return event.respondWith(documentIsolationPolicyHtml());
 	}
 
-	// The renderer is bundled from
-	// `packages/playground/remote/src/lib/capture-site-thumbnail.ts`; it imports its
-	// resource worker from `modern-screenshot/worker`. Vite serves the source path
-	// in development and emits a hashed root-level filename in builds. Both assets
-	// load from inside a scoped WordPress document, so keep them out of that site's
-	// virtual URL namespace, where WordPress would return a 404.
+	// Vite bundles
+	// `packages/playground/remote/src/lib/capture-site-thumbnail.ts` as the renderer
+	// and `modern-screenshot/worker` as its resource worker. Their requests originate
+	// from a scoped WordPress document, so the generic referrer handling below would
+	// redirect them into that site's virtual URL namespace, where WordPress returns
+	// a 404. Fetch these marked app assets directly instead.
 	const isSiteThumbnailModule =
 		url.searchParams.has('playground-site-thumbnail-module') &&
 		(url.pathname === '/src/lib/capture-site-thumbnail.ts' ||

--- a/packages/playground/remote/service-worker.ts
+++ b/packages/playground/remote/service-worker.ts
@@ -241,9 +241,14 @@ self.addEventListener('fetch', (event) => {
 	// from inside a scoped WordPress document. Serve them as app assets instead of
 	// redirecting them into that site's virtual URL namespace, where WordPress
 	// would return a 404.
+	const isSiteThumbnailModule =
+		url.searchParams.has('playground-site-thumbnail-module') &&
+		(/^\/capture-site-thumbnail-[A-Za-z0-9_-]+\.js$/.test(url.pathname) ||
+			(url.pathname === '/src/lib/capture-site-thumbnail.ts' &&
+				url.searchParams.has('worker_file') &&
+				url.searchParams.get('type') === 'module'));
 	if (
-		(url.pathname.includes('/capture-site-thumbnail') &&
-			url.searchParams.has('playground-site-thumbnail-module')) ||
+		isSiteThumbnailModule ||
 		(event.request.destination === 'worker' &&
 			url.searchParams.has('playground-site-thumbnail-worker'))
 	) {

--- a/packages/playground/remote/src/lib/boot-playground-remote.ts
+++ b/packages/playground/remote/src/lib/boot-playground-remote.ts
@@ -632,7 +632,25 @@ async function captureSiteThumbnailFromWordPress({
 				finish(() => reject(new Error(event.data.error)));
 				return;
 			}
-			finish(() => resolve(event.data.thumbnail));
+			const thumbnail = event.data.thumbnail;
+			if (
+				typeof thumbnail !== 'object' ||
+				thumbnail === null ||
+				(thumbnail.mime !== 'image/webp' &&
+					thumbnail.mime !== 'image/jpeg') ||
+				typeof thumbnail.data !== 'string' ||
+				thumbnail.data.length === 0
+			) {
+				finish(() =>
+					reject(
+						new Error(
+							'The site thumbnail renderer returned an invalid image.'
+						)
+					)
+				);
+				return;
+			}
+			finish(() => resolve(thumbnail));
 		};
 
 		const onLoad = () => {

--- a/packages/playground/remote/src/lib/boot-playground-remote.ts
+++ b/packages/playground/remote/src/lib/boot-playground-remote.ts
@@ -578,15 +578,15 @@ export async function bootPlaygroundRemote() {
 
 const SITE_THUMBNAIL_REQUEST = 'playground-capture-site-thumbnail';
 const SITE_THUMBNAIL_RESPONSE = 'playground-site-thumbnail-result';
-const SITE_THUMBNAIL_TIMEOUT_MS = 20000;
+const SITE_THUMBNAIL_TIMEOUT_MS = 3000;
 
 /**
  * Loads the front page in a disposable iframe and asks that document to render
  * itself. The WordPress MU plugin owns the receiving side because the remote
  * frame cannot inspect the WordPress DOM under Document-Isolation-Policy. A
  * separate iframe avoids navigating or capturing wp-admin in the visible one.
- * Every response path removes the iframe and listeners, and the timeout also
- * covers a page that never loads or never answers.
+ * Every response path removes the iframe and listeners. The short timeout
+ * bounds how long the disposable page may load or render.
  */
 async function captureSiteThumbnailFromWordPress({
 	frontPageUrl,

--- a/packages/playground/remote/src/lib/boot-playground-remote.ts
+++ b/packages/playground/remote/src/lib/boot-playground-remote.ts
@@ -578,15 +578,17 @@ export async function bootPlaygroundRemote() {
 
 const SITE_THUMBNAIL_REQUEST = 'playground-capture-site-thumbnail';
 const SITE_THUMBNAIL_RESPONSE = 'playground-site-thumbnail-result';
-const SITE_THUMBNAIL_TIMEOUT_MS = 3000;
+const SITE_THUMBNAIL_LOAD_TIMEOUT_MS = 20000;
+const SITE_THUMBNAIL_RENDER_TIMEOUT_MS = 3000;
 
 /**
  * Loads the front page in a disposable iframe and asks that document to render
  * itself. The WordPress MU plugin owns the receiving side because the remote
  * frame cannot inspect the WordPress DOM under Document-Isolation-Policy. A
  * separate iframe avoids navigating or capturing wp-admin in the visible one.
- * Every response path removes the iframe and listeners. The short timeout
- * bounds how long the disposable page may load or render.
+ * Every response path removes the iframe and listeners. The load watchdog
+ * covers a page that never loads; once it loads, a shorter deadline bounds the
+ * renderer work.
  */
 async function captureSiteThumbnailFromWordPress({
 	frontPageUrl,
@@ -613,11 +615,7 @@ async function captureSiteThumbnailFromWordPress({
 
 	return await new Promise<SiteThumbnail>((resolve, reject) => {
 		const requestId = `${Date.now()}-${Math.random()}`;
-		const timeout = setTimeout(() => {
-			finish(() =>
-				reject(new Error('Timed out capturing the site thumbnail.'))
-			);
-		}, SITE_THUMBNAIL_TIMEOUT_MS);
+		let timeout = setTimeout(onTimeout, SITE_THUMBNAIL_LOAD_TIMEOUT_MS);
 
 		const onMessage = (event: MessageEvent) => {
 			if (
@@ -654,6 +652,8 @@ async function captureSiteThumbnailFromWordPress({
 		};
 
 		const onLoad = () => {
+			clearTimeout(timeout);
+			timeout = setTimeout(onTimeout, SITE_THUMBNAIL_RENDER_TIMEOUT_MS);
 			const moduleUrl = new URL(
 				siteThumbnailModuleUrl,
 				document.location.href
@@ -670,6 +670,12 @@ async function captureSiteThumbnailFromWordPress({
 				frontPageOrigin
 			);
 		};
+
+		function onTimeout() {
+			finish(() =>
+				reject(new Error('Timed out capturing the site thumbnail.'))
+			);
+		}
 
 		function finish(callback: () => void) {
 			clearTimeout(timeout);

--- a/packages/playground/remote/src/lib/boot-playground-remote.ts
+++ b/packages/playground/remote/src/lib/boot-playground-remote.ts
@@ -14,9 +14,11 @@ import type {
 	MountDescriptor,
 } from './playground-worker-endpoint';
 export type { MountDescriptor, WorkerBootOptions };
-import type { WebClientMixin } from './playground-client';
+import type { SiteThumbnail, WebClientMixin } from './playground-client';
 import type { ProgressBarOptions } from './progress-bar';
 import ProgressBar from './progress-bar';
+// @ts-ignore -- Vite resolves this URL import; ambient declarations break package consumers.
+import siteThumbnailModuleUrl from './capture-site-thumbnail.ts?worker&url';
 
 type PHPRemoteApi = WebClientMixin & Pick<PlaygroundWorkerEndpoint, 'cli'>;
 
@@ -358,6 +360,12 @@ export async function bootPlaygroundRemote() {
 			}
 			return await playground.internalUrlToPath(url);
 		},
+		async captureSiteThumbnail() {
+			return await captureSiteThumbnailFromWordPress({
+				frontPageUrl: await playground.pathToInternalUrl('/'),
+				sandbox: wpFrame.getAttribute('sandbox'),
+			});
+		},
 		async setIframeSandboxFlags(flags: string[]) {
 			wpFrame.setAttribute('sandbox', flags.join(' '));
 		},
@@ -566,6 +574,97 @@ export async function bootPlaygroundRemote() {
 	 * with Remote<PlaygroundClient>
 	 */
 	return playground;
+}
+
+const SITE_THUMBNAIL_REQUEST = 'playground-capture-site-thumbnail';
+const SITE_THUMBNAIL_RESPONSE = 'playground-site-thumbnail-result';
+const SITE_THUMBNAIL_TIMEOUT_MS = 20000;
+
+/**
+ * Loads the front page in a disposable iframe and asks that document to render
+ * itself. The WordPress MU plugin owns the receiving side because the remote
+ * frame cannot inspect the WordPress DOM under Document-Isolation-Policy. A
+ * separate iframe avoids navigating or capturing wp-admin in the visible one.
+ * Every response path removes the iframe and listeners, and the timeout also
+ * covers a page that never loads or never answers.
+ */
+async function captureSiteThumbnailFromWordPress({
+	frontPageUrl,
+	sandbox,
+}: {
+	frontPageUrl: string;
+	sandbox: string | null;
+}): Promise<SiteThumbnail> {
+	const frontPageOrigin = new URL(frontPageUrl).origin;
+	const iframe = document.createElement('iframe');
+	iframe.setAttribute('aria-hidden', 'true');
+	iframe.tabIndex = -1;
+	iframe.style.position = 'fixed';
+	iframe.style.left = '-10000px';
+	iframe.style.top = '0';
+	iframe.style.width = '1024px';
+	iframe.style.height = '768px';
+	iframe.style.opacity = '0';
+	iframe.style.pointerEvents = 'none';
+	if (sandbox) {
+		iframe.setAttribute('sandbox', sandbox);
+	}
+	iframe.src = frontPageUrl;
+
+	return await new Promise<SiteThumbnail>((resolve, reject) => {
+		const requestId = `${Date.now()}-${Math.random()}`;
+		const timeout = setTimeout(() => {
+			finish(() =>
+				reject(new Error('Timed out capturing the site thumbnail.'))
+			);
+		}, SITE_THUMBNAIL_TIMEOUT_MS);
+
+		const onMessage = (event: MessageEvent) => {
+			if (
+				event.source !== iframe.contentWindow ||
+				event.origin !== frontPageOrigin ||
+				event.data?.type !== SITE_THUMBNAIL_RESPONSE ||
+				event.data?.requestId !== requestId
+			) {
+				return;
+			}
+			if (event.data.error) {
+				finish(() => reject(new Error(event.data.error)));
+				return;
+			}
+			finish(() => resolve(event.data.thumbnail));
+		};
+
+		const onLoad = () => {
+			const moduleUrl = new URL(
+				siteThumbnailModuleUrl,
+				document.location.href
+			);
+			// The marker lets the service worker distinguish this app asset
+			// from a path inside the scoped WordPress site.
+			moduleUrl.searchParams.set('playground-site-thumbnail-module', '1');
+			iframe.contentWindow?.postMessage(
+				{
+					type: SITE_THUMBNAIL_REQUEST,
+					requestId,
+					moduleUrl: moduleUrl.href,
+				},
+				frontPageOrigin
+			);
+		};
+
+		function finish(callback: () => void) {
+			clearTimeout(timeout);
+			window.removeEventListener('message', onMessage);
+			iframe.removeEventListener('load', onLoad);
+			iframe.remove();
+			callback();
+		}
+
+		window.addEventListener('message', onMessage);
+		iframe.addEventListener('load', onLoad, { once: true });
+		document.body.append(iframe);
+	});
 }
 
 /**

--- a/packages/playground/remote/src/lib/capture-site-thumbnail.ts
+++ b/packages/playground/remote/src/lib/capture-site-thumbnail.ts
@@ -58,7 +58,17 @@ export async function captureSiteThumbnail(): Promise<SiteThumbnail> {
 		await yieldToNextTask();
 		blob = await canvasToBlob(canvas, 'image/jpeg', 0.72);
 	}
-	return splitDataUrl(await blobToDataUrl(blob));
+	const dataUrl = await blobToDataUrl(blob);
+	const dataUrlPrefix = `data:${blob.type};base64,`;
+	if (!dataUrl.startsWith(dataUrlPrefix)) {
+		throw new Error(
+			'The site thumbnail renderer returned an invalid image.'
+		);
+	}
+	return {
+		mime: blob.type,
+		data: dataUrl.slice(dataUrlPrefix.length),
+	};
 }
 
 (
@@ -150,17 +160,4 @@ function blobToDataUrl(blob: Blob) {
 		reader.onerror = () => reject(reader.error);
 		reader.readAsDataURL(blob);
 	});
-}
-
-function splitDataUrl(dataUrl: string): SiteThumbnail {
-	const match = /^data:([^;,]+);base64,(.*)$/.exec(dataUrl);
-	if (!match) {
-		throw new Error(
-			'The site thumbnail renderer returned an invalid image.'
-		);
-	}
-	return {
-		mime: match[1],
-		data: match[2],
-	};
 }

--- a/packages/playground/remote/src/lib/capture-site-thumbnail.ts
+++ b/packages/playground/remote/src/lib/capture-site-thumbnail.ts
@@ -6,7 +6,7 @@ import resourceWorkerUrl from 'modern-screenshot/worker?url';
 const CAPTURE_WIDTH = 1024;
 const CAPTURE_HEIGHT = 768;
 const THUMBNAIL_WIDTH = 320;
-const CAPTURE_TIMEOUT_MS = 7000;
+const CAPTURE_TIMEOUT_MS = 3000;
 const CLONED_NODES_PER_YIELD = 100;
 
 /**

--- a/packages/playground/remote/src/lib/capture-site-thumbnail.ts
+++ b/packages/playground/remote/src/lib/capture-site-thumbnail.ts
@@ -1,0 +1,165 @@
+import { domToCanvas } from 'modern-screenshot';
+// @ts-ignore -- Vite resolves this URL import; ambient declarations break package consumers.
+import resourceWorkerUrl from 'modern-screenshot/worker?url';
+
+const CAPTURE_WIDTH = 1024;
+const CAPTURE_HEIGHT = 768;
+const THUMBNAIL_WIDTH = 320;
+const CAPTURE_TIMEOUT_MS = 7000;
+const CLONED_NODES_PER_YIELD = 100;
+
+/**
+ * Renders the current WordPress document as a compact site thumbnail.
+ *
+ * This module is loaded inside the WordPress iframe. The remote frame cannot
+ * read that document when Document-Isolation-Policy is active, so capture must
+ * happen on this side of the frame boundary. DOM and computed-style work must
+ * remain in this event loop. The resource worker handles supported fetches,
+ * and the phase callbacks yield so other tasks can run during the remaining
+ * renderer work.
+ */
+export async function captureSiteThumbnail() {
+	document
+		.querySelectorAll<HTMLImageElement>('img[loading="lazy"]')
+		.forEach((image) => (image.loading = 'eager'));
+
+	await yieldToNextTask();
+	await waitForFonts();
+	await yieldToNextTask();
+
+	let clonedNodeCount = 0;
+	const canvas = await domToCanvas(document.documentElement, {
+		width: CAPTURE_WIDTH,
+		height: CAPTURE_HEIGHT,
+		scale: THUMBNAIL_WIDTH / CAPTURE_WIDTH,
+		backgroundColor: '#ffffff',
+		timeout: CAPTURE_TIMEOUT_MS,
+		workerUrl: getResourceWorkerUrl(),
+		filter: (node) =>
+			!(node instanceof HTMLElement && node.id === 'wpadminbar'),
+		onCloneEachNode: async () => {
+			clonedNodeCount++;
+			if (clonedNodeCount % CLONED_NODES_PER_YIELD === 0) {
+				await yieldDuringClone();
+			}
+		},
+		onCloneNode: async (cloned) => {
+			prepareClonedDocument(cloned);
+			await yieldToNextTask();
+		},
+		onEmbedNode: yieldToNextTask,
+		onCreateForeignObjectSvg: yieldToNextTask,
+	});
+
+	await yieldToNextTask();
+	let blob = await canvasToBlob(canvas, 'image/webp', 0.68);
+	if (blob.type !== 'image/webp') {
+		await yieldToNextTask();
+		blob = await canvasToBlob(canvas, 'image/jpeg', 0.72);
+	}
+	return splitDataUrl(await blobToDataUrl(blob));
+}
+
+(
+	globalThis as typeof globalThis & {
+		__playgroundCaptureSiteThumbnail?: typeof captureSiteThumbnail;
+	}
+).__playgroundCaptureSiteThumbnail = captureSiteThumbnail;
+
+async function waitForFonts() {
+	if (!document.fonts) {
+		return;
+	}
+	await Promise.race([
+		document.fonts.ready,
+		new Promise((resolve) => setTimeout(resolve, CAPTURE_TIMEOUT_MS)),
+	]);
+}
+
+function getResourceWorkerUrl() {
+	const url = new URL(resourceWorkerUrl, window.location.href);
+	// The service worker uses this marker to serve the bundled worker instead
+	// of treating its URL as a file inside the scoped WordPress site.
+	url.searchParams.set('playground-site-thumbnail-worker', '1');
+	return url.href;
+}
+
+/**
+ * A timer lets Chromium navigate modern-screenshot's internal style iframe
+ * midway through cloning, when its document briefly has no body. The scheduler
+ * continuation stays ahead of navigation while still allowing input to run.
+ */
+async function yieldDuringClone() {
+	const scheduler = (
+		globalThis as typeof globalThis & {
+			scheduler?: { yield?: () => Promise<void> };
+		}
+	).scheduler;
+	if (scheduler?.yield) {
+		await scheduler.yield();
+		return;
+	}
+	await yieldToNextTask();
+}
+
+async function yieldToNextTask() {
+	await new Promise<void>((resolve) => setTimeout(resolve, 0));
+}
+
+function prepareClonedDocument(cloned: Node) {
+	if (!(cloned instanceof HTMLElement)) {
+		return;
+	}
+	cloned.style.setProperty('margin-top', '0', 'important');
+	const style = cloned.ownerDocument.createElement('style');
+	style.textContent = `
+		*, *::before, *::after {
+			animation: none !important;
+			caret-color: transparent !important;
+			transition: none !important;
+		}
+	`;
+	cloned.querySelector('head')?.append(style);
+}
+
+function canvasToBlob(
+	canvas: HTMLCanvasElement,
+	type: string,
+	quality: number
+) {
+	return new Promise<Blob>((resolve, reject) => {
+		canvas.toBlob(
+			(blob) => {
+				if (blob) {
+					resolve(blob);
+				} else {
+					reject(new Error('The site thumbnail encoder failed.'));
+				}
+			},
+			type,
+			quality
+		);
+	});
+}
+
+function blobToDataUrl(blob: Blob) {
+	return new Promise<string>((resolve, reject) => {
+		const reader = new FileReader();
+		reader.onload = () => resolve(reader.result as string);
+		reader.onerror = () => reject(reader.error);
+		reader.readAsDataURL(blob);
+	});
+}
+
+function splitDataUrl(dataUrl: string) {
+	const match = /^data:([^;,]+);base64,(.*)$/.exec(dataUrl);
+	if (!match) {
+		throw new Error(
+			'The site thumbnail renderer returned an invalid image.'
+		);
+	}
+	return {
+		mime: match[1],
+		data: match[2],
+	};
+}

--- a/packages/playground/remote/src/lib/capture-site-thumbnail.ts
+++ b/packages/playground/remote/src/lib/capture-site-thumbnail.ts
@@ -1,4 +1,5 @@
 import { domToCanvas } from 'modern-screenshot';
+import type { SiteThumbnail } from './playground-client';
 // @ts-ignore -- Vite resolves this URL import; ambient declarations break package consumers.
 import resourceWorkerUrl from 'modern-screenshot/worker?url';
 
@@ -18,7 +19,7 @@ const CLONED_NODES_PER_YIELD = 100;
  * and the phase callbacks yield so other tasks can run during the remaining
  * renderer work.
  */
-export async function captureSiteThumbnail() {
+export async function captureSiteThumbnail(): Promise<SiteThumbnail> {
 	document
 		.querySelectorAll<HTMLImageElement>('img[loading="lazy"]')
 		.forEach((image) => (image.loading = 'eager'));
@@ -151,7 +152,7 @@ function blobToDataUrl(blob: Blob) {
 	});
 }
 
-function splitDataUrl(dataUrl: string) {
+function splitDataUrl(dataUrl: string): SiteThumbnail {
 	const match = /^data:([^;,]+);base64,(.*)$/.exec(dataUrl);
 	if (!match) {
 		throw new Error(

--- a/packages/playground/remote/src/lib/playground-client.ts
+++ b/packages/playground/remote/src/lib/playground-client.ts
@@ -41,6 +41,20 @@ export interface WebClientMixin extends ProgressReceiver {
 	getCurrentURL(): Promise<string>;
 
 	/**
+	 * Renders the site's front page in a disposable 1024×768 browsing context
+	 * and returns a compact 320×240 image.
+	 *
+	 * This method does not persist the image or synchronize it with OPFS.
+	 * Callers own the result's lifecycle and must discard it if the site changes
+	 * while the asynchronous capture is running.
+	 *
+	 * DOM cloning and canvas rendering run in the captured document's event
+	 * loop. A worker handles supported resource fetches, while explicit task
+	 * yields keep that document responsive during cloning.
+	 */
+	captureSiteThumbnail(): Promise<SiteThumbnail>;
+
+	/**
 	 * Sets the iframe sandbox flags.
 	 * @param flags The iframe sandbox flags.
 	 */
@@ -80,6 +94,13 @@ export interface WebClientMixin extends ProgressReceiver {
 
 	boot(options: WorkerBootOptions): Promise<void>;
 }
+
+export type SiteThumbnail = {
+	/** The encoded image's MIME type. */
+	mime: string;
+	/** The base64 payload without a data URL prefix. */
+	data: string;
+};
 
 /**
  * The Playground Client interface.

--- a/packages/playground/remote/src/lib/playground-mu-plugin/0-playground.php
+++ b/packages/playground/remote/src/lib/playground-mu-plugin/0-playground.php
@@ -262,6 +262,17 @@ add_action('admin_head', 'playground_report_url_to_parent');
  * Captures this document when the trusted Playground parent requests a site
  * thumbnail. The renderer is loaded only for a capture, so normal WordPress
  * page loads do not pay its download or execution cost.
+ *
+ * This must run inside the WordPress document rather than reading the iframe
+ * DOM from the remote frame. For example, a plugin may send
+ * `Cross-Origin-Embedder-Policy: require-corp` and
+ * `Cross-Origin-Opener-Policy: same-origin` on the front page. In browsers
+ * that support Document-Isolation-Policy, Playground's service worker rewrites
+ * those headers to `Document-Isolation-Policy: isolate-and-require-corp`.
+ * Because the remote frame does not have the matching policy, the browser
+ * blocks its synchronous access to `iframe.contentDocument`, even though both
+ * frames are same-origin. The listener below therefore captures in the
+ * WordPress document and returns the thumbnail with `postMessage()`.
  */
 function playground_enable_site_thumbnail_capture() {
 	?>

--- a/packages/playground/remote/src/lib/playground-mu-plugin/0-playground.php
+++ b/packages/playground/remote/src/lib/playground-mu-plugin/0-playground.php
@@ -306,13 +306,11 @@ function playground_enable_site_thumbnail_capture() {
 					// the same-origin renderer asset marked by the trusted parent.
 					const moduleUrl = new URL(request.moduleUrl);
 					const isRendererModule =
+						moduleUrl.pathname ===
+							'/src/lib/capture-site-thumbnail.ts' ||
 						/^\/capture-site-thumbnail-[A-Za-z0-9_-]+\.js$/.test(
 							moduleUrl.pathname
-						) ||
-						(moduleUrl.pathname ===
-							'/src/lib/capture-site-thumbnail.ts' &&
-							moduleUrl.searchParams.has('worker_file') &&
-							moduleUrl.searchParams.get('type') === 'module');
+						);
 					if (
 						moduleUrl.origin !== event.origin ||
 						!isRendererModule ||

--- a/packages/playground/remote/src/lib/playground-mu-plugin/0-playground.php
+++ b/packages/playground/remote/src/lib/playground-mu-plugin/0-playground.php
@@ -294,9 +294,17 @@ function playground_enable_site_thumbnail_capture() {
 					// Dynamic import executes inside the WordPress document. Accept only
 					// the same-origin renderer asset marked by the trusted parent.
 					const moduleUrl = new URL(request.moduleUrl);
+					const isRendererModule =
+						/^\/capture-site-thumbnail-[A-Za-z0-9_-]+\.js$/.test(
+							moduleUrl.pathname
+						) ||
+						(moduleUrl.pathname ===
+							'/src/lib/capture-site-thumbnail.ts' &&
+							moduleUrl.searchParams.has('worker_file') &&
+							moduleUrl.searchParams.get('type') === 'module');
 					if (
 						moduleUrl.origin !== event.origin ||
-						!moduleUrl.pathname.includes('/capture-site-thumbnail') ||
+						!isRendererModule ||
 						moduleUrl.searchParams.get(
 							'playground-site-thumbnail-module'
 						) !== '1'

--- a/packages/playground/remote/src/lib/playground-mu-plugin/0-playground.php
+++ b/packages/playground/remote/src/lib/playground-mu-plugin/0-playground.php
@@ -259,6 +259,85 @@ add_action('wp_head', 'playground_report_url_to_parent');
 add_action('admin_head', 'playground_report_url_to_parent');
 
 /**
+ * Captures this document when the trusted Playground parent requests a site
+ * thumbnail. The renderer is loaded only for a capture, so normal WordPress
+ * page loads do not pay its download or execution cost.
+ */
+function playground_enable_site_thumbnail_capture() {
+	?>
+	<script>
+		(function () {
+			if (window.__playgroundSiteThumbnailCaptureEnabled) {
+				return;
+			}
+			window.__playgroundSiteThumbnailCaptureEnabled = true;
+
+			window.addEventListener('message', async function (event) {
+				// The origin protects the trust boundary. Checking source as well
+				// prevents another same-origin frame from requesting code execution.
+				if (
+					event.source !== window.parent ||
+					event.origin !== window.location.origin ||
+					event.data?.type !== 'playground-capture-site-thumbnail'
+				) {
+					return;
+				}
+
+				const request = event.data;
+				try {
+					if (
+						typeof request.moduleUrl !== 'string' ||
+						!request.moduleUrl
+					) {
+						throw new Error('Missing site thumbnail module URL.');
+					}
+					// Dynamic import executes inside the WordPress document. Accept only
+					// the same-origin renderer asset marked by the trusted parent.
+					const moduleUrl = new URL(request.moduleUrl);
+					if (
+						moduleUrl.origin !== event.origin ||
+						!moduleUrl.pathname.includes('/capture-site-thumbnail') ||
+						moduleUrl.searchParams.get(
+							'playground-site-thumbnail-module'
+						) !== '1'
+					) {
+						throw new Error('Invalid site thumbnail module URL.');
+					}
+					await import(moduleUrl.href);
+					if (typeof window.__playgroundCaptureSiteThumbnail !== 'function') {
+						throw new Error('Site thumbnail renderer did not load.');
+					}
+					const thumbnail = await window.__playgroundCaptureSiteThumbnail();
+					window.parent.postMessage(
+						{
+							type: 'playground-site-thumbnail-result',
+							requestId: request.requestId,
+							thumbnail,
+						},
+						event.origin
+					);
+				} catch (error) {
+					window.parent.postMessage(
+						{
+							type: 'playground-site-thumbnail-result',
+							requestId: request.requestId,
+							error:
+								error instanceof Error
+									? error.message
+									: String(error),
+						},
+						event.origin
+					);
+				}
+			});
+		})();
+	</script>
+	<?php
+}
+add_action('wp_head', 'playground_enable_site_thumbnail_capture');
+add_action('admin_head', 'playground_enable_site_thumbnail_capture');
+
+/**
  * The default WordPress requests transports have been disabled
  * at this point. However, the Requests class requires at least
  * one working transport or else it throws warnings and acts up.

--- a/packages/playground/website/playwright/e2e/client.spec.ts
+++ b/packages/playground/website/playwright/e2e/client.spec.ts
@@ -16,3 +16,30 @@ test('playground.cli() streams stdout', async ({ website }) => {
 
 	await expect(output).toContain('hi!');
 });
+
+test('playground.captureSiteThumbnail() captures the front page', async ({
+	website,
+}) => {
+	await website.goto('./');
+	await website.page.waitForFunction(() =>
+		Boolean((window as any).playground)
+	);
+
+	const thumbnail = await website.page.evaluate(async () => {
+		const playground = (window as any).playground;
+		return await playground.captureSiteThumbnail();
+	});
+
+	expect(thumbnail.mime).toMatch(/^image\/(webp|jpeg)$/);
+	expect(thumbnail.data.length).toBeGreaterThan(0);
+	const dimensions = await website.page.evaluate(async ({ mime, data }) => {
+		const image = new Image();
+		image.src = `data:${mime};base64,${data}`;
+		await image.decode();
+		return {
+			width: image.naturalWidth,
+			height: image.naturalHeight,
+		};
+	}, thumbnail);
+	expect(dimensions).toEqual({ width: 320, height: 240 });
+});


### PR DESCRIPTION
Adds `captureSiteThumbnail()` to `PlaygroundClient`:

```ts
const thumbnail = await client.captureSiteThumbnail();
const src = `data:${thumbnail.mime};base64,${thumbnail.data}`;
```

The method loads `/` in a disposable 1024×768 iframe and returns a 320×240 WebP image. It falls back to JPEG when WebP encoding is unavailable. The caller owns the result; this PR does not save it or change the Saved Playgrounds UI.

The renderer uses `modern-screenshot`'s `domToCanvas()`. It clones `document.documentElement`, embeds its styles and resources in an SVG `<foreignObject>`, draws that SVG onto a scaled canvas, and encodes the canvas with `toBlob()`.

## Why capture runs in WordPress

The remote frame cannot always read the WordPress DOM. For example, a site may send `Cross-Origin-Embedder-Policy: require-corp` and `Cross-Origin-Opener-Policy: same-origin`. Playground then uses `Document-Isolation-Policy`, which blocks synchronous DOM access from the remote frame even though both frames share an origin.

The MU plugin therefore receives the request from the trusted parent and lazy-loads the renderer inside the front page. It checks the source window, origin, and renderer URL. The remote frame accepts only the response with the matching request ID. Normal page loads do not download `modern-screenshot`.

The disposable page has a 20-second load watchdog. Once it loads, rendering has a 3-second deadline. DOM cloning and canvas rendering stay in the document, with periodic task yields. A resource worker handles supported fetches. Every result or failure removes the iframe and its listeners.

The service worker serves the marked renderer and resource worker as app assets. Without that exception, its scoped-referrer handling would redirect both requests into WordPress's virtual URL namespace, which returns a 404.

This is the first slice split from #4133. Nothing calls the API automatically yet, and this PR does not write OPFS metadata.

## Testing

Open a Playground and run `const thumbnail = await playground.captureSiteThumbnail()` in the browser console. Turn the result into a data URL, open it, and confirm it shows the front page as a 320×240 image. Repeat in Chrome, Firefox, and Safari.
