### PR TITLE
[Website] Surface Blueprint editor action feedback in the Dock toast

### DIFF
--- a/packages/playground/website/playwright/e2e/website-ui.spec.ts
+++ b/packages/playground/website/playwright/e2e/website-ui.spec.ts
@@ -904,11 +904,11 @@ test('should copy blueprint link to clipboard when share button is clicked', asy
 		.getByRole('menuitem', { name: 'Copy Blueprint URL' })
 		.click();
 
-	// Verify success message appears in the notice component
+	// Verify the copy confirmation surfaces in the Dock success toast
 	await expect(
 		website.page
-			.locator('.components-notice')
-			.getByText('Link copied to clipboard!')
+			.getByRole('group', { name: 'Operation succeeded' })
+			.filter({ hasText: 'Link copied to clipboard' })
 	).toBeVisible();
 
 	// Verify clipboard contains the correct URL format

--- a/packages/playground/website/src/components/blueprint-editor/BlueprintBundleEditor.tsx
+++ b/packages/playground/website/src/components/blueprint-editor/BlueprintBundleEditor.tsx
@@ -315,7 +315,6 @@ export const BlueprintBundleEditor = forwardRef<
 	const [currentPath, setCurrentPath] = useState<string | null>(null);
 	const [code, setCode] = useState<string>('');
 	const [saveError, setSaveError] = useState<string | null>(null);
-	const [successMessage, setSuccessMessage] = useState<string | null>(null);
 	const [showExplorerOnMobile, setShowExplorerOnMobile] =
 		useState<boolean>(false);
 	const [messageContent, setMessageContent] = useState<
@@ -771,11 +770,17 @@ export const BlueprintBundleEditor = forwardRef<
 			anchor.click();
 			document.body.removeChild(anchor);
 			setTimeout(() => URL.revokeObjectURL(url), 60_000);
+			dispatch(
+				setDockOperationNotice({
+					status: 'success',
+					title: 'Blueprint downloaded',
+				})
+			);
 		} catch (error) {
 			logger.error('Failed to download bundle', error);
 			setSaveError('Could not download bundle. Try again.');
 		}
-	}, [filesystem]);
+	}, [filesystem, dispatch]);
 
 	const handleShareBlueprint = async () => {
 		if (false === newUrl) {
@@ -787,8 +792,12 @@ export const BlueprintBundleEditor = forwardRef<
 		try {
 			await navigator.clipboard.writeText(newUrl);
 
-			setSuccessMessage('Link copied to clipboard!');
-			setTimeout(() => setSuccessMessage(null), 2000);
+			dispatch(
+				setDockOperationNotice({
+					status: 'success',
+					title: 'Link copied to clipboard',
+				})
+			);
 		} catch (error) {
 			logger.error('Failed to share blueprint', error);
 			setSaveError('Could not copy link. Try again.');
@@ -1073,13 +1082,6 @@ export const BlueprintBundleEditor = forwardRef<
 								</Notice>
 							</div>
 						) : null}
-						{successMessage ? (
-							<div style={{ padding: '8px 16px' }}>
-								<Notice status="success" isDismissible={false}>
-									{successMessage}
-								</Notice>
-							</div>
-						) : null}
 						{!dockPresentation &&
 						!readOnly &&
 						!isBundleShareable ? (
@@ -1103,8 +1105,8 @@ export const BlueprintBundleEditor = forwardRef<
 										'Run will wait for this Playground to finish saving.'
 									) : (
 										<>
-											Running this Blueprint creates a fresh
-											autosaved Playground. “
+											Running this Blueprint creates a
+											fresh autosaved Playground. “
 											{site?.metadata.name}” stays in{' '}
 											{isAutosaved
 												? 'Recent autosaves'


### PR DESCRIPTION
## What it does

Blueprint editor **Copy Blueprint URL** and **Download Zip** now confirm through the existing Dock success toast. Previously "Copy" rendered a plain inline `<Notice>` that blended into the paper editor pane, and "Download" gave no confirmation at all.

| Before | After |
| --- | --- |
| ![Before: copy feedback blends into the Blueprint pane](https://gist.githubusercontent.com/adamziel/a031f55343f8317e876063efb6d060e0/raw/cfcaa2992156c275b5b39718087136c06d4d2a29/crop-before.svg) | ![After: the copy confirmation appears as the Dock success toast](https://raw.githubusercontent.com/WordPress/wordpress-playground/adamziel/blueprint-notice-assets/blueprint-copy-toast.png) |

## Rationale

The app already has one transient-feedback surface — `dockOperationNotice` / `setDockOperationNotice`, the dark toast the **Run** action fires — with success styling, 4s auto-dismiss, and positioning. The first cut of this branch instead stood up a parallel `@wordpress/components` `<Snackbar>` with its own state, timer, and CSS. Reusing the existing toast deletes that duplication.

## Implementation

`handleShareBlueprint` / `handleDownloadBundle` dispatch the shared action instead of setting local state:

```ts
dispatch(
  setDockOperationNotice({ status: 'success', title: 'Link copied to clipboard' })
);
```

Removed the local `successMessage` state, its inline `<Notice>`, and the hand-rolled `setTimeout` (the toast auto-dismisses on its own).

Rebased onto `trunk`, where the toast's `status: 'success'` variant lives — it post-dates this branch's original base.

Toast **placement** is intentionally left unchanged here (it still renders above the pane, clamped to the viewport top for a full-height editor pane). Follow-up #4212 refines placement so the toast drops toward the Dock only when there isn't room for it above the pane.

## Testing instructions

Open the Blueprint pane → **Export**:

- **Copy Blueprint URL** → Dock success toast "Link copied to clipboard".
- **Download Zip** → Dock success toast "Blueprint downloaded".

Both auto-dismiss after ~4s or on an outside click. `nx typecheck playground-website` and lint pass; the copy e2e in `website-ui.spec.ts` asserts the toast via `getByRole('group', { name: 'Operation succeeded' })`.
