### PR TITLE
[Website] Retry transient OPFS access handle contention

### DIFF
--- a/packages/playground/website/playwright/e2e/opfs.spec.ts
+++ b/packages/playground/website/playwright/e2e/opfs.spec.ts
@@ -635,10 +635,14 @@ test('should wait for a temporary OPFS metadata lock', async ({
 			const writable = await metadataFile.createWritable({
 				keepExistingData: true,
 			});
-			const releaseLock = new Promise<void>((resolve) => {
+			const releaseLock = new Promise<void>((resolve, reject) => {
 				setTimeout(async () => {
-					await writable.close();
-					resolve();
+					try {
+						await writable.close();
+						resolve();
+					} catch (error) {
+						reject(error);
+					}
 				}, 200);
 			});
 

--- a/packages/playground/website/playwright/e2e/opfs.spec.ts
+++ b/packages/playground/website/playwright/e2e/opfs.spec.ts
@@ -606,6 +606,64 @@ test('should rename a saved Playground and persist after reload', async ({
 	await website.closePlaygroundsPane();
 });
 
+test('should wait for a temporary OPFS metadata lock', async ({
+	website,
+	browserName,
+}) => {
+	test.skip(
+		browserName !== 'chromium',
+		`This test relies on OPFS which isn't available in Playwright's flavor of ${browserName}.`
+	);
+
+	await website.goto(getTemporaryPlaygroundUrl());
+	await website.page.waitForFunction(() =>
+		Boolean((window as any).playgroundSites?.getClient())
+	);
+	await website.page.evaluate(() =>
+		(window as any).playgroundSites.saveInBrowser()
+	);
+	const site = await getActivePlaygroundSite(website.page);
+	const newName = 'Renamed after OPFS lock';
+
+	await website.page.evaluate(
+		async ({ dirName, newName, slug }) => {
+			const root = await navigator.storage.getDirectory();
+			const sites = await root.getDirectoryHandle('sites');
+			const siteDirectory = await sites.getDirectoryHandle(dirName);
+			const metadataFile =
+				await siteDirectory.getFileHandle('wp-runtime.json');
+			const writable = await metadataFile.createWritable({
+				keepExistingData: true,
+			});
+			const releaseLock = new Promise<void>((resolve) => {
+				setTimeout(async () => {
+					await writable.close();
+					resolve();
+				}, 200);
+			});
+
+			try {
+				await (window as any).playgroundSites.rename(newName, slug);
+			} finally {
+				await releaseLock;
+			}
+		},
+		{
+			dirName: getDirectoryNameForSlug(site.slug),
+			newName,
+			slug: site.slug,
+		}
+	);
+
+	await website.page.reload();
+	await website.page.waitForFunction(() =>
+		Boolean((window as any).playgroundSites?.getClient())
+	);
+	await expect
+		.poll(async () => (await getActivePlaygroundSite(website.page))?.name)
+		.toBe(newName);
+});
+
 test('should show the Store permanently pane with the save controls', async ({
 	website,
 	browserName,

--- a/packages/playground/website/src/lib/state/opfs/opfs-site-storage-worker-for-safari.ts
+++ b/packages/playground/website/src/lib/state/opfs/opfs-site-storage-worker-for-safari.ts
@@ -28,7 +28,8 @@ onmessage = async function (event: MessageEvent) {
 			create: true,
 		});
 
-		const syncAccessHandle = await fileHandle.createSyncAccessHandle();
+		const syncAccessHandle =
+			await createSyncAccessHandleWithRetry(fileHandle);
 		try {
 			const encodedContent = new TextEncoder().encode(content);
 			syncAccessHandle.truncate(0);
@@ -52,3 +53,41 @@ onmessage = async function (event: MessageEvent) {
 		});
 	}
 };
+
+/**
+ * Creates an exclusive OPFS access handle after transient contention clears.
+ *
+ * Chrome rejects `createSyncAccessHandle()` with
+ * `NoModificationAllowedError` while another tab or writable stream still
+ * holds the file. Same-page metadata writes are serialized by the caller, but
+ * those external handles cannot join that in-memory queue. Retrying every 50
+ * milliseconds for at most 20 attempts gives a short-lived handle time to
+ * close while remaining well inside the caller's five-second worker timeout.
+ *
+ * Only access-handle contention is retried. Missing directories, permission
+ * failures, and every other error are returned immediately.
+ *
+ * @param fileHandle OPFS file whose synchronous access handle is required.
+ * @returns The exclusive synchronous access handle.
+ * @throws The final contention error or any non-retryable error.
+ */
+async function createSyncAccessHandleWithRetry(
+	fileHandle: FileSystemFileHandle
+): Promise<FileSystemSyncAccessHandle> {
+	const maxAttempts = 20;
+	const retryDelayMs = 50;
+	for (let attempt = 1; ; attempt++) {
+		try {
+			return await fileHandle.createSyncAccessHandle();
+		} catch (error) {
+			if (
+				!(error instanceof DOMException) ||
+				error.name !== 'NoModificationAllowedError' ||
+				attempt === maxAttempts
+			) {
+				throw error;
+			}
+			await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
+		}
+	}
+}

--- a/packages/playground/website/src/lib/state/opfs/opfs-site-storage-worker-for-safari.ts
+++ b/packages/playground/website/src/lib/state/opfs/opfs-site-storage-worker-for-safari.ts
@@ -57,12 +57,13 @@ onmessage = async function (event: MessageEvent) {
 /**
  * Creates an exclusive OPFS access handle after transient contention clears.
  *
- * Chrome rejects `createSyncAccessHandle()` with
+ * The OPFS API may reject `createSyncAccessHandle()` with
  * `NoModificationAllowedError` while another tab or writable stream still
- * holds the file. Same-page metadata writes are serialized by the caller, but
- * those external handles cannot join that in-memory queue. Retrying every 50
- * milliseconds for at most 20 attempts gives a short-lived handle time to
- * close while remaining well inside the caller's five-second worker timeout.
+ * holds the file, as observed in Chromium. Same-page metadata writes are
+ * serialized by the caller, but those external handles cannot join that
+ * in-memory queue. Retrying every 50 milliseconds for at most 20 attempts
+ * gives a short-lived handle time to close while remaining well inside the
+ * caller's five-second worker timeout.
  *
  * Only access-handle contention is retried. Missing directories, permission
  * failures, and every other error are returned immediately.
@@ -76,18 +77,19 @@ async function createSyncAccessHandleWithRetry(
 ): Promise<FileSystemSyncAccessHandle> {
 	const maxAttempts = 20;
 	const retryDelayMs = 50;
-	for (let attempt = 1; ; attempt++) {
+	for (let attempt = 1; attempt < maxAttempts; attempt++) {
 		try {
 			return await fileHandle.createSyncAccessHandle();
 		} catch (error) {
 			if (
 				!(error instanceof DOMException) ||
-				error.name !== 'NoModificationAllowedError' ||
-				attempt === maxAttempts
+				error.name !== 'NoModificationAllowedError'
 			) {
 				throw error;
 			}
 			await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
 		}
 	}
+
+	return fileHandle.createSyncAccessHandle();
 }


### PR DESCRIPTION
Retries transient contention when the OPFS metadata worker creates its exclusive access handle.

Same-page metadata writes are serialized, and concurrent autosaves now share their persistence work. Neither mechanism covers another tab or an unrelated writable stream holding `wp-runtime.json`. Chrome rejects that overlap immediately with `NoModificationAllowedError`, even when the other handle closes a moment later.

This PR retries only that error every 50 milliseconds for at most 20 attempts. Missing paths, permission failures, and other errors still fail immediately. The retry window remains well below the caller's existing five-second worker timeout.

The first commit adds a Chromium E2E that keeps `wp-runtime.json` open for 200 milliseconds while renaming a stored Playground. It fails on trunk and confirms that the rename survives reload after the retry is added.

## Testing

Open a stored Playground in two tabs, briefly overlap a metadata update, and confirm the update completes once the other tab releases the file.
