### PR TITLE
[Website] Tweak confirmations copy and placement. And preserve the Playground URL through settings update.

### DIFF
--- a/packages/playground/website/playwright/e2e/website-ui.spec.ts
+++ b/packages/playground/website/playwright/e2e/website-ui.spec.ts
@@ -3074,28 +3074,22 @@ echo get_option('blogname');
 		await assertRestoreCardGeometry();
 
 		async function assertRestoreCardGeometry() {
-			const geometry = await website.page.evaluate(() => {
-				const card = document.querySelector<HTMLElement>(
-					'[aria-label="Recent autosaved Playground"]'
-				)!;
-				const cardRect = card.getBoundingClientRect();
-				return {
-					cardTop: cardRect.top,
-					cardLeft: cardRect.left,
-					cardRight: cardRect.right,
-					cardBottom: cardRect.bottom,
-					viewportWidth: window.innerWidth,
-					viewportHeight: window.innerHeight,
-				};
-			});
-			expect(geometry.cardTop).toBeGreaterThanOrEqual(0);
-			expect(geometry.cardLeft).toBeGreaterThanOrEqual(0);
-			expect(geometry.cardRight).toBeLessThanOrEqual(
-				geometry.viewportWidth
-			);
-			expect(geometry.cardBottom).toBeLessThanOrEqual(
-				geometry.viewportHeight
-			);
+			await expect
+				.poll(() =>
+					website.page.evaluate(() => {
+						const card = document.querySelector<HTMLElement>(
+							'[aria-label="Recent autosaved Playground"]'
+						)!;
+						const cardRect = card.getBoundingClientRect();
+						return (
+							cardRect.top >= 0 &&
+							cardRect.left >= 0 &&
+							cardRect.right <= window.innerWidth &&
+							cardRect.bottom <= window.innerHeight
+						);
+					})
+				)
+				.toBe(true);
 		}
 	});
 

--- a/packages/playground/website/src/components/blueprint-editor/BlueprintBundleEditor.tsx
+++ b/packages/playground/website/src/components/blueprint-editor/BlueprintBundleEditor.tsx
@@ -72,7 +72,10 @@ import {
 	useAppDispatch,
 	useAppSelector,
 } from '../../lib/state/redux/store';
-import { setDockPaneOpen } from '../../lib/state/redux/slice-ui';
+import {
+	setDockOperationNotice,
+	setDockPaneOpen,
+} from '../../lib/state/redux/slice-ui';
 import styles from './blueprint-bundle-editor.module.css';
 import hideRootStyles from './hide-root.module.css';
 import validationStyles from './validation-panel.module.css';
@@ -465,6 +468,23 @@ export const BlueprintBundleEditor = forwardRef<
 				return;
 			}
 			setSaveError(null);
+			if (runInNewPlayground) {
+				dispatch(
+					setDockOperationNotice({
+						status: 'success',
+						title: 'Blueprint is running in a new Playground',
+						message: 'Opening the new Playground now.',
+					})
+				);
+			} else {
+				dispatch(
+					setDockOperationNotice({
+						status: 'success',
+						title: 'Blueprint is running',
+						message: 'Recreating this Playground now.',
+					})
+				);
+			}
 			if (runInNewPlayground) {
 				const siteSlugToReturnToIfBlueprintFails =
 					site.metadata.siteSlugToReturnToIfBlueprintFails ??

--- a/packages/playground/website/src/components/delete-site-modal/index.tsx
+++ b/packages/playground/website/src/components/delete-site-modal/index.tsx
@@ -80,7 +80,7 @@ export function DeleteSiteModal() {
 					</Notice>
 				) : null}
 				<ModalButtons
-					submitText="Delete"
+					submitText="Delete Playground"
 					areBusy={isSubmitting}
 					onCancel={closeModal}
 				/>

--- a/packages/playground/website/src/components/dock/dock.tsx
+++ b/packages/playground/website/src/components/dock/dock.tsx
@@ -366,6 +366,16 @@ export function Dock({
 	}, [operationNotice]);
 
 	useEffect(() => {
+		if (operationNotice?.status !== 'success') {
+			return;
+		}
+		const timeout = window.setTimeout(() => {
+			dispatch(setDockOperationNotice(undefined));
+		}, 4000);
+		return () => window.clearTimeout(timeout);
+	}, [dispatch, operationNotice]);
+
+	useEffect(() => {
 		if (dockCenter === null || !dockSize.width) {
 			return;
 		}
@@ -1003,7 +1013,14 @@ export function Dock({
 	return (
 		<>
 			{operationNotice && (
-				<span className={css.visuallyHidden} role="alert">
+				<span
+					className={css.visuallyHidden}
+					role={
+						operationNotice.status === 'success'
+							? 'status'
+							: 'alert'
+					}
+				>
 					{operationNotice.title}
 					{operationNotice.message && `. ${operationNotice.message}`}
 				</span>
@@ -1150,9 +1167,16 @@ export function Dock({
 			{operationNotice && (
 				<div
 					ref={operationToastRef}
-					className={css.dockOperationToast}
+					className={classNames(css.dockOperationToast, {
+						[css.dockOperationToastSuccess]:
+							operationNotice.status === 'success',
+					})}
 					role="group"
-					aria-label="Operation failed"
+					aria-label={
+						operationNotice.status === 'success'
+							? 'Operation succeeded'
+							: 'Operation failed'
+					}
 					style={operationToastStyle}
 				>
 					<div className={css.dockOperationToastContent}>
@@ -1167,7 +1191,11 @@ export function Dock({
 					</div>
 					<button
 						type="button"
-						aria-label="Dismiss operation error"
+						aria-label={
+							operationNotice.status === 'success'
+								? 'Dismiss operation notification'
+								: 'Dismiss operation error'
+						}
 						onClick={() =>
 							dispatch(setDockOperationNotice(undefined))
 						}

--- a/packages/playground/website/src/components/dock/style.module.css
+++ b/packages/playground/website/src/components/dock/style.module.css
@@ -1309,6 +1309,16 @@
 	z-index: 60;
 }
 
+.dock-operation-toast-success {
+	background: #1f4f2b;
+	border-color: #4f8f59;
+	box-shadow: 0 15px 36px rgba(19, 68, 32, 0.28);
+}
+
+.dock-operation-toast-success .dock-operation-toast-message {
+	color: #d8f4dc;
+}
+
 .dock-operation-toast-content {
 	flex: 1;
 	min-width: 0;

--- a/packages/playground/website/src/components/saved-playgrounds-panel/index.tsx
+++ b/packages/playground/website/src/components/saved-playgrounds-panel/index.tsx
@@ -16,6 +16,7 @@ import {
 	layout,
 	fullscreen,
 	offline as offlineIcon,
+	check,
 } from '@wordpress/icons';
 import { Icon } from '@wordpress/icons';
 import { GitHubIcon } from '../../github/github';
@@ -992,6 +993,20 @@ export function SavedPlaygroundsPanel({
 											Save in a local directory…
 										</MenuItem>
 									)}
+								</MenuGroup>
+							)}
+							{site.metadata.storage === 'opfs' && (
+								<MenuGroup>
+									<MenuItem icon={check} disabled>
+										Saved in browser storage
+									</MenuItem>
+								</MenuGroup>
+							)}
+							{site.metadata.storage === 'local-fs' && (
+								<MenuGroup>
+									<MenuItem icon={check} disabled>
+										Saved in a local directory
+									</MenuItem>
 								</MenuGroup>
 							)}
 							{isStored && (

--- a/packages/playground/website/src/lib/state/redux/boot-site-client.spec.ts
+++ b/packages/playground/website/src/lib/state/redux/boot-site-client.spec.ts
@@ -337,6 +337,69 @@ describe('bootSiteClient', () => {
 		);
 	});
 
+	it('reopens the current page after a runtime settings reboot', async () => {
+		const playground = createPlaygroundClient({
+			goTo: vi.fn(async () => undefined),
+		});
+		vi.mocked(startPlaygroundWeb).mockImplementationOnce(
+			async (options: any) => {
+				options.onClientConnected(playground);
+				return playground;
+			}
+		);
+		const site = createSite('stored-save', {
+			loadedFromStorage: true,
+			urlToRestoreAfterRuntimeSettingsChange:
+				'/index.php?slashes=///#more/slashes',
+		});
+		const state = createState(site);
+		const dispatch = createDispatch(state);
+
+		await bootSiteClient('stored-save', document.createElement('iframe'), {
+			signal: new AbortController().signal,
+		})(dispatch, () => state);
+
+		expect(playground.goTo).toHaveBeenCalledWith(
+			'/index.php?slashes=///#more/slashes'
+		);
+		expect(
+			state.sites.entities['stored-save']
+				.urlToRestoreAfterRuntimeSettingsChange
+		).toBeUndefined();
+	});
+
+	it.each([
+		'https://example.com/wp-admin/',
+		'//example.com/wp-admin/',
+		'/\\example.com/wp-admin/',
+	])('skips unsafe runtime settings restore URL %s', async (urlToRestore) => {
+		const playground = createPlaygroundClient({
+			goTo: vi.fn(async () => undefined),
+		});
+		vi.mocked(startPlaygroundWeb).mockImplementationOnce(
+			async (options: any) => {
+				options.onClientConnected(playground);
+				return playground;
+			}
+		);
+		const site = createSite('stored-save', {
+			loadedFromStorage: true,
+			urlToRestoreAfterRuntimeSettingsChange: urlToRestore,
+		});
+		const state = createState(site);
+		const dispatch = createDispatch(state);
+
+		await bootSiteClient('stored-save', document.createElement('iframe'), {
+			signal: new AbortController().signal,
+		})(dispatch, () => state);
+
+		expect(playground.goTo).not.toHaveBeenCalled();
+		expect(
+			state.sites.entities['stored-save']
+				.urlToRestoreAfterRuntimeSettingsChange
+		).toBeUndefined();
+	});
+
 	it('mounts legacy OPFS directories from stored metadata', async () => {
 		const site = createSite('stored-save', {
 			loadedFromStorage: true,
@@ -653,12 +716,15 @@ function createSite(
 	slug: string,
 	options: {
 		loadedFromStorage?: boolean;
+		urlToRestoreAfterRuntimeSettingsChange?: string;
 		metadata?: Partial<SiteInfo['metadata']>;
 	} = {}
 ): SiteInfo {
 	return {
 		slug,
 		loadedFromStorage: options.loadedFromStorage,
+		urlToRestoreAfterRuntimeSettingsChange:
+			options.urlToRestoreAfterRuntimeSettingsChange,
 		metadata: {
 			id: slug,
 			name: slug,

--- a/packages/playground/website/src/lib/state/redux/boot-site-client.ts
+++ b/packages/playground/website/src/lib/state/redux/boot-site-client.ts
@@ -27,6 +27,7 @@ import {
 	isAutosavedSite,
 	isUnfinishedBlueprintRun,
 	selectSiteBySlug,
+	updateSite,
 	updateSiteMetadata,
 } from './slice-sites';
 // @ts-ignore
@@ -486,6 +487,37 @@ export function bootSiteClient(
 				})
 			);
 		});
+
+		if (site.urlToRestoreAfterRuntimeSettingsChange) {
+			const urlToRestore = site.urlToRestoreAfterRuntimeSettingsChange;
+			await dispatch(
+				updateSite({
+					slug: site.slug,
+					changes: {
+						urlToRestoreAfterRuntimeSettingsChange: undefined,
+					},
+				})
+			);
+			if (signal.aborted) {
+				return;
+			}
+			if (urlToRestore.startsWith('/')) {
+				const restoreBaseUrl = 'https://playground.internal';
+				const parsedUrlToRestore = new URL(
+					urlToRestore,
+					restoreBaseUrl
+				);
+				// Restore only paths inside this Playground. The URL parser
+				// catches protocol-relative URLs and browser backslash
+				// normalization quirks while preserving valid slashes in the
+				// path, query, and hash.
+				if (parsedUrlToRestore.origin === restoreBaseUrl) {
+					await connectedPlayground.goTo(
+						`${parsedUrlToRestore.pathname}${parsedUrlToRestore.search}${parsedUrlToRestore.hash}`
+					);
+				}
+			}
+		}
 	};
 }
 

--- a/packages/playground/website/src/lib/state/redux/site-management-api-middleware.ts
+++ b/packages/playground/website/src/lib/state/redux/site-management-api-middleware.ts
@@ -14,12 +14,15 @@ import { setActiveSiteError } from './slice-ui';
 import {
 	addClientInfo,
 	removeClientInfo,
+	selectClientBySiteSlug,
+	selectClientInfoBySiteSlug,
 	updateClientInfo,
 } from './slice-clients';
 import {
 	selectAllSites,
 	selectSiteBySlug,
 	setOPFSSitesLoadingState,
+	updateSite,
 	updateSiteMetadata,
 	removeSite,
 	pruneAutosavedSites,
@@ -36,10 +39,6 @@ import {
 } from './slice-sites';
 import { randomSiteName } from './random-site-name';
 import { persistTemporarySite } from './persist-temporary-site';
-import {
-	selectClientBySiteSlug,
-	selectClientInfoBySiteSlug,
-} from './slice-clients';
 import type { PlaygroundClient } from '@wp-playground/remote';
 import type { AllPHPVersion } from '@php-wasm/universal';
 import { opfsSiteStorage } from '../opfs/opfs-site-storage';
@@ -608,12 +607,18 @@ export function createSitesAPI(
 				);
 			}
 			await dispatch(
-				updateSiteMetadata({
+				updateSite({
 					slug: site.slug,
 					changes: {
-						runtimeConfiguration: {
-							...site.metadata.runtimeConfiguration,
-							phpVersion: version,
+						urlToRestoreAfterRuntimeSettingsChange:
+							selectClientInfoBySiteSlug(getState(), site.slug)
+								?.url,
+						metadata: {
+							...site.metadata,
+							runtimeConfiguration: {
+								...site.metadata.runtimeConfiguration,
+								phpVersion: version,
+							},
 						},
 					},
 				})
@@ -638,12 +643,18 @@ export function createSitesAPI(
 				);
 			}
 			await dispatch(
-				updateSiteMetadata({
+				updateSite({
 					slug: site.slug,
 					changes: {
-						runtimeConfiguration: {
-							...site.metadata.runtimeConfiguration,
-							networking: enabled,
+						urlToRestoreAfterRuntimeSettingsChange:
+							selectClientInfoBySiteSlug(getState(), site.slug)
+								?.url,
+						metadata: {
+							...site.metadata,
+							runtimeConfiguration: {
+								...site.metadata.runtimeConfiguration,
+								networking: enabled,
+							},
 						},
 					},
 				})
@@ -687,13 +698,19 @@ export function createSitesAPI(
 				return;
 			}
 			await dispatch(
-				updateSiteMetadata({
+				updateSite({
 					slug: site.slug,
 					changes: {
-						runtimeConfiguration: {
-							...site.metadata.runtimeConfiguration,
-							phpVersion: settings.phpVersion,
-							networking: settings.networking,
+						urlToRestoreAfterRuntimeSettingsChange:
+							selectClientInfoBySiteSlug(getState(), site.slug)
+								?.url,
+						metadata: {
+							...site.metadata,
+							runtimeConfiguration: {
+								...site.metadata.runtimeConfiguration,
+								phpVersion: settings.phpVersion,
+								networking: settings.networking,
+							},
 						},
 					},
 				})

--- a/packages/playground/website/src/lib/state/redux/slice-sites.ts
+++ b/packages/playground/website/src/lib/state/redux/slice-sites.ts
@@ -75,6 +75,7 @@ export interface SiteInfo {
 	slug: string;
 	loadedFromStorage?: boolean;
 	originalUrlParams?: OriginalUrlParams;
+	urlToRestoreAfterRuntimeSettingsChange?: string;
 	metadata: SiteMetadata;
 }
 

--- a/packages/playground/website/src/lib/state/redux/slice-ui.ts
+++ b/packages/playground/website/src/lib/state/redux/slice-ui.ts
@@ -182,6 +182,7 @@ export interface UIState {
 	/** Playground slug from which the current authoring draft was seeded. */
 	writeOwnSeededSlug?: string;
 	dockOperationNotice?: {
+		status?: 'error' | 'success';
 		title: string;
 		message?: string;
 	};


### PR DESCRIPTION
Polishes four rough edges in the Dock.

The delete confirmation now names the destructive action in the button: "Delete Playground". It does not explain where the app goes after deletion; the app should just pick the next sensible Playground.

Running a Blueprint from the editor now posts a Dock-level success toast. That matters on narrow screens because the editor closes before the user can see inline feedback.

Saved Playground menus keep a disabled "Saved in browser storage" or "Saved in a local directory" row, so the menu still says why the save action is gone.

Runtime setting changes now reopen the WordPress page the user was on after PHP or networking restarts. The URL is kept only in transient Redux state. Before restoring it, the browser URL parser checks that it still belongs to the same Playground, so query strings such as `?slashes=///` survive while protocol-relative or backslash-normalized external URLs are ignored.

## Testing

Delete a Playground and check that the confirm button says "Delete Playground". Run a Blueprint from the editor on a narrow viewport and check for a success toast. Open a saved Playground row menu and check that it says where the Playground is saved. Open a wp-admin page, change the PHP version, and check that the same page reopens after the runtime reload.
