### PR TITLE
[Website] Preserve concurrent cross-tab metadata changes

### DIFF
--- a/packages/playground/website/playwright/e2e/opfs.spec.ts
+++ b/packages/playground/website/playwright/e2e/opfs.spec.ts
@@ -682,6 +682,58 @@ test('should wait for a temporary OPFS metadata lock', async ({
 		.toBe(newName);
 });
 
+test('should preserve metadata changes made in different tabs', async ({
+	website,
+	context,
+	browserName,
+}) => {
+	test.skip(
+		browserName !== 'chromium',
+		`This test relies on OPFS which isn't available in Playwright's flavor of ${browserName}.`
+	);
+
+	await website.goto(getTemporaryPlaygroundUrl());
+	await website.page.waitForFunction(() =>
+		Boolean((window as any).playgroundSites?.getClient())
+	);
+	await website.page.evaluate(() =>
+		(window as any).playgroundSites.saveInBrowser()
+	);
+	const site = await getActivePlaygroundSite(website.page);
+
+	const secondTab = await context.newPage();
+	await secondTab.goto(
+		new URL(
+			`./?site-slug=${encodeURIComponent(site.slug)}`,
+			website.page.url()
+		).href
+	);
+	await secondTab.waitForFunction(() =>
+		Boolean((window as any).playgroundSites)
+	);
+	await secondTab.evaluate(() => (window as any).playgroundSites.isReady());
+
+	const newName = 'Renamed in the first tab';
+	await website.page.evaluate(
+		({ name, slug }) => (window as any).playgroundSites.rename(name, slug),
+		{ name: newName, slug: site.slug }
+	);
+	await secondTab.evaluate(() =>
+		(window as any).playgroundSites.setNetworking(false)
+	);
+
+	const persistedMetadata = await website.page.evaluate(async (dirName) => {
+		const root = await navigator.storage.getDirectory();
+		const sites = await root.getDirectoryHandle('sites');
+		const siteDirectory = await sites.getDirectoryHandle(dirName);
+		const metadataFile =
+			await siteDirectory.getFileHandle('wp-runtime.json');
+		return JSON.parse(await (await metadataFile.getFile()).text());
+	}, getDirectoryNameForSlug(site.slug));
+	expect(persistedMetadata.name).toBe(newName);
+	expect(persistedMetadata.runtimeConfiguration.networking).toBe(false);
+});
+
 test('should show the Store permanently pane with the save controls', async ({
 	website,
 	browserName,

--- a/packages/playground/website/playwright/e2e/opfs.spec.ts
+++ b/packages/playground/website/playwright/e2e/opfs.spec.ts
@@ -718,6 +718,9 @@ test('should preserve metadata changes made in different tabs', async ({
 		({ name, slug }) => (window as any).playgroundSites.rename(name, slug),
 		{ name: newName, slug: site.slug }
 	);
+	await website.page.evaluate(() =>
+		(window as any).playgroundSites.setPhpVersion('8.2')
+	);
 	await secondTab.evaluate(() =>
 		(window as any).playgroundSites.setNetworking(false)
 	);
@@ -731,6 +734,7 @@ test('should preserve metadata changes made in different tabs', async ({
 		return JSON.parse(await (await metadataFile.getFile()).text());
 	}, getDirectoryNameForSlug(site.slug));
 	expect(persistedMetadata.name).toBe(newName);
+	expect(persistedMetadata.runtimeConfiguration.phpVersion).toBe('8.2');
 	expect(persistedMetadata.runtimeConfiguration.networking).toBe(false);
 });
 

--- a/packages/playground/website/src/components/blueprint-editor/BlueprintBundleEditor.spec.tsx
+++ b/packages/playground/website/src/components/blueprint-editor/BlueprintBundleEditor.spec.tsx
@@ -382,12 +382,9 @@ describe('BlueprintBundleEditor Run barrier', () => {
 			slug: temporarySite.slug,
 			changes: {
 				metadata: {
-					...temporarySite.metadata,
 					originalBlueprintSource: { type: 'none' },
 					originalBlueprint: filesystem,
 					runtimeConfiguration,
-					initialOpfsSyncPending: false,
-					playgroundDefinedConstants: undefined,
 					whenCreated: expect.any(Number),
 				},
 				originalUrlParams: undefined,

--- a/packages/playground/website/src/components/blueprint-editor/BlueprintBundleEditor.tsx
+++ b/packages/playground/website/src/components/blueprint-editor/BlueprintBundleEditor.tsx
@@ -527,14 +527,9 @@ export const BlueprintBundleEditor = forwardRef<
 			);
 			const changes = {
 				metadata: {
-					...site.metadata,
 					originalBlueprintSource: { type: 'none' as const },
 					originalBlueprint: filesystem,
 					runtimeConfiguration,
-					initialOpfsSyncPending:
-						site.metadata.initialOpfsSyncPending,
-					playgroundDefinedConstants:
-						site.metadata.playgroundDefinedConstants,
 					whenCreated: Date.now(),
 				},
 				originalUrlParams: undefined,

--- a/packages/playground/website/src/lib/state/opfs/opfs-site-storage.spec.ts
+++ b/packages/playground/website/src/lib/state/opfs/opfs-site-storage.spec.ts
@@ -152,11 +152,10 @@ describe('opfsSiteStorage', () => {
 			},
 		};
 
-		await storage.update(
-			'stored-site',
-			createSiteMetadata({ name: 'Renamed Playground' }),
-			originalUrlParams
-		);
+		await storage.update('stored-site', {
+			metadata: { name: 'Renamed Playground' },
+			originalUrlParams,
+		});
 
 		await expect(storage.read('stored-site')).resolves.toMatchObject({
 			metadata: {
@@ -170,14 +169,12 @@ describe('opfsSiteStorage', () => {
 		await storage.create('stored-site', createSiteMetadata());
 
 		await Promise.all([
-			storage.update(
-				'stored-site',
-				createSiteMetadata({ name: 'First name' })
-			),
-			storage.update(
-				'stored-site',
-				createSiteMetadata({ name: 'Second name' })
-			),
+			storage.update('stored-site', {
+				metadata: { name: 'First name' },
+			}),
+			storage.update('stored-site', {
+				metadata: { name: 'Second name' },
+			}),
 		]);
 		const site = await storage.read('stored-site');
 		expect(['First name', 'Second name']).toContain(site?.metadata.name);

--- a/packages/playground/website/src/lib/state/opfs/opfs-site-storage.spec.ts
+++ b/packages/playground/website/src/lib/state/opfs/opfs-site-storage.spec.ts
@@ -165,6 +165,27 @@ describe('opfsSiteStorage', () => {
 		});
 	});
 
+	it('preserves runtime configuration fields across partial updates', async () => {
+		await storage.create('stored-site', createSiteMetadata());
+
+		await storage.update('stored-site', {
+			metadata: { runtimeConfiguration: { phpVersion: '8.2' } },
+		});
+		await storage.update('stored-site', {
+			metadata: { runtimeConfiguration: { networking: false } },
+		});
+
+		await expect(storage.read('stored-site')).resolves.toMatchObject({
+			metadata: {
+				runtimeConfiguration: {
+					phpVersion: '8.2',
+					wpVersion: 'latest',
+					networking: false,
+				},
+			},
+		});
+	});
+
 	it('serializes concurrent metadata updates to the same site', async () => {
 		await storage.create('stored-site', createSiteMetadata());
 

--- a/packages/playground/website/src/lib/state/opfs/opfs-site-storage.ts
+++ b/packages/playground/website/src/lib/state/opfs/opfs-site-storage.ts
@@ -120,7 +120,7 @@ class OpfsSiteStorage {
 	 *
 	 * @param slug Slug of the stored site to update.
 	 * @param changes Metadata and setup URL fields to merge.
-	 * @returns The complete site metadata written to OPFS.
+	 * @returns The merged site information written to OPFS.
 	 */
 	async update(slug: string, changes: StoredSiteChanges): Promise<SiteInfo> {
 		return await withSiteMetadataLock(slug, async () => {

--- a/packages/playground/website/src/lib/state/opfs/opfs-site-storage.ts
+++ b/packages/playground/website/src/lib/state/opfs/opfs-site-storage.ts
@@ -132,27 +132,16 @@ class OpfsSiteStorage {
 			const siteDirectory =
 				await this.root.getDirectoryHandle(siteDirName);
 			const currentSite = await this.readSiteFromDirHandle(siteDirectory);
-			const {
-				runtimeConfiguration: runtimeConfigurationChanges,
-				...metadataChanges
-			} = changes.metadata ?? {};
 			const updatedSite: SiteInfo = {
 				...currentSite,
-				...('originalUrlParams' in changes
-					? { originalUrlParams: changes.originalUrlParams }
-					: {}),
+				...changes,
 				metadata: {
 					...currentSite.metadata,
-					...metadataChanges,
-					...(runtimeConfigurationChanges
-						? {
-								runtimeConfiguration: {
-									...currentSite.metadata
-										.runtimeConfiguration,
-									...runtimeConfigurationChanges,
-								},
-							}
-						: {}),
+					...changes.metadata,
+					runtimeConfiguration: {
+						...currentSite.metadata.runtimeConfiguration,
+						...changes.metadata?.runtimeConfiguration,
+					},
 				},
 			};
 

--- a/packages/playground/website/src/lib/state/opfs/opfs-site-storage.ts
+++ b/packages/playground/website/src/lib/state/opfs/opfs-site-storage.ts
@@ -6,7 +6,11 @@
  */
 
 import metadataWorkerUrl from './opfs-site-storage-worker-for-safari?worker&url';
-import type { SiteInfo, SiteMetadata } from '../redux/slice-sites';
+import type {
+	SiteInfo,
+	SiteMetadata,
+	SiteMetadataChanges,
+} from '../redux/slice-sites';
 import type { OriginalUrlParams } from '../original-url-params';
 import { logger } from '@php-wasm/logger';
 import { joinPaths } from '@php-wasm/util';
@@ -58,6 +62,11 @@ export interface StoredSiteMetadata extends SiteMetadata {
 	originalUrlParams?: OriginalUrlParams;
 }
 
+type StoredSiteChanges = {
+	metadata?: SiteMetadataChanges;
+	originalUrlParams?: OriginalUrlParams;
+};
+
 let opfsSitesRoot: FileSystemDirectoryHandle | undefined = undefined;
 try {
 	opfsSitesRoot = await navigator.storage.getDirectory();
@@ -99,22 +108,64 @@ class OpfsSiteStorage {
 	}
 
 	/**
-	 * Updates OPFS site metadata without changing the site directory name.
+	 * Merges changes into a stored site's latest OPFS metadata.
+	 *
+	 * Every tab has its own Redux snapshot, so replacing the complete metadata
+	 * object can restore stale fields written by another tab. The Web Lock keeps
+	 * the read, merge, and write in one origin-wide transaction. Callers receive
+	 * the merged site so their local state also includes changes from other tabs.
+	 *
+	 * Browsers without the Web Locks API still perform the same merge, but cannot
+	 * prevent another tab from writing between the read and write.
+	 *
+	 * @param slug Slug of the stored site to update.
+	 * @param changes Metadata and setup URL fields to merge.
+	 * @returns The complete site metadata written to OPFS.
 	 */
-	async update(
-		slug: string,
-		metadata: SiteMetadata,
-		originalUrlParams?: OriginalUrlParams
-	): Promise<void> {
-		const siteDirName = await this.findExistingSiteDirName(slug);
-		if (!siteDirName) {
-			throw new Error(`Site with slug '${slug}' does not exist.`);
-		}
+	async update(slug: string, changes: StoredSiteChanges): Promise<SiteInfo> {
+		return await withSiteMetadataLock(slug, async () => {
+			const siteDirName = await this.findExistingSiteDirName(slug);
+			if (!siteDirName) {
+				throw new Error(`Site with slug '${slug}' does not exist.`);
+			}
 
-		await writeOpfsFile(
-			getSiteMetadataPath(siteDirName),
-			await metadataToStoredFormat(slug, metadata, originalUrlParams)
-		);
+			const siteDirectory =
+				await this.root.getDirectoryHandle(siteDirName);
+			const currentSite = await this.readSiteFromDirHandle(siteDirectory);
+			const {
+				runtimeConfiguration: runtimeConfigurationChanges,
+				...metadataChanges
+			} = changes.metadata ?? {};
+			const updatedSite: SiteInfo = {
+				...currentSite,
+				...('originalUrlParams' in changes
+					? { originalUrlParams: changes.originalUrlParams }
+					: {}),
+				metadata: {
+					...currentSite.metadata,
+					...metadataChanges,
+					...(runtimeConfigurationChanges
+						? {
+								runtimeConfiguration: {
+									...currentSite.metadata
+										.runtimeConfiguration,
+									...runtimeConfigurationChanges,
+								},
+							}
+						: {}),
+				},
+			};
+
+			await writeOpfsFile(
+				getSiteMetadataPath(siteDirName),
+				await metadataToStoredFormat(
+					slug,
+					updatedSite.metadata,
+					updatedSite.originalUrlParams
+				)
+			);
+			return updatedSite;
+		});
 	}
 
 	async list(): Promise<SiteInfo[]> {
@@ -333,6 +384,31 @@ export const opfsSiteStorage: OpfsSiteStorage | undefined = opfsSitesRoot
 	: undefined;
 
 export const isOpfsAvailable = !!opfsSiteStorage;
+
+/**
+ * Runs a site metadata transaction under an origin-wide exclusive lock.
+ *
+ * Web Locks coordinate same-origin tabs and workers. The callback begins only
+ * after an earlier transaction for the same site finishes, and the browser
+ * releases the lock when the callback settles. Different sites use different
+ * lock names and remain independent.
+ *
+ * @param slug Slug used to identify the site transaction.
+ * @param transaction Read, merge, and write operation to serialize.
+ * @returns The transaction result.
+ */
+async function withSiteMetadataLock<T>(
+	slug: string,
+	transaction: () => Promise<T>
+): Promise<T> {
+	if (!navigator.locks) {
+		return await transaction();
+	}
+	return await navigator.locks.request(
+		`wordpress-playground:site-metadata:${slug}`,
+		transaction
+	);
+}
 
 function getSiteMetadataPath(siteDirName: string) {
 	return joinPaths(OPFS_SITES_ROOT_PATH, siteDirName, SITE_METADATA_FILENAME);

--- a/packages/playground/website/src/lib/state/redux/boot-site-client.spec.ts
+++ b/packages/playground/website/src/lib/state/redux/boot-site-client.spec.ts
@@ -89,7 +89,30 @@ describe('bootSiteClient', () => {
 			opfsSiteStorage!.removeWordPressFilesKeepMetadata
 		).mockResolvedValue(undefined);
 		vi.mocked(opfsSiteStorage!.update).mockReset();
-		vi.mocked(opfsSiteStorage!.update).mockResolvedValue(undefined);
+		vi.mocked(opfsSiteStorage!.update).mockImplementation(
+			async (slug, changes) => {
+				const site = createSite(slug);
+				const {
+					runtimeConfiguration: runtimeConfigurationChanges,
+					...metadataChanges
+				} = changes.metadata ?? {};
+				return {
+					...site,
+					metadata: {
+						...site.metadata,
+						...metadataChanges,
+						...(runtimeConfigurationChanges
+							? {
+									runtimeConfiguration: {
+										...site.metadata.runtimeConfiguration,
+										...runtimeConfigurationChanges,
+									},
+								}
+							: {}),
+					},
+				};
+			}
+		);
 	});
 
 	it('does not report a missing site after boot is aborted', async () => {
@@ -129,11 +152,11 @@ describe('bootSiteClient', () => {
 		).toBeLessThan(
 			vi.mocked(startPlaygroundWeb).mock.invocationCallOrder[0]
 		);
-		expect(opfsSiteStorage!.update).toHaveBeenCalledWith(
-			'autosaved',
-			expect.objectContaining({ opfsSiteRemovalPending: undefined }),
-			undefined
-		);
+		expect(opfsSiteStorage!.update).toHaveBeenCalledWith('autosaved', {
+			metadata: expect.objectContaining({
+				opfsSiteRemovalPending: undefined,
+			}),
+		});
 		expect(startPlaygroundWeb).toHaveBeenCalled();
 	});
 
@@ -645,8 +668,11 @@ describe('bootSiteClient', () => {
 		expect(dispatch.mock.calls.length).toBe(actionCountAfterAbort);
 		expect(opfsSiteStorage!.update).not.toHaveBeenCalledWith(
 			'initial-sync',
-			expect.objectContaining({ initialOpfsSyncPending: false }),
-			undefined
+			{
+				metadata: expect.objectContaining({
+					initialOpfsSyncPending: false,
+				}),
+			}
 		);
 	});
 

--- a/packages/playground/website/src/lib/state/redux/persist-temporary-site.ts
+++ b/packages/playground/website/src/lib/state/redux/persist-temporary-site.ts
@@ -247,7 +247,7 @@ export function persistTemporarySite(
 			const persistedAt = Date.now();
 			const playgroundDefinedConstants =
 				await getPlaygroundDefinedPHPConstants(playground);
-			const siteChanges: Partial<SiteInfo> = {
+			const siteChanges: Parameters<typeof updateSite>[0]['changes'] = {
 				// Autosaves stay tied to their source setup URL so restore
 				// matching and boot-time query options can still inspect it.
 				// Explicit saves open by slug, but they still keep their setup
@@ -258,7 +258,6 @@ export function persistTemporarySite(
 							originalUrlParams: getSavedSetupUrlParams(siteInfo),
 						}),
 				metadata: {
-					...siteInfo.metadata,
 					storage: storageType,
 					persistence: options.persistence ?? 'explicit',
 					// The viewport key includes whenCreated. Changing it

--- a/packages/playground/website/src/lib/state/redux/site-management-api-middleware.ts
+++ b/packages/playground/website/src/lib/state/redux/site-management-api-middleware.ts
@@ -614,9 +614,7 @@ export function createSitesAPI(
 							selectClientInfoBySiteSlug(getState(), site.slug)
 								?.url,
 						metadata: {
-							...site.metadata,
 							runtimeConfiguration: {
-								...site.metadata.runtimeConfiguration,
 								phpVersion: version,
 							},
 						},
@@ -650,9 +648,7 @@ export function createSitesAPI(
 							selectClientInfoBySiteSlug(getState(), site.slug)
 								?.url,
 						metadata: {
-							...site.metadata,
 							runtimeConfiguration: {
-								...site.metadata.runtimeConfiguration,
 								networking: enabled,
 							},
 						},
@@ -705,9 +701,7 @@ export function createSitesAPI(
 							selectClientInfoBySiteSlug(getState(), site.slug)
 								?.url,
 						metadata: {
-							...site.metadata,
 							runtimeConfiguration: {
-								...site.metadata.runtimeConfiguration,
 								phpVersion: settings.phpVersion,
 								networking: settings.networking,
 							},

--- a/packages/playground/website/src/lib/state/redux/slice-sites.spec.ts
+++ b/packages/playground/website/src/lib/state/redux/slice-sites.spec.ts
@@ -17,6 +17,19 @@ describe('stored sites', () => {
 		deleteSite = vi.fn();
 		loggerError = vi.fn();
 		updateSiteStorage = vi.fn();
+		updateSiteStorage.mockImplementation(async (slug, changes) => {
+			const site = createSiteInfo({ slug });
+			return {
+				...site,
+				...('originalUrlParams' in changes
+					? { originalUrlParams: changes.originalUrlParams }
+					: {}),
+				metadata: {
+					...site.metadata,
+					...changes.metadata,
+				},
+			};
+		});
 		persistBlueprintBundle = vi.fn();
 		deleteBlueprintBundle = vi.fn();
 		resolveRuntimeConfiguration = vi.fn();
@@ -155,23 +168,16 @@ describe('stored sites', () => {
 			};
 			return action;
 		});
-		const updatedMetadata = {
-			...site.metadata,
-			name: 'Renamed Playground',
-		};
-
 		await updateSite({
 			slug: site.slug,
 			changes: {
-				metadata: updatedMetadata,
+				metadata: { name: 'Renamed Playground' },
 			},
 		})(dispatch as any, () => state as any);
 
-		expect(updateSiteStorage).toHaveBeenCalledWith(
-			site.slug,
-			updatedMetadata,
-			originalUrlParams
-		);
+		expect(updateSiteStorage).toHaveBeenCalledWith(site.slug, {
+			metadata: { name: 'Renamed Playground' },
+		});
 	});
 
 	it('updates redux only after persisted metadata is written', async () => {
@@ -184,8 +190,15 @@ describe('stored sites', () => {
 			),
 		};
 		const order: string[] = [];
-		updateSiteStorage.mockImplementation(async () => {
+		updateSiteStorage.mockImplementation(async (_slug, changes) => {
 			order.push('opfs');
+			return {
+				...site,
+				metadata: {
+					...site.metadata,
+					...changes.metadata,
+				},
+			};
 		});
 		const dispatch = vi.fn((action) => {
 			order.push('redux');
@@ -194,15 +207,10 @@ describe('stored sites', () => {
 			};
 			return action;
 		});
-		const updatedMetadata = {
-			...site.metadata,
-			name: 'Renamed Playground',
-		};
-
 		await updateSite({
 			slug: site.slug,
 			changes: {
-				metadata: updatedMetadata,
+				metadata: { name: 'Renamed Playground' },
 			},
 		})(dispatch as any, () => state as any);
 
@@ -224,16 +232,11 @@ describe('stored sites', () => {
 			state.sites = sitesSlice.reducer(state.sites, action);
 			return action;
 		});
-		const updatedMetadata = {
-			...site.metadata,
-			name: 'Renamed Playground',
-		};
-
 		await expect(
 			updateSite({
 				slug: site.slug,
 				changes: {
-					metadata: updatedMetadata,
+					metadata: { name: 'Renamed Playground' },
 				},
 			})(dispatch as any, () => state as any)
 		).rejects.toThrow(storageError);
@@ -261,21 +264,13 @@ describe('stored sites', () => {
 		await updateSite({
 			slug: site.slug,
 			changes: {
-				metadata: {
-					name: 'Renamed Playground',
-				} as any,
+				metadata: { name: 'Renamed Playground' },
 			},
 		})(dispatch as any, () => state as any);
 
-		expect(updateSiteStorage).toHaveBeenCalledWith(
-			site.slug,
-			expect.objectContaining({
-				name: 'Renamed Playground',
-				storage: 'opfs',
-				runtimeConfiguration: site.metadata.runtimeConfiguration,
-			}),
-			undefined
-		);
+		expect(updateSiteStorage).toHaveBeenCalledWith(site.slug, {
+			metadata: { name: 'Renamed Playground' },
+		});
 		expect(state.sites.entities[site.slug]?.metadata).toEqual({
 			...site.metadata,
 			name: 'Renamed Playground',

--- a/packages/playground/website/src/lib/state/redux/slice-sites.ts
+++ b/packages/playground/website/src/lib/state/redux/slice-sites.ts
@@ -231,7 +231,7 @@ export function updateSite({
 	changes,
 }: {
 	slug: string;
-	changes: Omit<Partial<SiteInfo>, 'metadata'> & {
+	changes: Omit<Partial<SiteInfo>, 'metadata' | 'slug'> & {
 		metadata?: SiteMetadataChanges;
 	};
 }) {
@@ -241,6 +241,9 @@ export function updateSite({
 	) => {
 		if ('storage' in changes) {
 			throw new Error('Cannot update storage for a site.');
+		}
+		if ('slug' in changes) {
+			throw new Error('Cannot update the slug for a site.');
 		}
 		const existingSite = selectSiteBySlug(getState(), slug);
 		if (!existingSite) {

--- a/packages/playground/website/src/lib/state/redux/slice-sites.ts
+++ b/packages/playground/website/src/lib/state/redux/slice-sites.ts
@@ -171,7 +171,7 @@ export function updateSiteMetadata({
 	changes,
 }: {
 	slug: string;
-	changes: Partial<SiteMetadata>;
+	changes: SiteMetadataChanges;
 }) {
 	return async (
 		dispatch: PlaygroundDispatch,
@@ -185,10 +185,7 @@ export function updateSiteMetadata({
 			updateSite({
 				slug,
 				changes: {
-					metadata: {
-						...storedSite.metadata,
-						...changes,
-					},
+					metadata: changes,
 				},
 			})
 		);
@@ -234,7 +231,9 @@ export function updateSite({
 	changes,
 }: {
 	slug: string;
-	changes: Partial<SiteInfo>;
+	changes: Omit<Partial<SiteInfo>, 'metadata'> & {
+		metadata?: SiteMetadataChanges;
+	};
 }) {
 	return async (
 		dispatch: PlaygroundDispatch,
@@ -248,13 +247,26 @@ export function updateSite({
 			throw new Error(`Site not found: ${slug}`);
 		}
 		const { metadata, ...topLevelChanges } = changes;
-		const updatedSite = {
+		const {
+			runtimeConfiguration: runtimeConfigurationChanges,
+			...metadataChanges
+		} = metadata ?? {};
+		let updatedSite = {
 			...existingSite,
 			...topLevelChanges,
 			metadata: metadata
 				? {
 						...existingSite.metadata,
-						...metadata,
+						...metadataChanges,
+						...(runtimeConfigurationChanges
+							? {
+									runtimeConfiguration: {
+										...existingSite.metadata
+											.runtimeConfiguration,
+										...runtimeConfigurationChanges,
+									},
+								}
+							: {}),
 					}
 				: existingSite.metadata,
 		};
@@ -264,18 +276,35 @@ export function updateSite({
 					'Cannot update a saved Playground because browser storage is not available.'
 				);
 			}
-			await opfsSiteStorage.update(
+			const persistedSite = await opfsSiteStorage.update(
 				updatedSite.slug,
-				updatedSite.metadata,
-				updatedSite.originalUrlParams
+				{
+					...(metadata ? { metadata } : {}),
+					...('originalUrlParams' in topLevelChanges
+						? { originalUrlParams: updatedSite.originalUrlParams }
+						: {}),
+				}
 			);
+			updatedSite = {
+				...updatedSite,
+				originalUrlParams: persistedSite.originalUrlParams,
+				metadata: persistedSite.metadata,
+			};
 		}
 		dispatch(
 			sitesSlice.actions.updateSite({
 				id: slug,
 				changes: {
 					...topLevelChanges,
-					...(metadata ? { metadata: updatedSite.metadata } : {}),
+					...(updatedSite.metadata.storage !== 'none'
+						? {
+								originalUrlParams:
+									updatedSite.originalUrlParams,
+								metadata: updatedSite.metadata,
+							}
+						: metadata
+							? { metadata: updatedSite.metadata }
+							: {}),
 				},
 			})
 		);
@@ -912,6 +941,19 @@ export interface SiteMetadata {
 	originalBlueprint: unknown;
 	originalBlueprintSource: BlueprintSource;
 }
+
+/**
+ * Fields to merge into existing site metadata.
+ *
+ * Runtime configuration is also a patch so one settings change does not
+ * restore unrelated runtime fields from an older tab's Redux snapshot.
+ */
+export type SiteMetadataChanges = Omit<
+	Partial<SiteMetadata>,
+	'runtimeConfiguration'
+> & {
+	runtimeConfiguration?: Partial<SiteMetadata['runtimeConfiguration']>;
+};
 
 export const { setOPFSSitesLoadingState } = sitesSlice.actions;
 export { sitesSlice };

--- a/packages/playground/website/src/lib/state/redux/slice-sites.ts
+++ b/packages/playground/website/src/lib/state/redux/slice-sites.ts
@@ -249,29 +249,17 @@ export function updateSite({
 		if (!existingSite) {
 			throw new Error(`Site not found: ${slug}`);
 		}
-		const { metadata, ...topLevelChanges } = changes;
-		const {
-			runtimeConfiguration: runtimeConfigurationChanges,
-			...metadataChanges
-		} = metadata ?? {};
-		let updatedSite = {
+		let updatedSite: SiteInfo = {
 			...existingSite,
-			...topLevelChanges,
-			metadata: metadata
-				? {
-						...existingSite.metadata,
-						...metadataChanges,
-						...(runtimeConfigurationChanges
-							? {
-									runtimeConfiguration: {
-										...existingSite.metadata
-											.runtimeConfiguration,
-										...runtimeConfigurationChanges,
-									},
-								}
-							: {}),
-					}
-				: existingSite.metadata,
+			...changes,
+			metadata: {
+				...existingSite.metadata,
+				...changes.metadata,
+				runtimeConfiguration: {
+					...existingSite.metadata.runtimeConfiguration,
+					...changes.metadata?.runtimeConfiguration,
+				},
+			},
 		};
 		if (updatedSite.metadata.storage !== 'none') {
 			if (!opfsSiteStorage) {
@@ -279,36 +267,17 @@ export function updateSite({
 					'Cannot update a saved Playground because browser storage is not available.'
 				);
 			}
-			const persistedSite = await opfsSiteStorage.update(
-				updatedSite.slug,
-				{
-					...(metadata ? { metadata } : {}),
-					...('originalUrlParams' in topLevelChanges
-						? { originalUrlParams: updatedSite.originalUrlParams }
-						: {}),
-				}
-			);
+			const persistedSite = await opfsSiteStorage.update(slug, changes);
 			updatedSite = {
 				...updatedSite,
-				originalUrlParams: persistedSite.originalUrlParams,
-				metadata: persistedSite.metadata,
+				...persistedSite,
 			};
 		}
+		const { slug: updatedSlug, ...updatedSiteChanges } = updatedSite;
 		dispatch(
 			sitesSlice.actions.updateSite({
-				id: slug,
-				changes: {
-					...topLevelChanges,
-					...(updatedSite.metadata.storage !== 'none'
-						? {
-								originalUrlParams:
-									updatedSite.originalUrlParams,
-								metadata: updatedSite.metadata,
-							}
-						: metadata
-							? { metadata: updatedSite.metadata }
-							: {}),
-				},
+				id: updatedSlug,
+				changes: updatedSiteChanges,
 			})
 		);
 	};


### PR DESCRIPTION
Stored Playground metadata updates now merge into the latest `wp-runtime.json` record instead of replacing it with one tab's complete Redux snapshot.

## Background

Each tab keeps its own Redux state. If two tabs loaded the same Playground, a later update from either tab could silently restore stale fields. For example, changing networking in one tab could undo a rename or PHP version change made in the other.

## This change

Stored-site callers now send only the fields they changed. `OpfsSiteStorage.update()` takes an origin-wide, per-site Web Lock, reads the current record, merges the patch, and writes it back. Runtime configuration is merged by field, and Redux receives the merged stored result. Different Playgrounds use different locks and remain independent.

The first commit adds a Chromium E2E that renames a Playground and changes its PHP version in one tab, then changes networking in another. It fails on `trunk` because the second tab restores the stale name.

## Testing

Open one saved Playground in two tabs. Rename it and change its PHP version in the first tab, then change networking in the second. Reload and confirm all three changes remain.
