### PR TITLE
[CI] Retry npm installs after transient network resets

### DIFF
--- a/.github/actions/prepare-playground/action.yml
+++ b/.github/actions/prepare-playground/action.yml
@@ -35,7 +35,17 @@ runs:
         - name: Install Dependencies
           shell: bash
           if: steps.cache-nodemodules.outputs.cache-hit != 'true'
-          run: npm ci
+          run: |
+              for attempt in 1 2 3; do
+                  echo "npm ci attempt $attempt of 3"
+                  npm ci && exit 0
+
+                  if [ "$attempt" = 3 ]; then
+                      exit 1
+                  fi
+
+                  sleep $((attempt * 10))
+              done
         - name: Disable unrelated Microsoft apt feeds
           shell: bash
           run: |


### PR DESCRIPTION
Retries `npm ci` in the shared `prepare-playground` action.

The failed trunk run did not reach lint or typecheck. CI exited during dependency installation after npm reported `ECONNRESET`, so the remaining lint/typecheck steps were skipped. A second or third install attempt lets the job survive transient npm registry or runner network resets while preserving the final failure if installation keeps failing.

## Testing

Lint and typecheck pass locally. The action YAML parses and the install script passes bash syntax checking.
