### PR TITLE
[Website] Fix phpMyAdmin page not found in Personal WP

### DIFF
--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -84,6 +84,7 @@ import {
 	getPhpMyAdminInstallSteps,
 	PHPMYADMIN_ENTRY_PATH,
 	PHPMYADMIN_INSTALL_PATH,
+	PHPMYADMIN_URL_PATH,
 } from '@wp-playground/tools';
 import { jspi } from 'wasm-feature-detect';
 
@@ -389,7 +390,7 @@ export async function parseOptionsAndRunCLI(
 					'Install phpMyAdmin for database management. The phpMyAdmin URL will be printed after boot. Optionally specify a custom URL path (default: /phpmyadmin).',
 				type: 'string',
 				coerce: (value?: string) =>
-					'' === value ? '/phpmyadmin' : value,
+					'' === value ? PHPMYADMIN_URL_PATH : value,
 			},
 		};
 
@@ -1032,7 +1033,7 @@ export async function runCLI(
 	// Setup phpMyAdmin if enabled.
 	if (args.phpmyadmin) {
 		if (true === args.phpmyadmin) {
-			args.phpmyadmin = '/phpmyadmin';
+			args.phpmyadmin = PHPMYADMIN_URL_PATH;
 		}
 
 		// Set up path alias for phpMyAdmin.

--- a/packages/playground/personal-wp/playwright/e2e/ui.spec.ts
+++ b/packages/playground/personal-wp/playwright/e2e/ui.spec.ts
@@ -1,4 +1,10 @@
 import { test, expect } from '../playground-fixtures';
+import type { Blueprint } from '@wp-playground/blueprints';
+import {
+	PHPMYADMIN_CONFIG_PATH,
+	PHPMYADMIN_INSTALL_PATH,
+	PHPMYADMIN_URL_PATH,
+} from '@wp-playground/tools';
 
 test('should open and close the Site Tools panel', async ({ website }) => {
 	await website.goto('./');
@@ -104,4 +110,46 @@ test('should navigate within WordPress from Site Tools shortcuts', async ({
 	await expect(
 		wordpress.locator('a[href$="/my-apps/?recipes"]')
 	).toBeVisible();
+});
+
+test('should open phpMyAdmin from the Database tools', async ({
+	website,
+	context,
+}) => {
+	const probeText = 'phpMyAdmin path alias works';
+	const blueprint: Blueprint = {
+		steps: [
+			{
+				step: 'mkdir',
+				path: PHPMYADMIN_INSTALL_PATH,
+			},
+			{
+				step: 'writeFile',
+				path: `${PHPMYADMIN_INSTALL_PATH}/index.php`,
+				data: `<?php echo ${JSON.stringify(probeText)};`,
+			},
+			{
+				step: 'writeFile',
+				path: PHPMYADMIN_CONFIG_PATH,
+				data: '<?php',
+			},
+		],
+	};
+	await website.goto(`./#${JSON.stringify(blueprint)}`);
+
+	await website.ensureSiteToolsIsOpen();
+	await website.page.getByRole('tab', { name: 'Database' }).click();
+
+	const phpMyAdminButton = website.page.getByRole('button', {
+		name: 'Open phpMyAdmin',
+	});
+	await expect(phpMyAdminButton).toBeEnabled();
+
+	const popupPromise = context.waitForEvent('page');
+	await phpMyAdminButton.click();
+	const popup = await popupPromise;
+
+	await popup.waitForLoadState();
+	expect(new URL(popup.url()).pathname).toContain(PHPMYADMIN_URL_PATH);
+	await expect(popup.locator('body')).toContainText(probeText);
 });

--- a/packages/playground/personal-wp/src/components/site-manager/site-database-panel/phpmyadmin-button.tsx
+++ b/packages/playground/personal-wp/src/components/site-manager/site-database-panel/phpmyadmin-button.tsx
@@ -12,6 +12,7 @@ import {
 	getPhpMyAdminInstallSteps,
 	PHPMYADMIN_CONFIG_PATH,
 	PHPMYADMIN_ENTRY_PATH,
+	PHPMYADMIN_URL_PATH,
 } from '@wp-playground/tools';
 // @ts-ignore
 import { corsProxyUrl } from 'virtual:cors-proxy-url';
@@ -30,10 +31,12 @@ export function PhpMyAdminButton({
 }: {
 	playground: PlaygroundClient | undefined;
 }) {
-	const [state, setState] = useState<'idle' | 'loading' | 'ready'>('idle');
+	const [state, setState] = useState<'idle' | 'loading' | 'ready'>('loading');
 	const [error, setError] = useState<string | null>(null);
 
 	useEffect(() => {
+		setState('loading');
+
 		async function detectPhpMyAdmin() {
 			if (!playground) {
 				return;
@@ -74,7 +77,7 @@ export function PhpMyAdminButton({
 		const playgroundUrl = await playground.absoluteUrl;
 		if (playgroundUrl) {
 			window.open(
-				`${playgroundUrl}/phpmyadmin${PHPMYADMIN_ENTRY_PATH}`,
+				`${playgroundUrl}${PHPMYADMIN_URL_PATH}${PHPMYADMIN_ENTRY_PATH}`,
 				'_blank',
 				'noopener,noreferrer'
 			);

--- a/packages/playground/personal-wp/src/lib/state/redux/boot-site-client.ts
+++ b/packages/playground/personal-wp/src/lib/state/redux/boot-site-client.ts
@@ -20,6 +20,7 @@ import {
 import { logger } from '@php-wasm/logger';
 import { setupPostMessageRelay } from '@php-wasm/web';
 import { startPlaygroundWeb } from '@wp-playground/client';
+import { PHPMYADMIN_PATH_ALIAS } from '@wp-playground/tools';
 import { ProgressTracker } from '@php-wasm/progress';
 import type { ProgressDetails, ProgressTrackerEvent } from '@php-wasm/progress';
 import type { PlaygroundClient } from '@wp-playground/remote';
@@ -297,6 +298,7 @@ export function bootSiteClient(
 					: [],
 				wordpressInstallMode,
 				corsProxy: corsProxyUrl,
+				pathAliases: [PHPMYADMIN_PATH_ALIAS],
 			});
 		} catch (e) {
 			logger.error(e);

--- a/packages/playground/tools/src/phpmyadmin/index.ts
+++ b/packages/playground/tools/src/phpmyadmin/index.ts
@@ -1,15 +1,39 @@
 import type { StepDefinition } from '@wp-playground/blueprints';
 import { joinPaths } from '@php-wasm/util';
 
+/**
+ * phpMyAdmin installation, detection, URL construction, and request routing
+ * live in separate consumers (Website, Personal WP, and CLI). These values are
+ * exported from one place to keep that shared contract in sync.
+ */
+
+// Keep the downloaded archive and its extracted directory name on the same release.
 export const PHPMYADMIN_VERSION = '5.2.3';
+
+// The archive installed by the shared Blueprint steps.
 export const PHPMYADMIN_DOWNLOAD_URL = `https://files.phpmyadmin.net/phpMyAdmin/${PHPMYADMIN_VERSION}/phpMyAdmin-${PHPMYADMIN_VERSION}-english.zip`;
+
+// PHP filesystem path, kept outside the WordPress document root and site exports.
 export const PHPMYADMIN_INSTALL_PATH = '/tools/phpmyadmin';
+
+// Complete-install marker checked by the UI before deciding whether to reinstall.
 export const PHPMYADMIN_CONFIG_PATH = joinPaths(
 	PHPMYADMIN_INSTALL_PATH,
 	'config.inc.php'
 );
+
+// Default public URL shared by the browser UIs and CLI.
+export const PHPMYADMIN_URL_PATH = '/phpmyadmin';
+
+// Initial phpMyAdmin route opened after installation.
 export const PHPMYADMIN_ENTRY_PATH =
 	'/index.php?route=/database/structure&db=wordpress';
+
+// Default browser-runtime mapping from the public URL to the PHP filesystem path.
+export const PHPMYADMIN_PATH_ALIAS = {
+	urlPrefix: PHPMYADMIN_URL_PATH,
+	fsPath: PHPMYADMIN_INSTALL_PATH,
+} as const;
 
 /**
  * Returns the blueprint steps needed to install phpMyAdmin in Playground.

--- a/packages/playground/website/src/components/site-manager/site-database-panel/phpmyadmin-button.tsx
+++ b/packages/playground/website/src/components/site-manager/site-database-panel/phpmyadmin-button.tsx
@@ -13,6 +13,7 @@ import {
 	getPhpMyAdminInstallSteps,
 	PHPMYADMIN_CONFIG_PATH,
 	PHPMYADMIN_ENTRY_PATH,
+	PHPMYADMIN_URL_PATH,
 } from '@wp-playground/tools';
 // @ts-ignore
 import { corsProxyUrl } from 'virtual:cors-proxy-url';
@@ -31,15 +32,16 @@ export function PhpMyAdminButton({
 }: {
 	playground: PlaygroundClient | undefined;
 }) {
-	const [state, setState] = useState<'idle' | 'loading' | 'ready'>('idle');
+	const [state, setState] = useState<'idle' | 'loading' | 'ready'>('loading');
 	const [error, setError] = useState<string | null>(null);
 
 	useEffect(() => {
 		if (!playground) {
-			setState('idle');
+			setState('loading');
 			setError(null);
 			return;
 		}
+		setState('loading');
 		let cancelled = false;
 
 		async function detectPhpMyAdmin() {
@@ -89,7 +91,7 @@ export function PhpMyAdminButton({
 		const playgroundUrl = await playground.absoluteUrl;
 		if (playgroundUrl) {
 			window.open(
-				`${playgroundUrl}/phpmyadmin${PHPMYADMIN_ENTRY_PATH}`,
+				`${playgroundUrl}${PHPMYADMIN_URL_PATH}${PHPMYADMIN_ENTRY_PATH}`,
 				'_blank',
 				'noopener,noreferrer'
 			);

--- a/packages/playground/website/src/lib/state/redux/boot-site-client.ts
+++ b/packages/playground/website/src/lib/state/redux/boot-site-client.ts
@@ -41,7 +41,7 @@ import {
 	findFirewallErrorInCauseChain,
 	findDownloadErrorInCauseChain,
 } from './error-utils';
-import { PHPMYADMIN_INSTALL_PATH } from '@wp-playground/tools';
+import { PHPMYADMIN_PATH_ALIAS } from '@wp-playground/tools';
 import { phpExtensionQueryArgsToExtensionsArray } from '../url/php-extension-query';
 import { runSiteFirstBootInitializer } from './site-first-boot-initializer';
 import { captureAndPersistSiteThumbnail } from './capture-site-thumbnail';
@@ -253,12 +253,7 @@ export function bootSiteClient(
 				wordpressInstallMode,
 				corsProxy: corsProxyUrl,
 				gitAdditionalHeadersCallback: createGitAuthHeaders(),
-				pathAliases: [
-					{
-						urlPrefix: '/phpmyadmin',
-						fsPath: PHPMYADMIN_INSTALL_PATH,
-					},
-				],
+				pathAliases: [PHPMYADMIN_PATH_ALIAS],
 			});
 		} catch (e) {
 			if (signal.aborted) {


### PR DESCRIPTION
## Motivation for the change, related issues

In Personal WP, choosing **Site Tools → Database → Open phpMyAdmin** opens a new tab, but that tab shows **Page Not Found**.

phpMyAdmin is installed at `/tools/phpmyadmin`, outside the WordPress document root. This location is intentional because it keeps phpMyAdmin out of site exports. The browser opens `/phpmyadmin`, so the PHP request handler needs a path alias that says: “serve `/phpmyadmin` requests from `/tools/phpmyadmin`.”

The regular Playground website registered this alias, but Personal WP has a separate boot path and did not register it. The request therefore fell through to WordPress, which returned its normal 404 page.

The public URL and filesystem path were also repeated across the website, Personal WP, and CLI. Keeping separate copies made it possible for one application to miss part of the routing setup.

## Implementation details

- Register the phpMyAdmin path alias when Personal WP boots.
- Export the default phpMyAdmin URL and path alias from `@wp-playground/tools`.
- Reuse those shared values in Personal WP, the regular website, and the CLI so the paths stay in sync.
- Add inline comments explaining why each shared phpMyAdmin value is exported.
- Keep the phpMyAdmin button in its loading state while it checks for an existing installation. This prevents an early click from starting a duplicate install.
- Add a Personal WP browser test that creates a small PHP probe at the real tool path, opens it through the Database button, and verifies the popup response.

The test uses a small probe instead of downloading the full phpMyAdmin archive. This keeps the regression test focused on the broken URL-to-filesystem mapping.

There are no intentional breaking changes.

## Testing Instructions (or ideally a Blueprint)

Automated checks run:

- `npm exec nx -- run-many --targets=typecheck,lint --projects=playground-tools,playground-personal-wp,playground-website,playground-cli --parallel=4 --output-style=static`
- `npm exec nx -- run playground-personal-wp:e2e:playwright -- --reporter=list --workers=1 --retries=0` — 9 tests passed with no retries.

Manual review:

1. Run `npx nx dev playground-personal-wp`.
2. Open **Site Tools** from the lower-left corner.
3. Select **Database**.
4. Click **Open phpMyAdmin**.
5. Confirm the new tab loads phpMyAdmin instead of **Page Not Found**.
6. Confirm the `wp_posts` table is listed.
