### PR TITLE
[Website] Preserve plugin proxy default response headers

### DIFF
--- a/packages/playground/website/playwright/e2e/plugin-proxy-test-router.php
+++ b/packages/playground/website/playwright/e2e/plugin-proxy-test-router.php
@@ -1,5 +1,10 @@
 <?php
 
+// This test needs a PHP request router because it verifies the HTTP headers
+// emitted by PHP's header() function, not just the helper's array bookkeeping.
+// The test-only route invokes sendBufferedResponseHeaders() with controlled
+// upstream, allowlist, and default-header inputs. Returning false for every
+// other URL lets the built-in server handle ordinary proxy requests.
 if (
 	parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH)
 	!== '/__test-default-response-headers'
@@ -7,14 +12,19 @@ if (
 	return false;
 }
 
+// plugin-proxy.php has no import-only entry point. Requiring it also dispatches
+// this test-only request, which dies with a 400 invalid-query response. Buffer
+// that response and replace it from a shutdown callback after the helper has
+// been defined.
+$allow_content_type = isset($_GET['allow-content-type']);
 ob_start();
-register_shutdown_function(function () {
+register_shutdown_function(function () use ($allow_content_type) {
 	ob_clean();
 	header_remove();
 	http_response_code(200);
 	sendBufferedResponseHeaders(
 		[['content-type', "Content-Type: application/octet-stream\r\n"]],
-		['content-length'],
+		$allow_content_type ? ['content-type'] : ['content-length'],
 		['Content-Type: application/zip']
 	);
 	echo 'body';

--- a/packages/playground/website/playwright/e2e/plugin-proxy-test-router.php
+++ b/packages/playground/website/playwright/e2e/plugin-proxy-test-router.php
@@ -1,0 +1,23 @@
+<?php
+
+if (
+	parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH)
+	!== '/__test-default-response-headers'
+) {
+	return false;
+}
+
+ob_start();
+register_shutdown_function(function () {
+	ob_clean();
+	header_remove();
+	http_response_code(200);
+	sendBufferedResponseHeaders(
+		[['content-type', "Content-Type: application/octet-stream\r\n"]],
+		['content-length'],
+		['Content-Type: application/zip']
+	);
+	echo 'body';
+});
+
+require __DIR__ . '/../../public/plugin-proxy.php';

--- a/packages/playground/website/playwright/e2e/plugin-proxy.spec.ts
+++ b/packages/playground/website/playwright/e2e/plugin-proxy.spec.ts
@@ -87,23 +87,35 @@ test('rejects a direct off-allowlist URL without fetching it', async ({
 });
 
 /**
- * Stable contract: A filtered upstream header does not suppress a configured
- * default header with the same name.
- * Plausible regression: Header buffering records received headers instead of
- * only the headers forwarded to the client.
- * Independent path: The test router invokes the real PHP header helper and the
- * HTTP client observes the resulting response headers.
+ * Stable contract: Forward an upstream Content-Type when it is allowed. When it
+ * is filtered out, send the configured default Content-Type instead.
+ *
+ * Plausible regressions: A filtered header could prevent the default from being
+ * sent, or the default could overwrite an allowed upstream header.
+ *
+ * Independent code path: The PHP fixture calls the production header helper.
+ * The test checks the Content-Type on the HTTP response returned to the client.
  */
-test('keeps a default header when the matching upstream header is filtered', async ({
+test('uses a default header only when the matching upstream header is filtered', async ({
 	request,
 }) => {
-	const response = await request.get(
-		new URL('/__test-default-response-headers', pluginProxyUrl).href
+	const filteredResponse = await request.get(
+		urlForDefaultResponseHeaders({ allowContentType: false })
 	);
 
-	expect(response.status()).toBe(200);
-	expect(response.headers()['content-type']).toBe('application/zip');
-	expect(await response.text()).toBe('body');
+	expect(filteredResponse.status()).toBe(200);
+	expect(filteredResponse.headers()['content-type']).toBe('application/zip');
+	expect(await filteredResponse.text()).toBe('body');
+
+	const allowedResponse = await request.get(
+		urlForDefaultResponseHeaders({ allowContentType: true })
+	);
+
+	expect(allowedResponse.status()).toBe(200);
+	expect(allowedResponse.headers()['content-type']).toBe(
+		'application/octet-stream'
+	);
+	expect(await allowedResponse.text()).toBe('body');
 });
 
 test('follows absolute and relative redirects within the allowlist', async ({
@@ -222,6 +234,25 @@ function urlForTarget(targetUrl: string) {
 	return url.href;
 }
 
+function urlForDefaultResponseHeaders({
+	allowContentType,
+}: {
+	allowContentType: boolean;
+}) {
+	const url = new URL('/__test-default-response-headers', pluginProxyUrl);
+	if (allowContentType) {
+		url.searchParams.set('allow-content-type', '1');
+	}
+	return url.href;
+}
+
+/**
+ * This in-process router is the plugin proxy's fake upstream service. The PHP
+ * cURL client reaches it through the http_proxy environment variable, allowing
+ * the tests to control redirects and echoed requests without external network
+ * calls. Running it in this process also lets each destination be recorded
+ * directly in requestDestinations for assertions.
+ */
 function routeUpstreamRequest(
 	request: IncomingMessage,
 	response: ServerResponse

--- a/packages/playground/website/playwright/e2e/plugin-proxy.spec.ts
+++ b/packages/playground/website/playwright/e2e/plugin-proxy.spec.ts
@@ -24,6 +24,7 @@ test.skip(
 );
 
 const pluginProxyDocumentRoot = joinPaths(__dirname, '../../public');
+const pluginProxyRouter = joinPaths(__dirname, 'plugin-proxy-test-router.php');
 
 let requestDestinations: string[] = [];
 let pluginProxyUrl = '';
@@ -44,6 +45,7 @@ test.beforeAll(async () => {
 			`127.0.0.1:${pluginProxyPort}`,
 			'-t',
 			pluginProxyDocumentRoot,
+			pluginProxyRouter,
 		],
 		{
 			http_proxy: `http://127.0.0.1:${upstreamPort}`,
@@ -82,6 +84,26 @@ test('rejects a direct off-allowlist URL without fetching it', async ({
 		'Error: The specified URL is not allowed.'
 	);
 	expect(requestDestinations).toEqual([]);
+});
+
+/**
+ * Stable contract: A filtered upstream header does not suppress a configured
+ * default header with the same name.
+ * Plausible regression: Header buffering records received headers instead of
+ * only the headers forwarded to the client.
+ * Independent path: The test router invokes the real PHP header helper and the
+ * HTTP client observes the resulting response headers.
+ */
+test('keeps a default header when the matching upstream header is filtered', async ({
+	request,
+}) => {
+	const response = await request.get(
+		new URL('/__test-default-response-headers', pluginProxyUrl).href
+	);
+
+	expect(response.status()).toBe(200);
+	expect(response.headers()['content-type']).toBe('application/zip');
+	expect(await response.text()).toBe('body');
 });
 
 test('follows absolute and relative redirects within the allowlist', async ({

--- a/packages/playground/website/public/plugin-proxy.php
+++ b/packages/playground/website/public/plugin-proxy.php
@@ -520,7 +520,6 @@ $downloader = new PluginDownloader(
 if (!array_key_exists('url', $_GET)) {
 	header('Access-Control-Allow-Origin: *');
 }
-$pluginResponse;
 try {
 	/** @deprecated Plugins and themes downloads are no longer needed now that WordPress.org serves
 	 *              the proper CORS headers. This code will be removed in one of the next releases.

--- a/packages/playground/website/public/plugin-proxy.php
+++ b/packages/playground/website/public/plugin-proxy.php
@@ -469,12 +469,12 @@ function sendBufferedResponseHeaders($response_headers, $allowed_response_header
 {
 	$seen_headers = [];
 	foreach ($response_headers as [$header_name, $header_line]) {
-		$seen_headers[$header_name] = true;
 		$header_allowed = (
 			NULL === $allowed_response_headers
 			|| in_array($header_name, $allowed_response_headers, true)
 		) && $header_name !== 'transfer-encoding';
 		if ($header_allowed) {
+			$seen_headers[$header_name] = true;
 			header($header_line);
 		}
 	}


### PR DESCRIPTION
## What changed

This stacked PR adds regression coverage for filtered upstream response headers and preserves configured default response headers when a same-named upstream header is filtered out.

## Why

PR #4137 buffers response headers while following redirects. The new helper marked every received header as seen before applying the response-header allowlist. A filtered upstream `Content-Type` therefore suppressed the configured `Content-Type: application/zip` fallback even though neither header reached the client.

The fix records a response header as seen only after it passes the allowlist and is forwarded.

## Impact

Plugin, theme, release, and artifact downloads retain their intended ZIP content type and download metadata when upstream headers are filtered.

## Commit and CI sequence

1. Commit `7161ff666` added the regression test only. [Chromium shard 2 failed](https://github.com/WordPress/wordpress-playground/actions/runs/30019151059/job/89246998902) with `Expected: "application/zip"` and `Received: undefined`.
2. Commit `75c40e2b5` applied the one-line production fix. [The same Chromium shard passed](https://github.com/WordPress/wordpress-playground/actions/runs/30020038612/job/89250060487), including `keeps a default header when the matching upstream header is filtered`.

This PR is stacked on #4137 and targets its head branch.

## Validation

- Focused Playwright suite after the fix: 7 passed
- Website lint: passed
- PHP syntax checks for `plugin-proxy.php` and the test router: passed
- GitHub Actions regression test: failed before the fix and passed after the fix
