### PR TITLE
[Website] Remove stray plugin proxy expression

### DIFF
--- a/packages/playground/website/public/plugin-proxy.php
+++ b/packages/playground/website/public/plugin-proxy.php
@@ -520,7 +520,6 @@ $downloader = new PluginDownloader(
 if (!array_key_exists('url', $_GET)) {
 	header('Access-Control-Allow-Origin: *');
 }
-$pluginResponse;
 try {
 	/** @deprecated Plugins and themes downloads are no longer needed now that WordPress.org serves
 	 *              the proper CORS headers. This code will be removed in one of the next releases.


### PR DESCRIPTION
## What changed

Remove the standalone `$pluginResponse;` expression from `plugin-proxy.php`.

## Why

The variable is never assigned or read, and it has no declaration or control-flow effect in PHP. The statement was introduced in 2023 with the Gutenberg pull-request preview flow and has remained unused. Evaluating the undefined variable can emit a warning even though `display_errors` hides it from the HTTP response.

## Impact

There is no intended behavior change. The cleanup removes a no-op expression and avoids a possible undefined-variable warning in server logs.

## Stack

This PR is stacked on #4157 and targets its head branch. It should be merged after #4157, which is itself stacked on #4137.

## Validation

- Focused plugin-proxy Playwright suite: 7 passed
- Website lint: passed
- PHP syntax check: passed
