### PR TITLE
[Website] Prevent stale thumbnail captures from overwriting saved metadata

### DIFF
--- a/packages/playground/website/src/lib/state/redux/boot-site-client.spec.ts
+++ b/packages/playground/website/src/lib/state/redux/boot-site-client.spec.ts
@@ -13,6 +13,7 @@ import type { PlaygroundReduxState } from './store';
 import { logBlueprintEvents } from '../../tracking';
 import { shouldShowGitHubAuthModal } from '../../../github/git-auth-helpers';
 import { registerSiteFirstBootInitializer } from './site-first-boot-initializer';
+import clientsReducer from './slice-clients';
 
 vi.mock('@wp-playground/client', () => ({
 	startPlaygroundWeb: vi.fn(),
@@ -676,6 +677,63 @@ describe('bootSiteClient', () => {
 		);
 	});
 
+	it('does not capture a thumbnail after the initial OPFS copy fails', async () => {
+		let rejectMount!: (error: Error) => void;
+		const mountFinished = new Promise<void>((_, reject) => {
+			rejectMount = reject;
+		});
+		const playground = createPlaygroundClient({
+			mountOpfs: vi.fn(() => mountFinished),
+			captureSiteThumbnail: vi.fn(),
+		});
+		vi.mocked(startPlaygroundWeb).mockImplementationOnce(
+			async (options: any) => {
+				options.onClientConnected(playground);
+				return playground;
+			}
+		);
+		const site = createSite('initial-sync', {
+			metadata: { initialOpfsSyncPending: true },
+		});
+		const state = createState(site);
+		const dispatch = createDispatch(state);
+
+		await bootSiteClient('initial-sync', document.createElement('iframe'), {
+			signal: new AbortController().signal,
+		})(dispatch, () => state);
+
+		// Another tab may clear this flag while this copy is still running.
+		// Thumbnail capture must follow this copy's result, not shared metadata.
+		dispatch(
+			sitesSlice.actions.updateSite({
+				id: 'initial-sync',
+				changes: {
+					metadata: {
+						...state.sites.entities['initial-sync'].metadata,
+						initialOpfsSyncPending: false,
+					},
+				},
+			})
+		);
+		rejectMount(new Error('OPFS copy failed'));
+		await vi.waitFor(() =>
+			expect(dispatch).toHaveBeenCalledWith(
+				expect.objectContaining({
+					type: 'clients/updateClientInfo',
+					payload: expect.objectContaining({
+						changes: expect.objectContaining({
+							opfsSync: expect.objectContaining({
+								status: 'error',
+							}),
+						}),
+					}),
+				})
+			)
+		);
+
+		expect(playground.captureSiteThumbnail).not.toHaveBeenCalled();
+	});
+
 	it('runs a first-boot initializer before the initial OPFS copy', async () => {
 		const calls: string[] = [];
 		const playground = createPlaygroundClient({
@@ -720,6 +778,9 @@ function createDispatch(state: PlaygroundReduxState) {
 		if (reduxAction.type?.startsWith('sites/')) {
 			state.sites = reducer(state.sites, action as any);
 		}
+		if (reduxAction.type?.startsWith('clients/')) {
+			state.clients = clientsReducer(state.clients, action as any);
+		}
 		return action;
 	}) as any;
 	return dispatch;
@@ -732,6 +793,7 @@ function createState(...sites: SiteInfo[]): PlaygroundReduxState {
 	}
 	return {
 		sites: sitesState,
+		clients: clientsReducer(undefined, { type: 'init' }),
 		ui: {
 			activeSite: sites[0] ? { slug: sites[0].slug } : undefined,
 		},

--- a/packages/playground/website/src/lib/state/redux/boot-site-client.ts
+++ b/packages/playground/website/src/lib/state/redux/boot-site-client.ts
@@ -415,18 +415,17 @@ export function bootSiteClient(
 				signal,
 				siteSlugToReturnToIfBlueprintFails:
 					site.metadata.siteSlugToReturnToIfBlueprintFails,
-			}).then(() => {
-				const storedSite = selectSiteBySlug(getState(), site.slug);
-				if (
-					!signal.aborted &&
-					storedSite?.metadata.initialOpfsSyncPending === false
-				) {
-					void captureAndPersistSiteThumbnail({
-						playground: connectedPlayground,
-						siteSlug: site.slug,
-						dispatch,
-					});
+			}).then((syncSucceeded) => {
+				if (!syncSucceeded) {
+					return;
 				}
+				void captureAndPersistSiteThumbnail({
+					playground: connectedPlayground,
+					siteSlug: site.slug,
+					dispatch,
+					getState,
+					signal,
+				});
 			});
 		} else {
 			try {
@@ -465,6 +464,8 @@ export function bootSiteClient(
 					playground: connectedPlayground,
 					siteSlug: site.slug,
 					dispatch,
+					getState,
+					signal,
 				});
 			}
 		}
@@ -640,7 +641,7 @@ async function syncInitialOpfsFilesInBackground({
 	dispatch: PlaygroundDispatch;
 	signal: AbortSignal;
 	siteSlugToReturnToIfBlueprintFails?: string;
-}) {
+}): Promise<boolean> {
 	let shouldReportProgress = true;
 	try {
 		// The first OPFS copy can outlive the iframe that started it. Once the
@@ -670,7 +671,7 @@ async function syncInitialOpfsFilesInBackground({
 			}
 		);
 		if (signal.aborted) {
-			return;
+			return false;
 		}
 		// Clear the return target in the same metadata write that completes the
 		// initial copy so failed copies retain their recovery action.
@@ -687,7 +688,7 @@ async function syncInitialOpfsFilesInBackground({
 			})
 		);
 		if (signal.aborted) {
-			return;
+			return false;
 		}
 		dispatch(
 			updateClientInfo({
@@ -697,9 +698,10 @@ async function syncInitialOpfsFilesInBackground({
 				},
 			})
 		);
+		return true;
 	} catch (error: unknown) {
 		if (signal.aborted) {
-			return;
+			return false;
 		}
 		logger.error('Error syncing saved Playground to OPFS', error);
 		dispatch(
@@ -713,7 +715,7 @@ async function syncInitialOpfsFilesInBackground({
 				},
 			})
 		);
-		return;
+		return false;
 	} finally {
 		// Progress is reported from a worker. Once the sync settles, ignore any
 		// queued progress message so it cannot overwrite the final UI state.

--- a/packages/playground/website/src/lib/state/redux/capture-site-thumbnail.spec.ts
+++ b/packages/playground/website/src/lib/state/redux/capture-site-thumbnail.spec.ts
@@ -1,0 +1,133 @@
+import type { PlaygroundClient, SiteThumbnail } from '@wp-playground/client';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { captureAndPersistSiteThumbnail } from './capture-site-thumbnail';
+import type { PlaygroundDispatch, PlaygroundReduxState } from './store';
+
+const mocks = vi.hoisted(() => ({
+	updateSiteMetadata: vi.fn((payload) => ({
+		type: 'sites/updateSiteMetadata',
+		payload,
+	})),
+}));
+
+vi.mock('./slice-sites', () => ({
+	updateSiteMetadata: mocks.updateSiteMetadata,
+}));
+
+vi.mock('@php-wasm/logger', () => ({
+	logger: {
+		warn: vi.fn(),
+	},
+}));
+
+describe('captureAndPersistSiteThumbnail', () => {
+	beforeEach(() => {
+		mocks.updateSiteMetadata.mockClear();
+	});
+
+	it('persists only the newest overlapping capture for a site', async () => {
+		const firstCapture = deferred<SiteThumbnail>();
+		const secondCapture = deferred<SiteThumbnail>();
+		const playground = {
+			captureSiteThumbnail: vi
+				.fn()
+				.mockReturnValueOnce(firstCapture.promise)
+				.mockReturnValueOnce(secondCapture.promise),
+		} as unknown as PlaygroundClient;
+		const state = createStateWithClient('test-site', playground);
+		const dispatch = vi.fn(async (action) => action);
+
+		const firstResult = captureAndPersistSiteThumbnail({
+			playground,
+			siteSlug: 'test-site',
+			dispatch: dispatch as unknown as PlaygroundDispatch,
+			getState: () => state,
+		});
+		const secondResult = captureAndPersistSiteThumbnail({
+			playground,
+			siteSlug: 'test-site',
+			dispatch: dispatch as unknown as PlaygroundDispatch,
+			getState: () => state,
+		});
+
+		const newestThumbnail = { mime: 'image/webp', data: 'newest' };
+		secondCapture.resolve(newestThumbnail);
+		await secondResult;
+		firstCapture.resolve({ mime: 'image/webp', data: 'stale' });
+		await firstResult;
+
+		expect(mocks.updateSiteMetadata).toHaveBeenCalledOnce();
+		expect(mocks.updateSiteMetadata).toHaveBeenCalledWith({
+			slug: 'test-site',
+			changes: { thumbnail: newestThumbnail },
+		});
+	});
+
+	it('discards a capture after the site client is replaced', async () => {
+		const capture = deferred<SiteThumbnail>();
+		const playground = {
+			captureSiteThumbnail: vi.fn(() => capture.promise),
+		} as unknown as PlaygroundClient;
+		const state = createStateWithClient('test-site', playground);
+		const result = captureAndPersistSiteThumbnail({
+			playground,
+			siteSlug: 'test-site',
+			dispatch: vi.fn() as unknown as PlaygroundDispatch,
+			getState: () => state,
+		});
+
+		state.clients.entities['test-site']!.client = {} as PlaygroundClient;
+		capture.resolve({ mime: 'image/webp', data: 'stale' });
+		await result;
+
+		expect(mocks.updateSiteMetadata).not.toHaveBeenCalled();
+	});
+
+	it('discards a capture after its caller is aborted', async () => {
+		const capture = deferred<SiteThumbnail>();
+		const playground = {
+			captureSiteThumbnail: vi.fn(() => capture.promise),
+		} as unknown as PlaygroundClient;
+		const state = createStateWithClient('test-site', playground);
+		const abortController = new AbortController();
+		const result = captureAndPersistSiteThumbnail({
+			playground,
+			siteSlug: 'test-site',
+			dispatch: vi.fn() as unknown as PlaygroundDispatch,
+			getState: () => state,
+			signal: abortController.signal,
+		});
+
+		abortController.abort();
+		capture.resolve({ mime: 'image/webp', data: 'stale' });
+		await result;
+
+		expect(mocks.updateSiteMetadata).not.toHaveBeenCalled();
+	});
+});
+
+function createStateWithClient(
+	siteSlug: string,
+	playground: PlaygroundClient
+): PlaygroundReduxState {
+	return {
+		clients: {
+			ids: [siteSlug],
+			entities: {
+				[siteSlug]: {
+					client: playground,
+					siteSlug,
+					url: '/',
+				},
+			},
+		},
+	} as unknown as PlaygroundReduxState;
+}
+
+function deferred<T>() {
+	let resolve!: (value: T) => void;
+	const promise = new Promise<T>((resolvePromise) => {
+		resolve = resolvePromise;
+	});
+	return { promise, resolve };
+}

--- a/packages/playground/website/src/lib/state/redux/capture-site-thumbnail.spec.ts
+++ b/packages/playground/website/src/lib/state/redux/capture-site-thumbnail.spec.ts
@@ -68,7 +68,7 @@ describe('captureAndPersistSiteThumbnail', () => {
 		const playground = {
 			captureSiteThumbnail: vi.fn(() => capture.promise),
 		} as unknown as PlaygroundClient;
-		const state = createStateWithClient('test-site', playground);
+		let state = createStateWithClient('test-site', playground);
 		const result = captureAndPersistSiteThumbnail({
 			playground,
 			siteSlug: 'test-site',
@@ -76,7 +76,7 @@ describe('captureAndPersistSiteThumbnail', () => {
 			getState: () => state,
 		});
 
-		state.clients.entities['test-site']!.client = {} as PlaygroundClient;
+		state = createStateWithClient('test-site', {} as PlaygroundClient);
 		capture.resolve({ mime: 'image/webp', data: 'stale' });
 		await result;
 

--- a/packages/playground/website/src/lib/state/redux/capture-site-thumbnail.ts
+++ b/packages/playground/website/src/lib/state/redux/capture-site-thumbnail.ts
@@ -1,23 +1,50 @@
 import { logger } from '@php-wasm/logger';
 import type { PlaygroundClient } from '@wp-playground/client';
-import type { PlaygroundDispatch } from './store';
+import { selectClientBySiteSlug } from './slice-clients';
+import type { PlaygroundDispatch, PlaygroundReduxState } from './store';
 import { updateSiteMetadata } from './slice-sites';
+
+const latestCaptureBySiteSlug = new Map<string, object>();
 
 /**
  * Captures and stores a thumbnail without making thumbnail failure fail the
  * save or boot operation that made the Playground available.
+ *
+ * `captureSiteThumbnail()` cannot be cancelled. Only the newest request for a
+ * site in this tab may write, and only while Redux still owns the client that
+ * started it.
  */
 export async function captureAndPersistSiteThumbnail({
 	playground,
 	siteSlug,
 	dispatch,
+	getState,
+	signal,
 }: {
 	playground: PlaygroundClient;
 	siteSlug: string;
 	dispatch: PlaygroundDispatch;
+	getState: () => PlaygroundReduxState;
+	signal?: AbortSignal;
 }) {
+	if (
+		signal?.aborted ||
+		selectClientBySiteSlug(getState(), siteSlug) !== playground
+	) {
+		return;
+	}
+
+	const captureRequest = {};
+	latestCaptureBySiteSlug.set(siteSlug, captureRequest);
 	try {
 		const thumbnail = await playground.captureSiteThumbnail();
+		if (
+			signal?.aborted ||
+			latestCaptureBySiteSlug.get(siteSlug) !== captureRequest ||
+			selectClientBySiteSlug(getState(), siteSlug) !== playground
+		) {
+			return;
+		}
 		await dispatch(
 			updateSiteMetadata({
 				slug: siteSlug,
@@ -25,6 +52,16 @@ export async function captureAndPersistSiteThumbnail({
 			})
 		);
 	} catch (error) {
+		if (
+			signal?.aborted ||
+			latestCaptureBySiteSlug.get(siteSlug) !== captureRequest
+		) {
+			return;
+		}
 		logger.warn('Could not update saved Playground thumbnail', error);
+	} finally {
+		if (latestCaptureBySiteSlug.get(siteSlug) === captureRequest) {
+			latestCaptureBySiteSlug.delete(siteSlug);
+		}
 	}
 }

--- a/packages/playground/website/src/lib/state/redux/capture-site-thumbnail.ts
+++ b/packages/playground/website/src/lib/state/redux/capture-site-thumbnail.ts
@@ -38,6 +38,11 @@ export async function captureAndPersistSiteThumbnail({
 	latestCaptureBySiteSlug.set(siteSlug, captureRequest);
 	try {
 		const thumbnail = await playground.captureSiteThumbnail();
+		/*
+		 * Rendering cannot be cancelled. By the time it returns, this iframe may
+		 * already be dead or a newer capture may have started. Do not let that
+		 * stale result touch saved metadata.
+		 */
 		if (
 			signal?.aborted ||
 			latestCaptureBySiteSlug.get(siteSlug) !== captureRequest ||

--- a/packages/playground/website/src/lib/state/redux/capture-site-thumbnail.ts
+++ b/packages/playground/website/src/lib/state/redux/capture-site-thumbnail.ts
@@ -4,7 +4,7 @@ import { selectClientBySiteSlug } from './slice-clients';
 import type { PlaygroundDispatch, PlaygroundReduxState } from './store';
 import { updateSiteMetadata } from './slice-sites';
 
-const latestCaptureBySiteSlug = new Map<string, object>();
+const latestCaptureBySiteSlug = new Map<string, symbol>();
 
 /**
  * Captures and stores a thumbnail without making thumbnail failure fail the
@@ -34,7 +34,7 @@ export async function captureAndPersistSiteThumbnail({
 		return;
 	}
 
-	const captureRequest = {};
+	const captureRequest = Symbol();
 	latestCaptureBySiteSlug.set(siteSlug, captureRequest);
 	try {
 		const thumbnail = await playground.captureSiteThumbnail();
@@ -54,7 +54,8 @@ export async function captureAndPersistSiteThumbnail({
 	} catch (error) {
 		if (
 			signal?.aborted ||
-			latestCaptureBySiteSlug.get(siteSlug) !== captureRequest
+			latestCaptureBySiteSlug.get(siteSlug) !== captureRequest ||
+			selectClientBySiteSlug(getState(), siteSlug) !== playground
 		) {
 			return;
 		}

--- a/packages/playground/website/src/lib/state/redux/persist-temporary-site.ts
+++ b/packages/playground/website/src/lib/state/redux/persist-temporary-site.ts
@@ -301,6 +301,7 @@ export function persistTemporarySite(
 				playground,
 				siteSlug,
 				dispatch,
+				getState,
 			});
 		} catch (error) {
 			if (


### PR DESCRIPTION
## Background

#4142 bounds page loading and gives `modern-screenshot` three seconds to render. That prevents one capture from hanging forever. It does not order results.

A saved Playground keeps its site metadata in `wp-runtime.json` inside that site's OPFS directory. Every open tab has its own Redux copy of the record, while all tabs write to the same OPFS file. #4152 made those writes atomic: `OpfsSiteStorage.update()` takes an origin-wide Web Lock keyed by site slug, reads the latest record, merges only the supplied patch, and writes it back. A thumbnail update therefore cannot restore an old name or runtime setting from that tab's Redux state.

The lock only serializes writes. It cannot know when `captureSiteThumbnail()` started. An old iframe can finish after a newer capture and then acquire the lock with a valid `{ thumbnail }` patch, replacing the newer image.

## This change

Before passing a thumbnail patch to `OpfsSiteStorage.update()`, this PR requires that the request is still the latest one for that site in the current tab, its boot signal has not been aborted, and Redux still owns the client that started it.

The initial OPFS copy now returns its own success result. Thumbnail capture no longer infers that copy's outcome from `initialOpfsSyncPending`, whose value can change independently.

Two live tabs remain valid writers. Their per-site Web Lock serializes thumbnail updates, and the last completed live-tab write wins.

## Testing

The focused tests resolve captures out of order, replace and abort clients, and fail an initial OPFS copy after the metadata flag changes.