### PR TITLE
[Blueprints] Report ZIP extraction progress during WordPress imports

### DIFF
--- a/packages/php-wasm/node/src/test/unzip-file.spec.ts
+++ b/packages/php-wasm/node/src/test/unzip-file.spec.ts
@@ -79,6 +79,26 @@ describe('unzipFile – concurrent calls avoid conflicts', () => {
 		expect(php.readFileAsText('/dst/absolute.txt')).toBe('absolute');
 	});
 
+	it('keeps normalized entries inside the target while reporting progress', async () => {
+		const zip = await createZipBuffer(php, {
+			'../escape.txt': 'escape',
+			'/absolute.txt': 'absolute',
+		});
+
+		await unzipFile(
+			php,
+			new File([zip], 'normalized-progress.zip'),
+			'/dst',
+			true,
+			() => {}
+		);
+
+		expect(php.fileExists('/escape.txt')).toBe(false);
+		expect(php.fileExists('/absolute.txt')).toBe(false);
+		expect(php.readFileAsText('/dst/escape.txt')).toBe('escape');
+		expect(php.readFileAsText('/dst/absolute.txt')).toBe('absolute');
+	});
+
 	it('preserves existing files when overwriteFiles is false', async () => {
 		php.mkdir('/dst');
 		php.writeFile('/dst/existing.txt', 'old');

--- a/packages/php-wasm/node/src/test/unzip-file.spec.ts
+++ b/packages/php-wasm/node/src/test/unzip-file.spec.ts
@@ -3,6 +3,7 @@ import {
 	zipDirectory,
 	RecommendedPHPVersion,
 } from '@wp-playground/common';
+import type { UnzipProgress } from '@wp-playground/common';
 import { phpVars } from '@php-wasm/util';
 import { PHP } from '@php-wasm/universal';
 import { loadNodeRuntime } from '../lib';
@@ -96,6 +97,74 @@ describe('unzipFile – concurrent calls avoid conflicts', () => {
 		expect(php.readFileAsText('/dst/existing.txt')).toBe('old');
 		expect(php.readFileAsText('/dst/fresh.txt')).toBe('fresh');
 	});
+
+	it('reports progress after every 100 files', async () => {
+		const zip = await createZipBufferWithFileSizes(
+			php,
+			new Array(201).fill(1)
+		);
+		const updates: UnzipProgress[] = [];
+
+		await unzipFile(
+			php,
+			new File([zip], 'many-files.zip'),
+			'/dst',
+			true,
+			(progress) => updates.push(progress)
+		);
+
+		expect(updates.map(({ filesProcessed }) => filesProcessed)).toEqual([
+			100, 200, 201,
+		]);
+		expect(updates.at(-1)).toEqual({
+			filesProcessed: 201,
+			totalFiles: 201,
+			uncompressedBytesProcessed: 201,
+			totalUncompressedBytes: 201,
+		});
+		expect(php.readFileAsText('/dst/file-200.txt')).toBe('x');
+	});
+
+	it('reports progress after every 400 KiB of uncompressed data', async () => {
+		const zip = await createZipBufferWithFileSizes(
+			php,
+			new Array(5).fill(200 * 1024)
+		);
+		const processedBytes: number[] = [];
+
+		await unzipFile(
+			php,
+			new File([zip], 'large-files.zip'),
+			'/dst',
+			true,
+			({ uncompressedBytesProcessed }) =>
+				processedBytes.push(uncompressedBytesProcessed)
+		);
+
+		expect(processedBytes).toEqual([400 * 1024, 800 * 1024, 1000 * 1024]);
+	});
+
+	it('reports progress on PHP 5.2', async () => {
+		const php52 = new PHP(await loadNodeRuntime('5.2'));
+		try {
+			const zip = await createZipBufferWithFileSizes(php52, [400 * 1024]);
+			const updates: UnzipProgress[] = [];
+
+			await unzipFile(
+				php52,
+				new File([zip], 'php-52.zip'),
+				'/dst-php-52',
+				true,
+				(progress) => updates.push(progress)
+			);
+
+			expect(updates).toHaveLength(1);
+			expect(updates[0].uncompressedBytesProcessed).toBe(400 * 1024);
+			expect(php52.fileExists('/dst-php-52/file-0.txt')).toBe(true);
+		} finally {
+			php52.exit();
+		}
+	});
 });
 
 /**
@@ -117,6 +186,28 @@ async function createZipBuffer(php: PHP, entries: Record<string, string>) {
 		}
 		foreach ($entries as $name => $contents) {
 			$zip->addFromString($name, $contents);
+		}
+		$zip->close();
+		`,
+	});
+	const zip = await php.readFileAsBuffer(zipPath);
+	await php.unlink(zipPath);
+	return zip;
+}
+
+async function createZipBufferWithFileSizes(php: PHP, fileSizes: number[]) {
+	const zipPath = `/tmp/source-${Math.random()}.zip`;
+	const js = phpVars({ fileSizes, zipPath });
+	await php.run({
+		code: `<?php
+		$fileSizes = ${js.fileSizes};
+		$zip = new ZipArchive;
+		$res = $zip->open(${js.zipPath}, ZipArchive::CREATE);
+		if ($res !== TRUE) {
+			throw new Exception('Failed to create ZIP: ' . $res);
+		}
+		foreach ($fileSizes as $index => $size) {
+			$zip->addFromString("file-$index.txt", str_repeat('x', $size));
 		}
 		$zip->close();
 		`,

--- a/packages/php-wasm/node/src/test/unzip-file.spec.ts
+++ b/packages/php-wasm/node/src/test/unzip-file.spec.ts
@@ -185,28 +185,6 @@ describe('unzipFile – concurrent calls avoid conflicts', () => {
 			php52.exit();
 		}
 	});
-
-	it('does not let directory entries escape the target on PHP 5.2', async () => {
-		const php52 = new PHP(await loadNodeRuntime('5.2'));
-		try {
-			const zip = await createZipBufferWithTraversalDirectory(php52);
-
-			await unzipFile(
-				php52,
-				new File([zip], 'php-52-traversal-directory.zip'),
-				'/dst-php-52',
-				true,
-				() => {}
-			);
-
-			expect(php52.fileExists('/outside-directory')).toBe(false);
-			expect(
-				php52.fileExists('/dst-php-52/outside-directory/file.txt')
-			).toBe(true);
-		} finally {
-			php52.exit();
-		}
-	});
 });
 
 /**
@@ -251,29 +229,6 @@ async function createZipBufferWithFileSizes(php: PHP, fileSizes: number[]) {
 		foreach ($fileSizes as $index => $size) {
 			$zip->addFromString("file-$index.txt", str_repeat('x', $size));
 		}
-		$zip->close();
-		`,
-	});
-	const zip = await php.readFileAsBuffer(zipPath);
-	await php.unlink(zipPath);
-	return zip;
-}
-
-async function createZipBufferWithTraversalDirectory(php: PHP) {
-	const zipPath = `/tmp/source-${Math.random()}.zip`;
-	const js = phpVars({ zipPath });
-	await php.run({
-		code: `<?php
-		$zip = new ZipArchive;
-		$res = $zip->open(${js.zipPath}, ZipArchive::CREATE);
-		if ($res !== TRUE) {
-			throw new Exception('Failed to create ZIP: ' . $res);
-		}
-		$zip->addEmptyDir('../outside-directory');
-		$zip->addFromString(
-			'../outside-directory/file.txt',
-			'directory traversal'
-		);
 		$zip->close();
 		`,
 	});

--- a/packages/php-wasm/node/src/test/unzip-file.spec.ts
+++ b/packages/php-wasm/node/src/test/unzip-file.spec.ts
@@ -237,17 +237,6 @@ async function createZipBuffer(php: PHP, entries: Record<string, string>) {
 	return zip;
 }
 
-/**
- * Creates a ZIP with one file for each requested uncompressed size.
- *
- * Entries are named `file-<index>.txt` and filled with repeated `x` bytes.
- * This gives progress tests exact file and byte thresholds without relying on
- * compression ratios.
- *
- * @param php - PHP runtime used to build the archive.
- * @param fileSizes - Uncompressed size of each entry, in bytes.
- * @returns The completed ZIP archive.
- */
 async function createZipBufferWithFileSizes(php: PHP, fileSizes: number[]) {
 	const zipPath = `/tmp/source-${Math.random()}.zip`;
 	const js = phpVars({ fileSizes, zipPath });
@@ -270,16 +259,6 @@ async function createZipBufferWithFileSizes(php: PHP, fileSizes: number[]) {
 	return zip;
 }
 
-/**
- * Creates a ZIP containing a directory entry that traverses above its target.
- *
- * The archive contains both `../outside-directory/` and a file below that
- * directory. PHP 5.2 handles those two entry types through different path
- * normalization branches, so the fixture exercises both branches together.
- *
- * @param php - PHP runtime used to build the archive.
- * @returns The completed ZIP archive.
- */
 async function createZipBufferWithTraversalDirectory(php: PHP) {
 	const zipPath = `/tmp/source-${Math.random()}.zip`;
 	const js = phpVars({ zipPath });

--- a/packages/php-wasm/node/src/test/unzip-file.spec.ts
+++ b/packages/php-wasm/node/src/test/unzip-file.spec.ts
@@ -185,6 +185,28 @@ describe('unzipFile – concurrent calls avoid conflicts', () => {
 			php52.exit();
 		}
 	});
+
+	it('does not let directory entries escape the target on PHP 5.2', async () => {
+		const php52 = new PHP(await loadNodeRuntime('5.2'));
+		try {
+			const zip = await createZipBufferWithTraversalDirectory(php52);
+
+			await unzipFile(
+				php52,
+				new File([zip], 'php-52-traversal-directory.zip'),
+				'/dst-php-52',
+				true,
+				() => {}
+			);
+
+			expect(php52.fileExists('/outside-directory')).toBe(false);
+			expect(
+				php52.fileExists('/dst-php-52/outside-directory/file.txt')
+			).toBe(true);
+		} finally {
+			php52.exit();
+		}
+	});
 });
 
 /**
@@ -229,6 +251,29 @@ async function createZipBufferWithFileSizes(php: PHP, fileSizes: number[]) {
 		foreach ($fileSizes as $index => $size) {
 			$zip->addFromString("file-$index.txt", str_repeat('x', $size));
 		}
+		$zip->close();
+		`,
+	});
+	const zip = await php.readFileAsBuffer(zipPath);
+	await php.unlink(zipPath);
+	return zip;
+}
+
+async function createZipBufferWithTraversalDirectory(php: PHP) {
+	const zipPath = `/tmp/source-${Math.random()}.zip`;
+	const js = phpVars({ zipPath });
+	await php.run({
+		code: `<?php
+		$zip = new ZipArchive;
+		$res = $zip->open(${js.zipPath}, ZipArchive::CREATE);
+		if ($res !== TRUE) {
+			throw new Exception('Failed to create ZIP: ' . $res);
+		}
+		$zip->addEmptyDir('../outside-directory');
+		$zip->addFromString(
+			'../outside-directory/file.txt',
+			'directory traversal'
+		);
 		$zip->close();
 		`,
 	});

--- a/packages/php-wasm/node/src/test/unzip-file.spec.ts
+++ b/packages/php-wasm/node/src/test/unzip-file.spec.ts
@@ -237,6 +237,17 @@ async function createZipBuffer(php: PHP, entries: Record<string, string>) {
 	return zip;
 }
 
+/**
+ * Creates a ZIP with one file for each requested uncompressed size.
+ *
+ * Entries are named `file-<index>.txt` and filled with repeated `x` bytes.
+ * This gives progress tests exact file and byte thresholds without relying on
+ * compression ratios.
+ *
+ * @param php - PHP runtime used to build the archive.
+ * @param fileSizes - Uncompressed size of each entry, in bytes.
+ * @returns The completed ZIP archive.
+ */
 async function createZipBufferWithFileSizes(php: PHP, fileSizes: number[]) {
 	const zipPath = `/tmp/source-${Math.random()}.zip`;
 	const js = phpVars({ fileSizes, zipPath });
@@ -259,6 +270,16 @@ async function createZipBufferWithFileSizes(php: PHP, fileSizes: number[]) {
 	return zip;
 }
 
+/**
+ * Creates a ZIP containing a directory entry that traverses above its target.
+ *
+ * The archive contains both `../outside-directory/` and a file below that
+ * directory. PHP 5.2 handles those two entry types through different path
+ * normalization branches, so the fixture exercises both branches together.
+ *
+ * @param php - PHP runtime used to build the archive.
+ * @returns The completed ZIP archive.
+ */
 async function createZipBufferWithTraversalDirectory(php: PHP) {
 	const zipPath = `/tmp/source-${Math.random()}.zip`;
 	const js = phpVars({ zipPath });

--- a/packages/php-wasm/universal/src/lib/php-worker.ts
+++ b/packages/php-wasm/universal/src/lib/php-worker.ts
@@ -218,7 +218,26 @@ export class PHPWorker implements LimitedPHPApi, AsyncDisposable {
 		}
 	}
 
-	/** @inheritDoc @php-wasm/universal!/PHP.runStream */
+	/**
+	 * Starts a PHP request and returns its output streams without buffering them.
+	 *
+	 * A worker backed by a request handler borrows a PHP instance from that
+	 * handler's pool. Returning a `StreamedPHPResponse` does not mean the PHP
+	 * process has finished, so the borrowed instance remains checked out until
+	 * `response.finished` settles. If the request fails before a response is
+	 * returned, the instance is released immediately.
+	 *
+	 * When the worker has a primary PHP instance and no request-handler pool,
+	 * the request is delegated directly to that instance.
+	 *
+	 * The caller owns the returned response streams. A non-zero PHP exit is
+	 * exposed through `response.exitCode`; it does not make this method reject
+	 * by itself.
+	 *
+	 * @param request - PHP code or script path, request metadata, and environment.
+	 * @returns A streamed response whose output can be consumed incrementally.
+	 * @throws When a PHP instance cannot be acquired or the request cannot start.
+	 */
 	async runStream(request: PHPRunOptions): Promise<StreamedPHPResponse> {
 		const state = _private.get(this)!;
 		const primaryPhp = state.php;

--- a/packages/php-wasm/universal/src/lib/php-worker.ts
+++ b/packages/php-wasm/universal/src/lib/php-worker.ts
@@ -239,7 +239,7 @@ export class PHPWorker implements LimitedPHPApi, AsyncDisposable {
 		}
 		// The caller still owns the response streams. Keep this PHP instance
 		// checked out until the process behind those streams has finished.
-		response.finished.finally(reap);
+		void response.finished.finally(reap);
 		return response;
 	}
 

--- a/packages/php-wasm/universal/src/lib/php-worker.ts
+++ b/packages/php-wasm/universal/src/lib/php-worker.ts
@@ -219,20 +219,12 @@ export class PHPWorker implements LimitedPHPApi, AsyncDisposable {
 	}
 
 	/**
-	 * Starts a PHP request and returns its output streams without buffering them.
+	 * Starts a PHP request and returns its output streams before PHP exits.
 	 *
-	 * A worker backed by a request handler borrows a PHP instance from that
-	 * handler's pool. Returning a `StreamedPHPResponse` does not mean the PHP
-	 * process has finished, so the borrowed instance remains checked out until
-	 * `response.finished` settles. If the request fails before a response is
-	 * returned, the instance is released immediately.
-	 *
-	 * When the worker has a primary PHP instance and no request-handler pool,
-	 * the request is delegated directly to that instance.
-	 *
-	 * The caller owns the returned response streams. A non-zero PHP exit is
-	 * exposed through `response.exitCode`; it does not make this method reject
-	 * by itself.
+	 * A pooled PHP instance remains checked out until `response.finished`
+	 * settles. If the request fails before returning a response, the instance
+	 * is released immediately. A non-zero PHP exit is exposed through
+	 * `response.exitCode` instead of making this method reject.
 	 *
 	 * @param request - PHP code or script path, request metadata, and environment.
 	 * @returns A streamed response whose output can be consumed incrementally.

--- a/packages/php-wasm/universal/src/lib/php-worker.ts
+++ b/packages/php-wasm/universal/src/lib/php-worker.ts
@@ -38,6 +38,7 @@ export type LimitedPHPApi = Pick<
 	| 'fileExists'
 	| 'chdir'
 	| 'run'
+	| 'runStream'
 	| 'onMessage'
 > & {
 	documentRoot: PHP['documentRoot'];
@@ -215,6 +216,31 @@ export class PHPWorker implements LimitedPHPApi, AsyncDisposable {
 		} finally {
 			reap();
 		}
+	}
+
+	/** @inheritDoc @php-wasm/universal!/PHP.runStream */
+	async runStream(request: PHPRunOptions): Promise<StreamedPHPResponse> {
+		const state = _private.get(this)!;
+		const primaryPhp = state.php;
+		if (
+			!state.requestHandler &&
+			!primaryPhp?.requestHandler &&
+			primaryPhp
+		) {
+			return await primaryPhp.runStream(request);
+		}
+		const { php, reap } = await this.acquirePHPInstance();
+		let response: StreamedPHPResponse;
+		try {
+			response = await php.runStream(request);
+		} catch (error) {
+			reap();
+			throw error;
+		}
+		// The caller still owns the response streams. Keep this PHP instance
+		// checked out until the process behind those streams has finished.
+		response.finished.finally(reap);
+		return response;
 	}
 
 	/** @inheritDoc @php-wasm/universal!/PHP.cli */

--- a/packages/php-wasm/universal/src/test/php-worker.spec.ts
+++ b/packages/php-wasm/universal/src/test/php-worker.spec.ts
@@ -2,6 +2,7 @@ import { PHPWorker } from '../lib/php-worker';
 import { describe, expect, test, vi } from 'vitest';
 import type { PHP } from '../lib/php';
 import type { PHPRequestHandler } from '../lib/php-request-handler';
+import type { StreamedPHPResponse } from '../lib/php-response';
 
 type PhpEvent = { type: string; [key: string]: unknown };
 type PhpEventListener = (event: PhpEvent) => void | Promise<void>;
@@ -214,6 +215,42 @@ describe('PlaygroundWorkerEndpoint', () => {
 			['php', '/tmp/script.php'],
 			undefined
 		);
+	});
+
+	test('keeps a pooled PHP instance alive until runStream finishes', async () => {
+		let finish!: () => void;
+		const finished = new Promise<void>((resolve) => {
+			finish = resolve;
+		});
+		const response = { finished } as StreamedPHPResponse;
+		const reap = vi.fn();
+		const streamedPhp = {
+			chdir: vi.fn(),
+			runStream: vi.fn().mockResolvedValue(response),
+			addEventListener: vi.fn(),
+			onMessage: vi.fn(),
+		};
+		const requestHandler = {
+			absoluteUrl: 'http://127.0.0.1/',
+			documentRoot: '/wordpress',
+			instanceManager: {
+				acquirePHPInstance: vi.fn().mockResolvedValue({
+					php: streamedPhp,
+					reap,
+				}),
+			},
+		};
+		const endpoint = new TestEndpoint(
+			requestHandler as unknown as PHPRequestHandler
+		);
+		const request = { code: "<?php echo 'hi!';" };
+
+		await expect(endpoint.runStream(request)).resolves.toBe(response);
+		expect(streamedPhp.runStream).toHaveBeenCalledWith(request);
+		expect(reap).not.toHaveBeenCalled();
+
+		finish();
+		await vi.waitFor(() => expect(reap).toHaveBeenCalledOnce());
 	});
 
 	test('uses the primary PHP instance before resolving a missing request handler', async () => {

--- a/packages/playground/blueprints/src/lib/steps/import-wordpress-files.ts
+++ b/packages/playground/blueprints/src/lib/steps/import-wordpress-files.ts
@@ -8,6 +8,7 @@ import {
 	randomFilename,
 } from '@php-wasm/util';
 import type { UniversalPHP } from '@php-wasm/universal';
+import type { UnzipProgress } from '@wp-playground/common';
 import { unzipFile } from '@wp-playground/common';
 import { ensureWpConfig } from '@wp-playground/wordpress';
 import { getLegacyPlaygroundRuntimeWpContentPaths } from '../utils/legacy-playground-runtime-wp-content-paths';
@@ -78,26 +79,30 @@ export const importWordPressFiles: StepHandler<
 	let oldSiteUrl: string | null = null;
 	try {
 		await playground.mkdir(unzipRoot);
+		let reportUnzipProgress:
+			| ((progress: UnzipProgress) => void)
+			| undefined;
+		if (progress) {
+			reportUnzipProgress = ({
+				filesProcessed,
+				totalFiles,
+				uncompressedBytesProcessed,
+				totalUncompressedBytes,
+			}) => {
+				let fraction = filesProcessed / Math.max(totalFiles, 1);
+				if (totalUncompressedBytes > 0) {
+					fraction =
+						uncompressedBytesProcessed / totalUncompressedBytes;
+				}
+				progress.tracker.set(fraction * 30);
+			};
+		}
 		await unzipFile(
 			playground,
 			wordPressFilesZip,
 			unzipRoot,
 			true,
-			progress
-				? ({
-						filesProcessed,
-						totalFiles,
-						uncompressedBytesProcessed,
-						totalUncompressedBytes,
-					}) => {
-						const fraction =
-							totalUncompressedBytes > 0
-								? uncompressedBytesProcessed /
-									totalUncompressedBytes
-								: filesProcessed / Math.max(totalFiles, 1);
-						progress.tracker.set(fraction * 30);
-					}
-				: undefined
+			reportUnzipProgress
 		);
 		let importPath = joinPaths(unzipRoot, pathInZip);
 		importPath =

--- a/packages/playground/blueprints/src/lib/steps/import-wordpress-files.ts
+++ b/packages/playground/blueprints/src/lib/steps/import-wordpress-files.ts
@@ -79,13 +79,8 @@ export const importWordPressFiles: StepHandler<
 	let oldSiteUrl: string | null = null;
 	try {
 		await playground.mkdir(unzipRoot);
-		/**
-		 * Maps archive extraction onto the first 30% of the import.
-		 *
-		 * Declared byte counts better represent work when archive entries have
-		 * different sizes. File counts are the fallback for archives whose
-		 * entries all have a declared uncompressed size of zero.
-		 */
+		// Unpacking owns the first 30% of the import. Bytes account for unequal
+		// entry sizes; file counts handle archives containing only empty files.
 		let reportUnzipProgress:
 			| ((progress: UnzipProgress) => void)
 			| undefined;

--- a/packages/playground/blueprints/src/lib/steps/import-wordpress-files.ts
+++ b/packages/playground/blueprints/src/lib/steps/import-wordpress-files.ts
@@ -79,6 +79,13 @@ export const importWordPressFiles: StepHandler<
 	let oldSiteUrl: string | null = null;
 	try {
 		await playground.mkdir(unzipRoot);
+		/**
+		 * Maps archive extraction onto the first 30% of the import.
+		 *
+		 * Declared byte counts better represent work when archive entries have
+		 * different sizes. File counts are the fallback for archives whose
+		 * entries all have a declared uncompressed size of zero.
+		 */
 		let reportUnzipProgress:
 			| ((progress: UnzipProgress) => void)
 			| undefined;

--- a/packages/playground/blueprints/src/lib/steps/import-wordpress-files.ts
+++ b/packages/playground/blueprints/src/lib/steps/import-wordpress-files.ts
@@ -1,5 +1,4 @@
 import type { StepHandler } from '.';
-import { unzip } from './unzip';
 import { logger } from '@php-wasm/logger';
 import {
 	dirname,
@@ -9,6 +8,7 @@ import {
 	randomFilename,
 } from '@php-wasm/util';
 import type { UniversalPHP } from '@php-wasm/universal';
+import { unzipFile } from '@wp-playground/common';
 import { ensureWpConfig } from '@wp-playground/wordpress';
 import { getLegacyPlaygroundRuntimeWpContentPaths } from '../utils/legacy-playground-runtime-wp-content-paths';
 import { wpContentPathsExcludedFromLegacyExports } from '../utils/legacy-wp-content-paths-excluded-from-exports';
@@ -78,10 +78,27 @@ export const importWordPressFiles: StepHandler<
 	let oldSiteUrl: string | null = null;
 	try {
 		await playground.mkdir(unzipRoot);
-		await unzip(playground, {
-			zipFile: wordPressFilesZip,
-			extractToPath: unzipRoot,
-		});
+		await unzipFile(
+			playground,
+			wordPressFilesZip,
+			unzipRoot,
+			true,
+			progress
+				? ({
+						filesProcessed,
+						totalFiles,
+						uncompressedBytesProcessed,
+						totalUncompressedBytes,
+					}) => {
+						const fraction =
+							totalUncompressedBytes > 0
+								? uncompressedBytesProcessed /
+									totalUncompressedBytes
+								: filesProcessed / Math.max(totalFiles, 1);
+						progress.tracker.set(fraction * 30);
+					}
+				: undefined
+		);
 		let importPath = joinPaths(unzipRoot, pathInZip);
 		importPath =
 			(await findWordPressFilesRoot(playground, importPath)) ||

--- a/packages/playground/blueprints/src/tests/steps/import-wordpress-files.spec.ts
+++ b/packages/playground/blueprints/src/tests/steps/import-wordpress-files.spec.ts
@@ -1,4 +1,6 @@
 import type { PHP, PHPRequestHandler } from '@php-wasm/universal';
+import { ProgressTracker } from '@php-wasm/progress';
+import type { ProgressTrackerEvent } from '@php-wasm/progress';
 import { RecommendedPHPVersion } from '@wp-playground/common';
 import { importWordPressFiles } from '../../lib/steps/import-wordpress-files';
 import { zipWpContent } from '../../lib/steps/zip-wp-content';
@@ -78,6 +80,43 @@ describe('Blueprint step importWordPressFiles', () => {
 		const manifest = JSON.parse(result.text);
 		expect(manifest.formatVersion).toBe(2);
 		expect(manifest.siteUrl).toContain(`scope:${sourceScope}`);
+	});
+
+	it('should report progress while unpacking the archive', async () => {
+		const zipPath = joinPaths('/tmp', `${randomFilename()}.zip`);
+		await targetPHP.run({
+			code: `<?php
+			$zip = new ZipArchive();
+			$zip->open(${phpVar(zipPath)}, ZipArchive::CREATE);
+			for ($i = 0; $i < 5; $i++) {
+				$zip->addFromString(
+					"wp-content/uploads/progress-$i.txt",
+					str_repeat('x', 200 * 1024)
+				);
+			}
+			$zip->close();
+			`,
+		});
+		const tracker = new ProgressTracker();
+		const reportedProgress: number[] = [];
+		tracker.addEventListener('progress', (event: ProgressTrackerEvent) => {
+			reportedProgress.push(event.detail.progress);
+		});
+
+		await importWordPressFiles(
+			targetPHP,
+			{
+				wordPressFilesZip: new File(
+					[await targetPHP.readFileAsBuffer(zipPath)],
+					'progress.zip'
+				),
+			},
+			{ tracker }
+		);
+
+		expect(
+			reportedProgress.some((progress) => progress > 0 && progress < 30)
+		).toBe(true);
 	});
 
 	it('should export all user-owned wp-content files and wp-config.php', async () => {

--- a/packages/playground/common/src/index.ts
+++ b/packages/playground/common/src/index.ts
@@ -249,6 +249,19 @@ export const unzipFile = async (
 	}
 };
 
+/**
+ * Runs a ZIP extraction request and forwards its framed progress records.
+ *
+ * PHP writes newline-delimited JSON records prefixed with
+ * `UNZIP_PROGRESS_LINE_PREFIX`. Stream chunks may split or combine records, so
+ * this function buffers partial lines and ignores unrelated stdout.
+ *
+ * The first progress parsing or callback failure is saved until stdout,
+ * stderr, and the PHP exit status have settled. This waits for extraction to
+ * finish and release any worker-backed PHP instance, and prevents the caller
+ * from cleaning up the temporary ZIP while PHP may still be reading it. A PHP
+ * process failure takes precedence over a progress-consumer failure.
+ */
 async function runUnzipFileWithProgress(
 	php: UniversalPHP,
 	request: PHPRunOptions,

--- a/packages/playground/common/src/index.ts
+++ b/packages/playground/common/src/index.ts
@@ -17,13 +17,11 @@ export { createMemoizedFetch } from './create-memoized-fetch';
 export const RecommendedPHPVersion = '8.3';
 
 /**
- * Describes cumulative progress through the non-directory entries in a ZIP.
+ * Reports cumulative progress through non-directory ZIP entries.
  *
- * The byte counts come from each entry's declared uncompressed size. They
- * advance when a complete entry has been processed, not while bytes within an
- * entry are being written. Entries skipped because `overwriteFiles` is false
- * still advance these counters because progress describes traversal through
- * the archive rather than the number of filesystem writes.
+ * Byte counts use declared uncompressed sizes and advance only between
+ * entries. Entries skipped because overwriting is disabled still count as
+ * processed.
  */
 export interface UnzipProgress {
 	/** Number of non-directory entries processed so far. */
@@ -43,38 +41,24 @@ const UNZIP_PROGRESS_LINE_PREFIX = 'PLAYGROUND_UNZIP_PROGRESS:';
 /**
  * Extracts a ZIP archive into Playground's virtual filesystem.
  *
- * `zipPath` may be an existing path in the PHP filesystem or a browser `File`.
- * A browser `File` is copied to a uniquely named temporary path before PHP
- * opens it. The temporary copy is removed after extraction has settled.
- *
  * Entries are extracted in batches after either 100 files or 400 KiB of
- * declared uncompressed data has been processed. The same batch loop is used
- * with and without progress reporting. When `onProgress` is provided, an
- * initial archive scan calculates the totals and the callback receives an
- * update after every batch. An empty archive produces one all-zero update.
+ * declared uncompressed data. An `onProgress` callback adds a totals scan and
+ * receives an update after every batch. Entries remain atomic, so a large
+ * entry may cross the byte threshold before the next update.
  *
- * ZIP entries remain atomic. A single entry larger than 400 KiB is fully
- * extracted before the next update. When `overwriteFiles` is false, entries
- * whose destination already exists are omitted from extraction, but they
- * still advance progress through the archive.
- *
- * `ZipArchive` handles archive-entry path normalization. PHP 5.2 does not
- * apply that normalization to directory-only entries, so those entries are
- * omitted on PHP 5.2. Regular files still create their parent directories,
- * but empty directories from the archive are not restored on that version.
- *
- * The destination must not contain untrusted pre-existing symlinks.
- * `ZipArchive` follows them while writing files.
+ * PHP 5.2 directory-only entries are omitted because that runtime does not
+ * apply its file-path cleanup to them. Empty directories are therefore not
+ * restored on PHP 5.2. The destination must not contain untrusted pre-existing
+ * symlinks because `ZipArchive` follows them while writing files.
  *
  * @param php - PHP runtime whose filesystem contains the archive and target.
  * @param zipPath - Archive path in the PHP filesystem, or a browser `File`.
  * @param extractToPath - Destination directory, created when it does not exist.
  * @param overwriteFiles - Whether archive entries may replace existing paths.
- * @param onProgress - Receives cumulative progress after each extracted batch.
- * @returns A promise that resolves after extraction and stream processing finish.
- * @throws When PHP cannot open, inspect, or extract the archive, or when the
- * progress callback throws. Callback failures are reported after extraction
- * finishes.
+ * Defaults to `true`.
+ * @param onProgress - Optional callback for cumulative extraction progress.
+ * @returns A promise that resolves when extraction finishes.
+ * @throws When extraction fails or the progress callback throws.
  */
 export const unzipFile = async (
 	php: UniversalPHP,
@@ -227,15 +211,11 @@ export const unzipFile = async (
 		chmod($extractTo, 0777);
 
 		/**
-		 * Extracts queued ZIP entries and clears the queue after success.
-		 *
-		 * An empty queue is a no-op. When ZipArchive reports an extraction
-		 * failure, the queue remains intact and an exception aborts the
-		 * surrounding extraction loop.
+		 * Extracts and clears the queued ZIP entries.
 		 *
 		 * @param ZipArchive $zip       Open archive containing the entries.
 		 * @param string     $extractTo Destination directory.
-		 * @param array      $entries   Entry names, passed by reference.
+		 * @param array      $entries   Entry names to extract.
 		 * @return void
 		 * @throws Exception When ZipArchive cannot extract the queued entries.
 		 */
@@ -251,12 +231,7 @@ export const unzipFile = async (
 		}
 
 		/**
-		 * Writes one framed progress record to standard output.
-		 *
-		 * Each record contains the configured prefix, a JSON object, and a
-		 * trailing newline. The prefix lets the JavaScript reader distinguish
-		 * progress from unrelated PHP output. Flushing requests delivery
-		 * before the next extraction batch begins.
+		 * Writes and flushes one prefixed JSON progress record.
 		 *
 		 * @param string $linePrefix                Progress record prefix.
 		 * @param int    $filesProcessed             Files processed so far.
@@ -317,28 +292,18 @@ export const unzipFile = async (
 };
 
 /**
- * Runs a ZIP extraction request and forwards its progress records.
+ * Runs ZIP extraction and forwards prefixed JSON progress records from stdout.
  *
- * The PHP extractor writes each update as a newline-delimited JSON record
- * prefixed with `UNZIP_PROGRESS_LINE_PREFIX`. `runStream()` returns arbitrary
- * byte chunks that may split one record or combine several records. This
- * function decodes those chunks incrementally, buffers incomplete lines, and
- * ignores complete lines without the progress prefix.
- *
- * Standard output and standard error are drained before this function
- * returns. The first JSON parsing or callback failure is retained instead of
- * being thrown immediately. This lets the PHP request finish before
- * `unzipFile()` removes a temporary archive and lets a worker-backed runtime
- * release the PHP instance associated with the streams. A non-zero PHP exit
- * takes precedence over a progress-consumer failure.
+ * Stream chunks do not align with lines, so partial lines are buffered.
+ * Parsing and callback failures are deferred until PHP finishes so temporary
+ * archive cleanup and pooled-instance release cannot race the request. A PHP
+ * process failure takes precedence.
  *
  * @param php - PHP runtime used to start the streaming request.
  * @param request - Extraction program and per-request environment variables.
  * @param onProgress - Receives each complete, valid progress record.
- * @returns A promise that resolves after both output streams and the PHP exit
- * status have settled.
- * @throws When the request cannot start, PHP exits with a non-zero status, a
- * prefixed line is not valid progress JSON, or `onProgress` throws.
+ * @returns A promise that resolves after the output streams and PHP process.
+ * @throws When PHP, progress parsing, or `onProgress` fails.
  */
 async function runUnzipFileWithProgress(
 	php: UniversalPHP,

--- a/packages/playground/common/src/index.ts
+++ b/packages/playground/common/src/index.ts
@@ -9,7 +9,7 @@
  * Let's always consider these questions before adding new code here.
  */
 
-import type { UniversalPHP } from '@php-wasm/universal';
+import type { PHPRunOptions, UniversalPHP } from '@php-wasm/universal';
 import { phpVars } from '@php-wasm/util';
 
 export { createMemoizedFetch } from './create-memoized-fetch';
@@ -33,6 +33,9 @@ const UNZIP_PROGRESS_LINE_PREFIX = 'PLAYGROUND_UNZIP_PROGRESS:';
  * When `onProgress` is provided, extraction reports after each batch reaches
  * 100 files or 400 KiB of uncompressed data. Each ZIP entry is extracted
  * atomically, so one large entry may cross the byte threshold.
+ *
+ * The destination must not contain untrusted pre-existing symlinks because
+ * ZipArchive follows them while writing files.
  */
 export const unzipFile = async (
 	php: UniversalPHP,
@@ -57,24 +60,19 @@ export const unzipFile = async (
 				new Uint8Array(await zipFile.arrayBuffer())
 			);
 		}
-		const js = phpVars({
-			zipPath,
-			extractToPath,
-			overwriteFiles,
-			reportProgress: !!onProgress,
-			filesInterval: UNZIP_PROGRESS_FILES_INTERVAL,
-			uncompressedBytesInterval:
-				UNZIP_PROGRESS_UNCOMPRESSED_BYTES_INTERVAL,
-			linePrefix: UNZIP_PROGRESS_LINE_PREFIX,
-		});
 		const code = `<?php
-		$zipPath = ${js.zipPath};
-		$extractTo = ${js.extractToPath};
-		$overwriteFiles = ${js.overwriteFiles};
-		$reportProgress = ${js.reportProgress};
-		$filesInterval = ${js.filesInterval};
-		$uncompressedBytesInterval = ${js.uncompressedBytesInterval};
-		$linePrefix = ${js.linePrefix};
+		$zipPath = getenv('PLAYGROUND_UNZIP_ZIP_PATH');
+		$extractTo = getenv('PLAYGROUND_UNZIP_EXTRACT_TO_PATH');
+		$overwriteFiles =
+			getenv('PLAYGROUND_UNZIP_OVERWRITE_FILES') === '1';
+		$reportProgress =
+			getenv('PLAYGROUND_UNZIP_REPORT_PROGRESS') === '1';
+		$filesInterval =
+			intval(getenv('PLAYGROUND_UNZIP_FILES_INTERVAL'));
+		$uncompressedBytesInterval = intval(
+			getenv('PLAYGROUND_UNZIP_UNCOMPRESSED_BYTES_INTERVAL')
+		);
+		$linePrefix = getenv('PLAYGROUND_UNZIP_LINE_PREFIX');
 
 		if (!is_dir($extractTo)) {
 			mkdir($extractTo, 0777, true);
@@ -122,13 +120,24 @@ export const unzipFile = async (
 					);
 				}
 				$filename = $stat['name'];
+				$isDirectory = substr($filename, -1) === '/';
+				// PHP 5.2 extracts explicit directory names without the path
+				// cleanup it applies to files. Skip those entries there; files
+				// still create their parent directories, but empty directories
+				// from the archive are omitted.
+				if (
+					$isDirectory &&
+					version_compare(PHP_VERSION, '5.3', '<')
+				) {
+					continue;
+				}
 				$extractFilePath =
 					rtrim($extractTo, '/') . '/' . $filename;
 				// Leave existing paths out when $overwriteFiles is false.
 				if ($overwriteFiles || !file_exists($extractFilePath)) {
 					$entriesToExtract[] = $filename;
 				}
-				if (substr($filename, -1) === '/') {
+				if ($isDirectory) {
 					continue;
 				}
 
@@ -205,10 +214,26 @@ export const unzipFile = async (
 			flush();
 		}
 		`;
+		const request: PHPRunOptions = {
+			code,
+			env: {
+				PLAYGROUND_UNZIP_ZIP_PATH: zipPath,
+				PLAYGROUND_UNZIP_EXTRACT_TO_PATH: extractToPath,
+				PLAYGROUND_UNZIP_OVERWRITE_FILES: overwriteFiles ? '1' : '0',
+				PLAYGROUND_UNZIP_REPORT_PROGRESS: onProgress ? '1' : '0',
+				PLAYGROUND_UNZIP_FILES_INTERVAL: String(
+					UNZIP_PROGRESS_FILES_INTERVAL
+				),
+				PLAYGROUND_UNZIP_UNCOMPRESSED_BYTES_INTERVAL: String(
+					UNZIP_PROGRESS_UNCOMPRESSED_BYTES_INTERVAL
+				),
+				PLAYGROUND_UNZIP_LINE_PREFIX: UNZIP_PROGRESS_LINE_PREFIX,
+			},
+		};
 		if (onProgress) {
-			await runUnzipFileWithProgress(php, code, onProgress);
+			await runUnzipFileWithProgress(php, request, onProgress);
 		} else {
-			await php.run({ code });
+			await php.run(request);
 		}
 	} finally {
 		if (shouldRemoveTmpPath) {
@@ -226,10 +251,10 @@ export const unzipFile = async (
 
 async function runUnzipFileWithProgress(
 	php: UniversalPHP,
-	code: string,
+	request: PHPRunOptions,
 	onProgress: (progress: UnzipProgress) => void
 ) {
-	const response = await php.runStream({ code });
+	const response = await php.runStream(request);
 	const stderrText = response.stderrText;
 	const reader = response.stdout.getReader();
 	const decoder = new TextDecoder();

--- a/packages/playground/common/src/index.ts
+++ b/packages/playground/common/src/index.ts
@@ -41,10 +41,14 @@ const UNZIP_PROGRESS_LINE_PREFIX = 'PLAYGROUND_UNZIP_PROGRESS:';
 /**
  * Extracts a ZIP archive into Playground's virtual filesystem.
  *
- * Entries are extracted in batches after either 100 files or 400 KiB of
- * declared uncompressed data. An `onProgress` callback adds a totals scan and
- * receives an update after every batch. Entries remain atomic, so a large
- * entry may cross the byte threshold before the next update.
+ * `ZipArchive::extractTo()` has no extraction-progress callback in any
+ * supported PHP version, so this function calls it in batches. Each batch ends
+ * after either 100 files or 400 KiB of declared uncompressed data.
+ *
+ * For example, 250 one-byte files are extracted as three batches of 100, 100,
+ * and 50 files. An `onProgress` callback receives an update after each batch.
+ * Entries remain atomic, so a single file larger than 400 KiB finishes before
+ * the update.
  *
  * `ZipArchive` follows symlinks already present in the destination. Do not
  * extract into a directory containing untrusted symlinks.

--- a/packages/playground/common/src/index.ts
+++ b/packages/playground/common/src/index.ts
@@ -46,10 +46,14 @@ const UNZIP_PROGRESS_LINE_PREFIX = 'PLAYGROUND_UNZIP_PROGRESS:';
  * receives an update after every batch. Entries remain atomic, so a large
  * entry may cross the byte threshold before the next update.
  *
- * PHP 5.2 directory-only entries are omitted because that runtime does not
- * apply its file-path cleanup to them. Empty directories are therefore not
- * restored on PHP 5.2. The destination must not contain untrusted pre-existing
- * symlinks because `ZipArchive` follows them while writing files.
+ * `ZipArchive::extractTo()` handles a directory entry such as `../empty/`
+ * differently across PHP versions. When extracting into `/site`, PHP 7.x and
+ * 8.x create `/site/empty/`, while PHP 5.2 would create `/empty/` outside the
+ * destination. Directory-only entries are therefore skipped on PHP 5.2. Files
+ * still create their parent directories, but empty directories are not restored.
+ *
+ * Separately, all PHP versions follow symlinks already present in the destination.
+ * Do not extract into a directory containing untrusted symlinks.
  *
  * @param php - PHP runtime whose filesystem contains the archive and target.
  * @param zipPath - Archive path in the PHP filesystem, or a browser `File`.

--- a/packages/playground/common/src/index.ts
+++ b/packages/playground/common/src/index.ts
@@ -16,10 +16,23 @@ export { createMemoizedFetch } from './create-memoized-fetch';
 
 export const RecommendedPHPVersion = '8.3';
 
+/**
+ * Describes cumulative progress through the non-directory entries in a ZIP.
+ *
+ * The byte counts come from each entry's declared uncompressed size. They
+ * advance when a complete entry has been processed, not while bytes within an
+ * entry are being written. Entries skipped because `overwriteFiles` is false
+ * still advance these counters because progress describes traversal through
+ * the archive rather than the number of filesystem writes.
+ */
 export interface UnzipProgress {
+	/** Number of non-directory entries processed so far. */
 	filesProcessed: number;
+	/** Total number of non-directory entries in the archive. */
 	totalFiles: number;
+	/** Declared uncompressed bytes processed so far. */
 	uncompressedBytesProcessed: number;
+	/** Declared uncompressed bytes across all non-directory entries. */
 	totalUncompressedBytes: number;
 }
 
@@ -28,14 +41,40 @@ const UNZIP_PROGRESS_UNCOMPRESSED_BYTES_INTERVAL = 400 * 1024;
 const UNZIP_PROGRESS_LINE_PREFIX = 'PLAYGROUND_UNZIP_PROGRESS:';
 
 /**
- * Unzip a zip file inside Playground.
+ * Extracts a ZIP archive into Playground's virtual filesystem.
  *
- * When `onProgress` is provided, extraction reports after each batch reaches
- * 100 files or 400 KiB of uncompressed data. Each ZIP entry is extracted
- * atomically, so one large entry may cross the byte threshold.
+ * `zipPath` may be an existing path in the PHP filesystem or a browser `File`.
+ * A browser `File` is copied to a uniquely named temporary path before PHP
+ * opens it. The temporary copy is removed after extraction has settled.
  *
- * The destination must not contain untrusted pre-existing symlinks because
- * ZipArchive follows them while writing files.
+ * Entries are extracted in batches after either 100 files or 400 KiB of
+ * declared uncompressed data has been processed. The same batch loop is used
+ * with and without progress reporting. When `onProgress` is provided, an
+ * initial archive scan calculates the totals and the callback receives an
+ * update after every batch. An empty archive produces one all-zero update.
+ *
+ * ZIP entries remain atomic. A single entry larger than 400 KiB is fully
+ * extracted before the next update. When `overwriteFiles` is false, entries
+ * whose destination already exists are omitted from extraction, but they
+ * still advance progress through the archive.
+ *
+ * `ZipArchive` handles archive-entry path normalization. PHP 5.2 does not
+ * apply that normalization to directory-only entries, so those entries are
+ * omitted on PHP 5.2. Regular files still create their parent directories,
+ * but empty directories from the archive are not restored on that version.
+ *
+ * The destination must not contain untrusted pre-existing symlinks.
+ * `ZipArchive` follows them while writing files.
+ *
+ * @param php - PHP runtime whose filesystem contains the archive and target.
+ * @param zipPath - Archive path in the PHP filesystem, or a browser `File`.
+ * @param extractToPath - Destination directory, created when it does not exist.
+ * @param overwriteFiles - Whether archive entries may replace existing paths.
+ * @param onProgress - Receives cumulative progress after each extracted batch.
+ * @returns A promise that resolves after extraction and stream processing finish.
+ * @throws When PHP cannot open, inspect, or extract the archive, or when the
+ * progress callback throws. Callback failures are reported after extraction
+ * finishes.
  */
 export const unzipFile = async (
 	php: UniversalPHP,
@@ -187,6 +226,19 @@ export const unzipFile = async (
 		$zip->close();
 		chmod($extractTo, 0777);
 
+		/**
+		 * Extracts queued ZIP entries and clears the queue after success.
+		 *
+		 * An empty queue is a no-op. When ZipArchive reports an extraction
+		 * failure, the queue remains intact and an exception aborts the
+		 * surrounding extraction loop.
+		 *
+		 * @param ZipArchive $zip       Open archive containing the entries.
+		 * @param string     $extractTo Destination directory.
+		 * @param array      $entries   Entry names, passed by reference.
+		 * @return void
+		 * @throws Exception When ZipArchive cannot extract the queued entries.
+		 */
 		function extractZipBatch($zip, $extractTo, &$entries)
 		{
 			if (count($entries) === 0) {
@@ -198,6 +250,21 @@ export const unzipFile = async (
 			$entries = array();
 		}
 
+		/**
+		 * Writes one framed progress record to standard output.
+		 *
+		 * Each record contains the configured prefix, a JSON object, and a
+		 * trailing newline. The prefix lets the JavaScript reader distinguish
+		 * progress from unrelated PHP output. Flushing requests delivery
+		 * before the next extraction batch begins.
+		 *
+		 * @param string $linePrefix                Progress record prefix.
+		 * @param int    $filesProcessed             Files processed so far.
+		 * @param int    $totalFiles                 Total files in the archive.
+		 * @param int    $uncompressedBytesProcessed Bytes processed so far.
+		 * @param int    $totalUncompressedBytes     Total uncompressed bytes.
+		 * @return void
+		 */
 		function reportUnzipProgress(
 			$linePrefix,
 			$filesProcessed,
@@ -250,23 +317,34 @@ export const unzipFile = async (
 };
 
 /**
- * Runs a ZIP extraction request and forwards its framed progress records.
+ * Runs a ZIP extraction request and forwards its progress records.
  *
- * PHP writes newline-delimited JSON records prefixed with
- * `UNZIP_PROGRESS_LINE_PREFIX`. Stream chunks may split or combine records, so
- * this function buffers partial lines and ignores unrelated stdout.
+ * The PHP extractor writes each update as a newline-delimited JSON record
+ * prefixed with `UNZIP_PROGRESS_LINE_PREFIX`. `runStream()` returns arbitrary
+ * byte chunks that may split one record or combine several records. This
+ * function decodes those chunks incrementally, buffers incomplete lines, and
+ * ignores complete lines without the progress prefix.
  *
- * The first progress parsing or callback failure is saved until stdout,
- * stderr, and the PHP exit status have settled. This waits for extraction to
- * finish and release any worker-backed PHP instance, and prevents the caller
- * from cleaning up the temporary ZIP while PHP may still be reading it. A PHP
- * process failure takes precedence over a progress-consumer failure.
+ * Standard output and standard error are drained before this function
+ * returns. The first JSON parsing or callback failure is retained instead of
+ * being thrown immediately. This lets the PHP request finish before
+ * `unzipFile()` removes a temporary archive and lets a worker-backed runtime
+ * release the PHP instance associated with the streams. A non-zero PHP exit
+ * takes precedence over a progress-consumer failure.
+ *
+ * @param php - PHP runtime used to start the streaming request.
+ * @param request - Extraction program and per-request environment variables.
+ * @param onProgress - Receives each complete, valid progress record.
+ * @returns A promise that resolves after both output streams and the PHP exit
+ * status have settled.
+ * @throws When the request cannot start, PHP exits with a non-zero status, a
+ * prefixed line is not valid progress JSON, or `onProgress` throws.
  */
 async function runUnzipFileWithProgress(
 	php: UniversalPHP,
 	request: PHPRunOptions,
 	onProgress: (progress: UnzipProgress) => void
-) {
+): Promise<void> {
 	const response = await php.runStream(request);
 	const stderrText = response.stderrText;
 	const reader = response.stdout.getReader();

--- a/packages/playground/common/src/index.ts
+++ b/packages/playground/common/src/index.ts
@@ -90,35 +90,9 @@ export const unzipFile = async (
 		}
 
 		try {
-			if (!$reportProgress) {
-				if ($overwriteFiles) {
-					if (!$zip->extractTo($extractTo)) {
-						throw new Exception("Could not extract ZIP file.");
-					}
-				} else {
-					for ($i = 0; $i < $zip->numFiles; $i++) {
-						$filename = $zip->getNameIndex($i);
-						if ($filename === false) {
-							throw new Exception(
-								"Could not inspect ZIP entry " . $i . "."
-							);
-						}
-						$extractFilePath =
-							rtrim($extractTo, '/') . '/' . $filename;
-						// Leave existing paths out when $overwriteFiles is false.
-						if (
-							!file_exists($extractFilePath) &&
-							!$zip->extractTo($extractTo, $filename)
-						) {
-							throw new Exception(
-								"Could not extract ZIP entry " . $filename . "."
-							);
-						}
-					}
-				}
-			} else {
-				$totalFiles = 0;
-				$totalUncompressedBytes = 0;
+			$totalFiles = 0;
+			$totalUncompressedBytes = 0;
+			if ($reportProgress) {
 				for ($i = 0; $i < $zip->numFiles; $i++) {
 					$stat = $zip->statIndex($i);
 					if ($stat === false) {
@@ -131,39 +105,44 @@ export const unzipFile = async (
 						$totalUncompressedBytes += $stat['size'];
 					}
 				}
+			}
 
-				$filesProcessed = 0;
-				$uncompressedBytesProcessed = 0;
-				$filesSinceUpdate = 0;
-				$uncompressedBytesSinceUpdate = 0;
-				$entriesToExtract = array();
-				for ($i = 0; $i < $zip->numFiles; $i++) {
-					$stat = $zip->statIndex($i);
-					if ($stat === false) {
-						throw new Exception(
-							"Could not inspect ZIP entry " . $i . "."
-						);
-					}
-					$filename = $stat['name'];
-					$extractFilePath =
-						rtrim($extractTo, '/') . '/' . $filename;
-					if ($overwriteFiles || !file_exists($extractFilePath)) {
-						$entriesToExtract[] = $filename;
-					}
-					if (substr($filename, -1) === '/') {
-						continue;
-					}
+			// Keep one extraction path for all callers. Progress reporting only
+			// adds the totals scan above and emits an update between batches.
+			$filesProcessed = 0;
+			$uncompressedBytesProcessed = 0;
+			$filesSinceUpdate = 0;
+			$uncompressedBytesSinceUpdate = 0;
+			$entriesToExtract = array();
+			for ($i = 0; $i < $zip->numFiles; $i++) {
+				$stat = $zip->statIndex($i);
+				if ($stat === false) {
+					throw new Exception(
+						"Could not inspect ZIP entry " . $i . "."
+					);
+				}
+				$filename = $stat['name'];
+				$extractFilePath =
+					rtrim($extractTo, '/') . '/' . $filename;
+				// Leave existing paths out when $overwriteFiles is false.
+				if ($overwriteFiles || !file_exists($extractFilePath)) {
+					$entriesToExtract[] = $filename;
+				}
+				if (substr($filename, -1) === '/') {
+					continue;
+				}
 
-					$filesProcessed++;
-					$uncompressedBytesProcessed += $stat['size'];
-					$filesSinceUpdate++;
-					$uncompressedBytesSinceUpdate += $stat['size'];
-					if (
-						$filesSinceUpdate >= $filesInterval ||
-						$uncompressedBytesSinceUpdate >=
-							$uncompressedBytesInterval
-					) {
-						extractZipBatch($zip, $extractTo, $entriesToExtract);
+				$filesProcessed++;
+				$uncompressedBytesProcessed += $stat['size'];
+				$filesSinceUpdate++;
+				$uncompressedBytesSinceUpdate += $stat['size'];
+				if (
+					$filesSinceUpdate >= $filesInterval ||
+					$uncompressedBytesSinceUpdate >=
+						$uncompressedBytesInterval
+				) {
+					extractZipBatch($zip, $extractTo, $entriesToExtract);
+					if ($reportProgress) {
 						reportUnzipProgress(
 							$linePrefix,
 							$filesProcessed,
@@ -171,24 +150,25 @@ export const unzipFile = async (
 							$uncompressedBytesProcessed,
 							$totalUncompressedBytes
 						);
-						$filesSinceUpdate = 0;
-						$uncompressedBytesSinceUpdate = 0;
 					}
+					$filesSinceUpdate = 0;
+					$uncompressedBytesSinceUpdate = 0;
 				}
-				extractZipBatch($zip, $extractTo, $entriesToExtract);
-				if (
-					$filesSinceUpdate > 0 ||
+			}
+			extractZipBatch($zip, $extractTo, $entriesToExtract);
+			if (
+				$reportProgress &&
+				($filesSinceUpdate > 0 ||
 					$uncompressedBytesSinceUpdate > 0 ||
-					$totalFiles === 0
-				) {
-					reportUnzipProgress(
-						$linePrefix,
-						$filesProcessed,
-						$totalFiles,
-						$uncompressedBytesProcessed,
-						$totalUncompressedBytes
-					);
-				}
+					$totalFiles === 0)
+			) {
+				reportUnzipProgress(
+					$linePrefix,
+					$filesProcessed,
+					$totalFiles,
+					$uncompressedBytesProcessed,
+					$totalUncompressedBytes
+				);
 			}
 		} catch (Exception $e) {
 			// PHP 5.2 does not support finally.

--- a/packages/playground/common/src/index.ts
+++ b/packages/playground/common/src/index.ts
@@ -269,18 +269,22 @@ async function runUnzipFileWithProgress(
 			progressError ??= error;
 		}
 	};
-	while (true) {
-		const { done, value } = await reader.read();
-		buffered += decoder.decode(value, { stream: !done });
-		let newline = buffered.indexOf('\n');
-		while (newline !== -1) {
-			processLine(buffered.slice(0, newline));
-			buffered = buffered.slice(newline + 1);
-			newline = buffered.indexOf('\n');
+	try {
+		while (true) {
+			const { done, value } = await reader.read();
+			buffered += decoder.decode(value, { stream: !done });
+			let newline = buffered.indexOf('\n');
+			while (newline !== -1) {
+				processLine(buffered.slice(0, newline));
+				buffered = buffered.slice(newline + 1);
+				newline = buffered.indexOf('\n');
+			}
+			if (done) {
+				break;
+			}
 		}
-		if (done) {
-			break;
-		}
+	} finally {
+		reader.releaseLock();
 	}
 	if (buffered) {
 		processLine(buffered);

--- a/packages/playground/common/src/index.ts
+++ b/packages/playground/common/src/index.ts
@@ -16,14 +16,30 @@ export { createMemoizedFetch } from './create-memoized-fetch';
 
 export const RecommendedPHPVersion = '8.3';
 
+export interface UnzipProgress {
+	filesProcessed: number;
+	totalFiles: number;
+	uncompressedBytesProcessed: number;
+	totalUncompressedBytes: number;
+}
+
+const UNZIP_PROGRESS_FILES_INTERVAL = 100;
+const UNZIP_PROGRESS_UNCOMPRESSED_BYTES_INTERVAL = 400 * 1024;
+const UNZIP_PROGRESS_LINE_PREFIX = 'PLAYGROUND_UNZIP_PROGRESS:';
+
 /**
  * Unzip a zip file inside Playground.
+ *
+ * When `onProgress` is provided, extraction reports after each batch reaches
+ * 100 files or 400 KiB of uncompressed data. Each ZIP entry is extracted
+ * atomically, so one large entry may cross the byte threshold.
  */
 export const unzipFile = async (
 	php: UniversalPHP,
 	zipPath: string | File,
 	extractToPath: string,
-	overwriteFiles = true
+	overwriteFiles = true,
+	onProgress?: (progress: UnzipProgress) => void
 ) => {
 	/**
 	 * Use a random file name to avoid conflicts across concurrent unzipFile()
@@ -45,47 +61,175 @@ export const unzipFile = async (
 			zipPath,
 			extractToPath,
 			overwriteFiles,
+			reportProgress: !!onProgress,
+			filesInterval: UNZIP_PROGRESS_FILES_INTERVAL,
+			uncompressedBytesInterval:
+				UNZIP_PROGRESS_UNCOMPRESSED_BYTES_INTERVAL,
+			linePrefix: UNZIP_PROGRESS_LINE_PREFIX,
 		});
-		await php.run({
-			code: `<?php
-        function unzip($zipPath, $extractTo, $overwriteFiles = true)
-        {
-            if (!is_dir($extractTo)) {
-                mkdir($extractTo, 0777, true);
-            }
-            $zip = new ZipArchive;
-            $res = $zip->open($zipPath);
-            if ($res === TRUE) {
-				try {
-					if ($overwriteFiles) {
-						if (!$zip->extractTo($extractTo)) {
-							throw new Exception('Could not extract ZIP file.');
+		const code = `<?php
+		$zipPath = ${js.zipPath};
+		$extractTo = ${js.extractToPath};
+		$overwriteFiles = ${js.overwriteFiles};
+		$reportProgress = ${js.reportProgress};
+		$filesInterval = ${js.filesInterval};
+		$uncompressedBytesInterval = ${js.uncompressedBytesInterval};
+		$linePrefix = ${js.linePrefix};
+
+		if (!is_dir($extractTo)) {
+			mkdir($extractTo, 0777, true);
+		}
+		$zip = new ZipArchive;
+		$res = $zip->open($zipPath);
+		if ($res !== TRUE) {
+			$fileSize = file_exists($zipPath) ? filesize($zipPath) : 'unknown';
+			throw new Exception(
+				"Could not unzip file. Error code: " . $res .
+				". File size: " . $fileSize . " bytes."
+			);
+		}
+
+		try {
+			if (!$reportProgress) {
+				if ($overwriteFiles) {
+					if (!$zip->extractTo($extractTo)) {
+						throw new Exception("Could not extract ZIP file.");
+					}
+				} else {
+					for ($i = 0; $i < $zip->numFiles; $i++) {
+						$filename = $zip->getNameIndex($i);
+						if ($filename === false) {
+							throw new Exception(
+								"Could not inspect ZIP entry " . $i . "."
+							);
 						}
-					} else {
-						for ($i = 0; $i < $zip->numFiles; $i++) {
-							$filename = $zip->getNameIndex($i);
-							$extractFilePath = rtrim($extractTo, '/') . '/' . $filename;
-							// Check if file exists and $overwriteFiles is false
-							if (!file_exists($extractFilePath)) {
-								// Extract file
-								$zip->extractTo($extractTo, $filename);
-							}
+						$extractFilePath =
+							rtrim($extractTo, '/') . '/' . $filename;
+						// Leave existing paths out when $overwriteFiles is false.
+						if (
+							!file_exists($extractFilePath) &&
+							!$zip->extractTo($extractTo, $filename)
+						) {
+							throw new Exception(
+								"Could not extract ZIP entry " . $filename . "."
+							);
 						}
 					}
-				} catch (Exception $e) {
-					$zip->close();
-					throw $e;
 				}
-				$zip->close();
-				chmod($extractTo, 0777);
-            } else {
-                $fileSize = file_exists($zipPath) ? filesize($zipPath) : 'unknown';
-	                throw new Exception("Could not unzip file. Error code: " . $res . ". File size: " . $fileSize . " bytes.");
-	            }
+			} else {
+				$totalFiles = 0;
+				$totalUncompressedBytes = 0;
+				for ($i = 0; $i < $zip->numFiles; $i++) {
+					$stat = $zip->statIndex($i);
+					if ($stat === false) {
+						throw new Exception(
+							"Could not inspect ZIP entry " . $i . "."
+						);
+					}
+					if (substr($stat['name'], -1) !== '/') {
+						$totalFiles++;
+						$totalUncompressedBytes += $stat['size'];
+					}
+				}
+
+				$filesProcessed = 0;
+				$uncompressedBytesProcessed = 0;
+				$filesSinceUpdate = 0;
+				$uncompressedBytesSinceUpdate = 0;
+				$entriesToExtract = array();
+				for ($i = 0; $i < $zip->numFiles; $i++) {
+					$stat = $zip->statIndex($i);
+					if ($stat === false) {
+						throw new Exception(
+							"Could not inspect ZIP entry " . $i . "."
+						);
+					}
+					$filename = $stat['name'];
+					$extractFilePath =
+						rtrim($extractTo, '/') . '/' . $filename;
+					if ($overwriteFiles || !file_exists($extractFilePath)) {
+						$entriesToExtract[] = $filename;
+					}
+					if (substr($filename, -1) === '/') {
+						continue;
+					}
+
+					$filesProcessed++;
+					$uncompressedBytesProcessed += $stat['size'];
+					$filesSinceUpdate++;
+					$uncompressedBytesSinceUpdate += $stat['size'];
+					if (
+						$filesSinceUpdate >= $filesInterval ||
+						$uncompressedBytesSinceUpdate >=
+							$uncompressedBytesInterval
+					) {
+						extractZipBatch($zip, $extractTo, $entriesToExtract);
+						reportUnzipProgress(
+							$linePrefix,
+							$filesProcessed,
+							$totalFiles,
+							$uncompressedBytesProcessed,
+							$totalUncompressedBytes
+						);
+						$filesSinceUpdate = 0;
+						$uncompressedBytesSinceUpdate = 0;
+					}
+				}
+				extractZipBatch($zip, $extractTo, $entriesToExtract);
+				if (
+					$filesSinceUpdate > 0 ||
+					$uncompressedBytesSinceUpdate > 0 ||
+					$totalFiles === 0
+				) {
+					reportUnzipProgress(
+						$linePrefix,
+						$filesProcessed,
+						$totalFiles,
+						$uncompressedBytesProcessed,
+						$totalUncompressedBytes
+					);
+				}
+			}
+		} catch (Exception $e) {
+			// PHP 5.2 does not support finally.
+			$zip->close();
+			throw $e;
 		}
-        unzip(${js.zipPath}, ${js.extractToPath}, ${js.overwriteFiles});
-        `,
-		});
+		$zip->close();
+		chmod($extractTo, 0777);
+
+		function extractZipBatch($zip, $extractTo, &$entries)
+		{
+			if (count($entries) === 0) {
+				return;
+			}
+			if (!$zip->extractTo($extractTo, $entries)) {
+				throw new Exception("Could not extract ZIP entries.");
+			}
+			$entries = array();
+		}
+
+		function reportUnzipProgress(
+			$linePrefix,
+			$filesProcessed,
+			$totalFiles,
+			$uncompressedBytesProcessed,
+			$totalUncompressedBytes
+		) {
+			echo $linePrefix . json_encode(array(
+				'filesProcessed' => $filesProcessed,
+				'totalFiles' => $totalFiles,
+				'uncompressedBytesProcessed' => $uncompressedBytesProcessed,
+				'totalUncompressedBytes' => $totalUncompressedBytes,
+			)) . "\\n";
+			flush();
+		}
+		`;
+		if (onProgress) {
+			await runUnzipFileWithProgress(php, code, onProgress);
+		} else {
+			await php.run({ code });
+		}
 	} finally {
 		if (shouldRemoveTmpPath) {
 			try {
@@ -99,6 +243,62 @@ export const unzipFile = async (
 		}
 	}
 };
+
+async function runUnzipFileWithProgress(
+	php: UniversalPHP,
+	code: string,
+	onProgress: (progress: UnzipProgress) => void
+) {
+	const response = await php.runStream({ code });
+	const stderrText = response.stderrText;
+	const reader = response.stdout.getReader();
+	const decoder = new TextDecoder();
+	let buffered = '';
+	let progressError: unknown;
+	const processLine = (line: string) => {
+		if (!line.startsWith(UNZIP_PROGRESS_LINE_PREFIX)) {
+			return;
+		}
+		try {
+			onProgress(
+				JSON.parse(
+					line.slice(UNZIP_PROGRESS_LINE_PREFIX.length)
+				) as UnzipProgress
+			);
+		} catch (error) {
+			progressError ??= error;
+		}
+	};
+	while (true) {
+		const { done, value } = await reader.read();
+		buffered += decoder.decode(value, { stream: !done });
+		let newline = buffered.indexOf('\n');
+		while (newline !== -1) {
+			processLine(buffered.slice(0, newline));
+			buffered = buffered.slice(newline + 1);
+			newline = buffered.indexOf('\n');
+		}
+		if (done) {
+			break;
+		}
+	}
+	if (buffered) {
+		processLine(buffered);
+	}
+	const [exitCode, stderr] = await Promise.all([
+		response.exitCode,
+		stderrText,
+	]);
+	if (exitCode !== 0) {
+		throw new Error(
+			stderr.trim() ||
+				`Could not unzip file. PHP exited with code ${exitCode}.`
+		);
+	}
+	if (progressError) {
+		throw progressError;
+	}
+}
 
 export const zipDirectory = async (
 	php: UniversalPHP,

--- a/packages/playground/common/src/index.ts
+++ b/packages/playground/common/src/index.ts
@@ -46,14 +46,8 @@ const UNZIP_PROGRESS_LINE_PREFIX = 'PLAYGROUND_UNZIP_PROGRESS:';
  * receives an update after every batch. Entries remain atomic, so a large
  * entry may cross the byte threshold before the next update.
  *
- * `ZipArchive::extractTo()` handles a directory entry such as `../empty/`
- * differently across PHP versions. When extracting into `/site`, PHP 7.x and
- * 8.x create `/site/empty/`, while PHP 5.2 would create `/empty/` outside the
- * destination. Directory-only entries are therefore skipped on PHP 5.2. Files
- * still create their parent directories, but empty directories are not restored.
- *
- * Separately, all PHP versions follow symlinks already present in the destination.
- * Do not extract into a directory containing untrusted symlinks.
+ * `ZipArchive` follows symlinks already present in the destination. Do not
+ * extract into a directory containing untrusted symlinks.
  *
  * @param php - PHP runtime whose filesystem contains the archive and target.
  * @param zipPath - Archive path in the PHP filesystem, or a browser `File`.
@@ -148,16 +142,6 @@ export const unzipFile = async (
 				}
 				$filename = $stat['name'];
 				$isDirectory = substr($filename, -1) === '/';
-				// PHP 5.2 extracts explicit directory names without the path
-				// cleanup it applies to files. Skip those entries there; files
-				// still create their parent directories, but empty directories
-				// from the archive are omitted.
-				if (
-					$isDirectory &&
-					version_compare(PHP_VERSION, '5.3', '<')
-				) {
-					continue;
-				}
 				$extractFilePath =
 					rtrim($extractTo, '/') . '/' . $filename;
 				// Leave existing paths out when $overwriteFiles is false.


### PR DESCRIPTION
`importWordPressFiles()` now advances its existing `Unpacking archive` phase while the ZIP is extracted, instead of jumping from zero to 30% after extraction.

`unzipFile()` accepts an optional progress callback:

```ts
await unzipFile(php, zip, target, true, (progress) => {
	renderProgress(progress);
});
```

`ZipArchive::extractTo()` has no extraction-progress callback in any supported PHP version, so this PR calls it in batches. Each batch ends after either 100 files or 400 KiB of uncompressed data, whichever comes first. For example, 250 one-byte files are extracted as three batches of 100, 100, and 50 files, with an update after each batch.

Each update includes cumulative file and byte counts plus their totals. Calls without a callback use the same extraction loop but skip the totals scan and progress output.

The run inputs are passed through the PHP request environment rather than interpolated into PHP source.

Browser clients receive the updates through `runStream()`. The worker keeps the PHP instance checked out until that stream finishes.

Updates happen between ZIP entries. A single entry larger than 400 KiB reports after that entry finishes; this does not replace `ZipArchive` with a custom ZIP reader.

This PR supplies real import progress. It does not replace the website's indeterminate full-page loader yet.

## Testing

Run `importWordPressFiles()` with a progress tracker against a multi-megabyte export. Confirm `Unpacking archive` reports intermediate values before reaching its existing 30% boundary.
