### PR TITLE
[PHP-WASM] Ignore null iframe relay messages

### DIFF
--- a/packages/php-wasm/web/project.json
+++ b/packages/php-wasm/web/project.json
@@ -138,7 +138,8 @@
 					"prf.spec.ts",
 					"certificates.spec.ts",
 					"tcp-over-fetch-websocket.spec.ts",
-					"directory-handle-mount.spec.ts"
+					"directory-handle-mount.spec.ts",
+					"setup-post-message-relay.spec.ts"
 				]
 			}
 		},

--- a/packages/php-wasm/web/src/lib/setup-post-message-relay.spec.ts
+++ b/packages/php-wasm/web/src/lib/setup-post-message-relay.spec.ts
@@ -32,18 +32,24 @@ describe('setupPostMessageRelay', () => {
 			contentWindow: nestedFrameWindow,
 		} as unknown as HTMLIFrameElement);
 
-		expect(() =>
-			messageListeners[0]({
+		expect(messageListeners.length).toBeGreaterThan(0);
+		const nullMessages = [
+			{
 				data: null,
 				source: nestedFrameWindow,
-			} as MessageEvent)
-		).not.toThrow();
-		expect(() =>
-			messageListeners[1]({
+			} as MessageEvent,
+			{
 				data: null,
 				source: parentWindow,
-			} as MessageEvent)
-		).not.toThrow();
+			} as MessageEvent,
+		];
+		for (const event of nullMessages) {
+			expect(() => {
+				for (const listener of messageListeners) {
+					listener(event);
+				}
+			}).not.toThrow();
+		}
 		expect(parentPostMessage).not.toHaveBeenCalled();
 		expect(nestedFramePostMessage).not.toHaveBeenCalled();
 	});

--- a/packages/php-wasm/web/src/lib/setup-post-message-relay.spec.ts
+++ b/packages/php-wasm/web/src/lib/setup-post-message-relay.spec.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { setupPostMessageRelay } from './setup-post-message-relay';
+
+describe('setupPostMessageRelay', () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('ignores null messages from both relay directions', () => {
+		const parentPostMessage = vi.fn();
+		const nestedFramePostMessage = vi.fn();
+		const parentWindow = {
+			postMessage: parentPostMessage,
+		} as unknown as Window;
+		const nestedFrameWindow = {
+			postMessage: nestedFramePostMessage,
+		} as unknown as Window;
+		const messageListeners: Array<(event: MessageEvent) => void> = [];
+		vi.stubGlobal('window', {
+			parent: parentWindow,
+			addEventListener: (
+				type: string,
+				listener: (event: MessageEvent) => void
+			) => {
+				if (type === 'message') {
+					messageListeners.push(listener);
+				}
+			},
+		});
+
+		setupPostMessageRelay({
+			contentWindow: nestedFrameWindow,
+		} as unknown as HTMLIFrameElement);
+
+		expect(() =>
+			messageListeners[0]({
+				data: null,
+				source: nestedFrameWindow,
+			} as MessageEvent)
+		).not.toThrow();
+		expect(() =>
+			messageListeners[1]({
+				data: null,
+				source: parentWindow,
+			} as MessageEvent)
+		).not.toThrow();
+		expect(parentPostMessage).not.toHaveBeenCalled();
+		expect(nestedFramePostMessage).not.toHaveBeenCalled();
+	});
+});

--- a/packages/php-wasm/web/src/lib/setup-post-message-relay.ts
+++ b/packages/php-wasm/web/src/lib/setup-post-message-relay.ts
@@ -25,7 +25,11 @@ export function setupPostMessageRelay(
 			return;
 		}
 
-		if (typeof event.data !== 'object' || event.data.type !== 'relay') {
+		if (
+			event.data === null ||
+			typeof event.data !== 'object' ||
+			event.data.type !== 'relay'
+		) {
 			return;
 		}
 
@@ -38,7 +42,11 @@ export function setupPostMessageRelay(
 			return;
 		}
 
-		if (typeof event.data !== 'object' || event.data.type !== 'relay') {
+		if (
+			event.data === null ||
+			typeof event.data !== 'object' ||
+			event.data.type !== 'relay'
+		) {
 			return;
 		}
 


### PR DESCRIPTION
`setupPostMessageRelay()` now ignores `null` payloads before reading their message type.

WordPress code and third-party scripts can send unrelated messages through either relay
direction:

```js
// Nested WordPress iframe → parent.
window.parent.postMessage(null, '*');

// Parent → nested WordPress iframe.
iframe.contentWindow?.postMessage(null, '*');
```

JavaScript classifies `null` as an object, so the previous guard continued to
`event.data.type` and raised `TypeError: Cannot read properties of null (reading 'type')`.

Non-relay messages should be ignored. This PR checks `null` explicitly in both listeners and
adds direct coverage for both sources.

## Testing

Import a Playground ZIP whose site posts `null` to its parent. Confirm the import proceeds
without an iframe relay error.
