### PR TITLE
[Website] Display ZIP import progress

### DIFF
--- a/packages/playground/blueprints/src/lib/steps/import-wordpress-files.ts
+++ b/packages/playground/blueprints/src/lib/steps/import-wordpress-files.ts
@@ -91,6 +91,9 @@ export const importWordPressFiles: StepHandler<
 				uncompressedBytesProcessed,
 				totalUncompressedBytes,
 			}) => {
+				progress.tracker.setCaption(
+					`Extracting ${filesProcessed}/${totalFiles}`
+				);
 				let fraction = filesProcessed / Math.max(totalFiles, 1);
 				if (totalUncompressedBytes > 0) {
 					fraction =

--- a/packages/playground/common/src/index.ts
+++ b/packages/playground/common/src/index.ts
@@ -47,8 +47,8 @@ const UNZIP_PROGRESS_LINE_PREFIX = 'PLAYGROUND_UNZIP_PROGRESS:';
  *
  * For example, 250 one-byte files are extracted as three batches of 100, 100,
  * and 50 files. An `onProgress` callback receives an update after each batch.
- * Entries remain atomic, so a single file larger than 400 KiB finishes before
- * the update.
+ * Browser delivery may group fast consecutive updates. Entries remain atomic,
+ * so a single file larger than 400 KiB finishes before the update.
  *
  * `ZipArchive` follows symlinks already present in the destination. Do not
  * extract into a directory containing untrusted symlinks.
@@ -136,6 +136,7 @@ export const unzipFile = async (
 			$uncompressedBytesProcessed = 0;
 			$filesSinceUpdate = 0;
 			$uncompressedBytesSinceUpdate = 0;
+			$lastProgressYieldAt = 0;
 			$entriesToExtract = array();
 			for ($i = 0; $i < $zip->numFiles; $i++) {
 				$stat = $zip->statIndex($i);
@@ -172,7 +173,8 @@ export const unzipFile = async (
 							$filesProcessed,
 							$totalFiles,
 							$uncompressedBytesProcessed,
-							$totalUncompressedBytes
+							$totalUncompressedBytes,
+							$lastProgressYieldAt
 						);
 					}
 					$filesSinceUpdate = 0;
@@ -191,7 +193,8 @@ export const unzipFile = async (
 					$filesProcessed,
 					$totalFiles,
 					$uncompressedBytesProcessed,
-					$totalUncompressedBytes
+					$totalUncompressedBytes,
+					$lastProgressYieldAt
 				);
 			}
 		} catch (Exception $e) {
@@ -230,6 +233,7 @@ export const unzipFile = async (
 		 * @param int    $totalFiles                 Total files in the archive.
 		 * @param int    $uncompressedBytesProcessed Bytes processed so far.
 		 * @param int    $totalUncompressedBytes     Total uncompressed bytes.
+		 * @param float  $lastProgressYieldAt        Last event-loop yield time.
 		 * @return void
 		 */
 		function reportUnzipProgress(
@@ -237,8 +241,15 @@ export const unzipFile = async (
 			$filesProcessed,
 			$totalFiles,
 			$uncompressedBytesProcessed,
-			$totalUncompressedBytes
+			$totalUncompressedBytes,
+			&$lastProgressYieldAt
 		) {
+			$now = microtime(true);
+			// Limit event-loop yields to keep large imports fast.
+			$shouldYield =
+				$lastProgressYieldAt === 0 ||
+				$filesProcessed === $totalFiles ||
+				$now - $lastProgressYieldAt >= 0.05;
 			echo $linePrefix . json_encode(array(
 				'filesProcessed' => $filesProcessed,
 				'totalFiles' => $totalFiles,
@@ -246,6 +257,13 @@ export const unzipFile = async (
 				'totalUncompressedBytes' => $totalUncompressedBytes,
 			)) . "\\n";
 			flush();
+			// PHP 5.2's Asyncify build cannot suspend from a nested function call.
+			if ($shouldYield && PHP_MAJOR_VERSION >= 7) {
+				// PHP runs synchronously inside the worker. Yield so stdout can cross
+				// the worker boundary before extraction finishes.
+				usleep(0);
+				$lastProgressYieldAt = microtime(true);
+			}
 		}
 		`;
 		const request: PHPRunOptions = {

--- a/packages/playground/website/playwright/e2e/opfs.spec.ts
+++ b/packages/playground/website/playwright/e2e/opfs.spec.ts
@@ -1271,16 +1271,12 @@ test('should close the pane, reveal the site, and finish during a ZIP import', a
 	const autosaveStarted = expect(autosaveProgress).toBeVisible({
 		timeout: 120000,
 	});
-	const unpackingProgressAdvanced = expect
+	const importProgressAdvanced = expect
 		.poll(
 			async () => {
-				const value = Number(
-					await importProgress.getAttribute('aria-valuenow')
-				);
-				const text =
-					await importProgress.getAttribute('aria-valuetext');
 				return (
-					text?.startsWith('Unpacking archive') === true && value > 0
+					Number(await importProgress.getAttribute('aria-valuenow')) >
+					0
 				);
 			},
 			{
@@ -1297,7 +1293,7 @@ test('should close the pane, reveal the site, and finish during a ZIP import', a
 	await expect(pane).not.toBeVisible();
 	await importProgressStarted;
 	await expect(autosaveProgress).toHaveCount(0);
-	await unpackingProgressAdvanced;
+	await importProgressAdvanced;
 	await expect(importProgress).toHaveCount(0, { timeout: 120000 });
 	await autosaveStarted;
 	await expect(

--- a/packages/playground/website/playwright/e2e/opfs.spec.ts
+++ b/packages/playground/website/playwright/e2e/opfs.spec.ts
@@ -1263,18 +1263,16 @@ test('should close the pane, reveal the site, and finish during a ZIP import', a
 	const autosaveStarted = expect(autosaveProgress).toBeVisible({
 		timeout: 120000,
 	});
-	const importProgressAdvanced = website.page.waitForFunction(
-		() =>
-			Number(
-				document
-					.querySelector(
-						'[role="progressbar"][aria-label="WordPress import progress"]'
-					)
-					?.getAttribute('aria-valuenow')
-			) > 0,
-		undefined,
-		{ timeout: 120000 }
-	);
+	const importProgressAdvanced = expect
+		.poll(
+			async () =>
+				Number(await importProgress.getAttribute('aria-valuenow')),
+			{
+				intervals: [16],
+				timeout: 120000,
+			}
+		)
+		.toBeGreaterThan(0);
 	await fileInput.setInputFiles({
 		name: 'playground-export-with-plugin-and-theme.zip',
 		mimeType: 'application/zip',
@@ -1282,11 +1280,9 @@ test('should close the pane, reveal the site, and finish during a ZIP import', a
 	});
 	await expect(pane).not.toBeVisible();
 	await loadingStarted;
-	await expect(importProgress).toHaveAttribute(
-		'aria-valuetext',
-		'Starting import, 0%',
-		{ timeout: 120000 }
-	);
+	await expect(importProgress).toHaveAttribute('aria-valuenow', '0', {
+		timeout: 120000,
+	});
 	await expect(autosaveProgress).toHaveCount(0);
 	await importProgressAdvanced;
 	await expect(loading).not.toBeVisible({ timeout: 120000 });

--- a/packages/playground/website/playwright/e2e/opfs.spec.ts
+++ b/packages/playground/website/playwright/e2e/opfs.spec.ts
@@ -92,6 +92,15 @@ Theme Name: Close Race Theme
 			'wp-content/themes/close-race-theme/index.php'
 		),
 	];
+	const progressFileContents = new Uint8Array(8 * 1024);
+	for (let index = 0; index < 5000; index++) {
+		files.push(
+			new File(
+				[progressFileContents],
+				`wp-content/uploads/import-progress-${index}.bin`
+			)
+		);
+	}
 	const zipStream = encodeZip(files);
 	const zipBytes = await collectBytes(zipStream);
 	return Buffer.from(zipBytes!);
@@ -1250,42 +1259,46 @@ test('should close the pane, reveal the site, and finish during a ZIP import', a
 	const pane = website.page.getByRole('dialog', {
 		name: 'New Playground pane',
 	});
-	const loading = website.page.getByRole('heading', {
-		name: 'Preparing WordPress',
-	});
 	const importProgress = website.page.getByRole('progressbar', {
 		name: 'WordPress import progress',
 	});
 	const autosaveProgress = website.page.getByRole('progressbar', {
 		name: 'Autosave progress',
 	});
-	const loadingStarted = expect(loading).toBeVisible({ timeout: 120000 });
+	const importProgressStarted = expect(importProgress).toBeVisible({
+		timeout: 120000,
+	});
 	const autosaveStarted = expect(autosaveProgress).toBeVisible({
 		timeout: 120000,
 	});
-	const importProgressAdvanced = expect
+	const unpackingProgressAdvanced = expect
 		.poll(
-			async () =>
-				Number(await importProgress.getAttribute('aria-valuenow')),
+			async () => {
+				const value = Number(
+					await importProgress.getAttribute('aria-valuenow')
+				);
+				const text =
+					await importProgress.getAttribute('aria-valuetext');
+				return (
+					text?.startsWith('Unpacking archive') === true && value > 0
+				);
+			},
 			{
 				intervals: [16],
 				timeout: 120000,
 			}
 		)
-		.toBeGreaterThan(0);
+		.toBe(true);
 	await fileInput.setInputFiles({
 		name: 'playground-export-with-plugin-and-theme.zip',
 		mimeType: 'application/zip',
 		buffer: zipBuffer,
 	});
 	await expect(pane).not.toBeVisible();
-	await loadingStarted;
-	await expect(importProgress).toHaveAttribute('aria-valuenow', '0', {
-		timeout: 120000,
-	});
+	await importProgressStarted;
 	await expect(autosaveProgress).toHaveCount(0);
-	await importProgressAdvanced;
-	await expect(loading).not.toBeVisible({ timeout: 120000 });
+	await unpackingProgressAdvanced;
+	await expect(importProgress).toHaveCount(0, { timeout: 120000 });
 	await autosaveStarted;
 	await expect(
 		website.page.locator('iframe.playground-viewport:visible')

--- a/packages/playground/website/playwright/e2e/opfs.spec.ts
+++ b/packages/playground/website/playwright/e2e/opfs.spec.ts
@@ -1253,6 +1253,9 @@ test('should close the pane, reveal the site, and finish during a ZIP import', a
 	const loading = website.page.getByRole('heading', {
 		name: 'Preparing WordPress',
 	});
+	const importProgress = website.page.getByRole('progressbar', {
+		name: 'WordPress import progress',
+	});
 	const autosaveProgress = website.page.getByRole('progressbar', {
 		name: 'Autosave progress',
 	});
@@ -1260,6 +1263,18 @@ test('should close the pane, reveal the site, and finish during a ZIP import', a
 	const autosaveStarted = expect(autosaveProgress).toBeVisible({
 		timeout: 120000,
 	});
+	const importProgressAdvanced = website.page.waitForFunction(
+		() =>
+			Number(
+				document
+					.querySelector(
+						'[role="progressbar"][aria-label="WordPress import progress"]'
+					)
+					?.getAttribute('aria-valuenow')
+			) > 0,
+		undefined,
+		{ timeout: 120000 }
+	);
 	await fileInput.setInputFiles({
 		name: 'playground-export-with-plugin-and-theme.zip',
 		mimeType: 'application/zip',
@@ -1267,7 +1282,13 @@ test('should close the pane, reveal the site, and finish during a ZIP import', a
 	});
 	await expect(pane).not.toBeVisible();
 	await loadingStarted;
+	await expect(importProgress).toHaveAttribute(
+		'aria-valuetext',
+		'Starting import, 0%',
+		{ timeout: 120000 }
+	);
 	await expect(autosaveProgress).toHaveCount(0);
+	await importProgressAdvanced;
 	await expect(loading).not.toBeVisible({ timeout: 120000 });
 	await autosaveStarted;
 	await expect(

--- a/packages/playground/website/src/components/browser-chrome/save-status-indicator.tsx
+++ b/packages/playground/website/src/components/browser-chrome/save-status-indicator.tsx
@@ -52,8 +52,8 @@ export function SaveStatusIndicator({
 	disabled?: boolean;
 }) {
 	const clientInfo = useAppSelector(getActiveClientInfo);
-	const siteImportIsRunning = useAppSelector(
-		(state) => state.ui.siteImportIsRunning
+	const siteImportProgress = useAppSelector(
+		(state) => state.ui.siteImportProgress
 	);
 	const activeSite = useActiveSite();
 	const dispatch = useAppDispatch();
@@ -65,7 +65,7 @@ export function SaveStatusIndicator({
 	const [statusAnnouncement, setStatusAnnouncement] = useState('');
 
 	const opfsSync = clientInfo?.opfsSync;
-	const status = siteImportIsRunning
+	const status = siteImportProgress
 		? 'loading'
 		: getSaveStatus(activeSite, clientInfo);
 	const siteSlug = activeSite?.slug;

--- a/packages/playground/website/src/components/playground-viewport/index.tsx
+++ b/packages/playground/website/src/components/playground-viewport/index.tsx
@@ -135,19 +135,10 @@ export const KeepAliveTemporarySitesViewport = () => {
 	const hasVisibleSite = !!slugsSeenSoFar.find(
 		(slug) => slug === activeSite?.slug
 	);
-	const siteImportProgressIsDeterminate =
-		!!siteImportProgress && siteImportProgress.progress > 0;
 
 	const sitesFinishedLoading = useAppSelector(selectSitesLoaded);
 	if (!sitesFinishedLoading) {
-		return (
-			<div className={css.loadingViewport}>
-				<h1 className={css.loadingCaption}>Loading Playgrounds</h1>
-				<div className={css.progressWrapper}>
-					<div className={css.progressBar} />
-				</div>
-			</div>
-		);
+		return <LoadingViewport caption="Loading Playgrounds" />;
 	}
 
 	return (
@@ -171,53 +162,12 @@ export const KeepAliveTemporarySitesViewport = () => {
 				</div>
 			)}
 			{(!hasVisibleSite || siteImportProgress) && (
-				<div className={css.loadingViewport}>
-					<h1 className={css.loadingCaption}>
-						{siteImportProgress?.caption ?? 'Preparing WordPress'}
-					</h1>
-					<div
-						className={classNames(css.progressWrapper, {
-							[css.progressWrapperDeterminate]:
-								siteImportProgressIsDeterminate,
-						})}
-						aria-label={
-							siteImportProgress
-								? 'WordPress import progress'
-								: 'WordPress loading progress'
-						}
-						aria-valuemax={100}
-						aria-valuemin={0}
-						aria-valuenow={
-							siteImportProgressIsDeterminate
-								? Math.round(siteImportProgress.progress)
-								: undefined
-						}
-						aria-valuetext={
-							siteImportProgress
-								? siteImportProgressIsDeterminate
-									? `${siteImportProgress.caption}, ${Math.round(
-											siteImportProgress.progress
-										)}%`
-									: siteImportProgress.caption
-								: undefined
-						}
-						role="progressbar"
-					>
-						<div
-							className={classNames(css.progressBar, {
-								[css.progressBarDeterminate]:
-									siteImportProgressIsDeterminate,
-							})}
-							style={
-								siteImportProgressIsDeterminate
-									? {
-											width: `${siteImportProgress.progress}%`,
-										}
-									: undefined
-							}
-						/>
-					</div>
-				</div>
+				<LoadingViewport
+					caption={
+						siteImportProgress?.caption ?? 'Preparing WordPress'
+					}
+					progress={siteImportProgress?.progress}
+				/>
 			)}
 			{slugsSeenSoFar.map((slug) => {
 				const site = sitesBySlug.get(slug);
@@ -242,6 +192,49 @@ export const KeepAliveTemporarySitesViewport = () => {
 		</>
 	);
 };
+
+function LoadingViewport({
+	caption,
+	progress,
+}: {
+	caption: string;
+	progress?: number;
+}) {
+	const progressPercent =
+		progress !== undefined && progress > 0
+			? Math.round(progress)
+			: undefined;
+
+	return (
+		<div className={css.loadingViewport}>
+			<h1 className={css.loadingCaption}>{caption}</h1>
+			<div
+				className={css.progressWrapper}
+				aria-label={
+					progress === undefined
+						? 'WordPress loading progress'
+						: 'WordPress import progress'
+				}
+				aria-valuemax={100}
+				aria-valuemin={0}
+				aria-valuenow={progressPercent}
+				aria-valuetext={
+					progressPercent === undefined
+						? caption
+						: `${caption}, ${progressPercent}%`
+				}
+				role="progressbar"
+				style={
+					{
+						'--loading-progress': `${progress ?? 0}%`,
+					} as React.CSSProperties
+				}
+			>
+				<div className={css.progressBar} />
+			</div>
+		</div>
+	);
+}
 
 export const JustViewport = function JustViewport({
 	siteSlug,

--- a/packages/playground/website/src/components/playground-viewport/index.tsx
+++ b/packages/playground/website/src/components/playground-viewport/index.tsx
@@ -63,8 +63,8 @@ export const KeepAliveTemporarySitesViewport = () => {
 	const activeSiteSlugIsSet = useAppSelector(
 		(state) => !!state.ui.activeSite?.slug
 	);
-	const siteImportIsRunning = useAppSelector(
-		(state) => state.ui.siteImportIsRunning
+	const siteImportProgress = useAppSelector(
+		(state) => state.ui.siteImportProgress
 	);
 	const siteSlugsToRender = useMemo(() => {
 		let sites = temporarySites.filter(
@@ -168,12 +168,57 @@ export const KeepAliveTemporarySitesViewport = () => {
 					</div>
 				</div>
 			)}
-			{(!hasVisibleSite || siteImportIsRunning) && (
+			{(!hasVisibleSite || siteImportProgress) && (
 				<div className={css.loadingViewport}>
 					<h1 className={css.loadingCaption}>Preparing WordPress</h1>
-					<div className={css.progressWrapper}>
-						<div className={css.progressBar} />
+					<div
+						className={classNames(css.progressWrapper, {
+							[css.progressWrapperDeterminate]:
+								!!siteImportProgress,
+						})}
+						aria-label={
+							siteImportProgress
+								? 'WordPress import progress'
+								: 'WordPress loading progress'
+						}
+						aria-valuemax={100}
+						aria-valuemin={0}
+						aria-valuenow={
+							siteImportProgress
+								? Math.round(siteImportProgress.progress)
+								: undefined
+						}
+						aria-valuetext={
+							siteImportProgress
+								? `${siteImportProgress.caption}, ${Math.round(
+										siteImportProgress.progress
+									)}%`
+								: undefined
+						}
+						role="progressbar"
+					>
+						<div
+							className={classNames(css.progressBar, {
+								[css.progressBarDeterminate]:
+									!!siteImportProgress,
+							})}
+							style={
+								siteImportProgress
+									? {
+											width: `${siteImportProgress.progress}%`,
+										}
+									: undefined
+							}
+						/>
 					</div>
+					{siteImportProgress && (
+						<div className={css.progressDetails}>
+							<span>{siteImportProgress.caption}</span>
+							<span>
+								{Math.round(siteImportProgress.progress)}%
+							</span>
+						</div>
+					)}
 				</div>
 			)}
 			{slugsSeenSoFar.map((slug) => {
@@ -187,7 +232,7 @@ export const KeepAliveTemporarySitesViewport = () => {
 						className={classNames(css.fullSize, {
 							[css.hidden]:
 								slug !== activeSite?.slug ||
-								siteImportIsRunning,
+								!!siteImportProgress,
 						})}
 					>
 						{siteSlugsToRender.includes(slug) ? (

--- a/packages/playground/website/src/components/playground-viewport/index.tsx
+++ b/packages/playground/website/src/components/playground-viewport/index.tsx
@@ -170,7 +170,9 @@ export const KeepAliveTemporarySitesViewport = () => {
 			)}
 			{(!hasVisibleSite || siteImportProgress) && (
 				<div className={css.loadingViewport}>
-					<h1 className={css.loadingCaption}>Preparing WordPress</h1>
+					<h1 className={css.loadingCaption}>
+						{siteImportProgress?.caption ?? 'Preparing WordPress'}
+					</h1>
 					<div
 						className={classNames(css.progressWrapper, {
 							[css.progressWrapperDeterminate]:
@@ -211,14 +213,6 @@ export const KeepAliveTemporarySitesViewport = () => {
 							}
 						/>
 					</div>
-					{siteImportProgress && (
-						<div className={css.progressDetails}>
-							<span>{siteImportProgress.caption}</span>
-							<span>
-								{Math.round(siteImportProgress.progress)}%
-							</span>
-						</div>
-					)}
 				</div>
 			)}
 			{slugsSeenSoFar.map((slug) => {

--- a/packages/playground/website/src/components/playground-viewport/index.tsx
+++ b/packages/playground/website/src/components/playground-viewport/index.tsx
@@ -135,6 +135,8 @@ export const KeepAliveTemporarySitesViewport = () => {
 	const hasVisibleSite = !!slugsSeenSoFar.find(
 		(slug) => slug === activeSite?.slug
 	);
+	const siteImportProgressIsDeterminate =
+		!!siteImportProgress && siteImportProgress.progress > 0;
 
 	const sitesFinishedLoading = useAppSelector(selectSitesLoaded);
 	if (!sitesFinishedLoading) {
@@ -176,7 +178,7 @@ export const KeepAliveTemporarySitesViewport = () => {
 					<div
 						className={classNames(css.progressWrapper, {
 							[css.progressWrapperDeterminate]:
-								!!siteImportProgress,
+								siteImportProgressIsDeterminate,
 						})}
 						aria-label={
 							siteImportProgress
@@ -186,15 +188,17 @@ export const KeepAliveTemporarySitesViewport = () => {
 						aria-valuemax={100}
 						aria-valuemin={0}
 						aria-valuenow={
-							siteImportProgress
+							siteImportProgressIsDeterminate
 								? Math.round(siteImportProgress.progress)
 								: undefined
 						}
 						aria-valuetext={
 							siteImportProgress
-								? `${siteImportProgress.caption}, ${Math.round(
-										siteImportProgress.progress
-									)}%`
+								? siteImportProgressIsDeterminate
+									? `${siteImportProgress.caption}, ${Math.round(
+											siteImportProgress.progress
+										)}%`
+									: siteImportProgress.caption
 								: undefined
 						}
 						role="progressbar"
@@ -202,10 +206,10 @@ export const KeepAliveTemporarySitesViewport = () => {
 						<div
 							className={classNames(css.progressBar, {
 								[css.progressBarDeterminate]:
-									!!siteImportProgress,
+									siteImportProgressIsDeterminate,
 							})}
 							style={
-								siteImportProgress
+								siteImportProgressIsDeterminate
 									? {
 											width: `${siteImportProgress.progress}%`,
 										}

--- a/packages/playground/website/src/components/playground-viewport/style.module.css
+++ b/packages/playground/website/src/components/playground-viewport/style.module.css
@@ -71,7 +71,7 @@
 	transform: translateX(-100%);
 }
 
-.progress-wrapper-determinate::after {
+.progress-wrapper[aria-valuenow]::after {
 	display: none;
 }
 
@@ -109,8 +109,9 @@
 	animation: indefinite-loading 2s linear infinite;
 }
 
-.progress-bar-determinate {
+.progress-wrapper[aria-valuenow] .progress-bar {
 	right: auto;
+	width: var(--loading-progress);
 	animation: none;
 	transition: width 150ms ease-out;
 }
@@ -150,7 +151,7 @@
 		animation: none;
 	}
 
-	.progress-bar-determinate {
+	.progress-wrapper[aria-valuenow] .progress-bar {
 		transition: none;
 	}
 }

--- a/packages/playground/website/src/components/playground-viewport/style.module.css
+++ b/packages/playground/website/src/components/playground-viewport/style.module.css
@@ -71,6 +71,22 @@
 	transform: translateX(-100%);
 }
 
+.progress-wrapper-determinate::after {
+	display: none;
+}
+
+.progress-details {
+	display: flex;
+	justify-content: space-between;
+	width: calc(100% - 48px);
+	max-width: 420px;
+	margin-top: 8px;
+	color: #646970;
+	font-family: -apple-system, BlinkMacSystemFont, sans-serif;
+	font-size: 12px;
+	line-height: 1.4;
+}
+
 @media (prefers-color-scheme: dark) {
 	.loading-viewport {
 		background: #1e1e1e;
@@ -78,6 +94,10 @@
 
 	.loading-caption {
 		color: #fff;
+	}
+
+	.progress-details {
+		color: #a7aaad;
 	}
 
 	.progress-wrapper {
@@ -103,6 +123,12 @@
 	background: linear-gradient(90deg, #3858e9 0%, #6f7dff 100%);
 	border-radius: inherit;
 	animation: indefinite-loading 2s linear infinite;
+}
+
+.progress-bar-determinate {
+	right: auto;
+	animation: none;
+	transition: width 150ms ease-out;
 }
 
 @keyframes track-shimmer {
@@ -138,5 +164,9 @@
 	.progress-wrapper::after,
 	.progress-bar {
 		animation: none;
+	}
+
+	.progress-bar-determinate {
+		transition: none;
 	}
 }

--- a/packages/playground/website/src/components/playground-viewport/style.module.css
+++ b/packages/playground/website/src/components/playground-viewport/style.module.css
@@ -75,18 +75,6 @@
 	display: none;
 }
 
-.progress-details {
-	display: flex;
-	justify-content: space-between;
-	width: calc(100% - 48px);
-	max-width: 420px;
-	margin-top: 8px;
-	color: #646970;
-	font-family: -apple-system, BlinkMacSystemFont, sans-serif;
-	font-size: 12px;
-	line-height: 1.4;
-}
-
 @media (prefers-color-scheme: dark) {
 	.loading-viewport {
 		background: #1e1e1e;
@@ -94,10 +82,6 @@
 
 	.loading-caption {
 		color: #fff;
-	}
-
-	.progress-details {
-		color: #a7aaad;
 	}
 
 	.progress-wrapper {

--- a/packages/playground/website/src/lib/state/redux/site-management-api-middleware.ts
+++ b/packages/playground/website/src/lib/state/redux/site-management-api-middleware.ts
@@ -10,7 +10,7 @@ import {
 	useAppDispatch,
 } from './store';
 import type { SerializedSiteErrorDetails, SiteError } from './slice-ui';
-import { setActiveSiteError, setSiteImportIsRunning } from './slice-ui';
+import { setActiveSiteError, setSiteImportProgress } from './slice-ui';
 import {
 	addClientInfo,
 	removeClientInfo,
@@ -845,7 +845,12 @@ export function createSitesAPI(
 			wordPressFilesZip: File,
 			onProgress?: (progress: ZipImportProgress) => void
 		): Promise<string> {
-			dispatch(setSiteImportIsRunning(true));
+			dispatch(
+				setSiteImportProgress({
+					caption: 'Starting import',
+					progress: 0,
+				})
+			);
 			try {
 				const tracker = new ProgressTracker();
 				const importWeight = opfsSiteStorage
@@ -854,10 +859,12 @@ export function createSitesAPI(
 				tracker.addEventListener(
 					'progress',
 					(event: ProgressTrackerEvent) => {
-						onProgress?.({
+						const progress = {
 							caption: event.detail.caption,
 							progress: event.detail.progress * importWeight,
-						});
+						};
+						dispatch(setSiteImportProgress(progress));
+						onProgress?.(progress);
 					}
 				);
 				const initialOpfsSyncProgress = opfsSiteStorage
@@ -889,7 +896,7 @@ export function createSitesAPI(
 					});
 					// The imported page is ready. Reveal it while createSavedSite waits
 					// for the initial OPFS autosave to finish.
-					dispatch(setSiteImportIsRunning(false));
+					dispatch(setSiteImportProgress(undefined));
 				};
 				if (!opfsSiteStorage) {
 					return await createTemporarySite(
@@ -908,7 +915,7 @@ export function createSitesAPI(
 				onProgress?.({ caption: 'Import complete', progress: 100 });
 				return siteSlug;
 			} finally {
-				dispatch(setSiteImportIsRunning(false));
+				dispatch(setSiteImportProgress(undefined));
 			}
 		},
 	};

--- a/packages/playground/website/src/lib/state/redux/slice-ui.ts
+++ b/packages/playground/website/src/lib/state/redux/slice-ui.ts
@@ -1,5 +1,6 @@
 import type { PayloadAction, Middleware } from '@reduxjs/toolkit';
 import { createSlice } from '@reduxjs/toolkit';
+import type { ProgressDetails } from '@php-wasm/progress';
 import { BlueprintStepExecutionError } from '@wp-playground/blueprints';
 import { BREAKPOINTS } from '../../constants/breakpoints';
 
@@ -172,7 +173,7 @@ export interface UIState {
 	githubAuthRepoUrl?: string;
 	offline: boolean;
 	shareExportOpen: boolean;
-	siteImportIsRunning: boolean;
+	siteImportProgress?: ProgressDetails;
 	dockPaneIsOpen: boolean;
 	dockPaneSection: DockPaneSection;
 	/**
@@ -215,7 +216,6 @@ const initialState: UIState = {
 			: query.get('modal') || null,
 	offline: !navigator.onLine,
 	shareExportOpen: false,
-	siteImportIsRunning: false,
 	// NOTE: Please do not eliminate the cases in this dockPaneIsOpen expression,
 	// even if they seem redundant. We may experiment with toggling the Dock
 	// pane to be open by default or closed by default, and we do not want to
@@ -304,8 +304,11 @@ const uiSlice = createSlice({
 		setShareExportOpen: (state, action: PayloadAction<boolean>) => {
 			state.shareExportOpen = action.payload;
 		},
-		setSiteImportIsRunning: (state, action: PayloadAction<boolean>) => {
-			state.siteImportIsRunning = action.payload;
+		setSiteImportProgress: (
+			state,
+			action: PayloadAction<ProgressDetails | undefined>
+		) => {
+			state.siteImportProgress = action.payload;
 		},
 		setDockPaneSection: (state, action: PayloadAction<DockPaneSection>) => {
 			state.dockPaneSection = action.payload;
@@ -389,7 +392,7 @@ export const {
 	setGitHubAuthRepoUrl,
 	setOffline,
 	setShareExportOpen,
-	setSiteImportIsRunning,
+	setSiteImportProgress,
 	setDockPaneOpen,
 	setDockPaneSection,
 	setWriteOwnBlueprintDraft,


### PR DESCRIPTION
#4168 reports progress between `ZipArchive` extraction batches. The website
still discarded those details and showed the same indeterminate viewport for
the entire import.

This PR keeps that progress in Redux and renders it in the site viewport. The
bar remains animated until the first non-zero update, then becomes determinate
and shows `Extracting {processed}/{total}` as its only status line. Ordinary
boot and import progress use the same `LoadingViewport` rendering path.

PHP executes synchronously inside its worker, so `flush()` alone cannot deliver
a progress line until execution returns. On PHP 7+, `unzipFile()` yields after
the first and final updates and no more than once every 50 ms between them.
Extraction still uses only `ZipArchive`; this PR adds no file-transfer,
metadata-scanning, or alternate ZIP-extraction path.

| | Before | After |
| --- | --- | --- |
| Desktop | ![Indeterminate ZIP import loader on desktop](https://raw.githubusercontent.com/articles-adamziel-com/wordpress-playground/dd264da9c33266c59731047a8513654470a2028d/before-desktop.png) | ![ZIP extraction file count and determinate progress bar on desktop](https://raw.githubusercontent.com/articles-adamziel-com/wordpress-playground/d98da202ce8b6e8100614f7c5929d462d8fdce9e/pr4176-after-reduced-desktop.png) |
| Mobile | ![Indeterminate ZIP import loader on mobile](https://raw.githubusercontent.com/articles-adamziel-com/wordpress-playground/dd264da9c33266c59731047a8513654470a2028d/before-mobile.png) | ![ZIP extraction file count and determinate progress bar on mobile](https://raw.githubusercontent.com/articles-adamziel-com/wordpress-playground/d98da202ce8b6e8100614f7c5929d462d8fdce9e/pr4176-after-reduced-mobile.png) |

## Testing

Open the website without `storage=temp` and import a ZIP containing thousands
of entries. Confirm the viewport changes from an animated bar to
`Extracting {processed}/{total}` with a determinate bar, then opens the imported
site. Reload and confirm the saved site remains available.
