### PR TITLE
[Website] Start a fresh Playground after interrupted OPFS sync

### DIFF
--- a/packages/playground/website/playwright/e2e/opfs.spec.ts
+++ b/packages/playground/website/playwright/e2e/opfs.spec.ts
@@ -276,6 +276,65 @@ async function writePendingOpfsResetSite(page: Page, slug: string) {
 	);
 }
 
+/**
+ * Writes the OPFS state left when a site's first WordPress file copy stops.
+ *
+ * The metadata exists, but `initialOpfsSyncPending` still marks the WordPress
+ * files as incomplete.
+ */
+async function writeInterruptedInitialOpfsSite(page: Page, slug: string) {
+	await page.evaluate(
+		async ({ dirName, siteSlug }) => {
+			const root = await navigator.storage.getDirectory();
+			try {
+				await root.removeEntry('sites', { recursive: true });
+			} catch (error) {
+				if (error?.name !== 'NotFoundError') {
+					throw error;
+				}
+			}
+			const sites = await root.getDirectoryHandle('sites', {
+				create: true,
+			});
+			const siteDirectory = await sites.getDirectoryHandle(dirName, {
+				create: true,
+			});
+			const metadata = {
+				slug: siteSlug,
+				originalUrlParams: {
+					searchParams: {},
+					hash: '',
+				},
+				originalBlueprintSource: { type: 'none' },
+				originalBlueprint: {},
+				name: siteSlug,
+				id: siteSlug,
+				whenCreated: Date.now(),
+				whenLastUsed: Date.now(),
+				persistence: 'autosave',
+				storage: 'opfs',
+				initialOpfsSyncPending: true,
+				runtimeConfiguration: {
+					phpVersion: '8.4',
+					wpVersion: 'latest',
+					intl: false,
+					networking: true,
+					extraLibraries: [],
+					constants: {},
+				},
+			};
+			const metadataFile = await siteDirectory.getFileHandle(
+				'wp-runtime.json',
+				{ create: true }
+			);
+			const writable = await metadataFile.createWritable();
+			await writable.write(JSON.stringify(metadata, null, 2));
+			await writable.close();
+		},
+		{ dirName: getDirectoryNameForSlug(slug), siteSlug: slug }
+	);
+}
+
 async function readPendingResetSiteState(page: Page, slug: string) {
 	return await page.evaluate(
 		async ({ dirName }) => {
@@ -477,6 +536,42 @@ test('should retry pending OPFS cleanup after another tab releases storage', asy
 	const storedSite = await readPendingResetSiteState(website.page, slug);
 	expect(storedSite.metadata.opfsSiteRemovalPending).toBeUndefined();
 	expect(storedSite.hasOldResetSentinel).toBe(false);
+});
+
+test('should start a new Playground after an initial OPFS sync was interrupted', async ({
+	website,
+	browserName,
+}) => {
+	test.skip(
+		browserName !== 'chromium',
+		`This test relies on OPFS which isn't available in Playwright's flavor of ${browserName}.`
+	);
+
+	const interruptedSiteSlug = `interrupted-initial-sync-${Date.now()}`;
+	await website.page.goto(getTemporaryPlaygroundUrl());
+	await website.page.waitForFunction(() => !!navigator.storage?.getDirectory);
+	await writeInterruptedInitialOpfsSite(website.page, interruptedSiteSlug);
+
+	await website.page.goto(
+		`./?site-slug=${encodeURIComponent(interruptedSiteSlug)}`
+	);
+	await expect(
+		website.page.getByText('Start a new Playground to continue')
+	).toBeVisible();
+
+	await website.page
+		.getByRole('button', { name: 'Start a new Playground' })
+		.click();
+
+	await expect
+		.poll(async () => (await getActivePlaygroundSite(website.page))?.slug, {
+			timeout: 15000,
+		})
+		.not.toBe(interruptedSiteSlug);
+	await expect(
+		website.page.getByText('Start a new Playground to continue')
+	).not.toBeVisible();
+	await website.waitForNestedIframes();
 });
 
 test('should switch between sites', async ({ website, browserName }) => {

--- a/packages/playground/website/src/components/ensure-playground-site/ensure-playground-site-is-selected.tsx
+++ b/packages/playground/website/src/components/ensure-playground-site/ensure-playground-site-is-selected.tsx
@@ -214,11 +214,20 @@ export function EnsurePlaygroundSiteIsSelected({
 			if (shouldUseTemporarySite) {
 				await sitesAPI.createNewTemporarySite();
 			} else {
-				// A matching autosave may already be waiting for its first OPFS
-				// sync. Keep it selected instead of creating a duplicate for the
-				// same setup URL.
+				// `initialOpfsSyncPending` describes two different situations:
+				//
+				// 1. A site created in this tab is still copying WordPress files
+				//    into OPFS. If this effect runs again before the copy finishes,
+				//    keep that site active instead of creating a duplicate.
+				// 2. A site loaded from OPFS still has the flag because an earlier
+				//    tab closed or reloaded during the copy. That site is incomplete
+				//    and cannot boot. For example, "Start a new Playground" must be
+				//    allowed to create a different site instead of keeping it active.
+				//
+				// `loadedFromStorage` distinguishes the interrupted second case.
 				if (
 					activeSite &&
+					activeSite.loadedFromStorage !== true &&
 					isAutosavedSite(activeSite) &&
 					activeSite.metadata.initialOpfsSyncPending &&
 					getAutosaveFingerprintFromSite(activeSite) ===


### PR DESCRIPTION
An interrupted initial OPFS copy leaves a stored site with `initialOpfsSyncPending`. The **Start a new Playground** action changed the URL, but site selection treated the broken stored site like an in-progress autosave created in the current tab and kept it active.

Only pending autosaves created in the current tab are now reused. Pending autosaves loaded from OPFS let new-site navigation continue.

## Testing

Recreate an interrupted initial browser-storage copy, click **Start a new Playground**, and confirm a different Playground boots.
