### PR TITLE
[PHP-WASM] Route Window APIs through dedicated MessagePorts

### DIFF
--- a/packages/php-wasm/universal/src/lib/api.ts
+++ b/packages/php-wasm/universal/src/lib/api.ts
@@ -127,9 +127,18 @@ export function consumeAPI<APIType>(
 }
 
 /**
- * Uses the observable Window channel only to bootstrap a point-to-point port.
- * Waiting for `isConnected()` first matters because `consumeAPI()` may run before
- * the remote Window has installed its Comlink listener.
+ * Moves a Window-backed API onto a point-to-point MessagePort.
+ *
+ * Unlike Worker messages, Window messages are visible to the application's main
+ * world and to browser-extension isolated worlds. In Chromium, an isolated-world
+ * listener that evaluates `event.data` first can take ownership of a transferred
+ * ReadableStream before Comlink receives it. Evernote Web Clipper 7.41.1 exposed
+ * this by leaving the parent-side `runStream()` call pending during a ZIP import.
+ *
+ * The Window message used here transfers only Comlink's endpoint port. Later API
+ * calls and streams use that port, where unrelated Window listeners cannot
+ * observe them. The handshake is retried because `consumeAPI()` may run before
+ * the remote Window installs its Comlink listener.
  */
 async function connectWindowApiThroughMessagePort(
 	bootstrapApi: Remote<WithAPIState> & ProxyMethods
@@ -146,8 +155,12 @@ async function connectWindowApiThroughMessagePort(
 }
 
 /**
- * `consumeAPI()` returns synchronously, while the MessagePort handshake is
- * asynchronous. Buffer the Comlink endpoint operations until that port arrives.
+ * Adapts the asynchronous MessagePort handshake to `consumeAPI()`'s synchronous
+ * return type.
+ *
+ * Comlink starts registering listeners and posting requests immediately. Buffer
+ * those operations until the port arrives, then attach and start the listeners
+ * before replaying requests so no response can arrive without a listener.
  */
 function deferredEndpoint(portPromise: Promise<MessagePort>): Endpoint {
 	let port: MessagePort | undefined;
@@ -548,60 +561,8 @@ function setupTransferHandlers() {
 // Utilities for transferring ReadableStreams and Promises via MessagePorts:
 
 /**
- * Detects whether this runtime can transfer a ReadableStream directly.
- *
- * A `StreamedPHPResponse` reaches the website through two message boundaries:
- *
- * 1. The PHP worker sends the response to `remote.html` with
- *    `Worker.postMessage()`.
- * 2. `remote.html` re-exposes that response to the website parent through
- *    Comlink's Window endpoint, which uses `Window.postMessage()`.
- *
- * The worker boundary is point-to-point: its message has one destination global.
- * Browser-extension content scripts run in isolated Window worlds attached to
- * documents, not inside that worker, so they do not observe this first message.
- *
- * The Window boundary has a different shape. Chromium documents may contain the
- * application's main world and isolated worlds created for browser-extension
- * content scripts. Listeners in all of those worlds can observe the same Window
- * messages. A normal structured-clone value can be materialized independently in
- * each world. A ReadableStream cannot because transferring it moves the stream
- * instead of cloning it.
- *
- * Chromium 150 resolves that conflict according to listener order. Its Window
- * message data is materialized lazily for each execution world. If an isolated-
- * world listener runs first and evaluates `event.data`, the transferred stream is
- * materialized in that world. The application listener is then never invoked;
- * Chromium does not dispatch a `messageerror` either. A minimal reproduction
- * confirmed the ownership transfer by reading the stream contents from the
- * extension while the application timed out. If the application listener was
- * registered first, the same transfer completed there instead.
- *
- * Evernote Web Clipper 7.41.1 exposed this ordering in Playground. It injects a
- * content script into the parent page and registers a `message` listener that
- * evaluates `event.data` in a `switch`. When that listener was registered before
- * Playground's Comlink listener, it received the transferred response streams.
- * The parent-side `runStream()` promise never resolved.
- *
- * This happened immediately after a ZIP had crossed into PHP in 16 MiB chunks.
- * The next operation, the streamed ZIP-metadata scan, waited for `runStream()`.
- * The UI therefore kept its last completed update, `Reading archive, 45%`, and
- * never received the first `Inspecting archive` update. The exact same saved-site
- * profile completed when the extension was absent, as in private browsing, and
- * when the Window boundary used MessagePorts.
- *
- * Listener order is not a usable safeguard. An extension may register at
- * `document_start`, before any application script. Instead, `consumeAPI()` uses
- * the Window channel only to request a dedicated MessagePort from Comlink. That
- * bootstrap message contains no streams, and Chromium delivers the transferred
- * port even when an extension reads `event.data` first. Every subsequent API
- * message travels through the point-to-point port, where unrelated Window
- * listeners cannot observe it. ReadableStreams can therefore remain directly
- * transferable across both the worker and parent-page boundaries.
- *
- * The capability probe below uses a MessageChannel because all stream-bearing API
- * messages use a Worker or MessagePort endpoint. Safari rejects the probe and
- * uses the existing `chunk`, `close`, `error`, and `cancel` port-message fallback.
+ * Safari does not support transferable streams. Use the MessagePort bridge when
+ * this point-to-point capability probe fails.
  */
 let _cachedSupportsTransferableStreams: boolean | undefined;
 function supportsTransferableStreams(): boolean {

--- a/packages/php-wasm/universal/src/lib/api.ts
+++ b/packages/php-wasm/universal/src/lib/api.ts
@@ -130,10 +130,10 @@ export function consumeAPI<APIType>(
  * Moves a Window-backed API onto a point-to-point MessagePort.
  *
  * Unlike Worker messages, Window messages are visible to the application's main
- * world and to browser-extension isolated worlds. In Chromium, an isolated-world
+ * world and to browser-extension isolated worlds. In Chromium, a browser extension
  * listener that evaluates `event.data` first can take ownership of a transferred
- * ReadableStream before Comlink receives it. Evernote Web Clipper 7.41.1 exposed
- * this by leaving the parent-side `runStream()` call pending during a ZIP import.
+ * ReadableStream before Comlink receives it. Evernote Web Clipper 7.41.1 is one
+ * such extension.
  *
  * The Window message used here transfers only Comlink's endpoint port. Later API
  * calls and streams use that port, where unrelated Window listeners cannot

--- a/packages/php-wasm/universal/src/lib/api.ts
+++ b/packages/php-wasm/universal/src/lib/api.ts
@@ -137,12 +137,12 @@ async function connectWindowApiThroughMessagePort(
 	while (true) {
 		try {
 			await runWithTimeout(bootstrapApi.isConnected(), 200);
-			break;
+			return await bootstrapApi[createEndpoint]();
 		} catch {
-			// The remote Window has not exposed its API yet.
+			// The remote Window has not exposed its API yet, or it changed
+			// before the endpoint request completed.
 		}
 	}
-	return bootstrapApi[createEndpoint]();
 }
 
 /**
@@ -229,8 +229,17 @@ async function runWithTimeout<T>(
 	timeout: number
 ): Promise<T> {
 	return new Promise<T>((resolve, reject) => {
-		setTimeout(reject, timeout);
-		promise.then(resolve);
+		const timeoutId = setTimeout(reject, timeout);
+		promise.then(
+			(value) => {
+				clearTimeout(timeoutId);
+				resolve(value);
+			},
+			(error) => {
+				clearTimeout(timeoutId);
+				reject(error);
+			}
+		);
 	});
 }
 

--- a/packages/php-wasm/universal/src/lib/api.ts
+++ b/packages/php-wasm/universal/src/lib/api.ts
@@ -7,6 +7,7 @@ import { PHPResponse, StreamedPHPResponse } from './php-response';
 import * as Comlink from './comlink-sync';
 import {
 	NodeSABSyncReceiveMessageTransport,
+	createEndpoint,
 	nodeEndpoint as nodeWorkerEndpoint,
 	releaseProxy,
 	type NodeEndpoint as NodeWorker,
@@ -77,11 +78,17 @@ export function consumeAPI<APIType>(
 				'consumeAPI: remote does not look like a Worker, MessagePort, or Process'
 			);
 		}
+	} else if (remote instanceof Worker) {
+		endpoint = remote;
 	} else {
-		endpoint =
-			remote instanceof Worker
-				? remote
-				: Comlink.windowEndpoint(remote as Window, context);
+		const windowEndpoint = Comlink.windowEndpoint(
+			remote as Window,
+			context
+		);
+		const bootstrapApi = Comlink.wrap<WithAPIState>(windowEndpoint);
+		endpoint = deferredEndpoint(
+			connectWindowApiThroughMessagePort(bootstrapApi)
+		);
 	}
 
 	/**
@@ -117,6 +124,104 @@ export function consumeAPI<APIType>(
 			return (api as any)[prop];
 		},
 	}) as unknown as RemoteAPI<APIType>;
+}
+
+/**
+ * Uses the observable Window channel only to bootstrap a point-to-point port.
+ * Waiting for `isConnected()` first matters because `consumeAPI()` may run before
+ * the remote Window has installed its Comlink listener.
+ */
+async function connectWindowApiThroughMessagePort(
+	bootstrapApi: Remote<WithAPIState> & ProxyMethods
+): Promise<MessagePort> {
+	while (true) {
+		try {
+			await runWithTimeout(bootstrapApi.isConnected(), 200);
+			break;
+		} catch {
+			// The remote Window has not exposed its API yet.
+		}
+	}
+	return bootstrapApi[createEndpoint]();
+}
+
+/**
+ * `consumeAPI()` returns synchronously, while the MessagePort handshake is
+ * asynchronous. Buffer the Comlink endpoint operations until that port arrives.
+ */
+function deferredEndpoint(portPromise: Promise<MessagePort>): Endpoint {
+	let port: MessagePort | undefined;
+	let shouldStart = false;
+	const listeners: Array<{
+		type: string;
+		listener: EventListenerOrEventListenerObject;
+		options?: object;
+	}> = [];
+	const messages: Array<{
+		message: unknown;
+		transfer?: Transferable[];
+	}> = [];
+
+	void portPromise.then((connectedPort) => {
+		port = connectedPort;
+		for (const { type, listener, options } of listeners) {
+			port.addEventListener(type, listener, options);
+		}
+		if (shouldStart) {
+			port.start();
+		}
+		for (const { message, transfer } of messages) {
+			if (transfer) {
+				port.postMessage(message, transfer);
+			} else {
+				port.postMessage(message);
+			}
+		}
+		messages.length = 0;
+	});
+
+	return {
+		postMessage(message, transfer) {
+			if (port) {
+				if (transfer) {
+					port.postMessage(message, transfer);
+				} else {
+					port.postMessage(message);
+				}
+			} else {
+				messages.push({ message, transfer });
+			}
+		},
+		addEventListener(type, listener, options) {
+			if (port) {
+				port.addEventListener(type, listener, options);
+			} else {
+				listeners.push({ type, listener, options });
+			}
+		},
+		removeEventListener(type, listener, options) {
+			if (port) {
+				port.removeEventListener(type, listener, options);
+				return;
+			}
+			const index = listeners.findIndex(
+				(entry) =>
+					entry.type === type &&
+					entry.listener === listener &&
+					entry.options === options
+			);
+			if (index !== -1) {
+				listeners.splice(index, 1);
+			}
+		},
+		start() {
+			if (port) {
+				port.start();
+			} else {
+				shouldStart = true;
+			}
+		},
+	};
 }
 
 async function runWithTimeout<T>(
@@ -434,11 +539,60 @@ function setupTransferHandlers() {
 // Utilities for transferring ReadableStreams and Promises via MessagePorts:
 
 /**
- * Safari does not support transferable streams, so we need to fallback to
- * MessagePorts.
- * Feature-detects whether this runtime supports transferring ReadableStreams
- * directly through postMessage (aka "transferable streams"). When false,
- * we must fall back to port-bridged streaming.
+ * Detects whether this runtime can transfer a ReadableStream directly.
+ *
+ * A `StreamedPHPResponse` reaches the website through two message boundaries:
+ *
+ * 1. The PHP worker sends the response to `remote.html` with
+ *    `Worker.postMessage()`.
+ * 2. `remote.html` re-exposes that response to the website parent through
+ *    Comlink's Window endpoint, which uses `Window.postMessage()`.
+ *
+ * The worker boundary is point-to-point: its message has one destination global.
+ * Browser-extension content scripts run in isolated Window worlds attached to
+ * documents, not inside that worker, so they do not observe this first message.
+ *
+ * The Window boundary has a different shape. Chromium documents may contain the
+ * application's main world and isolated worlds created for browser-extension
+ * content scripts. Listeners in all of those worlds can observe the same Window
+ * messages. A normal structured-clone value can be materialized independently in
+ * each world. A ReadableStream cannot because transferring it moves the stream
+ * instead of cloning it.
+ *
+ * Chromium 150 resolves that conflict according to listener order. Its Window
+ * message data is materialized lazily for each execution world. If an isolated-
+ * world listener runs first and evaluates `event.data`, the transferred stream is
+ * materialized in that world. The application listener is then never invoked;
+ * Chromium does not dispatch a `messageerror` either. A minimal reproduction
+ * confirmed the ownership transfer by reading the stream contents from the
+ * extension while the application timed out. If the application listener was
+ * registered first, the same transfer completed there instead.
+ *
+ * Evernote Web Clipper 7.41.1 exposed this ordering in Playground. It injects a
+ * content script into the parent page and registers a `message` listener that
+ * evaluates `event.data` in a `switch`. When that listener was registered before
+ * Playground's Comlink listener, it received the transferred response streams.
+ * The parent-side `runStream()` promise never resolved.
+ *
+ * This happened immediately after a ZIP had crossed into PHP in 16 MiB chunks.
+ * The next operation, the streamed ZIP-metadata scan, waited for `runStream()`.
+ * The UI therefore kept its last completed update, `Reading archive, 45%`, and
+ * never received the first `Inspecting archive` update. The exact same saved-site
+ * profile completed when the extension was absent, as in private browsing, and
+ * when the Window boundary used MessagePorts.
+ *
+ * Listener order is not a usable safeguard. An extension may register at
+ * `document_start`, before any application script. Instead, `consumeAPI()` uses
+ * the Window channel only to request a dedicated MessagePort from Comlink. That
+ * bootstrap message contains no streams, and Chromium delivers the transferred
+ * port even when an extension reads `event.data` first. Every subsequent API
+ * message travels through the point-to-point port, where unrelated Window
+ * listeners cannot observe it. ReadableStreams can therefore remain directly
+ * transferable across both the worker and parent-page boundaries.
+ *
+ * The capability probe below uses a MessageChannel because all stream-bearing API
+ * messages use a Worker or MessagePort endpoint. Safari rejects the probe and
+ * uses the existing `chunk`, `close`, `error`, and `cancel` port-message fallback.
  */
 let _cachedSupportsTransferableStreams: boolean | undefined;
 function supportsTransferableStreams(): boolean {

--- a/packages/php-wasm/web/src/test/playwright/window-api-frame.html
+++ b/packages/php-wasm/web/src/test/playwright/window-api-frame.html
@@ -1,0 +1,2 @@
+<!doctype html>
+<script type="module" src="./window-api-frame.ts"></script>

--- a/packages/php-wasm/web/src/test/playwright/window-api-frame.ts
+++ b/packages/php-wasm/web/src/test/playwright/window-api-frame.ts
@@ -1,0 +1,30 @@
+import { exposeAPI } from '@php-wasm/universal';
+
+const originalPostMessage = MessagePort.prototype.postMessage;
+let transferredReadableStream = false;
+MessagePort.prototype.postMessage = function (
+	message: unknown,
+	optionsOrTransfer?: StructuredSerializeOptions | Transferable[]
+) {
+	const transfer = Array.isArray(optionsOrTransfer)
+		? optionsOrTransfer
+		: (optionsOrTransfer?.transfer ?? []);
+	if (transfer.some((value) => value instanceof ReadableStream)) {
+		transferredReadableStream = true;
+	}
+	return originalPostMessage.call(
+		this,
+		message,
+		optionsOrTransfer as StructuredSerializeOptions
+	);
+};
+
+const [setReady] = exposeAPI({
+	getStream() {
+		return new Blob(['stream from iframe']).stream();
+	},
+	wasStreamTransferred() {
+		return transferredReadableStream;
+	},
+});
+setReady();

--- a/packages/php-wasm/web/src/test/readable-stream-transfer.spec.ts
+++ b/packages/php-wasm/web/src/test/readable-stream-transfer.spec.ts
@@ -1,11 +1,77 @@
 import test from '@playwright/test';
 
-test.describe('worker event stdin stream transfer', () => {
+test.describe('readable stream transfer', () => {
 	test.beforeEach(async ({ page }) => {
 		await page.goto('/');
 		await page.addScriptTag({
 			type: 'module',
 			url: '/src/test/playwright/browser-globals.ts',
+		});
+	});
+
+	test('keeps Window API streams away from isolated-world listeners', async ({
+		page,
+	}) => {
+		const cdp = await page.context().newCDPSession(page);
+		const frameTree = await cdp.send('Page.getFrameTree');
+		const isolatedWorld = await cdp.send('Page.createIsolatedWorld', {
+			frameId: frameTree.frameTree.frame.id,
+			worldName: 'window-stream-observer',
+		});
+		await cdp.send('Runtime.evaluate', {
+			contextId: isolatedWorld.executionContextId,
+			expression: `
+				window.addEventListener('message', (event) => {
+					void event.data;
+				});
+			`,
+		});
+
+		const result = await page.evaluate(async () => {
+			type WindowAPI = {
+				isReady(): Promise<void>;
+				getStream(): Promise<ReadableStream<Uint8Array>>;
+				wasStreamTransferred(): Promise<boolean>;
+			};
+
+			const iframe = document.createElement('iframe');
+			iframe.src = '/src/test/playwright/window-api-frame.html';
+			document.body.appendChild(iframe);
+
+			const withTimeout = <T>(promise: Promise<T>) =>
+				Promise.race([
+					promise,
+					new Promise<never>((_, reject) =>
+						setTimeout(
+							() =>
+								reject(
+									new Error(
+										'Window API stream did not arrive'
+									)
+								),
+							5000
+						)
+					),
+				]);
+
+			try {
+				const api = window.consumeAPI<WindowAPI>(iframe.contentWindow!);
+				await withTimeout(api.isReady());
+				const stream = await withTimeout(api.getStream());
+				return {
+					text: await withTimeout(new Response(stream).text()),
+					transferredReadableStream: await withTimeout(
+						api.wasStreamTransferred()
+					),
+				};
+			} finally {
+				iframe.remove();
+			}
+		});
+
+		test.expect(result).toEqual({
+			text: 'stream from iframe',
+			transferredReadableStream: true,
 		});
 	});
 


### PR DESCRIPTION
Window-backed `consumeAPI()` connections now use `Window.postMessage()` only
to request a dedicated Comlink `MessagePort`. Every later request and response
uses that point-to-point port.

## Background

Window messages fan out to the application's main world and browser-extension
isolated worlds. In Chromium 150, an isolated-world listener registered first
could evaluate `event.data` and receive a transferred `ReadableStream`. The
application listener was then skipped without receiving either `message` or
`messageerror`.

Evernote Web Clipper 7.41.1 triggered this path. Its content script evaluates
`event.data` in a `switch`. When `remote.html` returned a
`StreamedPHPResponse` containing headers, stdout, and stderr streams, Evernote's
listener ran before Playground's Comlink listener. The parent-side
`runStream()` promise never resolved.

The saved-site importer had already copied the uploaded ZIP into PHP. It then
waited for a streamed PHP response to scan the ZIP metadata, leaving the UI at
`Reading archive, 45%`.

## This change

The Window bootstrap message transfers only Comlink's endpoint port. Later API
messages, including transferred streams, travel through that port and are not
visible to unrelated Window listeners. Chromium retains native stream transfer;
Safari retains the existing MessagePort chunk protocol when its capability
probe fails.

The browser regression test creates a Chromium isolated world, installs its
listener first, and confirms that an iframe API stream still arrives through a
native MessagePort transfer.

#4176 is stacked on this PR and adds measured ZIP-import progress.

## Testing

Import a large saved Playground with Evernote Web Clipper enabled and several
other Playgrounds already stored in the browser. Confirm that the import
continues past `Reading archive` and survives a reload.

With 11 saved Playgrounds in the tested profile, a 135.9 MiB OPFS export
completed in 15.2 seconds. Its 134,217,728-byte file and PHP marker remained
after reload.
