### PR TITLE
[Website] Keep the ZIP drop overlay active over frames

### DIFF
--- a/packages/playground/website/playwright/e2e/opfs.spec.ts
+++ b/packages/playground/website/playwright/e2e/opfs.spec.ts
@@ -51,7 +51,18 @@ async function dropZipFile(
 	const paneText = await pane.innerText();
 	const pageBody = page.locator('body');
 	await pageBody.dispatchEvent('dragenter', { dataTransfer });
-	await expect(page.locator('[data-cy="zip-drop-overlay"]')).toBeVisible();
+	const overlay = page.locator('[data-cy="zip-drop-overlay"]');
+	await expect(overlay).toBeVisible();
+	expect(
+		await overlay.evaluate((element) => {
+			const bounds = element.getBoundingClientRect();
+			const hitTarget = document.elementFromPoint(
+				bounds.left + bounds.width / 2,
+				bounds.top + bounds.height / 2
+			);
+			return element.contains(hitTarget);
+		})
+	).toBe(true);
 	expect(await pane.innerText()).toBe(paneText);
 	if (verifyDragLeaveStability) {
 		await pageBody.dispatchEvent('dragleave', { dataTransfer });

--- a/packages/playground/website/playwright/e2e/opfs.spec.ts
+++ b/packages/playground/website/playwright/e2e/opfs.spec.ts
@@ -53,16 +53,18 @@ async function dropZipFile(
 	await pageBody.dispatchEvent('dragenter', { dataTransfer });
 	const overlay = page.locator('[data-cy="zip-drop-overlay"]');
 	await expect(overlay).toBeVisible();
-	expect(
-		await overlay.evaluate((element) => {
-			const bounds = element.getBoundingClientRect();
-			const hitTarget = document.elementFromPoint(
-				bounds.left + bounds.width / 2,
-				bounds.top + bounds.height / 2
-			);
-			return element.contains(hitTarget);
-		})
-	).toBe(true);
+	await expect
+		.poll(() =>
+			overlay.evaluate((element) => {
+				const bounds = element.getBoundingClientRect();
+				const hitTarget = document.elementFromPoint(
+					bounds.left + bounds.width / 2,
+					bounds.top + bounds.height / 2
+				);
+				return element.contains(hitTarget);
+			})
+		)
+		.toBe(true);
 	expect(await pane.innerText()).toBe(paneText);
 	if (verifyDragLeaveStability) {
 		await pageBody.dispatchEvent('dragleave', { dataTransfer });
@@ -72,8 +74,8 @@ async function dropZipFile(
 			page.locator('[data-cy="zip-drop-overlay"]')
 		).toBeVisible();
 	}
-	await pageBody.dispatchEvent('dragover', { dataTransfer });
-	await pageBody.dispatchEvent('drop', { dataTransfer });
+	await overlay.dispatchEvent('dragover', { dataTransfer });
+	await overlay.dispatchEvent('drop', { dataTransfer });
 	await dataTransfer.dispose();
 }
 

--- a/packages/playground/website/src/components/saved-playgrounds-panel/style.module.css
+++ b/packages/playground/website/src/components/saved-playgrounds-panel/style.module.css
@@ -1074,7 +1074,8 @@
 	gap: 16px;
 	inset: 12px;
 	justify-content: center;
-	pointer-events: none;
+	/* Keep the drag in the parent document instead of handing it to an iframe below. */
+	pointer-events: auto;
 	position: fixed;
 	z-index: 100;
 }


### PR DESCRIPTION
The full-page ZIP drop overlay had `pointer-events: none`. It looked like the
drop target, but left drag hit-testing to the page content underneath. When the
pointer crossed an iframe, the parent document received `dragleave` while the
corresponding `dragenter` occurred inside the iframe. The parent's drag-depth
counter reached zero and removed the overlay 50 ms later. Moving back into the
parent made it reappear.

The overlay now participates in hit-testing while mounted. It remains the drag
target above embedded frames, so the parent document keeps the overlay visible
and receives the eventual drop. The ZIP-drop E2E helper checks that the visible
overlay is the topmost hit target before dropping.

## Testing

Open **New Playground → Import zip**. Drag a ZIP around the page, including
across the Playground preview, and confirm the overlay stays visible. Drop it
and confirm the import starts.
