### PR TITLE
[Website] Label mobile Blueprint file explorer as Files

### DIFF
--- a/packages/playground/components/src/PlaygroundFileEditor/file-explorer-sidebar.tsx
+++ b/packages/playground/components/src/PlaygroundFileEditor/file-explorer-sidebar.tsx
@@ -45,6 +45,7 @@ export type FileExplorerSidebarProps = {
 	documentRoot: string;
 	readOnly?: boolean;
 	title?: string;
+	mobileSubsectionTitle?: string;
 	showBinaryPreviewHeader?: boolean;
 	dockPresentation?: boolean;
 	useWordPressTooltips?: boolean;
@@ -64,6 +65,7 @@ export function FileExplorerSidebar({
 	documentRoot,
 	readOnly = false,
 	title = 'Files',
+	mobileSubsectionTitle,
 	showBinaryPreviewHeader = true,
 	dockPresentation = false,
 	useWordPressTooltips = false,
@@ -287,6 +289,11 @@ export function FileExplorerSidebar({
 		>
 			<div className={styles['fileExplorerHeader']}>
 				<span className={styles['fileExplorerTitle']}>{title}</span>
+				{mobileSubsectionTitle ? (
+					<span className={styles['fileExplorerSubsectionTitle']}>
+						{mobileSubsectionTitle}
+					</span>
+				) : null}
 				{!readOnly ? (
 					<div className={styles['fileExplorerActions']}>
 						<FileActionTooltip

--- a/packages/playground/components/src/PlaygroundFileEditor/file-explorer.module.css
+++ b/packages/playground/components/src/PlaygroundFileEditor/file-explorer.module.css
@@ -28,6 +28,10 @@
 	color: var(--color-gray-700);
 }
 
+.fileExplorerSubsectionTitle {
+	display: none;
+}
+
 .fileExplorerActions {
 	display: flex;
 	align-items: center;
@@ -148,4 +152,22 @@
 .dockPresentation .fileExplorerUploadButton svg {
 	width: 16px;
 	height: 16px;
+}
+
+@media (max-width: 1024px) {
+	/* The mobile Dock toolbar names the editor, so this row labels its files. */
+	.dockPresentation .fileExplorerTitle {
+		display: none;
+	}
+
+	.dockPresentation .fileExplorerSubsectionTitle {
+		color: var(--ink-muted, #5f5b54);
+		display: inline;
+		font-size: 13px;
+		font-weight: 600;
+	}
+
+	.dockPresentation .fileExplorerActions {
+		margin-left: auto;
+	}
 }

--- a/packages/playground/website/src/components/blueprint-editor/BlueprintBundleEditor.tsx
+++ b/packages/playground/website/src/components/blueprint-editor/BlueprintBundleEditor.tsx
@@ -962,6 +962,7 @@ export const BlueprintBundleEditor = forwardRef<
 							{...(dockPresentation
 								? {
 										title: 'Blueprint',
+										mobileSubsectionTitle: 'Files',
 										showBinaryPreviewHeader: false,
 										dockPresentation: true,
 										useWordPressTooltips: true,


### PR DESCRIPTION
The mobile Blueprint pane no longer repeats its title in the file explorer. The inner toolbar now reads “Files” in smaller, muted type, leaving “Blueprint” as the pane heading. Desktop keeps the full file explorer title.

| | Before | After |
| --- | --- | --- |
| Mobile | ![Mobile Blueprint pane with a repeated Blueprint file explorer title](https://gist.githubusercontent.com/adamziel/5f31b8721fb6a3681d99c517d3f82f3f/raw/05ce158a97a6f1fb064cc3f01ae2c90c8f8ac221/mobile-before.png) | ![Mobile Blueprint pane with a smaller Files subsection title](https://gist.githubusercontent.com/adamziel/5f31b8721fb6a3681d99c517d3f82f3f/raw/332ce5b038fe2f1a643cc51cbc097ea2b2356d79/mobile-after.png) |
| Desktop | ![Desktop Blueprint editor before the change](https://gist.githubusercontent.com/adamziel/5f31b8721fb6a3681d99c517d3f82f3f/raw/5d938cdbb53c7c9bcd8096ebd60936ae44a7db38/desktop-before.png) | ![Desktop Blueprint editor unchanged after the change](https://gist.githubusercontent.com/adamziel/5f31b8721fb6a3681d99c517d3f82f3f/raw/5d938cdbb53c7c9bcd8096ebd60936ae44a7db38/desktop-after.png) |

## Testing

Open the Blueprint pane at mobile width, show its file explorer, and check that the hierarchy reads “Blueprint” then “Files”. Resize to desktop and check that the file explorer still reads “Blueprint”.
