### PR TITLE
[Website] Keep Dock focus rings inside tool buttons

### DIFF
--- a/packages/playground/website/src/components/dock/style.module.css
+++ b/packages/playground/website/src/components/dock/style.module.css
@@ -149,8 +149,8 @@
 }
 
 .dock-item:focus-visible {
-	box-shadow: inset 0 0 0 1.5px #afbcf6;
-	outline: none;
+	outline: 1px solid #afbcf6;
+	outline-offset: -1px;
 }
 
 .dock-item-primary {
@@ -1393,7 +1393,6 @@
 	}
 
 	.dock-item:focus-visible {
-		box-shadow: none;
 		outline: 2px solid CanvasText;
 		outline-offset: -2px;
 	}

--- a/packages/playground/website/src/components/dock/style.module.css
+++ b/packages/playground/website/src/components/dock/style.module.css
@@ -149,8 +149,8 @@
 }
 
 .dock-item:focus-visible {
-	outline: 2px solid #ffffff;
-	outline-offset: -2px;
+	box-shadow: inset 0 0 0 1.5px #ffffff;
+	outline: none;
 }
 
 .dock-item-primary {
@@ -1390,6 +1390,12 @@
 @media (forced-colors: active) {
 	.dock-operation-toast {
 		border: 2px solid CanvasText;
+	}
+
+	.dock-item:focus-visible {
+		box-shadow: none;
+		outline: 2px solid CanvasText;
+		outline-offset: -2px;
 	}
 }
 

--- a/packages/playground/website/src/components/dock/style.module.css
+++ b/packages/playground/website/src/components/dock/style.module.css
@@ -149,8 +149,12 @@
 }
 
 .dock-item:focus-visible {
-	box-shadow: inset 0 0 0 1.5px #ffffff;
+	box-shadow: inset 0 0 0 1.5px #2271b1;
 	outline: none;
+}
+
+.dock-item-primary:focus-visible {
+	box-shadow: inset 0 0 0 1.5px #ffffff;
 }
 
 .dock-item-primary {

--- a/packages/playground/website/src/components/dock/style.module.css
+++ b/packages/playground/website/src/components/dock/style.module.css
@@ -150,7 +150,11 @@
 
 .dock-item:focus-visible {
 	outline: 2px solid #3858e9;
-	outline-offset: 3px;
+	outline-offset: -2px;
+}
+
+.dock-item-primary:focus-visible {
+	outline-color: #ffffff;
 }
 
 .dock-item-primary {
@@ -766,17 +770,6 @@
 	.dock-item {
 		flex-shrink: 0;
 		min-width: 60px;
-	}
-
-	/* The horizontal scroller clips outlines drawn outside its block edge.
-	   Keep keyboard focus rings inside each button, with a contrasting ring on
-	   the blue primary button. */
-	.dock-item:focus-visible {
-		outline-offset: -2px;
-	}
-
-	.dock-item-primary:focus-visible {
-		outline-color: #ffffff;
 	}
 
 	/* 16px keeps iOS from auto-zooming when the inline rename field focuses. */

--- a/packages/playground/website/src/components/dock/style.module.css
+++ b/packages/playground/website/src/components/dock/style.module.css
@@ -149,12 +149,8 @@
 }
 
 .dock-item:focus-visible {
-	outline: 2px solid #3858e9;
+	outline: 2px solid #ffffff;
 	outline-offset: -2px;
-}
-
-.dock-item-primary:focus-visible {
-	outline-color: #ffffff;
 }
 
 .dock-item-primary {

--- a/packages/playground/website/src/components/dock/style.module.css
+++ b/packages/playground/website/src/components/dock/style.module.css
@@ -768,6 +768,17 @@
 		min-width: 60px;
 	}
 
+	/* The horizontal scroller clips outlines drawn outside its block edge.
+	   Keep keyboard focus rings inside each button, with a contrasting ring on
+	   the blue primary button. */
+	.dock-item:focus-visible {
+		outline-offset: -2px;
+	}
+
+	.dock-item-primary:focus-visible {
+		outline-color: #ffffff;
+	}
+
 	/* 16px keeps iOS from auto-zooming when the inline rename field focuses. */
 	.settings-name-input {
 		font-size: 16px;

--- a/packages/playground/website/src/components/dock/style.module.css
+++ b/packages/playground/website/src/components/dock/style.module.css
@@ -149,12 +149,8 @@
 }
 
 .dock-item:focus-visible {
-	box-shadow: inset 0 0 0 1.5px #2271b1;
+	box-shadow: inset 0 0 0 1.5px #afbcf6;
 	outline: none;
-}
-
-.dock-item-primary:focus-visible {
-	box-shadow: inset 0 0 0 1.5px #ffffff;
 }
 
 .dock-item-primary {


### PR DESCRIPTION
Dock focus rings now use a contained 1px solid outline at every breakpoint. Every tile uses the same light tint of the New button's existing `#3858e9` blue: `#afbcf6`, a 40% blue and 60% white mix. It has 3.03:1 contrast against the blue button and 8.8:1 against the dark Dock. The integral outline avoids the uneven antialiasing produced by the fractional inset shadow. It follows the button edge instead of extending beyond it, where the mobile scroller clipped it and adjacent buttons could cover it.

These 4× close-ups keep the one-pixel outline visible in GitHub's two-column table.

| | Before | After |
| --- | --- | --- |
| Mobile · Playgrounds | ![Mobile Dock with a clipped blue Playgrounds focus ring](https://gist.githubusercontent.com/adamziel/299b1c26853a69d53803797581119857/raw/d18b75040a983be50d1d3b7f8ae0f10c38192dd7/mobile-before.png) | ![Mobile Dock with the uniform light-blue Playgrounds focus ring contained inside the button](https://gist.githubusercontent.com/adamziel/299b1c26853a69d53803797581119857/raw/d18b75040a983be50d1d3b7f8ae0f10c38192dd7/mobile-after.png) |
| Mobile · New | ![Mobile Dock with the clipped blue New focus ring](https://gist.githubusercontent.com/adamziel/299b1c26853a69d53803797581119857/raw/d18b75040a983be50d1d3b7f8ae0f10c38192dd7/mobile-primary-before.png) | ![Mobile Dock with the uniform light-blue New focus ring contained inside the button](https://gist.githubusercontent.com/adamziel/299b1c26853a69d53803797581119857/raw/d18b75040a983be50d1d3b7f8ae0f10c38192dd7/mobile-primary-after.png) |
| Desktop · Playgrounds | ![Desktop Dock with a blue Playgrounds focus ring larger than the button](https://gist.githubusercontent.com/adamziel/299b1c26853a69d53803797581119857/raw/d18b75040a983be50d1d3b7f8ae0f10c38192dd7/desktop-before.png) | ![Desktop Dock with the uniform light-blue Playgrounds focus ring contained inside the button](https://gist.githubusercontent.com/adamziel/299b1c26853a69d53803797581119857/raw/d18b75040a983be50d1d3b7f8ae0f10c38192dd7/desktop-after.png) |
| Desktop · New | ![Desktop Dock with the external blue New focus ring](https://gist.githubusercontent.com/adamziel/299b1c26853a69d53803797581119857/raw/d18b75040a983be50d1d3b7f8ae0f10c38192dd7/desktop-primary-before.png) | ![Desktop Dock with the uniform light-blue New focus ring contained inside the button](https://gist.githubusercontent.com/adamziel/299b1c26853a69d53803797581119857/raw/d18b75040a983be50d1d3b7f8ae0f10c38192dd7/desktop-primary-after.png) |

## Testing

Use the keyboard to focus New and Playgrounds at mobile and desktop widths. Check that both use the same uniform, contained light-blue ring and that it follows the button edge.
