### PR TITLE
[Website] Explain what happens after deleting the active Playground

### DIFF
--- a/packages/playground/website/src/components/delete-site-modal/index.tsx
+++ b/packages/playground/website/src/components/delete-site-modal/index.tsx
@@ -1,6 +1,10 @@
 import { useEffect, useState } from 'react';
 import { Notice, __experimentalText as Text } from '@wordpress/components';
-import { useAppDispatch, useAppSelector } from '../../lib/state/redux/store';
+import {
+	selectActiveSite,
+	useAppDispatch,
+	useAppSelector,
+} from '../../lib/state/redux/store';
 import {
 	setActiveModal,
 	setSiteSlugToDelete,
@@ -19,6 +23,7 @@ export function DeleteSiteModal() {
 	const site = useAppSelector((state) =>
 		siteSlugToDelete ? state.sites.entities[siteSlugToDelete] : undefined
 	);
+	const activeSite = useAppSelector(selectActiveSite);
 
 	const [isSubmitting, setIsSubmitting] = useState(false);
 	const [error, setError] = useState<string | null>(null);
@@ -33,6 +38,8 @@ export function DeleteSiteModal() {
 	if (!site) {
 		return null;
 	}
+
+	const isDeletingActiveSite = activeSite?.slug === site.slug;
 
 	const closeModal = () => {
 		dispatch(setActiveModal(null));
@@ -74,6 +81,13 @@ export function DeleteSiteModal() {
 					Are you sure you want to delete the site &ldquo;
 					{site.metadata.name}&rdquo;? This action cannot be undone.
 				</Text>
+				{isDeletingActiveSite ? (
+					<Text>
+						You&rsquo;re viewing this Playground now. Deleting it
+						opens your most recent Playground, or starts a new one
+						if it&rsquo;s your last.
+					</Text>
+				) : null}
 				{error ? (
 					<Notice status="error" isDismissible={false}>
 						{error}


### PR DESCRIPTION
Fixes one item from #4092.

Deleting the Playground you're _currently viewing_ doesn't just remove it — the app immediately swaps in another saved Playground, or boots a fresh site if that was your last one. The confirmation dialog never said so, so the screen changing out from under you read as a glitch. [tibiii reported](https://github.com/WordPress/wordpress-playground/issues/4092#issuecomment-5015534113) not knowing "what template it will load."

When the site being deleted is the active one, the dialog now spells out the outcome. Deleting a _background_ Playground (one you're not viewing) is unchanged — nothing visibly happens there, so no extra copy is added.

| | Confirmation copy |
| --- | --- |
| Before | "Are you sure you want to delete the site "X"? This action cannot be undone." |
| After (active site) | …same, plus a second line: **"You're viewing this Playground now. Deleting it opens your most recent Playground, or starts a new one if it's your last."** |

The wording matches what `removeSite()` actually does: when the active site is deleted it activates `selectSortedSites()[0]` (the most recent remaining Playground), and boots a fresh welcome site when none remain.

## Testing

Open the Dock → Saved Playgrounds, delete the Playground you're currently on, and confirm the dialog explains what happens next. Delete a different (non-active) Playground and confirm the extra line does not appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
