### PR TITLE
[Website] Preserve auto-login across browser-stored Playground reopens

### DIFF
--- a/packages/playground/website/playwright/e2e/reopen-relogin.spec.ts
+++ b/packages/playground/website/playwright/e2e/reopen-relogin.spec.ts
@@ -1,0 +1,74 @@
+import type { Blueprint } from '@wp-playground/blueprints';
+import type { Page } from '@playwright/test';
+import { test, expect } from '../playground-fixtures';
+import { getDirectoryNameForSlug } from '../../src/lib/state/opfs/opfs-site-path';
+
+test('reopening a browser-stored Playground keeps auto-login enabled', async ({
+	website,
+	wordpress,
+	browserName,
+}) => {
+	test.skip(
+		browserName !== 'chromium',
+		`This test relies on OPFS which isn't available in Playwright's flavor of ${browserName}.`
+	);
+
+	const blueprint: Blueprint = {
+		landingPage: '/wp-admin/',
+		login: true,
+	};
+	await website.goto(`./#${encodeURIComponent(JSON.stringify(blueprint))}`);
+	await expect(
+		wordpress.getByRole('heading', { name: 'Dashboard', level: 1 })
+	).toBeVisible();
+
+	const firstSite = await website.page.evaluate(() => {
+		const api = (window as any).playgroundSites;
+		const activeSite = api.list().find((site: any) => site.isActive);
+		(window as any).__firstPlaygroundClient = api.getClient();
+		return activeSite;
+	});
+	expect(firstSite.storage).toBe('opfs');
+
+	// Wait until the first runtime has finished writing the files and metadata
+	// that the next runtime will restore.
+	await expect
+		.poll(async () => {
+			const metadata = await readStoredSiteMetadata(
+				website.page,
+				firstSite.slug
+			);
+			return metadata.initialOpfsSyncPending;
+		})
+		.toBe(false);
+
+	await website.page.evaluate(async (firstSiteSlug) => {
+		const api = (window as any).playgroundSites;
+		await api.createNewTemporarySite('reopen-relogin-second');
+		await api.setActiveSite(firstSiteSlug, { updateUrl: false });
+	}, firstSite.slug);
+
+	const result = await website.page.evaluate(async () => {
+		const api = (window as any).playgroundSites;
+		return {
+			sameClient:
+				api.getClient() === (window as any).__firstPlaygroundClient,
+			wpAdminStatus: (
+				await api.getClient().request({ url: '/wp-admin/' })
+			).httpStatusCode,
+		};
+	});
+	expect(result.sameClient).toBe(false);
+	expect(result.wpAdminStatus).toBe(200);
+	await expect(wordpress.locator('body.logged-in')).toBeVisible();
+});
+
+async function readStoredSiteMetadata(page: Page, slug: string) {
+	return await page.evaluate(async (siteDirectoryName) => {
+		const root = await navigator.storage.getDirectory();
+		const sites = await root.getDirectoryHandle('sites');
+		const site = await sites.getDirectoryHandle(siteDirectoryName);
+		const metadata = await site.getFileHandle('wp-runtime.json');
+		return JSON.parse(await (await metadata.getFile()).text());
+	}, getDirectoryNameForSlug(slug));
+}

--- a/packages/playground/website/src/lib/state/redux/boot-site-client.spec.ts
+++ b/packages/playground/website/src/lib/state/redux/boot-site-client.spec.ts
@@ -470,6 +470,123 @@ describe('bootSiteClient', () => {
 		);
 	});
 
+	it('replays live auto-login constants after a saved site finishes its initial OPFS copy', async () => {
+		const firstPlayground = createPlaygroundClient({
+			fileExists: vi.fn(async () => true),
+			readFileAsText: vi.fn(async () =>
+				JSON.stringify({
+					PLAYGROUND_AUTO_LOGIN_AS_USER: 'admin',
+				})
+			),
+		});
+		vi.mocked(startPlaygroundWeb).mockImplementationOnce(
+			async (options: any) => {
+				options.onClientConnected(firstPlayground);
+				return firstPlayground;
+			}
+		);
+		const site = createSite('auto-login', {
+			metadata: { initialOpfsSyncPending: true },
+		});
+		const state = createState(site);
+		const dispatch = createDispatch(state);
+
+		await bootSiteClient('auto-login', document.createElement('iframe'), {
+			signal: new AbortController().signal,
+		})(dispatch, () => state);
+		await vi.waitFor(() =>
+			expect(
+				state.sites.entities['auto-login'].metadata
+					.playgroundDefinedConstants
+			).toEqual({
+				PLAYGROUND_AUTO_LOGIN_AS_USER: 'admin',
+			})
+		);
+		expect(opfsSiteStorage!.update).toHaveBeenCalledWith('auto-login', {
+			metadata: expect.objectContaining({
+				initialOpfsSyncPending: false,
+				playgroundDefinedConstants: {
+					PLAYGROUND_AUTO_LOGIN_AS_USER: 'admin',
+				},
+			}),
+		});
+
+		const reloadedSite = {
+			...state.sites.entities['auto-login'],
+			loadedFromStorage: true,
+		};
+		const reloadedState = createState(reloadedSite);
+		await bootSiteClient('auto-login', document.createElement('iframe'), {
+			signal: new AbortController().signal,
+		})(createDispatch(reloadedState), () => reloadedState);
+
+		expect(startPlaygroundWeb).toHaveBeenLastCalledWith(
+			expect.objectContaining({
+				blueprint: expect.objectContaining({
+					constants: expect.objectContaining({
+						PLAYGROUND_AUTO_LOGIN_AS_USER: 'admin',
+					}),
+				}),
+			})
+		);
+	});
+
+	it('keeps the initial OPFS copy pending when live constants cannot be read', async () => {
+		const constantsError = new Error('Unable to read live constants');
+		const playground = createPlaygroundClient({
+			fileExists: vi.fn(async () => true),
+			readFileAsText: vi.fn(async () => {
+				throw constantsError;
+			}),
+		});
+		vi.mocked(startPlaygroundWeb).mockImplementationOnce(
+			async (options: any) => {
+				options.onClientConnected(playground);
+				return playground;
+			}
+		);
+		const site = createSite('constants-read-failed', {
+			metadata: { initialOpfsSyncPending: true },
+		});
+		const state = createState(site);
+		const dispatch = createDispatch(state);
+
+		await bootSiteClient(
+			'constants-read-failed',
+			document.createElement('iframe'),
+			{ signal: new AbortController().signal }
+		)(dispatch, () => state);
+		await vi.waitFor(() =>
+			expect(dispatch).toHaveBeenCalledWith(
+				expect.objectContaining({
+					type: 'clients/updateClientInfo',
+					payload: expect.objectContaining({
+						siteSlug: 'constants-read-failed',
+						changes: {
+							opfsSync: {
+								status: 'error',
+								operation: 'autosave',
+							},
+						},
+					}),
+				})
+			)
+		);
+
+		expect(
+			state.sites.entities['constants-read-failed'].metadata
+				.initialOpfsSyncPending
+		).toBe(true);
+		expect(opfsSiteStorage!.update).not.toHaveBeenCalledWith(
+			'constants-read-failed',
+			{
+				metadata: expect.objectContaining({
+					initialOpfsSyncPending: false,
+				}),
+			}
+		);
+	});
+
 	it('clears the return target after the initial OPFS copy succeeds', async () => {
 		let resolveMount = () => {};
 		const mountFinished = new Promise<void>((resolve) => {
@@ -835,6 +952,7 @@ function createSite(
 
 function createPlaygroundClient(overrides: Record<string, unknown> = {}): any {
 	return {
+		fileExists: vi.fn(async () => false),
 		mountOpfs: vi.fn(async () => undefined),
 		onNavigation: vi.fn(),
 		...overrides,

--- a/packages/playground/website/src/lib/state/redux/boot-site-client.ts
+++ b/packages/playground/website/src/lib/state/redux/boot-site-client.ts
@@ -45,6 +45,7 @@ import { PHPMYADMIN_PATH_ALIAS } from '@wp-playground/tools';
 import { phpExtensionQueryArgsToExtensionsArray } from '../url/php-extension-query';
 import { runSiteFirstBootInitializer } from './site-first-boot-initializer';
 import { captureAndPersistSiteThumbnail } from './capture-site-thumbnail';
+import { getPlaygroundDefinedPHPConstants } from './playground-defined-php-constants';
 
 const PENDING_OPFS_SITE_REMOVAL_RETRY_DELAYS_MS = [700, 1400];
 
@@ -620,7 +621,8 @@ function waitForPendingOpfsSiteRemovalRetry(
 }
 
 /**
- * Copies files created during a saved site's first boot from MEMFS into OPFS.
+ * Copies files and live PHP constants from a saved site's first boot into
+ * browser storage.
  *
  * The iframe is already usable when this runs. Redux keeps showing sync
  * progress until the copy succeeds, then future boots can mount OPFS normally.
@@ -673,6 +675,11 @@ async function syncInitialOpfsFilesInBackground({
 		if (signal.aborted) {
 			return false;
 		}
+		const playgroundDefinedConstants =
+			await getPlaygroundDefinedPHPConstants(playground);
+		if (signal.aborted) {
+			return false;
+		}
 		// Clear the return target in the same metadata write that completes the
 		// initial copy so failed copies retain their recovery action.
 		await dispatch(
@@ -681,6 +688,7 @@ async function syncInitialOpfsFilesInBackground({
 				changes: {
 					initialOpfsSyncPending: false,
 					whenLastUsed: Date.now(),
+					playgroundDefinedConstants,
 					...(siteSlugToReturnToIfBlueprintFails
 						? { siteSlugToReturnToIfBlueprintFails: undefined }
 						: {}),

--- a/packages/playground/website/src/lib/state/redux/persist-temporary-site.spec.ts
+++ b/packages/playground/website/src/lib/state/redux/persist-temporary-site.spec.ts
@@ -446,6 +446,7 @@ function createDispatch(
 
 function createPlaygroundWithConstants(contents: string | undefined) {
 	return {
+		fileExists: vi.fn(async () => contents !== undefined),
 		readFileAsText: vi.fn(async (path: string) => {
 			expect(path).toBe('/internal/shared/consts.json');
 			if (contents === undefined) {

--- a/packages/playground/website/src/lib/state/redux/persist-temporary-site.ts
+++ b/packages/playground/website/src/lib/state/redux/persist-temporary-site.ts
@@ -1,6 +1,5 @@
 import { logger } from '@php-wasm/logger';
-import type { MountDescriptor, PlaygroundClient } from '@wp-playground/remote';
-import type { PHPConstants } from '@wp-playground/blueprints';
+import type { MountDescriptor } from '@wp-playground/remote';
 import { saveDirectoryHandle } from '../opfs/opfs-directory-handle-storage';
 import {
 	opfsSiteStorage,
@@ -29,6 +28,7 @@ import type { SiteStorageType } from './slice-sites';
 import { setActiveModal } from './slice-ui';
 import { getSetupUrlFromSite } from '../playground-identity';
 import { captureAndPersistSiteThumbnail } from './capture-site-thumbnail';
+import { getPlaygroundDefinedPHPConstants } from './playground-defined-php-constants';
 
 /**
  * Copies the running Playground into a durable storage backend.
@@ -396,26 +396,4 @@ function getOriginalUrlParamsFromUrl(
 		searchParams,
 		hash: url.hash,
 	};
-}
-
-/**
- * Returns constants registered through Playground's live PHP API.
- *
- * Calls to `playground.defineConstant()` are persisted in consts.json after the
- * iframe has already booted. Examples include `PLAYGROUND_AUTO_LOGIN_AS_USER`
- * from the login step, `WPLANG` from the language step, and caller-defined
- * constants such as `WP_DEBUG`. Saved sites need to replay them on reload, but
- * writing them into `runtimeConfiguration` during autosave would change the
- * running iframe's boot fingerprint and force an unnecessary reboot.
- */
-async function getPlaygroundDefinedPHPConstants(playground: PlaygroundClient) {
-	let constants: PHPConstants = {};
-	try {
-		constants = JSON.parse(
-			await playground.readFileAsText('/internal/shared/consts.json')
-		);
-	} catch {
-		// The file is absent until code defines constants through Playground.
-	}
-	return constants;
 }

--- a/packages/playground/website/src/lib/state/redux/playground-defined-php-constants.ts
+++ b/packages/playground/website/src/lib/state/redux/playground-defined-php-constants.ts
@@ -1,0 +1,22 @@
+import type { PHPConstants } from '@wp-playground/blueprints';
+import type { PlaygroundClient } from '@wp-playground/remote';
+
+/**
+ * Returns constants registered through Playground's live PHP API.
+ *
+ * Calls to `playground.defineConstant()` are persisted in consts.json after the
+ * iframe has already booted. Examples include `PLAYGROUND_AUTO_LOGIN_AS_USER`
+ * from the login step, `WPLANG` from the language step, and caller-defined
+ * constants such as `WP_DEBUG`. Saved sites need to replay them on reload, but
+ * storing them in `runtimeConfiguration` would change the running iframe's boot
+ * fingerprint and force an unnecessary reboot.
+ */
+export async function getPlaygroundDefinedPHPConstants(
+	playground: PlaygroundClient
+): Promise<PHPConstants> {
+	const constantsPath = '/internal/shared/consts.json';
+	if (!(await playground.fileExists(constantsPath))) {
+		return {};
+	}
+	return JSON.parse(await playground.readFileAsText(constantsPath));
+}


### PR DESCRIPTION
Browser-stored Playgrounds now preserve auto-login after they are reopened.

Before this PR, the first MEMFS-to-OPFS copy stored WordPress files but not constants registered by live Blueprint steps. Reopening the Playground created a new runtime without `PLAYGROUND_AUTO_LOGIN_AS_USER`, so `/wp-admin/` showed the login screen.

After this PR, that initial copy persists live PHP constants in the same metadata write that marks the copy complete, and later runtimes replay them. A failed constants read leaves the copy pending instead of silently saving incomplete state. Older completed saves cannot be backfilled because their retired runtime was the only authoritative source.

## Test plan

Wait for browser autosave, switch to another Playground and back, then confirm `/wp-admin/` opens logged in.