### PR TITLE
[Website] Increase mobile Files heading to 18px

### DIFF
--- a/packages/playground/components/src/PlaygroundFileEditor/file-explorer.module.css
+++ b/packages/playground/components/src/PlaygroundFileEditor/file-explorer.module.css
@@ -163,7 +163,7 @@
 	.dockPresentation .fileExplorerSubsectionTitle {
 		color: var(--ink-muted, #5f5b54);
 		display: inline;
-		font-size: 13px;
+		font-size: 18px;
 		font-weight: 600;
 	}
 


### PR DESCRIPTION
The mobile Blueprint file explorer now renders its “Files” subsection heading at 18px instead of 13px. The muted color and two-pixel size difference keep it below the 20px pane title. Desktop is unchanged.

| | Before | After |
| --- | --- | --- |
| Mobile | ![Mobile Blueprint file explorer with a 13px Files heading](https://gist.githubusercontent.com/adamziel/80f3ad27d8b7ba6211e372bd9fa2c671/raw/84c8114652d7a220147150c2f7e7cc27937cb990/mobile-before-13px.png) | ![Mobile Blueprint file explorer with an 18px Files heading](https://gist.githubusercontent.com/adamziel/80f3ad27d8b7ba6211e372bd9fa2c671/raw/84c8114652d7a220147150c2f7e7cc27937cb990/mobile-after-18px.png) |
| Desktop (unchanged) | ![Desktop Blueprint editor](https://gist.githubusercontent.com/adamziel/5f31b8721fb6a3681d99c517d3f82f3f/raw/5d938cdbb53c7c9bcd8096ebd60936ae44a7db38/desktop-before.png) | ![Desktop Blueprint editor unchanged](https://gist.githubusercontent.com/adamziel/5f31b8721fb6a3681d99c517d3f82f3f/raw/5d938cdbb53c7c9bcd8096ebd60936ae44a7db38/desktop-after.png) |

## Testing

Open the Blueprint pane at mobile width, show its file explorer, and check that “Files” is readable but remains subordinate to “Blueprint”. Resize to desktop and check that the file explorer title is unchanged.
