### PR TITLE
[CLI] Fix concurrent SQLite stress fixture length

### DIFF
--- a/packages/playground/cli/tests/sqlite-concurrent-publish.spec.ts
+++ b/packages/playground/cli/tests/sqlite-concurrent-publish.spec.ts
@@ -171,7 +171,7 @@ ob_start();
 for ($i = 0; $i < 11; $i++) {
 	$columns = array();
 	for ($j = 0; $j < 11; $j++) {
-		$columns[] = "c$j varchar(191) NOT NULL DEFAULT '' COMMENT 'stress comment $j'";
+		$columns[] = "c$j varchar(500) NOT NULL DEFAULT '' COMMENT 'stress comment $j'";
 	}
 
 	$table = $wpdb->prefix . 'playground_stress_' . $i;


### PR DESCRIPTION
## What

Updates the concurrent SQLite publish regression fixture so its `varchar` columns accept the 500-character values the test intentionally inserts.

## Root cause

The test created every stress column as `varchar(191)` and then inserted a 500-character value into each column. Current WordPress field validation rejects those values before the test reaches the SQLite concurrency behavior it is meant to exercise, returning HTTP 500 with an error that the supplied values may be too long or invalid.

The mismatch has existed since the test was introduced in #3920. It was exposed while working on #4184 because changes to `@wp-playground/storage` mark Playground CLI as affected and therefore execute the entire CLI suite. Running the focused test directly on the current `trunk` commit reproduces the same failure, so this is independent of the OPFS work.

Changing the schema to `varchar(500)` preserves the intended payload and concurrency pressure while making the fixture internally valid.

## Impact

This changes test setup only. Production CLI and SQLite behavior are unchanged.

This is the first of two stacked PRs. #4190 is stacked on this branch and corrects the CI base/head calculation used by `nx affected`, which currently compares `trunk` to itself on post-merge push runs and skips affected Nx tasks.

## Testing

- `npm exec nx run playground-cli:test-playground-cli -- --testFile=sqlite-concurrent-publish.spec.ts`
- `npm exec nx run playground-cli:typecheck`
- `npm exec nx lint playground-cli`
- `npx nx format:check --base=origin/trunk --head=HEAD`
