### PR TITLE
[CI] Compare affected tasks with the last successful run

### DIFF
--- a/.github/actions/prepare-playground/action.yml
+++ b/.github/actions/prepare-playground/action.yml
@@ -6,20 +6,14 @@ inputs:
         required: true
         description: 'Node.js version to use'
         default: '20'
-    set-nx-shas:
-        type: boolean
-        required: false
-        description: 'Set the base and head SHAs used by nx affected'
-        default: false
 
 runs:
     using: 'composite'
     steps:
-        - name: Derive appropriate SHAs for nx affected
-          if: inputs.set-nx-shas == 'true'
-          uses: nrwl/nx-set-shas@v5
-          with:
-              main-branch-name: trunk
+        - name: Fetch base SHA for nx affected
+          if: env.NX_BASE != ''
+          shell: bash
+          run: git fetch --no-tags --depth=1 --filter=blob:none origin "$NX_BASE"
         - uses: actions/setup-node@v4
           with:
               node-version: ${{ inputs.node-version }}

--- a/.github/actions/prepare-playground/action.yml
+++ b/.github/actions/prepare-playground/action.yml
@@ -6,13 +6,20 @@ inputs:
         required: true
         description: 'Node.js version to use'
         default: '20'
+    set-nx-shas:
+        type: boolean
+        required: false
+        description: 'Set the base and head SHAs used by nx affected'
+        default: false
 
 runs:
     using: 'composite'
     steps:
-        - name: Fetch trunk
-          shell: bash
-          run: git fetch origin trunk --depth=1 --recurse-submodules
+        - name: Derive appropriate SHAs for nx affected
+          if: inputs.set-nx-shas == 'true'
+          uses: nrwl/nx-set-shas@v5
+          with:
+              main-branch-name: trunk
         - uses: actions/setup-node@v4
           with:
               node-version: ${{ inputs.node-version }}
@@ -48,12 +55,6 @@ runs:
                   /etc/apt/sources.list.d/azure-cli.sources \
                   /etc/apt/sources.list.d/microsoft-prod.list \
                   /etc/apt/sources.list.d/microsoft-prod.sources || true
-        - name: Set NX_BASE
-          shell: bash
-          run: echo "NX_BASE=$(git rev-parse origin/trunk)" >> $GITHUB_ENV
-        - name: Set NX_HEAD
-          shell: bash
-          run: echo "NX_HEAD=$(git rev-parse HEAD)" >> $GITHUB_ENV
         - name: Reset NX cache
           shell: bash
           run: npx nx reset

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,29 @@ on:
 permissions: {}
 
 jobs:
+    set-nx-shas:
+        name: 'Resolve Nx affected SHAs'
+        if: github.repository == 'WordPress/wordpress-playground' || github.event_name == 'pull_request'
+        runs-on: ubuntu-latest
+        timeout-minutes: 5
+        permissions:
+            actions: read # Required to find the last successful CI run.
+            contents: read # Required to clone the repo.
+        outputs:
+            base: ${{ steps.set_shas.outputs.base }}
+            head: ${{ steps.set_shas.outputs.head }}
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
+                  filter: tree:0
+            - id: set_shas
+              name: Derive appropriate SHAs for nx affected
+              uses: nrwl/nx-set-shas@v5
+              with:
+                  main-branch-name: trunk
+                  set-environment-variables-for-job: false
+
     # This step:
     # * Warms up the node_modules cache
     # * Performs linting and typechecking
@@ -20,31 +43,34 @@ jobs:
     # take ~25s just to run git clone and restore node_modules.
     lint-and-typecheck:
         name: 'Lint and typecheck'
+        needs: set-nx-shas
         if: github.repository == 'WordPress/wordpress-playground' || github.event_name == 'pull_request'
         runs-on: ubuntu-latest
         timeout-minutes: 30
         permissions:
-            actions: read # Required to find the last successful CI run.
             contents: read # Required to clone the repo.
+        env:
+            NX_BASE: ${{ needs.set-nx-shas.outputs.base }}
+            NX_HEAD: ${{ needs.set-nx-shas.outputs.head }}
         steps:
             - uses: actions/checkout@v4
               with:
-                  fetch-depth: 0
                   submodules: true
             - uses: ./.github/actions/prepare-playground
-              with:
-                  set-nx-shas: true
             - run: npx nx affected --target=lint
             - run: npx nx affected --target=typecheck
             - run: npx nx check-orphan-pages docs-site
             - run: bash tools/check-node-engine-alignment.sh
     test-unit-asyncify:
+        needs: set-nx-shas
         if: github.repository == 'WordPress/wordpress-playground' || github.event_name == 'pull_request'
         runs-on: ubuntu-latest
         timeout-minutes: 30
         permissions:
-            actions: read # Required to find the last successful CI run.
             contents: read # Required to clone the repo.
+        env:
+            NX_BASE: ${{ needs.set-nx-shas.outputs.base }}
+            NX_HEAD: ${{ needs.set-nx-shas.outputs.head }}
         strategy:
             fail-fast: false
             matrix:
@@ -82,24 +108,25 @@ jobs:
         steps:
             - uses: actions/checkout@v4
               with:
-                  fetch-depth: 0
                   submodules: true
             - uses: ./.github/actions/prepare-playground
               with:
                   node-version: 20
-                  set-nx-shas: true
             - run: node --expose-gc node_modules/nx/bin/nx affected --target=${{ matrix.target }}
               env:
                   MYSQL_DATABASE: test_db
                   MYSQL_USER: user
                   MYSQL_PASSWORD: password
     test-unit-jspi:
+        needs: set-nx-shas
         if: github.repository == 'WordPress/wordpress-playground' || github.event_name == 'pull_request'
         runs-on: ubuntu-latest
         timeout-minutes: 30
         permissions:
-            actions: read # Required to find the last successful CI run.
             contents: read # Required to clone the repo.
+        env:
+            NX_BASE: ${{ needs.set-nx-shas.outputs.base }}
+            NX_HEAD: ${{ needs.set-nx-shas.outputs.head }}
         strategy:
             fail-fast: false
             matrix:
@@ -135,18 +162,17 @@ jobs:
         steps:
             - uses: actions/checkout@v4
               with:
-                  fetch-depth: 0
                   submodules: true
             - uses: ./.github/actions/prepare-playground
               with:
                   node-version: 24
-                  set-nx-shas: true
             - run: node --expose-gc node_modules/nx/bin/nx affected --target=${{ matrix.target }}
               env:
                   MYSQL_DATABASE: test_db
                   MYSQL_USER: user
                   MYSQL_PASSWORD: password
     test-playground-cli:
+        needs: set-nx-shas
         if: github.repository == 'WordPress/wordpress-playground' || github.event_name == 'pull_request'
         strategy:
             matrix:
@@ -154,21 +180,22 @@ jobs:
         runs-on: ${{ matrix.os }}
         timeout-minutes: 30
         permissions:
-            actions: read # Required to find the last successful CI run.
             contents: read # Required to clone the repo.
+        env:
+            NX_BASE: ${{ needs.set-nx-shas.outputs.base }}
+            NX_HEAD: ${{ needs.set-nx-shas.outputs.head }}
         name: 'test-playground-cli (${{ matrix.os }})'
         steps:
             - uses: actions/checkout@v4
               with:
-                  fetch-depth: 0
                   submodules: true
             - uses: ./.github/actions/prepare-playground
               with:
                   node-version: 22
-                  set-nx-shas: true
             - name: Run full test suite
               run: node node_modules/nx/bin/nx affected --target=test-playground-cli
     test-file-locking:
+        needs: set-nx-shas
         if: github.repository == 'WordPress/wordpress-playground' || github.event_name == 'pull_request'
         strategy:
             matrix:
@@ -178,18 +205,18 @@ jobs:
         runs-on: ${{ matrix.os }}
         timeout-minutes: 30
         permissions:
-            actions: read # Required to find the last successful CI run.
             contents: read # Required to clone the repo.
+        env:
+            NX_BASE: ${{ needs.set-nx-shas.outputs.base }}
+            NX_HEAD: ${{ needs.set-nx-shas.outputs.head }}
         name: 'test-file-locking-${{ matrix.async-strategy }} (${{ matrix.os }})'
         steps:
             - uses: actions/checkout@v4
               with:
-                  fetch-depth: 0
                   submodules: true
             - uses: ./.github/actions/prepare-playground
               with:
                   node-version: 22
-                  set-nx-shas: true
             - name: Run full test suite
               run: node node_modules/nx/bin/nx affected --target=test-file-locking-${{ matrix.async-strategy }}
     test-e2e-php-wasm-web-jspi:
@@ -521,13 +548,15 @@ jobs:
                   fi
 
     test-compile-extension-helper:
-        needs: detect-compile-extension-helper-changes
+        needs: [detect-compile-extension-helper-changes, set-nx-shas]
         if: (github.repository == 'WordPress/wordpress-playground' || github.event_name == 'pull_request') && needs.detect-compile-extension-helper-changes.outputs.changed == 'true'
         runs-on: ubuntu-latest
         timeout-minutes: 60
         permissions:
-            actions: read # Required to find the last successful CI run.
             contents: read # Required to clone the repo.
+        env:
+            NX_BASE: ${{ needs.set-nx-shas.outputs.base }}
+            NX_HEAD: ${{ needs.set-nx-shas.outputs.head }}
         steps:
             - name: Free up runner disk space
               shell: bash
@@ -549,12 +578,10 @@ jobs:
                   df -h
             - uses: actions/checkout@v4
               with:
-                  fetch-depth: 0
                   submodules: true
             - uses: ./.github/actions/prepare-playground
               with:
                   node-version: 24
-                  set-nx-shas: true
             - name: Verify lazy Docker asset fetch from built package
               run: node --expose-gc node_modules/nx/bin/nx run php-wasm-compile-extension:test-lazy-docker-asset-fetch --output-style=stream
             - name: Build and load PHP.wasm extension fixtures
@@ -651,21 +678,22 @@ jobs:
                   MEMCACHED_PORT: 11211
 
     build:
+        needs: set-nx-shas
         if: github.repository == 'WordPress/wordpress-playground' || github.event_name == 'pull_request'
         runs-on: ubuntu-latest
         timeout-minutes: 30
         permissions:
-            actions: read # Required to find the last successful CI run.
             contents: read # Required to clone the repo.
+        env:
+            NX_BASE: ${{ needs.set-nx-shas.outputs.base }}
+            NX_HEAD: ${{ needs.set-nx-shas.outputs.head }}
         steps:
             - uses: actions/checkout@v4
               with:
-                  fetch-depth: 0
                   submodules: true
             - uses: ./.github/actions/prepare-playground
               with:
                   node-version: 20
-                  set-nx-shas: true
             - run: |
                   if ADDITIONAL_REMOTE_ORIGINS=invalid-origin npx nx build playground-client; then
                     echo "The Playground client build should have failed due to an invalid additional origin."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,12 +24,16 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 30
         permissions:
+            actions: read # Required to find the last successful CI run.
             contents: read # Required to clone the repo.
         steps:
             - uses: actions/checkout@v4
               with:
+                  fetch-depth: 0
                   submodules: true
             - uses: ./.github/actions/prepare-playground
+              with:
+                  set-nx-shas: true
             - run: npx nx affected --target=lint
             - run: npx nx affected --target=typecheck
             - run: npx nx check-orphan-pages docs-site
@@ -39,6 +43,7 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 30
         permissions:
+            actions: read # Required to find the last successful CI run.
             contents: read # Required to clone the repo.
         strategy:
             fail-fast: false
@@ -77,10 +82,12 @@ jobs:
         steps:
             - uses: actions/checkout@v4
               with:
+                  fetch-depth: 0
                   submodules: true
             - uses: ./.github/actions/prepare-playground
               with:
                   node-version: 20
+                  set-nx-shas: true
             - run: node --expose-gc node_modules/nx/bin/nx affected --target=${{ matrix.target }}
               env:
                   MYSQL_DATABASE: test_db
@@ -91,6 +98,7 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 30
         permissions:
+            actions: read # Required to find the last successful CI run.
             contents: read # Required to clone the repo.
         strategy:
             fail-fast: false
@@ -127,10 +135,12 @@ jobs:
         steps:
             - uses: actions/checkout@v4
               with:
+                  fetch-depth: 0
                   submodules: true
             - uses: ./.github/actions/prepare-playground
               with:
                   node-version: 24
+                  set-nx-shas: true
             - run: node --expose-gc node_modules/nx/bin/nx affected --target=${{ matrix.target }}
               env:
                   MYSQL_DATABASE: test_db
@@ -141,19 +151,21 @@ jobs:
         strategy:
             matrix:
                 os: [ubuntu-latest, windows-latest, macos-latest]
-        continue-on-error: true
         runs-on: ${{ matrix.os }}
         timeout-minutes: 30
         permissions:
+            actions: read # Required to find the last successful CI run.
             contents: read # Required to clone the repo.
         name: 'test-playground-cli (${{ matrix.os }})'
         steps:
             - uses: actions/checkout@v4
               with:
+                  fetch-depth: 0
                   submodules: true
             - uses: ./.github/actions/prepare-playground
               with:
                   node-version: 22
+                  set-nx-shas: true
             - name: Run full test suite
               run: node node_modules/nx/bin/nx affected --target=test-playground-cli
     test-file-locking:
@@ -166,15 +178,18 @@ jobs:
         runs-on: ${{ matrix.os }}
         timeout-minutes: 30
         permissions:
+            actions: read # Required to find the last successful CI run.
             contents: read # Required to clone the repo.
         name: 'test-file-locking-${{ matrix.async-strategy }} (${{ matrix.os }})'
         steps:
             - uses: actions/checkout@v4
               with:
+                  fetch-depth: 0
                   submodules: true
             - uses: ./.github/actions/prepare-playground
               with:
                   node-version: 22
+                  set-nx-shas: true
             - name: Run full test suite
               run: node node_modules/nx/bin/nx affected --target=test-file-locking-${{ matrix.async-strategy }}
     test-e2e-php-wasm-web-jspi:
@@ -511,6 +526,7 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 60
         permissions:
+            actions: read # Required to find the last successful CI run.
             contents: read # Required to clone the repo.
         steps:
             - name: Free up runner disk space
@@ -533,10 +549,12 @@ jobs:
                   df -h
             - uses: actions/checkout@v4
               with:
+                  fetch-depth: 0
                   submodules: true
             - uses: ./.github/actions/prepare-playground
               with:
                   node-version: 24
+                  set-nx-shas: true
             - name: Verify lazy Docker asset fetch from built package
               run: node --expose-gc node_modules/nx/bin/nx run php-wasm-compile-extension:test-lazy-docker-asset-fetch --output-style=stream
             - name: Build and load PHP.wasm extension fixtures
@@ -637,14 +655,17 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 30
         permissions:
+            actions: read # Required to find the last successful CI run.
             contents: read # Required to clone the repo.
         steps:
             - uses: actions/checkout@v4
               with:
+                  fetch-depth: 0
                   submodules: true
             - uses: ./.github/actions/prepare-playground
               with:
                   node-version: 20
+                  set-nx-shas: true
             - run: |
                   if ADDITIONAL_REMOTE_ORIGINS=invalid-origin npx nx build playground-client; then
                     echo "The Playground client build should have failed due to an invalid additional origin."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
                   filter: tree:0
             - id: set_shas
               name: Derive appropriate SHAs for nx affected
-              uses: nrwl/nx-set-shas@v5
+              uses: nrwl/nx-set-shas@afb73a62d26e41464e9254689e1fd6122ee683c1 # v5.0.1
               with:
                   main-branch-name: trunk
                   set-environment-variables-for-job: false

--- a/packages/playground/cli/tests/sqlite-concurrent-publish.spec.ts
+++ b/packages/playground/cli/tests/sqlite-concurrent-publish.spec.ts
@@ -171,7 +171,7 @@ ob_start();
 for ($i = 0; $i < 11; $i++) {
 	$columns = array();
 	for ($j = 0; $j < 11; $j++) {
-		$columns[] = "c$j varchar(191) NOT NULL DEFAULT '' COMMENT 'stress comment $j'";
+		$columns[] = "c$j varchar(500) NOT NULL DEFAULT '' COMMENT 'stress comment $j'";
 	}
 
 	$table = $wpdb->prefix . 'playground_stress_' . $i;


### PR DESCRIPTION
Post-merge CI now detects which projects changed since the last successful trunk run and runs their Nx tasks. 

Before this PR, `origin/trunk` was used as both NX_BASE and NX_HEAD, leaving `nx affected` with an empty comparison.

With this PR, NX_BASE and NX_HEAD are set to the expected values. As a result, Playground CLI test failures that were previously ignored will now fail the CI workflow. 

## Testing

Inspect the CI logs and confirm the affected jobs receive `NX_BASE` and `NX_HEAD`, fetch the base commit, and run their expected targets.