### PR TITLE
[Website] Separate Playground storage status from save actions

### DIFF
--- a/packages/playground/website/playwright/e2e/website-ui.spec.ts
+++ b/packages/playground/website/playwright/e2e/website-ui.spec.ts
@@ -1937,17 +1937,12 @@ test.describe('Default Playground storage', () => {
 		await expect(
 			website.page.getByRole('button', { name: 'Autosaved' })
 		).toBeVisible({ timeout: 120000 });
-		const originalSite = await getActivePlaygroundSite(website.page);
-		const activeSite = await website.page.evaluate(async (originalSlug) => {
+		const activeSite = await website.page.evaluate(async () => {
 			const api = (window as any).playgroundSites;
 			const slug = `operation-error-active-${Date.now().toString(36)}`;
-			await api.createNewSavedSite(slug, undefined, {
-				persistence: 'autosave',
-				updateUrl: false,
-				excludeFromPruning: [originalSlug],
-			});
+			await api.createNewTemporarySite(slug);
 			return api.list().find((site: any) => site.slug === slug);
-		}, originalSite.slug);
+		});
 		await website.page.evaluate(() => {
 			Object.defineProperty(window, 'showDirectoryPicker', {
 				configurable: true,

--- a/packages/playground/website/src/components/saved-playgrounds-panel/index.tsx
+++ b/packages/playground/website/src/components/saved-playgrounds-panel/index.tsx
@@ -1043,25 +1043,24 @@ export function SavedPlaygroundsPanel({
 		});
 	}
 
-	// Every row carries one calm "..." menu (no separate buttons). It groups the
-	// two save destinations — "Save in browser storage" (OPFS) and "Save in a
-	// local directory…" — above Rename / Delete. Clicking anywhere on the row switches
-	// to it. The menu only lists what applies to that Playground's storage.
+	// Every row carries one calm "..." menu (no separate buttons). Temporary
+	// Playgrounds show the save destinations. Stored Playgrounds show the current
+	// destination and explain why the other one is unavailable. Autosaves also
+	// offer one way to keep them permanently. Clicking anywhere on the row
+	// switches to it.
 	function renderRowActions(site: SiteInfo) {
 		const isAutosave = isAutosavedSite(site);
 		const isTemporary = site.metadata.storage === 'none';
 		const isStored = !isTemporary;
-		// Temporary and autosaved Playgrounds live in the browser and can be
-		// stored permanently in the browser (OPFS) and/or copied to a local
-		// directory. Already-saved and local-directory Playgrounds can't.
-		const canStoreInBrowser =
-			(isTemporary || isAutosave) && isOpfsAvailable;
-		const canSaveToLocal =
-			(isTemporary || isAutosave) && localFsAvailability === 'available';
-		const hasSaveActions = canStoreInBrowser || canSaveToLocal;
-		if (!hasSaveActions && !isStored) {
-			return null;
-		}
+		// Temporary Playgrounds have not chosen storage yet, so they show both
+		// destinations and explain any unavailable option. A stored Playground's
+		// backend is fixed. An autosave can only be kept permanently in place.
+		const localFsUnavailableReason =
+			localFsAvailability === 'available'
+				? undefined
+				: localFsAvailability === null
+					? 'Checking availability…'
+					: 'Not available in this browser';
 		return (
 			<div className={css.siteRowActions}>
 				<DropdownMenu
@@ -1073,45 +1072,93 @@ export function SavedPlaygroundsPanel({
 				>
 					{({ onClose: closeMenu }) => (
 						<>
-							{hasSaveActions && (
+							{isStored && (
 								<MenuGroup>
-									{canStoreInBrowser && (
-										<MenuItem
-											onClick={() =>
-												handleStoreInBrowser(
-													site,
-													closeMenu
-												)
-											}
-										>
-											Save in browser storage
-										</MenuItem>
-									)}
-									{canSaveToLocal && (
-										<MenuItem
-											onClick={() =>
-												handleSaveToLocalDirectory(
-													site,
-													closeMenu
-												)
-											}
-										>
-											Save in a local directory…
-										</MenuItem>
-									)}
-								</MenuGroup>
-							)}
-							{site.metadata.storage === 'opfs' && (
-								<MenuGroup>
-									<MenuItem icon={check} disabled>
-										Saved in browser storage
+									<MenuItem
+										disabled
+										icon={
+											site.metadata.storage === 'opfs'
+												? check
+												: undefined
+										}
+										info={
+											site.metadata.storage !== 'opfs'
+												? 'Storage can’t be changed'
+												: undefined
+										}
+									>
+										{site.metadata.storage === 'opfs'
+											? 'Saved in browser storage'
+											: 'Save in browser storage'}
+									</MenuItem>
+									<MenuItem
+										disabled
+										icon={
+											site.metadata.storage === 'local-fs'
+												? check
+												: undefined
+										}
+										info={
+											site.metadata.storage !== 'local-fs'
+												? 'Storage can’t be changed'
+												: undefined
+										}
+									>
+										{site.metadata.storage === 'local-fs'
+											? 'Saved in a local directory'
+											: 'Save in a local directory'}
 									</MenuItem>
 								</MenuGroup>
 							)}
-							{site.metadata.storage === 'local-fs' && (
+							{isTemporary && (
+								<MenuGroup label="Save Playground">
+									<MenuItem
+										disabled={!isOpfsAvailable}
+										info={
+											!isOpfsAvailable
+												? 'Not available in this browser'
+												: undefined
+										}
+										onClick={() =>
+											handleStoreInBrowser(
+												site,
+												closeMenu
+											)
+										}
+									>
+										Save in browser storage
+									</MenuItem>
+									<MenuItem
+										disabled={!!localFsUnavailableReason}
+										info={localFsUnavailableReason}
+										onClick={() =>
+											handleSaveToLocalDirectory(
+												site,
+												closeMenu
+											)
+										}
+									>
+										Save in a local directory…
+									</MenuItem>
+								</MenuGroup>
+							)}
+							{isAutosave && (
 								<MenuGroup>
-									<MenuItem icon={check} disabled>
-										Saved in a local directory
+									<MenuItem
+										disabled={!isOpfsAvailable}
+										info={
+											!isOpfsAvailable
+												? 'Browser storage is unavailable'
+												: undefined
+										}
+										onClick={() =>
+											handleStoreInBrowser(
+												site,
+												closeMenu
+											)
+										}
+									>
+										Keep autosave permanently
 									</MenuItem>
 								</MenuGroup>
 							)}


### PR DESCRIPTION
Playground row menus now list each storage destination once. Stored Playgrounds mark the chosen destination and disable the other with a short reason instead of offering a storage change. Autosaves expose one separate “Keep autosave permanently” action.

### Desktop

| Before | After |
| --- | --- |
| ![Before: duplicate browser storage controls](https://gist.githubusercontent.com/adamziel/ee2feb798c219ea2b854a823c28c23ba/raw/f5d98ddab9e4f11706db3ce3ddb1b76d43a0ba32/before-desktop.svg) | ![After: checked browser storage, disabled local storage, and a permanent autosave action](https://gist.githubusercontent.com/adamziel/ee2feb798c219ea2b854a823c28c23ba/raw/6a90afcfee962905412918d265bcb7fc146c6f1e/after-desktop.svg) |

### Mobile

| Before | After |
| --- | --- |
| ![Before: duplicate browser storage controls on mobile](https://gist.githubusercontent.com/adamziel/ee2feb798c219ea2b854a823c28c23ba/raw/06de0996c579280d888c490558a0a6bd477adade/before-mobile.svg) | ![After: checked browser storage, disabled local storage, and a permanent autosave action on mobile](https://gist.githubusercontent.com/adamziel/ee2feb798c219ea2b854a823c28c23ba/raw/85b308bfc1611f2b8fc3f872cb5437f4932e784f/after-mobile.svg) |

## Testing

Open the row menu for a temporary Playground and confirm that the two storage destinations appear once each. Open an autosaved Playground and confirm that browser storage is checked, local-directory storage is disabled with a short reason, and “Keep autosave permanently” appears. Keep it and confirm that the permanent action disappears while the fixed storage rows, Rename, and Delete remain.
