### PR TITLE
[Website] Reuse MenuItem descriptions for contextual action hints

### DIFF
--- a/packages/playground/website/src/components/blueprint-editor/BlueprintBundleEditor.tsx
+++ b/packages/playground/website/src/components/blueprint-editor/BlueprintBundleEditor.tsx
@@ -820,18 +820,21 @@ export const BlueprintBundleEditor = forwardRef<
 	const dockExportDropdown = (
 		<DropdownMenu
 			className={styles.editorExport}
-			icon={chevronDown}
+			icon={null}
 			label="Export"
-			text="Export"
 			toggleProps={{
 				variant: 'secondary',
 				className: classNames(
 					styles.editorToolbarButton,
 					styles.editorExportToggle
 				),
-				iconPosition: 'right',
-				iconSize: 16,
 				showTooltip: false,
+				children: (
+					<>
+						Export
+						<Icon icon={chevronDown} size={16} />
+					</>
+				),
 			}}
 			popoverProps={{
 				placement: 'bottom-end',

--- a/packages/playground/website/src/components/blueprint-editor/BlueprintBundleEditor.tsx
+++ b/packages/playground/website/src/components/blueprint-editor/BlueprintBundleEditor.tsx
@@ -32,7 +32,6 @@ import {
 	forwardRef,
 	useCallback,
 	useEffect,
-	useId,
 	useImperativeHandle,
 	useMemo,
 	useRef,
@@ -343,7 +342,6 @@ export const BlueprintBundleEditor = forwardRef<
 		}
 		return state.clients.entities[storedSiteSlug]?.opfsSync?.status;
 	});
-	const copyBlueprintUrlHintId = useId();
 	const [stringEditorState, setStringEditorState] =
 		useState<StringEditorState>({
 			isOpen: false,
@@ -843,35 +841,22 @@ export const BlueprintBundleEditor = forwardRef<
 				<MenuGroup>
 					<MenuItem
 						icon={link}
-						className={
+						info={
 							!isBundleShareable
-								? styles.exportMenuItemWithHint
+								? 'Multi-file Blueprints can’t be shared as a URL — download a zip instead.'
 								: undefined
 						}
-						aria-label="Copy Blueprint URL"
-						aria-describedby={
-							!isBundleShareable
-								? copyBlueprintUrlHintId
+						aria-disabled={!isBundleShareable}
+						onClick={
+							isBundleShareable
+								? () => {
+										handleShareBlueprint();
+										onClose();
+									}
 								: undefined
 						}
-						disabled={!isBundleShareable}
-						onClick={() => {
-							handleShareBlueprint();
-							onClose();
-						}}
 					>
-						<span className={styles.exportMenuItemBody}>
-							<span>Copy Blueprint URL</span>
-							{!isBundleShareable && (
-								<span
-									id={copyBlueprintUrlHintId}
-									className={styles.exportMenuItemHint}
-								>
-									Multi-file Blueprints can’t be shared as a
-									URL — download a zip instead.
-								</span>
-							)}
-						</span>
+						Copy Blueprint URL
 					</MenuItem>
 					<MenuItem
 						icon={download}

--- a/packages/playground/website/src/components/blueprint-editor/BlueprintBundleEditor.tsx
+++ b/packages/playground/website/src/components/blueprint-editor/BlueprintBundleEditor.tsx
@@ -75,6 +75,7 @@ import {
 	setDockOperationNotice,
 	setDockPaneOpen,
 } from '../../lib/state/redux/slice-ui';
+import { MenuItemWithDescription } from '../menu-item-with-description';
 import styles from './blueprint-bundle-editor.module.css';
 import hideRootStyles from './hide-root.module.css';
 import validationStyles from './validation-panel.module.css';
@@ -838,7 +839,7 @@ export const BlueprintBundleEditor = forwardRef<
 		>
 			{({ onClose }) => (
 				<MenuGroup>
-					<MenuItem
+					<MenuItemWithDescription
 						icon={link}
 						info={
 							!isBundleShareable
@@ -856,7 +857,7 @@ export const BlueprintBundleEditor = forwardRef<
 						}
 					>
 						Copy Blueprint URL
-					</MenuItem>
+					</MenuItemWithDescription>
 					<MenuItem
 						icon={download}
 						onClick={() => {

--- a/packages/playground/website/src/components/blueprint-editor/BlueprintBundleEditor.tsx
+++ b/packages/playground/website/src/components/blueprint-editor/BlueprintBundleEditor.tsx
@@ -9,7 +9,7 @@ import {
 import { logger } from '@php-wasm/logger';
 import {
 	Button,
-	Dropdown,
+	DropdownMenu,
 	Icon,
 	MenuGroup,
 	MenuItem,
@@ -817,27 +817,26 @@ export const BlueprintBundleEditor = forwardRef<
 		</Button>
 	);
 	const dockExportDropdown = (
-		<Dropdown
+		<DropdownMenu
 			className={styles.editorExport}
+			icon={chevronDown}
+			label="Export"
+			text="Export"
+			toggleProps={{
+				variant: 'secondary',
+				className: classNames(
+					styles.editorToolbarButton,
+					styles.editorExportToggle
+				),
+				iconPosition: 'right',
+				iconSize: 16,
+				showTooltip: false,
+			}}
 			popoverProps={{
 				placement: 'bottom-end',
 			}}
-			renderToggle={({ isOpen, onToggle }) => (
-				<Button
-					variant="secondary"
-					className={classNames(
-						styles.editorToolbarButton,
-						styles.editorExportToggle
-					)}
-					onClick={onToggle}
-					aria-expanded={isOpen}
-					aria-haspopup="menu"
-				>
-					Export
-					<Icon icon={chevronDown} size={16} />
-				</Button>
-			)}
-			renderContent={({ onClose }) => (
+		>
+			{({ onClose }) => (
 				<MenuGroup>
 					<MenuItem
 						icon={link}
@@ -869,7 +868,7 @@ export const BlueprintBundleEditor = forwardRef<
 					</MenuItem>
 				</MenuGroup>
 			)}
-		/>
+		</DropdownMenu>
 	);
 	const dockDocsLink = (
 		<WpTooltip

--- a/packages/playground/website/src/components/blueprint-editor/BlueprintBundleEditor.tsx
+++ b/packages/playground/website/src/components/blueprint-editor/BlueprintBundleEditor.tsx
@@ -858,8 +858,11 @@ export const BlueprintBundleEditor = forwardRef<
 					>
 						Copy Blueprint URL
 					</MenuItemWithDescription>
+					{/* Start on the available action. ArrowUp still reaches the
+					    unavailable item's explanation. */}
 					<MenuItem
 						icon={download}
+						autoFocus={!isBundleShareable}
 						onClick={() => {
 							handleDownloadBundle();
 							onClose();

--- a/packages/playground/website/src/components/blueprint-editor/BlueprintBundleEditor.tsx
+++ b/packages/playground/website/src/components/blueprint-editor/BlueprintBundleEditor.tsx
@@ -838,7 +838,7 @@ export const BlueprintBundleEditor = forwardRef<
 			}}
 		>
 			{({ onClose }) => (
-				<MenuGroup>
+				<MenuGroup className={styles.editorExportMenu}>
 					<MenuItemWithDescription
 						icon={link}
 						info={

--- a/packages/playground/website/src/components/blueprint-editor/blueprint-bundle-editor.module.css
+++ b/packages/playground/website/src/components/blueprint-editor/blueprint-bundle-editor.module.css
@@ -196,39 +196,6 @@
 	gap: 4px;
 }
 
-.exportMenuItemWithHint {
-	height: auto;
-	justify-content: flex-start;
-	min-height: 52px;
-	padding-bottom: 8px;
-	padding-top: 8px;
-	text-align: left;
-}
-
-.exportMenuItemWithHint :global(.components-menu-item__item) {
-	align-items: flex-start;
-	min-width: 0;
-	white-space: normal;
-}
-
-.exportMenuItemBody {
-	align-items: flex-start;
-	display: flex;
-	flex-direction: column;
-	gap: 4px;
-	line-height: 1.4;
-	white-space: normal;
-}
-
-.exportMenuItemHint {
-	color: var(--ink-muted);
-	font-size: 12px;
-	font-weight: 400;
-	line-height: 1.4;
-	max-width: 240px;
-	white-space: normal;
-}
-
 .runHint {
 	align-items: flex-start;
 	background: #fff8e5;

--- a/packages/playground/website/src/components/blueprint-editor/blueprint-bundle-editor.module.css
+++ b/packages/playground/website/src/components/blueprint-editor/blueprint-bundle-editor.module.css
@@ -196,6 +196,11 @@
 	gap: 4px;
 }
 
+.editorExportMenu :global(.components-menu-item__button.components-button) {
+	padding-left: 12px;
+	padding-right: 12px;
+}
+
 .runHint {
 	align-items: flex-start;
 	background: #fff8e5;

--- a/packages/playground/website/src/components/menu-item-with-description.module.css
+++ b/packages/playground/website/src/components/menu-item-with-description.module.css
@@ -1,0 +1,23 @@
+.withDescription:global(.components-button) {
+	height: auto;
+	justify-content: flex-start;
+	min-height: 52px;
+	padding-bottom: 8px;
+	padding-top: 8px;
+	text-align: left;
+}
+
+.withDescription :global(.components-menu-item__item) {
+	align-items: flex-start;
+	min-width: 0;
+	white-space: normal;
+}
+
+.withDescription :global(.components-menu-item__info-wrapper),
+.withDescription :global(.components-menu-item__info) {
+	line-height: 1.4;
+}
+
+.withDescription :global(.components-menu-item__info) {
+	max-width: 240px;
+}

--- a/packages/playground/website/src/components/menu-item-with-description.tsx
+++ b/packages/playground/website/src/components/menu-item-with-description.tsx
@@ -1,0 +1,20 @@
+import { MenuItem } from '@wordpress/components';
+import classNames from 'classnames';
+import type { ComponentPropsWithoutRef } from 'react';
+import css from './menu-item-with-description.module.css';
+
+type MenuItemWithDescriptionProps = ComponentPropsWithoutRef<typeof MenuItem>;
+
+export function MenuItemWithDescription({
+	className,
+	info,
+	...props
+}: MenuItemWithDescriptionProps) {
+	return (
+		<MenuItem
+			{...props}
+			className={classNames(className, info && css.withDescription)}
+			info={info}
+		/>
+	);
+}

--- a/packages/playground/website/src/components/saved-playgrounds-panel/index.tsx
+++ b/packages/playground/website/src/components/saved-playgrounds-panel/index.tsx
@@ -69,6 +69,7 @@ import useFetch from '../../lib/hooks/use-fetch';
 import { PlaygroundRoute, redirectTo } from '../../lib/state/url/router';
 import { OverlaySection } from '../overlay';
 import { TruncatedText } from '../truncated-text';
+import { MenuItemWithDescription } from '../menu-item-with-description';
 import { isOpfsAvailable } from '../../lib/state/opfs/opfs-site-storage';
 import type { DockPaneHeaderOverride } from '../dock/dock-pane';
 
@@ -1177,7 +1178,7 @@ export function SavedPlaygroundsPanel({
 									    deleting it would swap the view out from under you.
 									    Switch away first, then delete it as an ordinary
 									    background Playground. */}
-									<MenuItem
+									<MenuItemWithDescription
 										className={css.dangerMenuItem}
 										info={
 											isActiveSite
@@ -1196,7 +1197,7 @@ export function SavedPlaygroundsPanel({
 										}
 									>
 										Delete
-									</MenuItem>
+									</MenuItemWithDescription>
 								</MenuGroup>
 							)}
 						</>

--- a/packages/playground/website/src/components/saved-playgrounds-panel/index.tsx
+++ b/packages/playground/website/src/components/saved-playgrounds-panel/index.tsx
@@ -1069,7 +1069,7 @@ export function SavedPlaygroundsPanel({
 					label={`Actions for ${site.metadata.name}`}
 					className={css.siteRowMenu}
 					toggleProps={{ disabled: isImportingZip }}
-					popoverProps={{ placement: 'bottom-end' }}
+					popoverProps={{ placement: 'top-end' }}
 				>
 					{({ onClose: closeMenu }) => (
 						<>

--- a/packages/playground/website/src/components/saved-playgrounds-panel/index.tsx
+++ b/packages/playground/website/src/components/saved-playgrounds-panel/index.tsx
@@ -1052,6 +1052,7 @@ export function SavedPlaygroundsPanel({
 		const isAutosave = isAutosavedSite(site);
 		const isTemporary = site.metadata.storage === 'none';
 		const isStored = !isTemporary;
+		const isActiveSite = site.slug === activeSite?.slug;
 		// Temporary Playgrounds have not chosen storage yet, so they show both
 		// destinations and explain any unavailable option. A stored Playground's
 		// backend is fixed. An autosave can only be kept permanently in place.
@@ -1172,48 +1173,30 @@ export function SavedPlaygroundsPanel({
 									>
 										Rename
 									</MenuItem>
-									{site.slug === activeSite?.slug ? (
-										// You can't delete the Playground you're
-										// currently in — deleting it would swap
-										// the view out from under you. Switch
-										// away first, then delete it as an
-										// ordinary background Playground.
-										<MenuItem
-											className={classNames(
-												css.dangerMenuItem,
-												css.deleteMenuItemWithHint
-											)}
-											aria-disabled
-										>
-											<span
-												className={
-													css.deleteMenuItemBody
-												}
-											>
-												<span>Delete</span>
-												<span
-													className={
-														css.deleteMenuItemHint
-													}
-												>
-													Switch to another Playground
-													first to delete this one.
-												</span>
-											</span>
-										</MenuItem>
-									) : (
-										<MenuItem
-											className={css.dangerMenuItem}
-											onClick={() =>
-												handleDeleteSite(
-													site,
-													closeMenu
-												)
-											}
-										>
-											Delete
-										</MenuItem>
-									)}
+									{/* You can't delete the Playground you're currently in:
+									    deleting it would swap the view out from under you.
+									    Switch away first, then delete it as an ordinary
+									    background Playground. */}
+									<MenuItem
+										className={css.dangerMenuItem}
+										info={
+											isActiveSite
+												? 'Switch to another Playground first to delete this one.'
+												: undefined
+										}
+										aria-disabled={isActiveSite}
+										onClick={
+											isActiveSite
+												? undefined
+												: () =>
+														handleDeleteSite(
+															site,
+															closeMenu
+														)
+										}
+									>
+										Delete
+									</MenuItem>
 								</MenuGroup>
 							)}
 						</>

--- a/packages/playground/website/src/components/saved-playgrounds-panel/style.module.css
+++ b/packages/playground/website/src/components/saved-playgrounds-panel/style.module.css
@@ -402,41 +402,6 @@
 	background: rgba(220, 38, 38, 0.1) !important;
 }
 
-/* Disabled "Delete" on the active Playground, with a hint explaining why.
-   Mirrors the export-menu-item hint in the Blueprint editor. */
-.deleteMenuItemWithHint {
-	height: auto;
-	justify-content: flex-start;
-	min-height: 52px;
-	padding-bottom: 8px;
-	padding-top: 8px;
-	text-align: left;
-}
-
-.deleteMenuItemWithHint :global(.components-menu-item__item) {
-	align-items: flex-start;
-	min-width: 0;
-	white-space: normal;
-}
-
-.deleteMenuItemBody {
-	align-items: flex-start;
-	display: flex;
-	flex-direction: column;
-	gap: 4px;
-	line-height: 1.4;
-	white-space: normal;
-}
-
-.deleteMenuItemHint {
-	color: var(--ink-muted, #50575e) !important;
-	font-size: 12px;
-	font-weight: 400;
-	line-height: 1.4;
-	max-width: 240px;
-	white-space: normal;
-}
-
 /* Loading state */
 .loadingContainer {
 	display: flex;


### PR DESCRIPTION
Uses `DropdownMenu` for Blueprint export actions and a shared
`MenuItemWithDescription` wrapper for the Export and active-Playground Delete
hints. The Blueprint menu keeps its original horizontal item inset and
responsive toggle padding.

Unavailable items now use `aria-disabled` without a click handler. They stay in menu navigation, so keyboard and assistive-technology users can reach the explanation without enabling the action.

When URL copying is unavailable, the Export menu starts on **Download Zip**. **Arrow Up** still reaches the explanation.

The Playground row menu prefers opening above the row when space allows, keeping the longer **Delete** item clear of the Dock controls.

## Before and after

### Your Playgrounds action menu

#### Desktop

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/articles-adamziel-com/wordpress-playground/2347a30586af1839eee9a8f24967bc6133e3c964/consolidate-widget-styles/saved-playgrounds-before-desktop.png" width="720" alt="Your Playgrounds action menu on desktop before reusing MenuItem descriptions"> | <img src="https://raw.githubusercontent.com/articles-adamziel-com/wordpress-playground/2347a30586af1839eee9a8f24967bc6133e3c964/consolidate-widget-styles/saved-playgrounds-after-desktop.png" width="720" alt="Your Playgrounds action menu on desktop after reusing MenuItem descriptions"> |

#### Mobile

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/articles-adamziel-com/wordpress-playground/2347a30586af1839eee9a8f24967bc6133e3c964/consolidate-widget-styles/saved-playgrounds-before-mobile.png" width="390" alt="Your Playgrounds action menu on mobile before reusing MenuItem descriptions"> | <img src="https://raw.githubusercontent.com/articles-adamziel-com/wordpress-playground/2347a30586af1839eee9a8f24967bc6133e3c964/consolidate-widget-styles/saved-playgrounds-after-mobile.png" width="390" alt="Your Playgrounds action menu on mobile after reusing MenuItem descriptions"> |

### Blueprint Export menu

#### Desktop

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/articles-adamziel-com/wordpress-playground/2347a30586af1839eee9a8f24967bc6133e3c964/consolidate-widget-styles/blueprint-export-before-desktop.png" width="720" alt="Blueprint Export menu on desktop before reusing MenuItem descriptions"> | <img src="https://raw.githubusercontent.com/articles-adamziel-com/wordpress-playground/2347a30586af1839eee9a8f24967bc6133e3c964/consolidate-widget-styles/blueprint-export-after-desktop.png" width="720" alt="Blueprint Export menu on desktop after reusing MenuItem descriptions"> |

#### Mobile

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/articles-adamziel-com/wordpress-playground/2347a30586af1839eee9a8f24967bc6133e3c964/consolidate-widget-styles/blueprint-export-before-mobile.png" width="390" alt="Blueprint Export menu on mobile before reusing MenuItem descriptions"> | <img src="https://raw.githubusercontent.com/articles-adamziel-com/wordpress-playground/2347a30586af1839eee9a8f24967bc6133e3c964/consolidate-widget-styles/blueprint-export-after-mobile.png" width="390" alt="Blueprint Export menu on mobile after reusing MenuItem descriptions"> |

## Testing

Open a multi-file Blueprint's **Export** menu and check the explanation below **Copy Blueprint URL**. Open the active Playground's action menu and check the explanation below **Delete**. Move through both menus with the keyboard and confirm neither unavailable action runs.
