### PR TITLE
[Website] Keep autosaves running after switching Playgrounds

### DIFF
--- a/packages/playground/website/playwright/e2e/opfs.spec.ts
+++ b/packages/playground/website/playwright/e2e/opfs.spec.ts
@@ -462,6 +462,29 @@ async function getStoredPlaygroundSiteSlugs(page: Page) {
 	});
 }
 
+async function getInitialOpfsSyncPending(page: Page, siteSlug: string) {
+	return page.evaluate(
+		async ({ directoryName }) => {
+			try {
+				const root = await navigator.storage.getDirectory();
+				const sites = await root.getDirectoryHandle('sites');
+				const siteDirectory =
+					await sites.getDirectoryHandle(directoryName);
+				const metadataFile =
+					await siteDirectory.getFileHandle('wp-runtime.json');
+				const metadata = JSON.parse(
+					await (await metadataFile.getFile()).text()
+				);
+				return metadata.initialOpfsSyncPending === true;
+			} catch {
+				// Treat transient reads during the metadata rewrite as still syncing.
+				return true;
+			}
+		},
+		{ directoryName: getDirectoryNameForSlug(siteSlug) }
+	);
+}
+
 async function waitForActivePlaygroundSiteSlug(
 	page: Page,
 	matchesSlug: (slug: string) => boolean
@@ -1250,7 +1273,7 @@ test('should show an inline error for a non-ZIP drop', async ({
 	).toBeVisible();
 });
 
-test('should close the pane, reveal the site, and finish during a ZIP import', async ({
+test('should finish autosaving a ZIP import after switching Playgrounds', async ({
 	website,
 	browserName,
 }) => {
@@ -1260,6 +1283,8 @@ test('should close the pane, reveal the site, and finish during a ZIP import', a
 	);
 
 	await website.goto(getTemporaryPlaygroundUrl());
+	const sourceSite = await getActivePlaygroundSite(website.page);
+	expect(sourceSite?.slug).toBeTruthy();
 	await website.openDockPane('New Playground');
 	await website.page
 		.getByRole('tab', { name: 'Import zip', exact: true })
@@ -1281,9 +1306,16 @@ test('should close the pane, reveal the site, and finish during a ZIP import', a
 	const importProgressStarted = expect(importProgress).toBeVisible({
 		timeout: 120000,
 	});
-	const autosaveStarted = expect(autosaveProgress).toBeVisible({
-		timeout: 120000,
-	});
+	const switchWhileAutosaving = (async () => {
+		await expect(autosaveProgress).toBeVisible({ timeout: 120000 });
+		const importedSite = await getActivePlaygroundSite(website.page);
+		expect(importedSite).toMatchObject({
+			storage: 'opfs',
+			persistence: 'autosave',
+		});
+		await setActivePlaygroundSite(website.page, sourceSite.slug);
+		return importedSite;
+	})();
 	const importProgressAdvanced = expect
 		.poll(
 			async () => {
@@ -1308,10 +1340,15 @@ test('should close the pane, reveal the site, and finish during a ZIP import', a
 	await expect(autosaveProgress).toHaveCount(0);
 	await importProgressAdvanced;
 	await expect(importProgress).toHaveCount(0, { timeout: 120000 });
-	await autosaveStarted;
-	await expect(
-		website.page.locator('iframe.playground-viewport:visible')
-	).toHaveCount(1);
+	const importedSite = await switchWhileAutosaving;
+
+	await expect
+		.poll(
+			() => getInitialOpfsSyncPending(website.page, importedSite.slug),
+			{ timeout: 120000 }
+		)
+		.toBe(false);
+
 	const newPlaygroundButton = website.page.getByRole('button', {
 		name: 'New Playground',
 		exact: true,
@@ -1320,11 +1357,8 @@ test('should close the pane, reveal the site, and finish during a ZIP import', a
 	await expect(
 		website.page.getByText('Playground imported', { exact: true })
 	).toBeVisible({ timeout: 120000 });
-	const importedSite = await getActivePlaygroundSite(website.page);
-	expect(importedSite).toMatchObject({
-		storage: 'opfs',
-		persistence: 'autosave',
-	});
+
+	await website.goto(`./?site-slug=${encodeURIComponent(importedSite.slug)}`);
 
 	await expect
 		.poll(

--- a/packages/playground/website/playwright/e2e/opfs.spec.ts
+++ b/packages/playground/website/playwright/e2e/opfs.spec.ts
@@ -465,21 +465,15 @@ async function getStoredPlaygroundSiteSlugs(page: Page) {
 async function getInitialOpfsSyncPending(page: Page, siteSlug: string) {
 	return page.evaluate(
 		async ({ directoryName }) => {
-			try {
-				const root = await navigator.storage.getDirectory();
-				const sites = await root.getDirectoryHandle('sites');
-				const siteDirectory =
-					await sites.getDirectoryHandle(directoryName);
-				const metadataFile =
-					await siteDirectory.getFileHandle('wp-runtime.json');
-				const metadata = JSON.parse(
-					await (await metadataFile.getFile()).text()
-				);
-				return metadata.initialOpfsSyncPending === true;
-			} catch {
-				// Treat transient reads during the metadata rewrite as still syncing.
-				return true;
-			}
+			const root = await navigator.storage.getDirectory();
+			const sites = await root.getDirectoryHandle('sites');
+			const siteDirectory = await sites.getDirectoryHandle(directoryName);
+			const metadataFile =
+				await siteDirectory.getFileHandle('wp-runtime.json');
+			const metadata = JSON.parse(
+				await (await metadataFile.getFile()).text()
+			);
+			return metadata.initialOpfsSyncPending === true;
 		},
 		{ directoryName: getDirectoryNameForSlug(siteSlug) }
 	);

--- a/packages/playground/website/src/components/playground-viewport/index.tsx
+++ b/packages/playground/website/src/components/playground-viewport/index.tsx
@@ -9,9 +9,13 @@ import {
 	useAppDispatch,
 	useAppSelector,
 } from '../../lib/state/redux/store';
-import { removeClientInfo } from '../../lib/state/redux/slice-clients';
+import {
+	removeClientInfo,
+	selectAllClientInfo,
+} from '../../lib/state/redux/slice-clients';
 import { bootSiteClient } from '../../lib/state/redux/boot-site-client';
 import {
+	selectAllSites,
 	selectSiteBySlug,
 	selectSitesLoaded,
 	selectTemporarySites,
@@ -37,26 +41,27 @@ export const PlaygroundViewport = ({
 	className,
 }: PlaygroundViewportProps) => {
 	if (displayMode === 'seamless') {
-		return <KeepAliveTemporarySitesViewport />;
+		return <KeepAliveTemporaryAndSyncingSitesViewport />;
 	}
 	return (
 		<BrowserChrome className={className}>
-			<KeepAliveTemporarySitesViewport />
+			<KeepAliveTemporaryAndSyncingSitesViewport />
 		</BrowserChrome>
 	);
 };
 
 /**
- * A multi-viewport component that keeps all rendered temporary sites alive.
+ * A multi-viewport component that keeps temporary and syncing sites alive.
  * Technically, it retains their iframe node in the DOM. When the user switches
- * to another site, the iframe is hidden but not removed. This way, the state
- * of each temporary site is preserved as long as the browser tab remains open.
+ * to another site, the iframe is hidden but not removed. This preserves
+ * temporary state and lets an in-progress storage sync finish in the background.
  *
- * Persistent sites are not affected by this. They are unmounted and rendered as usual
- * as there's no risk of data loss
+ * Persistent sites are otherwise unmounted and rendered as usual.
  */
-export const KeepAliveTemporarySitesViewport = () => {
+export const KeepAliveTemporaryAndSyncingSitesViewport = () => {
 	const temporarySites = useAppSelector(selectTemporarySites);
+	const allSites = useAppSelector(selectAllSites);
+	const allClientInfo = useAppSelector(selectAllClientInfo);
 	const activeSite = useActiveSite();
 	// Check if a site slug is set (even if the entity doesn't exist yet).
 	// This handles the transitional state when navigating to create a new site.
@@ -66,24 +71,26 @@ export const KeepAliveTemporarySitesViewport = () => {
 	const siteImportProgress = useAppSelector(
 		(state) => state.ui.siteImportProgress
 	);
-	const siteSlugsToRender = useMemo(() => {
-		let sites = temporarySites.filter(
-			(site) => site.slug !== activeSite?.slug
-		);
-		if (activeSite) {
-			sites = [...sites, activeSite];
-		}
-		return sites.map((site) => site.slug);
-	}, [temporarySites, activeSite]);
-
 	// Create a map of slug to site for easy lookup
 	const sitesBySlug = useMemo(() => {
-		const sites = [...temporarySites];
-		if (activeSite) {
-			sites.push(activeSite);
+		return new Map(allSites.map((site) => [site.slug, site]));
+	}, [allSites]);
+	const siteSlugsToRender = useMemo(() => {
+		const siteSlugs = new Set(temporarySites.map((site) => site.slug));
+		for (const client of allClientInfo) {
+			if (
+				client.opfsSync?.status === 'syncing' &&
+				sitesBySlug.has(client.siteSlug)
+			) {
+				siteSlugs.add(client.siteSlug);
+			}
 		}
-		return new Map(sites.map((site) => [site.slug, site]));
-	}, [temporarySites, activeSite]);
+		if (activeSite) {
+			siteSlugs.delete(activeSite.slug);
+			siteSlugs.add(activeSite.slug);
+		}
+		return Array.from(siteSlugs);
+	}, [temporarySites, allClientInfo, activeSite, sitesBySlug]);
 	/**
 	 * ## Critical data loss prevention mechanism
 	 *

--- a/packages/playground/website/src/lib/state/redux/site-management-api-middleware.ts
+++ b/packages/playground/website/src/lib/state/redux/site-management-api-middleware.ts
@@ -764,6 +764,12 @@ export function createSitesAPI(
 			if (activeSite?.slug === siteSlug) {
 				return;
 			}
+			if (selectClientInfoBySiteSlug(state, siteSlug)) {
+				// Retained temporary or syncing viewports already have a running
+				// client, so activation does not emit addClientInfo again.
+				dispatch(setActiveSite(siteSlug, options));
+				return;
+			}
 			const bootPromise = new Promise<void>((resolve, reject) => {
 				const unsubscribe = startListening({
 					predicate: (action) =>

--- a/packages/playground/website/src/lib/state/redux/site-management-api-middleware.ts
+++ b/packages/playground/website/src/lib/state/redux/site-management-api-middleware.ts
@@ -767,7 +767,7 @@ export function createSitesAPI(
 			if (selectClientInfoBySiteSlug(state, siteSlug)) {
 				// Retained temporary or syncing viewports already have a running
 				// client, so activation does not emit addClientInfo again.
-				dispatch(setActiveSite(siteSlug, options));
+				await dispatch(setActiveSite(siteSlug, options));
 				return;
 			}
 			const bootPromise = new Promise<void>((resolve, reject) => {


### PR DESCRIPTION
Playgrounds with an active browser-storage sync now keep their iframe mounted after the user switches away. The sync finishes in the background; once it settles, the inactive stored runtime unmounts normally.

`playgroundSites.setActiveSite()` also completes after activating a runtime that is already retained instead of waiting for another client-added event.

## Testing

Import a large Playground ZIP, switch back to the previous Playground while autosave is running, then reopen the imported Playground after a full page load and confirm its plugin and theme files remain.
