### PR TITLE
[Website] Hide Blueprint file browser toggle on desktop

### DIFF
--- a/packages/playground/website/src/components/blueprint-editor/blueprint-bundle-editor.module.css
+++ b/packages/playground/website/src/components/blueprint-editor/blueprint-bundle-editor.module.css
@@ -286,10 +286,6 @@
 	display: none;
 }
 
-.editorHeaderSlotActions .mobileToggle {
-	display: inline-flex;
-}
-
 .mobileOverlay {
 	display: none;
 }
@@ -438,6 +434,7 @@
 
 @media (max-width: 1024px) {
 	.editorHeaderSlotActions .mobileToggle {
+		display: inline-flex;
 		order: initial;
 	}
 


### PR DESCRIPTION
## What

Hide the Blueprint file browser toggle above 1024px, where the file explorer is already visible.

Keep the toggle on narrow layouts, where it controls the file explorer overlay.

## Testing

- Opened the Current Blueprint pane at desktop width and confirmed the toggle is absent.
- Resized the pane to 375×812 and confirmed the Browse files toggle remains visible.
