### PR TITLE
[Website] Keep ZIP reimports from reusing stored Playground slugs

### DIFF
--- a/packages/playground/website/playwright/e2e/opfs.spec.ts
+++ b/packages/playground/website/playwright/e2e/opfs.spec.ts
@@ -1739,6 +1739,107 @@ test('should retain files omitted from a legacy ZIP export', async ({
 	);
 });
 
+test('should re-import an exported ZIP without switching sites', async ({
+	website,
+	context,
+	browserName,
+}) => {
+	test.skip(
+		browserName !== 'chromium',
+		`This test relies on OPFS which isn't available in Playwright's flavor of ${browserName}.`
+	);
+
+	const blueprint: Blueprint = {
+		meta: {
+			title: 'ZIP Reimport Regression',
+			author: 'wordpress',
+		},
+		steps: [],
+	};
+	const sourceUrl = getTemporaryPlaygroundUrl(
+		`#${JSON.stringify(blueprint)}`
+	);
+	await website.goto(sourceUrl);
+	const sourceSiteSlug = await website.page.evaluate(() =>
+		(window as any).playgroundSites.createNewSavedSite(
+			undefined,
+			undefined,
+			{
+				persistence: 'autosave',
+				updateUrl: false,
+			}
+		)
+	);
+
+	// Occupy the next slug after this tab loaded. Its Redux snapshot will not
+	// include this site, but both tabs share OPFS.
+	const secondTab = await context.newPage();
+	await secondTab.goto(new URL(sourceUrl, website.page.url()).href);
+	await secondTab.waitForFunction(() =>
+		Boolean((window as any).playgroundSites?.getClient())
+	);
+	const occupiedSiteSlug = await secondTab.evaluate(
+		(slugToKeep) =>
+			(window as any).playgroundSites.createNewSavedSite(
+				undefined,
+				undefined,
+				{
+					updateUrl: false,
+					excludeFromPruning: [slugToKeep],
+				}
+			),
+		sourceSiteSlug
+	);
+	await secondTab.close();
+
+	expect(occupiedSiteSlug).not.toBe(sourceSiteSlug);
+	expect((await getActivePlaygroundSite(website.page))?.slug).toBe(
+		sourceSiteSlug
+	);
+
+	await website.openDockPane('Export');
+	const downloadPromise = website.page.waitForEvent('download');
+	await website.page
+		.getByRole('dialog', { name: 'Export pane' })
+		.getByRole('button', { name: 'Download as .zip' })
+		.click();
+	const download = await downloadPromise;
+	const downloadPath = await download.path();
+	expect(downloadPath).toBeTruthy();
+	const zipBuffer = await readFile(downloadPath!);
+
+	// Downloading must not change the active site before the ZIP is imported.
+	expect((await getActivePlaygroundSite(website.page))?.slug).toBe(
+		sourceSiteSlug
+	);
+
+	await website.openDockPane('New Playground');
+	await website.page
+		.getByRole('tab', { name: 'Import zip', exact: true })
+		.click();
+	const acceptImportDialog = async (dialog: { accept(): Promise<void> }) => {
+		await dialog.accept();
+	};
+	website.page.on('dialog', acceptImportDialog);
+	await website.page
+		.locator('input[type="file"][accept*=".zip"]')
+		.setInputFiles({
+			name: 'zip-reimport-regression.zip',
+			mimeType: 'application/zip',
+			buffer: zipBuffer,
+		});
+
+	await expect(
+		website.page.getByText('Playground imported', { exact: true })
+	).toBeVisible({ timeout: 120000 });
+	const importedSite = await waitForActivePlaygroundSiteSlug(
+		website.page,
+		(slug) => slug !== sourceSiteSlug
+	);
+	website.page.off('dialog', acceptImportDialog);
+	expect(importedSite.slug).not.toBe(occupiedSiteSlug);
+});
+
 test('should preserve a customized default-theme background through export and import', async ({
 	website,
 	wordpress,

--- a/packages/playground/website/src/lib/state/opfs/opfs-site-storage.ts
+++ b/packages/playground/website/src/lib/state/opfs/opfs-site-storage.ts
@@ -179,20 +179,15 @@ class OpfsSiteStorage {
 	}
 
 	/**
-	 * Lists persisted site names and slugs without loading Blueprint bundles.
+	 * Lists persisted site metadata without loading Blueprint bundles.
 	 */
-	async listSiteNamesAndSlugs(): Promise<
-		Array<{ slug: string; name: string }>
-	> {
-		const sites: Array<{ slug: string; name: string }> = [];
+	async listMetadata(): Promise<SiteInfo[]> {
+		const sites: SiteInfo[] = [];
 		for await (const entry of this.root.values()) {
 			if (entry.kind === 'directory') {
 				try {
 					const site = await this.readStoredSiteMetadata(entry);
-					sites.push({
-						slug: site.slug,
-						name: site.metadata.name,
-					});
+					sites.push(site);
 				} catch (error) {
 					logger.error(`Error reading site ${entry.name}:`, error);
 				}

--- a/packages/playground/website/src/lib/state/opfs/opfs-site-storage.ts
+++ b/packages/playground/website/src/lib/state/opfs/opfs-site-storage.ts
@@ -178,6 +178,29 @@ class OpfsSiteStorage {
 		return sites;
 	}
 
+	/**
+	 * Lists persisted site names and slugs without loading Blueprint bundles.
+	 */
+	async listSiteNamesAndSlugs(): Promise<
+		Array<{ slug: string; name: string }>
+	> {
+		const sites: Array<{ slug: string; name: string }> = [];
+		for await (const entry of this.root.values()) {
+			if (entry.kind === 'directory') {
+				try {
+					const site = await this.readStoredSiteMetadata(entry);
+					sites.push({
+						slug: site.slug,
+						name: site.metadata.name,
+					});
+				} catch (error) {
+					logger.error(`Error reading site ${entry.name}:`, error);
+				}
+			}
+		}
+		return sites;
+	}
+
 	async read(slug: string): Promise<SiteInfo | undefined> {
 		const siteDirName = await this.findExistingSiteDirName(slug);
 		if (!siteDirName) {

--- a/packages/playground/website/src/lib/state/redux/slice-sites.spec.ts
+++ b/packages/playground/website/src/lib/state/redux/slice-sites.spec.ts
@@ -612,63 +612,6 @@ describe('stored sites', () => {
 		});
 	});
 
-	it('avoids slugs occupied in OPFS outside the current Redux state', async () => {
-		const { createStoredSite } = await import('./slice-sites');
-		resolveRuntimeConfiguration.mockResolvedValue({
-			phpVersion: '8.3',
-			wpVersion: 'latest',
-			intl: false,
-			networking: true,
-			extraLibraries: [],
-			constants: {},
-		});
-		listMetadata.mockResolvedValue([
-			createSiteInfo({
-				slug: 'playground-welcome-landing-page',
-				name: 'Stored Playground',
-			}),
-		]);
-
-		const newSite = await createStoredSite(
-			'Imported Playground',
-			createBundleBlueprint(),
-			'playground-welcome-landing-page'
-		)(createThunkDispatch() as any, createEmptyGetState() as any);
-
-		expect(newSite.slug).toBe('playground-welcome-landing-page-2');
-		expect(createSite).toHaveBeenCalledWith(
-			'playground-welcome-landing-page-2',
-			newSite.metadata,
-			undefined
-		);
-	});
-
-	it('creates from the Redux snapshot when OPFS enumeration fails', async () => {
-		const { createStoredSite } = await import('./slice-sites');
-		resolveRuntimeConfiguration.mockResolvedValue({
-			phpVersion: '8.3',
-			wpVersion: 'latest',
-			intl: false,
-			networking: true,
-			extraLibraries: [],
-			constants: {},
-		});
-		listMetadata.mockRejectedValue(new Error('Unable to enumerate OPFS'));
-
-		const newSite = await createStoredSite(
-			'Imported Playground',
-			createBundleBlueprint(),
-			'imported-playground'
-		)(createThunkDispatch() as any, createEmptyGetState() as any);
-
-		expect(newSite.slug).toBe('imported-playground');
-		expect(createSite).toHaveBeenCalledWith(
-			'imported-playground',
-			newSite.metadata,
-			undefined
-		);
-	});
-
 	it('does not persist an edited Blueprint bundle when its runtime is invalid', async () => {
 		resolveRuntimeConfiguration.mockRejectedValue(
 			new Error('Invalid setup')

--- a/packages/playground/website/src/lib/state/redux/slice-sites.spec.ts
+++ b/packages/playground/website/src/lib/state/redux/slice-sites.spec.ts
@@ -5,7 +5,7 @@ import type { TraversableFilesystemBackend } from '@wp-playground/storage';
 describe('stored sites', () => {
 	let createSite: ReturnType<typeof vi.fn>;
 	let deleteSite: ReturnType<typeof vi.fn>;
-	let listSites: ReturnType<typeof vi.fn>;
+	let listSiteNamesAndSlugs: ReturnType<typeof vi.fn>;
 	let loggerError: ReturnType<typeof vi.fn>;
 	let updateSiteStorage: ReturnType<typeof vi.fn>;
 	let persistBlueprintBundle: ReturnType<typeof vi.fn>;
@@ -16,7 +16,7 @@ describe('stored sites', () => {
 		vi.resetModules();
 		createSite = vi.fn();
 		deleteSite = vi.fn();
-		listSites = vi.fn().mockResolvedValue([]);
+		listSiteNamesAndSlugs = vi.fn().mockResolvedValue([]);
 		loggerError = vi.fn();
 		updateSiteStorage = vi.fn();
 		updateSiteStorage.mockImplementation(async (slug, changes) => {
@@ -39,6 +39,7 @@ describe('stored sites', () => {
 		vi.doMock('@php-wasm/logger', () => ({
 			logger: {
 				error: loggerError,
+				warn: vi.fn(),
 			},
 		}));
 		vi.doMock('@wp-playground/common', () => ({
@@ -69,7 +70,7 @@ describe('stored sites', () => {
 			opfsSiteStorage: {
 				create: createSite,
 				delete: deleteSite,
-				list: listSites,
+				listSiteNamesAndSlugs,
 				update: updateSiteStorage,
 			},
 		}));
@@ -621,8 +622,11 @@ describe('stored sites', () => {
 			extraLibraries: [],
 			constants: {},
 		});
-		listSites.mockResolvedValue([
-			createSiteInfo({ slug: 'playground-welcome-landing-page' }),
+		listSiteNamesAndSlugs.mockResolvedValue([
+			{
+				slug: 'playground-welcome-landing-page',
+				name: 'Stored Playground',
+			},
 		]);
 
 		const newSite = await createStoredSite(
@@ -634,6 +638,34 @@ describe('stored sites', () => {
 		expect(newSite.slug).toBe('playground-welcome-landing-page-2');
 		expect(createSite).toHaveBeenCalledWith(
 			'playground-welcome-landing-page-2',
+			newSite.metadata,
+			undefined
+		);
+	});
+
+	it('creates from the Redux snapshot when OPFS enumeration fails', async () => {
+		const { createStoredSite } = await import('./slice-sites');
+		resolveRuntimeConfiguration.mockResolvedValue({
+			phpVersion: '8.3',
+			wpVersion: 'latest',
+			intl: false,
+			networking: true,
+			extraLibraries: [],
+			constants: {},
+		});
+		listSiteNamesAndSlugs.mockRejectedValue(
+			new Error('Unable to enumerate OPFS')
+		);
+
+		const newSite = await createStoredSite(
+			'Imported Playground',
+			createBundleBlueprint(),
+			'imported-playground'
+		)(createThunkDispatch() as any, createEmptyGetState() as any);
+
+		expect(newSite.slug).toBe('imported-playground');
+		expect(createSite).toHaveBeenCalledWith(
+			'imported-playground',
 			newSite.metadata,
 			undefined
 		);

--- a/packages/playground/website/src/lib/state/redux/slice-sites.spec.ts
+++ b/packages/playground/website/src/lib/state/redux/slice-sites.spec.ts
@@ -5,7 +5,7 @@ import type { TraversableFilesystemBackend } from '@wp-playground/storage';
 describe('stored sites', () => {
 	let createSite: ReturnType<typeof vi.fn>;
 	let deleteSite: ReturnType<typeof vi.fn>;
-	let listSiteNamesAndSlugs: ReturnType<typeof vi.fn>;
+	let listMetadata: ReturnType<typeof vi.fn>;
 	let loggerError: ReturnType<typeof vi.fn>;
 	let updateSiteStorage: ReturnType<typeof vi.fn>;
 	let persistBlueprintBundle: ReturnType<typeof vi.fn>;
@@ -16,7 +16,7 @@ describe('stored sites', () => {
 		vi.resetModules();
 		createSite = vi.fn();
 		deleteSite = vi.fn();
-		listSiteNamesAndSlugs = vi.fn().mockResolvedValue([]);
+		listMetadata = vi.fn().mockResolvedValue([]);
 		loggerError = vi.fn();
 		updateSiteStorage = vi.fn();
 		updateSiteStorage.mockImplementation(async (slug, changes) => {
@@ -70,7 +70,7 @@ describe('stored sites', () => {
 			opfsSiteStorage: {
 				create: createSite,
 				delete: deleteSite,
-				listSiteNamesAndSlugs,
+				listMetadata,
 				update: updateSiteStorage,
 			},
 		}));
@@ -622,11 +622,11 @@ describe('stored sites', () => {
 			extraLibraries: [],
 			constants: {},
 		});
-		listSiteNamesAndSlugs.mockResolvedValue([
-			{
+		listMetadata.mockResolvedValue([
+			createSiteInfo({
 				slug: 'playground-welcome-landing-page',
 				name: 'Stored Playground',
-			},
+			}),
 		]);
 
 		const newSite = await createStoredSite(
@@ -653,9 +653,7 @@ describe('stored sites', () => {
 			extraLibraries: [],
 			constants: {},
 		});
-		listSiteNamesAndSlugs.mockRejectedValue(
-			new Error('Unable to enumerate OPFS')
-		);
+		listMetadata.mockRejectedValue(new Error('Unable to enumerate OPFS'));
 
 		const newSite = await createStoredSite(
 			'Imported Playground',

--- a/packages/playground/website/src/lib/state/redux/slice-sites.spec.ts
+++ b/packages/playground/website/src/lib/state/redux/slice-sites.spec.ts
@@ -5,6 +5,7 @@ import type { TraversableFilesystemBackend } from '@wp-playground/storage';
 describe('stored sites', () => {
 	let createSite: ReturnType<typeof vi.fn>;
 	let deleteSite: ReturnType<typeof vi.fn>;
+	let listSites: ReturnType<typeof vi.fn>;
 	let loggerError: ReturnType<typeof vi.fn>;
 	let updateSiteStorage: ReturnType<typeof vi.fn>;
 	let persistBlueprintBundle: ReturnType<typeof vi.fn>;
@@ -15,6 +16,7 @@ describe('stored sites', () => {
 		vi.resetModules();
 		createSite = vi.fn();
 		deleteSite = vi.fn();
+		listSites = vi.fn().mockResolvedValue([]);
 		loggerError = vi.fn();
 		updateSiteStorage = vi.fn();
 		updateSiteStorage.mockImplementation(async (slug, changes) => {
@@ -67,6 +69,7 @@ describe('stored sites', () => {
 			opfsSiteStorage: {
 				create: createSite,
 				delete: deleteSite,
+				list: listSites,
 				update: updateSiteStorage,
 			},
 		}));
@@ -606,6 +609,34 @@ describe('stored sites', () => {
 			'source-site': sourceSite,
 			'source-site-2': newSite,
 		});
+	});
+
+	it('avoids slugs occupied in OPFS outside the current Redux state', async () => {
+		const { createStoredSite } = await import('./slice-sites');
+		resolveRuntimeConfiguration.mockResolvedValue({
+			phpVersion: '8.3',
+			wpVersion: 'latest',
+			intl: false,
+			networking: true,
+			extraLibraries: [],
+			constants: {},
+		});
+		listSites.mockResolvedValue([
+			createSiteInfo({ slug: 'playground-welcome-landing-page' }),
+		]);
+
+		const newSite = await createStoredSite(
+			'Imported Playground',
+			createBundleBlueprint(),
+			'playground-welcome-landing-page'
+		)(createThunkDispatch() as any, createEmptyGetState() as any);
+
+		expect(newSite.slug).toBe('playground-welcome-landing-page-2');
+		expect(createSite).toHaveBeenCalledWith(
+			'playground-welcome-landing-page-2',
+			newSite.metadata,
+			undefined
+		);
 	});
 
 	it('does not persist an edited Blueprint bundle when its runtime is invalid', async () => {

--- a/packages/playground/website/src/lib/state/redux/slice-sites.ts
+++ b/packages/playground/website/src/lib/state/redux/slice-sites.ts
@@ -689,7 +689,13 @@ export function createStoredSite(
 		const runtimeConfiguration =
 			await resolveRuntimeConfiguration(blueprint);
 		const now = Date.now();
-		const sites = selectAllSites(getState());
+		// Redux belongs to this tab, while OPFS is shared across same-origin
+		// tabs. Include storage records created after this tab loaded so a new
+		// Playground never reuses their slugs.
+		const sites = [
+			...selectAllSites(getState()),
+			...(await opfsSiteStorage.list()),
+		];
 		let displayName = siteName;
 		let slugBaseName = siteName;
 		if (!preferredSlug) {

--- a/packages/playground/website/src/lib/state/redux/slice-sites.ts
+++ b/packages/playground/website/src/lib/state/redux/slice-sites.ts
@@ -690,14 +690,16 @@ export function createStoredSite(
 			await resolveRuntimeConfiguration(blueprint);
 		const now = Date.now();
 		// Redux belongs to this tab, while OPFS is shared across same-origin
-		// tabs. Read names and slugs from storage so records created after this
-		// tab loaded still participate in allocation.
-		const sites = selectAllSites(getState()).map((site) => ({
-			slug: site.slug,
-			name: site.metadata.name,
-		}));
+		// tabs. Read metadata from storage so records created after this tab
+		// loaded still participate in allocation.
+		const sitesBySlug = new Map<string, SiteInfo>(
+			selectAllSites(getState()).map((site) => [site.slug, site])
+		);
 		try {
-			sites.push(...(await opfsSiteStorage.listSiteNamesAndSlugs()));
+			for (const site of await opfsSiteStorage.listMetadata()) {
+				// Fresh OPFS metadata replaces the same site's Redux snapshot.
+				sitesBySlug.set(site.slug, site);
+			}
 		} catch (error) {
 			logger.warn(
 				'Unable to list stored Playgrounds before choosing a new site slug.',
@@ -705,13 +707,14 @@ export function createStoredSite(
 			);
 			// Creating the OPFS record still refuses to overwrite an occupied slug.
 		}
+		const sites = [...sitesBySlug.values()];
 		let displayName = siteName;
 		let slugBaseName = siteName;
 		if (!preferredSlug) {
 			slugBaseName = getDefaultSiteNameFromBlueprint(blueprint, siteName);
 			displayName = getSiteNameWithCreationTimeIfDuplicate(
 				slugBaseName,
-				sites.map((site) => site.name),
+				sites.map((site) => site.metadata.name),
 				new Date(now)
 			);
 		}

--- a/packages/playground/website/src/lib/state/redux/slice-sites.ts
+++ b/packages/playground/website/src/lib/state/redux/slice-sites.ts
@@ -690,19 +690,28 @@ export function createStoredSite(
 			await resolveRuntimeConfiguration(blueprint);
 		const now = Date.now();
 		// Redux belongs to this tab, while OPFS is shared across same-origin
-		// tabs. Include storage records created after this tab loaded so a new
-		// Playground never reuses their slugs.
-		const sites = [
-			...selectAllSites(getState()),
-			...(await opfsSiteStorage.list()),
-		];
+		// tabs. Read names and slugs from storage so records created after this
+		// tab loaded still participate in allocation.
+		const sites = selectAllSites(getState()).map((site) => ({
+			slug: site.slug,
+			name: site.metadata.name,
+		}));
+		try {
+			sites.push(...(await opfsSiteStorage.listSiteNamesAndSlugs()));
+		} catch (error) {
+			logger.warn(
+				'Unable to list stored Playgrounds before choosing a new site slug.',
+				error
+			);
+			// Creating the OPFS record still refuses to overwrite an occupied slug.
+		}
 		let displayName = siteName;
 		let slugBaseName = siteName;
 		if (!preferredSlug) {
 			slugBaseName = getDefaultSiteNameFromBlueprint(blueprint, siteName);
 			displayName = getSiteNameWithCreationTimeIfDuplicate(
 				slugBaseName,
-				sites.map((site) => site.metadata.name),
+				sites.map((site) => site.name),
 				new Date(now)
 			);
 		}


### PR DESCRIPTION
## Problem solved

Re-importing a Playground ZIP could fail with `Site with slug '…' already exists`, even though the user was importing it as a new Playground.

## Before this PR

A tab chose the new Playground slug from its own Redux site list. Browser storage is shared across tabs, so OPFS could already contain a slug missing from that tab's list. The ZIP import then tried to create an already occupied site and stopped before importing the archive.

## After this PR

Stored Playground creation also reads lightweight site metadata from OPFS before choosing a slug. Redux and OPFS records are merged by slug, so the import chooses an available slug without loading Blueprint bundles. If OPFS cannot be listed, creation still falls back to the Redux list, while the final storage write continues to reject overwrites.

The E2E regression creates the stale-tab condition, exports the active Playground, and immediately imports the same ZIP without switching sites.

## Testing

1. Export the current Playground as a ZIP.
2. Without opening another Playground, import that ZIP.
3. Confirm a new autosaved Playground opens without an import error.
