### PR TITLE
[Website] Skip incomplete OPFS site directories during startup listing

### DIFF
--- a/packages/playground/website/src/lib/state/opfs/opfs-site-storage.spec.ts
+++ b/packages/playground/website/src/lib/state/opfs/opfs-site-storage.spec.ts
@@ -7,11 +7,13 @@ describe('opfsSiteStorage', () => {
 	let storage: NonNullable<typeof exportedOpfsSiteStorage>;
 	let loadPersistedBlueprintBundle: ReturnType<typeof vi.fn>;
 	let loadPersistedBlueprintBundleFromPath: ReturnType<typeof vi.fn>;
+	let loggerError: ReturnType<typeof vi.fn>;
 
 	beforeEach(async () => {
 		vi.resetModules();
 		loadPersistedBlueprintBundle = vi.fn();
 		loadPersistedBlueprintBundleFromPath = vi.fn();
+		loggerError = vi.fn();
 		const activeWorkerWrites = new Set<string>();
 		opfsRoot = new MemoryDirectoryHandle('');
 		vi.stubGlobal('navigator', {
@@ -73,6 +75,9 @@ describe('opfsSiteStorage', () => {
 		vi.doMock('@wp-playground/blueprints', () => ({
 			getBlueprintDeclaration: vi.fn(async (blueprint) => blueprint),
 		}));
+		vi.doMock('@php-wasm/logger', () => ({
+			logger: { error: loggerError },
+		}));
 
 		const module = await import('./opfs-site-storage');
 		storage = module.opfsSiteStorage!;
@@ -105,6 +110,14 @@ describe('opfsSiteStorage', () => {
 		await expect(
 			storage.create('a/b', createSiteMetadata())
 		).rejects.toThrow("Site with slug 'a/b' already exists.");
+	});
+
+	it('silently skips directories left by interrupted first saves', async () => {
+		const sitesRoot = await getSitesRoot(opfsRoot);
+		await sitesRoot.getDirectoryHandle('site-incomplete', { create: true });
+
+		await expect(storage.list()).resolves.toEqual([]);
+		expect(loggerError).not.toHaveBeenCalled();
 	});
 
 	it('stores setup URL params alongside site metadata', async () => {

--- a/packages/playground/website/src/lib/state/opfs/opfs-site-storage.ts
+++ b/packages/playground/website/src/lib/state/opfs/opfs-site-storage.ts
@@ -167,6 +167,11 @@ class OpfsSiteStorage {
 						sites.push(site);
 					}
 				} catch (e) {
+					if (isMissingOpfsEntry(e)) {
+						// An interrupted first save can leave the directory behind
+						// before its metadata file is written.
+						continue;
+					}
 					// @TODO: Still return this site's info, just in an error state.
 					logger.error(`Error reading site ${entry.name}:`, e);
 					// @TODO: Handle per-site errors somehow.


### PR DESCRIPTION
An interrupted first save can leave an OPFS `site-*` directory behind before `wp-runtime.json` is written. Startup treated every directory as a stored Playground and logged a `NotFoundError` while listing it.

Skip missing or mismatched OPFS entries during startup listing. Other read failures still reach the existing error log.

| Before | After |
| --- | --- |
| ![Before: an incomplete OPFS directory logs a NotFoundError on reload](https://gist.githubusercontent.com/adamziel/3c97264d3294411ec64ebe090b9b3889/raw/d7301be828bd2896d26f9168fc7798f9dfbd7932/before-incomplete-site-read.png) | ![After: the console filtered for Error reading site has no matching message](https://gist.githubusercontent.com/adamziel/3c97264d3294411ec64ebe090b9b3889/raw/d7301be828bd2896d26f9168fc7798f9dfbd7932/after-incomplete-site-read.png) |

The after capture reloads with `site-funny-sunny-country` still present without `wp-runtime.json`; the console filter has no matching startup error.

## Testing

Reload with a metadata-less directory under OPFS `/sites` and confirm startup skips it without a site-read console error.
