### PR TITLE
[Website] Handle failed background CacheStorage writes

### DIFF
--- a/packages/playground/remote/src/lib/offline-mode-cache.spec.ts
+++ b/packages/playground/remote/src/lib/offline-mode-cache.spec.ts
@@ -14,12 +14,16 @@ describe('offline mode cache', () => {
 	] as const)(
 		'settles failed background writes for the %s strategy',
 		async (_strategy, fetchFunctionName) => {
-			let rejectCacheWrite!: (reason: unknown) => void;
-			const cacheWrite = new Promise<void>((_resolve, reject) => {
-				rejectCacheWrite = reject;
+			const cacheWriteError = new DOMException(
+				'Cache.put() encountered a network error',
+				'NetworkError'
+			);
+			const cacheWriteCatch = vi.fn((onRejected) =>
+				Promise.resolve(onRejected(cacheWriteError))
+			);
+			const cachePut = vi.fn().mockReturnValue({
+				catch: cacheWriteCatch,
 			});
-			const cacheWriteCatch = vi.spyOn(cacheWrite, 'catch');
-			const cachePut = vi.fn().mockReturnValue(cacheWrite);
 			vi.stubGlobal('caches', {
 				open: vi.fn().mockResolvedValue({
 					match: vi.fn().mockResolvedValue(undefined),
@@ -38,14 +42,6 @@ describe('offline mode cache', () => {
 
 			expect(cachePut).toHaveBeenCalledOnce();
 			expect(cacheWriteCatch).toHaveBeenCalledOnce();
-
-			rejectCacheWrite(
-				new DOMException(
-					'Cache.put() encountered a network error',
-					'NetworkError'
-				)
-			);
-			await Promise.resolve();
 		}
 	);
 });

--- a/packages/playground/remote/src/lib/offline-mode-cache.spec.ts
+++ b/packages/playground/remote/src/lib/offline-mode-cache.spec.ts
@@ -1,0 +1,51 @@
+describe('offline mode cache', () => {
+	beforeEach(() => {
+		vi.resetModules();
+		vi.stubGlobal('self', {});
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it.each([
+		['cache first', 'cacheFirstFetch'],
+		['network first', 'networkFirstFetch'],
+	] as const)(
+		'settles failed background writes for the %s strategy',
+		async (_strategy, fetchFunctionName) => {
+			let rejectCacheWrite!: (reason: unknown) => void;
+			const cacheWrite = new Promise<void>((_resolve, reject) => {
+				rejectCacheWrite = reject;
+			});
+			const cacheWriteCatch = vi.spyOn(cacheWrite, 'catch');
+			const cachePut = vi.fn().mockReturnValue(cacheWrite);
+			vi.stubGlobal('caches', {
+				open: vi.fn().mockResolvedValue({
+					match: vi.fn().mockResolvedValue(undefined),
+					put: cachePut,
+				}),
+			});
+			const response = new Response('response body');
+			vi.stubGlobal('fetch', vi.fn().mockResolvedValue(response));
+			const offlineModeCache = await import('./offline-mode-cache');
+
+			await expect(
+				offlineModeCache[fetchFunctionName](
+					new Request('https://playground.wordpress.net/asset.js')
+				)
+			).resolves.toBe(response);
+
+			expect(cachePut).toHaveBeenCalledOnce();
+			expect(cacheWriteCatch).toHaveBeenCalledOnce();
+
+			rejectCacheWrite(
+				new DOMException(
+					'Cache.put() encountered a network error',
+					'NetworkError'
+				)
+			);
+			await Promise.resolve();
+		}
+	);
+});

--- a/packages/playground/remote/src/lib/offline-mode-cache.ts
+++ b/packages/playground/remote/src/lib/offline-mode-cache.ts
@@ -48,6 +48,8 @@ export async function cacheFirstFetch(request: Request): Promise<Response> {
 		) {
 			// Intentionally do not await writing to the cache so the response
 			// promise can be returned immediately and observed for progress events.
+			// A failed write only reduces offline availability, so settle it here
+			// instead of surfacing an unhandled rejection after the response returns.
 			// NOTE: This is a race condition for simultaneous requests for the same asset.
 			void offlineModeCache
 				.put(requestWithoutRangeHeader, response.clone())
@@ -93,6 +95,8 @@ export async function networkFirstFetch(request: Request): Promise<Response> {
 	if (response.ok) {
 		// Intentionally do not await writing to the cache so the response
 		// promise can be returned immediately and observed for progress events.
+		// A failed write only reduces offline availability, so settle it here
+		// instead of surfacing an unhandled rejection after the response returns.
 		// NOTE: This is a race condition for simultaneous requests for the same asset.
 		void offlineModeCache
 			.put(request, response.clone())

--- a/packages/playground/remote/src/lib/offline-mode-cache.ts
+++ b/packages/playground/remote/src/lib/offline-mode-cache.ts
@@ -49,7 +49,9 @@ export async function cacheFirstFetch(request: Request): Promise<Response> {
 			// Intentionally do not await writing to the cache so the response
 			// promise can be returned immediately and observed for progress events.
 			// NOTE: This is a race condition for simultaneous requests for the same asset.
-			offlineModeCache.put(requestWithoutRangeHeader, response.clone());
+			void offlineModeCache
+				.put(requestWithoutRangeHeader, response.clone())
+				.catch(() => undefined);
 		}
 	}
 
@@ -92,7 +94,9 @@ export async function networkFirstFetch(request: Request): Promise<Response> {
 		// Intentionally do not await writing to the cache so the response
 		// promise can be returned immediately and observed for progress events.
 		// NOTE: This is a race condition for simultaneous requests for the same asset.
-		offlineModeCache.put(request, response.clone());
+		void offlineModeCache
+			.put(request, response.clone())
+			.catch(() => undefined);
 		return response;
 	}
 


### PR DESCRIPTION
The cache-first and network-first paths intentionally return the network response without waiting for `Cache.put()`. A failed background write therefore rejected an unobserved promise, which Chrome reported as an uncaught `NetworkError` during boot.

Settle both background cache-write promises while keeping response delivery non-blocking. A failed write still means that asset will not be available offline, but it no longer leaks an unhandled rejection into the page.

This addresses the `Cache.put()` half of #1943.

## Testing

Force `Cache.put()` to reject in both caching strategies and confirm the network response still resolves without an unhandled rejection.
