### PR TITLE
[CI] Reclaim Cypress browser memory between Playground boots

### DIFF
--- a/packages/playground/website/cypress.config.ts
+++ b/packages/playground/website/cypress.config.ts
@@ -7,4 +7,7 @@ export default defineConfig({
 	}),
 	// Playground may be slow on GitHub CI
 	defaultCommandTimeout: 60000 * 2,
+	// Each query API test boots a full PHP-Wasm runtime. Reclaim Chromium's
+	// heap between tests so repeated boots do not exhaust CI runners.
+	experimentalMemoryManagement: true,
 });


### PR DESCRIPTION
The Cypress Query API spec boots a full PHP runtime in each of its 18 tests. In a [post-merge trunk run](https://github.com/WordPress/wordpress-playground/actions/runs/30459666223/job/90602137193), the application went blank during the PHP 7.4 boot, then recovered and passed the remaining 16 tests. The same spec already skips ZIP export tests on CI because Chrome can run out of memory.

Enable Cypress's Chromium memory management so it reclaims the browser heap between tests instead of carrying every Playground boot through the entire spec.

## Testing

Run the Query API E2E spec in Chrome against the port-80 preview. Confirm the PHP 8.3 and PHP 7.4 boots pass and Cypress reports `experimentalMemoryManagement=true`.
