### PR TITLE
[Website] Keep Blueprint loading status visible during filesystem setup

### DIFF
--- a/packages/playground/website/playwright/e2e/website-ui.spec.ts
+++ b/packages/playground/website/playwright/e2e/website-ui.spec.ts
@@ -1433,6 +1433,65 @@ test.describe('Default Playground storage', () => {
 		).toBe(false);
 	});
 
+	test('should keep the Blueprint loading status visible while its filesystem initializes', async ({
+		website,
+		browserName,
+	}) => {
+		test.skip(browserName !== 'chromium', 'This test requires OPFS.');
+
+		await website.goto(
+			getUniqueSavedPlaygroundSetupUrl('blueprint-loading')
+		);
+		await expect(
+			website.page.getByRole('button', { name: 'Autosaved' })
+		).toBeVisible({ timeout: 120000 });
+		await website.page.evaluate(() => {
+			let releaseBlueprintBundleDirectory!: () => void;
+			const blueprintBundleDirectoryCanOpen = new Promise<void>(
+				(resolve) => {
+					releaseBlueprintBundleDirectory = resolve;
+				}
+			);
+			const directoryHandlePrototype =
+				FileSystemDirectoryHandle.prototype;
+			const getDirectoryHandle =
+				directoryHandlePrototype.getDirectoryHandle;
+			(window as any).__releaseBlueprintBundleDirectory =
+				releaseBlueprintBundleDirectory;
+			directoryHandlePrototype.getDirectoryHandle = async function (
+				name,
+				options
+			) {
+				if (name === 'blueprint-bundle') {
+					(window as any).__blueprintBundleDirectoryRequested = true;
+					await blueprintBundleDirectoryCanOpen;
+				}
+				return await getDirectoryHandle.call(this, name, options);
+			};
+		});
+
+		try {
+			await website.openDockPane('Current Blueprint', 'Blueprint pane');
+			await website.page.waitForFunction(
+				() =>
+					(window as any).__blueprintBundleDirectoryRequested === true
+			);
+			await expect(
+				website.page
+					.getByRole('dialog', { name: 'Blueprint pane' })
+					.getByRole('status')
+			).toHaveText('Loading the Blueprint editor…');
+		} finally {
+			await website.page.evaluate(() =>
+				(window as any).__releaseBlueprintBundleDirectory()
+			);
+		}
+
+		await expect(
+			website.page.locator('[class*="blueprint-editor"] .cm-content')
+		).toBeVisible();
+	});
+
 	test('should edit a Blueprint for an autosaved Playground and run it in a new Playground', async ({
 		website,
 		wordpress,

--- a/packages/playground/website/playwright/e2e/website-ui.spec.ts
+++ b/packages/playground/website/playwright/e2e/website-ui.spec.ts
@@ -1458,6 +1458,8 @@ test.describe('Default Playground storage', () => {
 				directoryHandlePrototype.getDirectoryHandle;
 			(window as any).__releaseBlueprintBundleDirectory =
 				releaseBlueprintBundleDirectory;
+			(window as any).__originalBlueprintGetDirectoryHandle =
+				getDirectoryHandle;
 			directoryHandlePrototype.getDirectoryHandle = async function (
 				name,
 				options
@@ -1482,13 +1484,21 @@ test.describe('Default Playground storage', () => {
 					.getByRole('status')
 			).toHaveText('Loading the Blueprint editor…');
 		} finally {
-			await website.page.evaluate(() =>
-				(window as any).__releaseBlueprintBundleDirectory()
-			);
+			await website.page.evaluate(() => {
+				(window as any).__releaseBlueprintBundleDirectory();
+				FileSystemDirectoryHandle.prototype.getDirectoryHandle = (
+					window as any
+				).__originalBlueprintGetDirectoryHandle;
+				delete (window as any).__releaseBlueprintBundleDirectory;
+				delete (window as any).__originalBlueprintGetDirectoryHandle;
+				delete (window as any).__blueprintBundleDirectoryRequested;
+			});
 		}
 
 		await expect(
-			website.page.locator('[class*="blueprint-editor"] .cm-content')
+			website.page
+				.getByRole('dialog', { name: 'Blueprint pane' })
+				.getByRole('button', { name: 'Create new file' })
 		).toBeVisible();
 	});
 

--- a/packages/playground/website/src/components/blueprint-editor/SiteBlueprintBundleEditor.tsx
+++ b/packages/playground/website/src/components/blueprint-editor/SiteBlueprintBundleEditor.tsx
@@ -24,6 +24,7 @@ import {
 	updateSiteMetadata,
 } from '../../lib/state/redux/slice-sites';
 import { useAppDispatch } from '../../lib/state/redux/store';
+import { PaneLoading } from '../pane-loading';
 import styles from './blueprint-bundle-editor.module.css';
 import {
 	type BlueprintBundleEditorHandle,
@@ -331,7 +332,7 @@ export const SiteBlueprintBundleEditor = forwardRef<
 
 	return (
 		<div className={classNames(styles.container, className)}>
-			{filesystem && (
+			{filesystem ? (
 				<BlueprintBundleEditor
 					ref={innerEditorRef}
 					filesystem={filesystem}
@@ -340,6 +341,8 @@ export const SiteBlueprintBundleEditor = forwardRef<
 					dockPresentation={dockPresentation}
 					mobileHeaderTarget={mobileHeaderTarget}
 				/>
+			) : (
+				<PaneLoading message="Loading the Blueprint editor…" />
 			)}
 		</div>
 	);


### PR DESCRIPTION
## Motivation for the change, related issues

The Blueprint pane removes its lazy-loading fallback before its editable
filesystem is ready. Autosaved Blueprint bundles may still be copying into
OPFS at that point, leaving the pane empty.

## Implementation details

Keep the shared pane loading status mounted until the Blueprint editor receives
its stable filesystem.

The Playwright regression pauses the OPFS bundle open after the lazy editor
module has loaded, checks the loading status, then releases the filesystem and
checks that the editor appears.

## Testing Instructions (or ideally a Blueprint)

Open the Blueprint pane immediately after starting a Playground. Confirm the
loading spinner remains visible until the editor appears instead of showing an
empty pane.
