### PR TITLE
[Website] Reuse DropdownMenu for Site Settings actions

### DIFF
--- a/packages/playground/website/src/components/blueprint-editor/BlueprintBundleEditor.tsx
+++ b/packages/playground/website/src/components/blueprint-editor/BlueprintBundleEditor.tsx
@@ -9,7 +9,6 @@ import {
 import { logger } from '@php-wasm/logger';
 import {
 	Button,
-	DropdownMenu,
 	Icon,
 	MenuGroup,
 	MenuItem,
@@ -75,6 +74,7 @@ import {
 	setDockOperationNotice,
 	setDockPaneOpen,
 } from '../../lib/state/redux/slice-ui';
+import { DropdownMenu } from '../dropdown-menu';
 import { MenuItemWithDescription } from '../menu-item-with-description';
 import styles from './blueprint-bundle-editor.module.css';
 import hideRootStyles from './hide-root.module.css';
@@ -1094,8 +1094,8 @@ export const BlueprintBundleEditor = forwardRef<
 										'Run will wait for this Playground to finish saving.'
 									) : (
 										<>
-											Running this Blueprint creates a fresh
-											autosaved Playground. “
+											Running this Blueprint creates a
+											fresh autosaved Playground. “
 											{site?.metadata.name}” stays in{' '}
 											{isAutosaved
 												? 'Recent autosaves'

--- a/packages/playground/website/src/components/dropdown-menu.module.css
+++ b/packages/playground/website/src/components/dropdown-menu.module.css
@@ -1,0 +1,4 @@
+.menu :global(.components-menu-item__button:focus:not(:disabled)) {
+	box-shadow: inset 0 0 0 2px
+		var(--wp-components-color-accent, var(--wp-admin-theme-color, #3858e9));
+}

--- a/packages/playground/website/src/components/dropdown-menu.spec.tsx
+++ b/packages/playground/website/src/components/dropdown-menu.spec.tsx
@@ -1,0 +1,118 @@
+// @vitest-environment jsdom
+
+import { MenuGroup } from '@wordpress/components';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { DropdownMenu } from './dropdown-menu';
+
+describe('DropdownMenu', () => {
+	let container: HTMLDivElement;
+	let root: Root;
+
+	beforeAll(() => {
+		vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+		vi.stubGlobal(
+			'matchMedia',
+			vi.fn((query: string) => ({
+				matches: false,
+				media: query,
+				onchange: null,
+				addEventListener: vi.fn(),
+				removeEventListener: vi.fn(),
+				addListener: vi.fn(),
+				removeListener: vi.fn(),
+				dispatchEvent: vi.fn(),
+			}))
+		);
+	});
+
+	afterAll(() => {
+		vi.unstubAllGlobals();
+	});
+
+	beforeEach(() => {
+		container = document.createElement('div');
+		document.body.append(container);
+		root = createRoot(container);
+	});
+
+	afterEach(() => {
+		act(() => root.unmount());
+		container.remove();
+	});
+
+	it('adds Home and End navigation without replacing the menu key handler', async () => {
+		const onKeyDown = vi.fn();
+		await act(async () => {
+			root.render(
+				<DropdownMenu
+					icon={null}
+					label="Actions"
+					menuProps={{ onKeyDown }}
+					popoverProps={{ focusOnMount: false }}
+				>
+					{() => (
+						<MenuGroup>
+							<button type="button" role="menuitem">
+								First
+							</button>
+							<button type="button" role="menuitem">
+								Middle
+							</button>
+							<button type="button" role="menuitem">
+								Last
+							</button>
+						</MenuGroup>
+					)}
+				</DropdownMenu>
+			);
+		});
+
+		await act(async () => getButton('Actions').click());
+
+		const menu = document.querySelector<HTMLElement>(
+			'[role="menu"][aria-label="Actions"]'
+		);
+		const menuItems =
+			menu?.querySelectorAll<HTMLElement>('[role="menuitem"]');
+		if (!menuItems || menuItems.length !== 3) {
+			throw new Error(
+				'Expected the Actions menu to contain three items.'
+			);
+		}
+
+		act(() => {
+			menuItems[1].focus();
+			menuItems[1].dispatchEvent(
+				new KeyboardEvent('keydown', {
+					key: 'Home',
+					code: 'Home',
+					bubbles: true,
+				})
+			);
+		});
+		expect(document.activeElement).toBe(menuItems[0]);
+
+		act(() => {
+			menuItems[0].dispatchEvent(
+				new KeyboardEvent('keydown', {
+					key: 'End',
+					code: 'End',
+					bubbles: true,
+				})
+			);
+		});
+		expect(document.activeElement).toBe(menuItems[2]);
+		expect(onKeyDown).toHaveBeenCalledTimes(2);
+	});
+
+	function getButton(name: string): HTMLButtonElement {
+		const button = container.querySelector<HTMLButtonElement>(
+			`button[aria-label="${name}"]`
+		);
+		if (!button) {
+			throw new Error(`Button not found: ${name}`);
+		}
+		return button;
+	}
+});

--- a/packages/playground/website/src/components/dropdown-menu.tsx
+++ b/packages/playground/website/src/components/dropdown-menu.tsx
@@ -25,6 +25,10 @@ export function DropdownMenu({
 	);
 }
 
+/**
+ * Handles Home and End for the current menu without moving focus into a
+ * nested menu.
+ */
 function focusMenuBoundary(event: KeyboardEvent) {
 	if (event.key !== 'Home' && event.key !== 'End') {
 		return;

--- a/packages/playground/website/src/components/dropdown-menu.tsx
+++ b/packages/playground/website/src/components/dropdown-menu.tsx
@@ -1,5 +1,7 @@
 import { DropdownMenu as WordPressDropdownMenu } from '@wordpress/components';
+import classNames from 'classnames';
 import type { ComponentProps } from 'react';
+import css from './dropdown-menu.module.css';
 
 type DropdownMenuProps = ComponentProps<typeof WordPressDropdownMenu>;
 
@@ -14,6 +16,7 @@ export function DropdownMenu({
 			{...dropdownMenuProps}
 			menuProps={{
 				...menuProps,
+				className: classNames(css.menu, menuProps?.className),
 				onKeyDown: (event) => {
 					onKeyDown?.(event);
 					if (!event.defaultPrevented) {

--- a/packages/playground/website/src/components/dropdown-menu.tsx
+++ b/packages/playground/website/src/components/dropdown-menu.tsx
@@ -1,0 +1,48 @@
+import { DropdownMenu as WordPressDropdownMenu } from '@wordpress/components';
+import type { ComponentProps } from 'react';
+
+type DropdownMenuProps = ComponentProps<typeof WordPressDropdownMenu>;
+
+export function DropdownMenu({
+	menuProps,
+	...dropdownMenuProps
+}: DropdownMenuProps) {
+	const onKeyDown = menuProps?.onKeyDown;
+
+	return (
+		<WordPressDropdownMenu
+			{...dropdownMenuProps}
+			menuProps={{
+				...menuProps,
+				onKeyDown: (event) => {
+					onKeyDown?.(event);
+					if (!event.defaultPrevented) {
+						focusMenuBoundary(event);
+					}
+				},
+			}}
+		/>
+	);
+}
+
+function focusMenuBoundary(event: KeyboardEvent) {
+	if (event.key !== 'Home' && event.key !== 'End') {
+		return;
+	}
+
+	// WordPress components wrap arrow navigation, but do not handle these
+	// boundary keys. Supply them once for every Playground dropdown menu.
+	const menu = event.currentTarget as HTMLElement;
+	const menuItems = Array.from(
+		menu.querySelectorAll<HTMLElement>(
+			'[role="menuitem"], [role="menuitemcheckbox"], [role="menuitemradio"]'
+		)
+	).filter((item) => item.closest('[role="menu"]') === menu);
+	const target =
+		event.key === 'Home' ? menuItems[0] : menuItems[menuItems.length - 1];
+
+	if (target) {
+		event.preventDefault();
+		target.focus();
+	}
+}

--- a/packages/playground/website/src/components/saved-playgrounds-panel/index.tsx
+++ b/packages/playground/website/src/components/saved-playgrounds-panel/index.tsx
@@ -3,7 +3,6 @@ import classNames from 'classnames';
 import { createPortal } from 'react-dom';
 import {
 	Spinner,
-	DropdownMenu,
 	MenuGroup,
 	MenuItem,
 	TextControl,
@@ -69,6 +68,7 @@ import useFetch from '../../lib/hooks/use-fetch';
 import { PlaygroundRoute, redirectTo } from '../../lib/state/url/router';
 import { OverlaySection } from '../overlay';
 import { TruncatedText } from '../truncated-text';
+import { DropdownMenu } from '../dropdown-menu';
 import { MenuItemWithDescription } from '../menu-item-with-description';
 import { isOpfsAvailable } from '../../lib/state/opfs/opfs-site-storage';
 import type { DockPaneHeaderOverride } from '../dock/dock-pane';

--- a/packages/playground/website/src/components/site-manager/site-settings-form/site-settings-action-footer.tsx
+++ b/packages/playground/website/src/components/site-manager/site-settings-form/site-settings-action-footer.tsx
@@ -154,9 +154,7 @@ function SettingsActionMenu({
 				autoFocus={primaryAction === 'apply'}
 				info={applyUnavailableReason}
 				aria-disabled={!!applyUnavailableReason}
-				className={`${css.actionMenuItem} ${
-					primaryAction === 'apply' ? css.selectedApplyMenuItem : ''
-				}`}
+				className={css.actionMenuItem}
 				onClick={applyUnavailableReason ? undefined : onSelectApply}
 			>
 				Apply to this Playground
@@ -168,7 +166,7 @@ function SettingsActionMenu({
 						? 'Start a clean site. Your current Playground stays in Saved Playgrounds.'
 						: `Start a clean site. Your current Playground stays in Recent autosaves until ${MAX_AUTOSAVED_SITES} newer autosaves replace it.`
 				}
-				className={`${css.actionMenuItem} ${css.createFreshMenuItem}`}
+				className={css.actionMenuItem}
 				onClick={onSelectCreateFresh}
 			>
 				Create a fresh Playground

--- a/packages/playground/website/src/components/site-manager/site-settings-form/site-settings-action-footer.tsx
+++ b/packages/playground/website/src/components/site-manager/site-settings-form/site-settings-action-footer.tsx
@@ -1,6 +1,7 @@
 import {
 	Button,
-	Dropdown,
+	DropdownMenu,
+	MenuGroup,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { useEffect, useRef, useState } from 'react';
@@ -8,6 +9,7 @@ import {
 	MAX_AUTOSAVED_SITES,
 	type SitePersistence,
 } from '../../../lib/state/redux/site-lifecycle';
+import { MenuItemWithDescription } from '../../menu-item-with-description';
 import type { SiteFormData } from './unconnected-site-settings-form';
 import type { SiteSettingsFormFooterContext } from './unconnected-site-settings-form';
 import { getFreshPlaygroundReason } from './site-settings-actions';
@@ -83,36 +85,32 @@ export function SiteSettingsActionFooter({
 						? 'Apply to this Playground'
 						: 'Create a fresh Playground'}
 				</Button>
-				<Dropdown
+				<DropdownMenu
 					className={css.splitButtonDropdown}
-					focusOnMount={false}
+					icon={null}
+					label="More settings actions"
+					toggleProps={{
+						variant: 'primary',
+						className:
+							primaryAction === 'apply'
+								? css.splitButtonToggle
+								: `${css.splitButtonToggle} ${css.createFreshButton}`,
+						disabled: isPending,
+						showTooltip: false,
+						children: (
+							<span className={css.caret} aria-hidden="true" />
+						),
+					}}
+					menuProps={{ className: css.actionMenu }}
 					popoverProps={{
 						placement: 'top-end',
 						className: css.actionMenuPopover,
 					}}
-					renderToggle={({ isOpen, onToggle }) => (
-						<Button
-							type="button"
-							variant="primary"
-							className={
-								primaryAction === 'apply'
-									? css.splitButtonToggle
-									: `${css.splitButtonToggle} ${css.createFreshButton}`
-							}
-							onClick={onToggle}
-							aria-expanded={isOpen}
-							aria-haspopup="menu"
-							aria-label="More settings actions"
-							disabled={isPending}
-						>
-							<span className={css.caret} aria-hidden="true" />
-						</Button>
-					)}
-					renderContent={({ onClose }) => (
+				>
+					{({ onClose }) => (
 						<SettingsActionMenu
-							canApplyToCurrent={canApplyToCurrent}
 							applyUnavailableReason={applyUnavailableReason}
-							selectedAction={primaryAction}
+							primaryAction={primaryAction}
 							sitePersistence={sitePersistence}
 							onSelectApply={() => {
 								onClose();
@@ -126,7 +124,7 @@ export function SiteSettingsActionFooter({
 							}}
 						/>
 					)}
-				/>
+				</DropdownMenu>
 			</div>
 			{error && (
 				<p className={css.actionError} role="alert">
@@ -138,106 +136,44 @@ export function SiteSettingsActionFooter({
 }
 
 function SettingsActionMenu({
-	canApplyToCurrent,
 	applyUnavailableReason,
-	selectedAction,
+	primaryAction,
 	sitePersistence,
 	onSelectApply,
 	onSelectCreateFresh,
 }: {
-	canApplyToCurrent: boolean;
 	applyUnavailableReason?: string;
-	selectedAction: SettingsAction;
+	primaryAction: SettingsAction;
 	sitePersistence: SitePersistence;
 	onSelectApply: () => void;
 	onSelectCreateFresh: () => void;
 }) {
-	const applyRef = useRef<HTMLButtonElement>(null);
-	const freshRef = useRef<HTMLButtonElement>(null);
-	const items = [applyRef, freshRef];
-
-	useEffect(() => {
-		(selectedAction === 'apply' && canApplyToCurrent
-			? applyRef
-			: freshRef
-		).current?.focus();
-	}, [canApplyToCurrent, selectedAction]);
-
-	const moveFocus = (event: React.KeyboardEvent, nextIndex: number) => {
-		event.preventDefault();
-		items[nextIndex].current?.focus();
-	};
-
 	return (
-		<div
-			className={css.actionMenu}
-			role="menu"
-			onKeyDown={(event) => {
-				const currentIndex = items.findIndex(
-					(ref) => ref.current === document.activeElement
-				);
-				if (event.key === 'ArrowDown') {
-					moveFocus(event, (currentIndex + 1) % items.length);
-				} else if (event.key === 'ArrowUp') {
-					moveFocus(
-						event,
-						(currentIndex - 1 + items.length) % items.length
-					);
-				} else if (event.key === 'Home') {
-					moveFocus(event, 0);
-				} else if (event.key === 'End') {
-					moveFocus(event, items.length - 1);
-				}
-			}}
-		>
-			<button
-				ref={applyRef}
-				type="button"
-				role="menuitem"
+		<MenuGroup className={css.actionMenuGroup}>
+			<MenuItemWithDescription
+				autoFocus={primaryAction === 'apply'}
+				info={applyUnavailableReason}
 				aria-disabled={!!applyUnavailableReason}
-				disabled={!!applyUnavailableReason}
 				className={`${css.actionMenuItem} ${
-					selectedAction === 'apply' && canApplyToCurrent
-						? css.selectedApplyMenuItem
-						: ''
+					primaryAction === 'apply' ? css.selectedApplyMenuItem : ''
 				}`}
-				onClick={onSelectApply}
+				onClick={applyUnavailableReason ? undefined : onSelectApply}
 			>
-				<span className={css.actionMenuTitle}>
-					Apply to this Playground
-				</span>
-				{applyUnavailableReason && (
-					<span className={css.actionMenuDescription}>
-						{applyUnavailableReason}
-					</span>
-				)}
-			</button>
-			<button
-				ref={freshRef}
-				type="button"
-				role="menuitem"
+				Apply to this Playground
+			</MenuItemWithDescription>
+			<MenuItemWithDescription
+				autoFocus={primaryAction === 'fresh'}
+				info={
+					sitePersistence === 'explicit'
+						? 'Start a clean site. Your current Playground stays in Saved Playgrounds.'
+						: `Start a clean site. Your current Playground stays in Recent autosaves until ${MAX_AUTOSAVED_SITES} newer autosaves replace it.`
+				}
 				className={`${css.actionMenuItem} ${css.createFreshMenuItem}`}
 				onClick={onSelectCreateFresh}
 			>
-				<span className={css.actionMenuTitle}>
-					Create a fresh Playground
-				</span>
-				<span className={css.actionMenuDescription}>
-					{sitePersistence === 'explicit' ? (
-						<>
-							Start a clean site. Your current Playground stays in
-							Saved Playgrounds.
-						</>
-					) : (
-						<>
-							Start a clean site. Your current Playground stays in
-							Recent autosaves until {MAX_AUTOSAVED_SITES} newer
-							autosaves replace it.
-						</>
-					)}
-				</span>
-			</button>
-		</div>
+				Create a fresh Playground
+			</MenuItemWithDescription>
+		</MenuGroup>
 	);
 }
 

--- a/packages/playground/website/src/components/site-manager/site-settings-form/site-settings-action-footer.tsx
+++ b/packages/playground/website/src/components/site-manager/site-settings-form/site-settings-action-footer.tsx
@@ -101,7 +101,27 @@ export function SiteSettingsActionFooter({
 							<span className={css.caret} aria-hidden="true" />
 						),
 					}}
-					menuProps={{ className: css.actionMenu }}
+					menuProps={{
+						className: css.actionMenu,
+						onKeyDown: (event) => {
+							if (event.key !== 'Home' && event.key !== 'End') {
+								return;
+							}
+							const menu = event.currentTarget as HTMLElement;
+							const items =
+								menu.querySelectorAll<HTMLElement>(
+									'[role="menuitem"]'
+								);
+							const target =
+								event.key === 'Home'
+									? items[0]
+									: items[items.length - 1];
+							if (target) {
+								event.preventDefault();
+								target.focus();
+							}
+						},
+					}}
 					popoverProps={{
 						placement: 'top-end',
 						className: css.actionMenuPopover,

--- a/packages/playground/website/src/components/site-manager/site-settings-form/site-settings-action-footer.tsx
+++ b/packages/playground/website/src/components/site-manager/site-settings-form/site-settings-action-footer.tsx
@@ -1,6 +1,5 @@
 import {
 	Button,
-	DropdownMenu,
 	MenuGroup,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
@@ -9,6 +8,7 @@ import {
 	MAX_AUTOSAVED_SITES,
 	type SitePersistence,
 } from '../../../lib/state/redux/site-lifecycle';
+import { DropdownMenu } from '../../dropdown-menu';
 import { MenuItemWithDescription } from '../../menu-item-with-description';
 import type { SiteFormData } from './unconnected-site-settings-form';
 import type { SiteSettingsFormFooterContext } from './unconnected-site-settings-form';
@@ -101,27 +101,7 @@ export function SiteSettingsActionFooter({
 							<span className={css.caret} aria-hidden="true" />
 						),
 					}}
-					menuProps={{
-						className: css.actionMenu,
-						onKeyDown: (event) => {
-							if (event.key !== 'Home' && event.key !== 'End') {
-								return;
-							}
-							const menu = event.currentTarget as HTMLElement;
-							const items =
-								menu.querySelectorAll<HTMLElement>(
-									'[role="menuitem"]'
-								);
-							const target =
-								event.key === 'Home'
-									? items[0]
-									: items[items.length - 1];
-							if (target) {
-								event.preventDefault();
-								target.focus();
-							}
-						},
-					}}
+					menuProps={{ className: css.actionMenu }}
 					popoverProps={{
 						placement: 'top-end',
 						className: css.actionMenuPopover,

--- a/packages/playground/website/src/components/site-manager/site-settings-form/style.module.css
+++ b/packages/playground/website/src/components/site-manager/site-settings-form/style.module.css
@@ -145,6 +145,11 @@
 	width: min(330px, calc(100vw - 24px));
 }
 
+:global(.components-dropdown__content) .action-menu > .action-menu-group {
+	margin: 0;
+	padding: 0;
+}
+
 .action-menu-popover :global(.components-popover__content) {
 	overflow: hidden;
 	padding: 0;
@@ -153,12 +158,13 @@
 	box-shadow: 0 16px 38px rgb(0 0 0 / 20%);
 }
 
-.action-menu-item {
+.action-menu .action-menu-item:global(.components-button) {
 	display: flex;
 	flex-direction: column;
 	justify-content: center;
 	box-sizing: border-box;
 	width: 100%;
+	height: auto;
 	padding: 16px 20px;
 	border: 0;
 	border-radius: 0;
@@ -170,21 +176,45 @@
 	white-space: normal;
 }
 
-.action-menu-item:first-child {
+.action-menu .action-menu-item :global(.components-menu-item__item),
+.action-menu .action-menu-item :global(.components-menu-item__info-wrapper) {
+	width: 100%;
+}
+
+.action-menu .action-menu-item :global(.components-menu-item__item) {
+	font-weight: 500;
+	line-height: 1.4;
+}
+
+.action-menu .action-menu-item :global(.components-menu-item__info) {
+	max-width: 100%;
+	margin-top: 2px;
+	color: var(--ink-muted);
+	font-weight: 300;
+	line-height: 1.4;
+	overflow-wrap: anywhere;
+}
+
+.action-menu .action-menu-item:first-child {
 	border-radius: 9px 9px 0 0;
 }
 
-.action-menu-item:last-child {
+.action-menu .action-menu-item:last-child {
 	border-radius: 0 0 9px 9px;
 }
 
-.action-menu-item + .action-menu-item {
+.action-menu .action-menu-item + .action-menu-item {
 	border-top: 1px solid #d6d6d9;
 }
 
-.action-menu-item:focus-visible {
+.action-menu .action-menu-item:focus-visible {
 	outline: none;
 	box-shadow: inset 0 0 0 2px #3858e9;
+}
+
+.action-menu .action-menu-item:focus:not(:focus-visible) {
+	outline: none;
+	box-shadow: none;
 }
 
 .action-error {
@@ -212,47 +242,32 @@
 	}
 }
 
-.action-menu-title {
-	display: block;
-	font-weight: 500;
-	line-height: 1.4;
-	white-space: normal;
-}
-
-.action-menu-description {
-	display: block;
-	max-width: 100%;
-	margin-top: 2px;
-	color: var(--ink-muted);
-	font-size: 12px;
-	line-height: 1.4;
-	overflow-wrap: anywhere;
-	white-space: normal;
-}
-
-.create-fresh-menu-item {
+.action-menu .action-menu-item.create-fresh-menu-item {
 	color: var(--create-fresh-action-hover);
 }
 
-.action-menu-item.selected-apply-menu-item {
+.action-menu .action-menu-item.selected-apply-menu-item {
 	color: var(--accent-hover);
 }
 
-.action-menu-item:disabled {
+.action-menu .action-menu-item[aria-disabled='true'] {
 	color: #757575;
 	cursor: not-allowed;
+	opacity: 1;
 }
 
-.action-menu-item:disabled .action-menu-description {
+.action-menu
+	.action-menu-item[aria-disabled='true']
+	:global(.components-menu-item__info) {
 	color: inherit;
 }
 
-.action-menu-item:disabled:focus-visible {
+.action-menu .action-menu-item[aria-disabled='true']:focus-visible {
 	box-shadow: inset 0 0 0 2px #949494;
 }
 
 @media (forced-colors: active) {
-	.action-menu-item:focus-visible {
+	.action-menu .action-menu-item:focus-visible {
 		outline: 2px solid CanvasText;
 		outline-offset: -2px;
 		box-shadow: none;

--- a/packages/playground/website/src/components/site-manager/site-settings-form/style.module.css
+++ b/packages/playground/website/src/components/site-manager/site-settings-form/style.module.css
@@ -168,10 +168,7 @@
 	padding: 16px 20px;
 	border: 0;
 	border-radius: 0;
-	background: #fff;
-	color: var(--ink);
 	cursor: pointer;
-	font: inherit;
 	text-align: left;
 	white-space: normal;
 }
@@ -207,18 +204,6 @@
 	border-top: 1px solid #d6d6d9;
 }
 
-.action-menu .action-menu-item:hover:not([aria-disabled='true']) {
-	color: var(
-		--wp-components-color-accent,
-		var(--wp-admin-theme-color, #3858e9)
-	);
-}
-
-.action-menu .action-menu-item:focus {
-	outline: none;
-	box-shadow: inset 0 0 0 2px #3858e9;
-}
-
 .action-error {
 	animation: action-error-in 120ms ease-out;
 	color: var(--destructive);
@@ -242,14 +227,6 @@
 	.action-error {
 		animation: none;
 	}
-}
-
-.action-menu .action-menu-item.create-fresh-menu-item {
-	color: var(--create-fresh-action-hover);
-}
-
-.action-menu .action-menu-item.selected-apply-menu-item {
-	color: var(--accent-hover);
 }
 
 .action-menu .action-menu-item[aria-disabled='true'] {

--- a/packages/playground/website/src/components/site-manager/site-settings-form/style.module.css
+++ b/packages/playground/website/src/components/site-manager/site-settings-form/style.module.css
@@ -207,14 +207,13 @@
 	border-top: 1px solid #d6d6d9;
 }
 
-.action-menu .action-menu-item:focus-visible {
-	outline: none;
-	box-shadow: inset 0 0 0 2px #3858e9;
+.action-menu .action-menu-item:hover:not([aria-disabled='true']) {
+	background: var(--surface-control-hover);
 }
 
-.action-menu .action-menu-item:focus:not(:focus-visible) {
+.action-menu .action-menu-item:focus {
 	outline: none;
-	box-shadow: none;
+	box-shadow: inset 0 0 0 2px #3858e9;
 }
 
 .action-error {

--- a/packages/playground/website/src/components/site-manager/site-settings-form/style.module.css
+++ b/packages/playground/website/src/components/site-manager/site-settings-form/style.module.css
@@ -208,7 +208,10 @@
 }
 
 .action-menu .action-menu-item:hover:not([aria-disabled='true']) {
-	background: var(--wp-components-color-gray-100, #f0f0f0);
+	color: var(
+		--wp-components-color-accent,
+		var(--wp-admin-theme-color, #3858e9)
+	);
 }
 
 .action-menu .action-menu-item:focus {

--- a/packages/playground/website/src/components/site-manager/site-settings-form/style.module.css
+++ b/packages/playground/website/src/components/site-manager/site-settings-form/style.module.css
@@ -158,7 +158,7 @@
 	box-shadow: 0 16px 38px rgb(0 0 0 / 20%);
 }
 
-.action-menu .action-menu-item:global(.components-button) {
+.action-menu .action-menu-item:global(.components-menu-item__button) {
 	display: flex;
 	flex-direction: column;
 	justify-content: center;
@@ -267,7 +267,8 @@
 }
 
 @media (forced-colors: active) {
-	.action-menu .action-menu-item:focus-visible {
+	.action-menu .action-menu-item:focus-visible,
+	.action-menu .action-menu-item[aria-disabled='true']:focus-visible {
 		outline: 2px solid CanvasText;
 		outline-offset: -2px;
 		box-shadow: none;

--- a/packages/playground/website/src/components/site-manager/site-settings-form/style.module.css
+++ b/packages/playground/website/src/components/site-manager/site-settings-form/style.module.css
@@ -208,7 +208,7 @@
 }
 
 .action-menu .action-menu-item:hover:not([aria-disabled='true']) {
-	background: var(--surface-control-hover);
+	background: var(--wp-components-color-gray-100, #f0f0f0);
 }
 
 .action-menu .action-menu-item:focus {


### PR DESCRIPTION
Replaces the Site Settings action menu's hand-rolled buttons with
`DropdownMenu`, `MenuGroup`, and `MenuItemWithDescription`.

All website `DropdownMenu` uses now go through one wrapper. It supplies Home
and End navigation and a visible inset focus ring. Ordinary choices use
Gutenberg's menu states: black text on a transparent background at rest, then
accent-blue text on the same transparent background on hover. Disabled choices
stay muted and destructive choices stay red.

Site Settings keeps its split-button shape, 20px horizontal menu padding,
descriptions, separators, and responsive placement. Opening a menu focuses its
first available action. An unavailable **Apply to this Playground** remains in
keyboard navigation so its explanation is reachable without enabling it.

## Before and after

### Blueprint Export

#### Desktop

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/articles-adamziel-com/wordpress-playground/61a6cdc821cd75240b699d554e2bcbaf1a7927bd/blueprint-export-before-desktop.png" width="720" alt="Blueprint Export menu on desktop before the shared interaction styles"> | <img src="https://raw.githubusercontent.com/articles-adamziel-com/wordpress-playground/61a6cdc821cd75240b699d554e2bcbaf1a7927bd/blueprint-export-after-desktop.png" width="720" alt="Blueprint Export menu on desktop with shared hover and focus styles"> |

#### Mobile

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/articles-adamziel-com/wordpress-playground/61a6cdc821cd75240b699d554e2bcbaf1a7927bd/blueprint-export-before-mobile.png" width="390" alt="Blueprint Export menu on mobile before the shared interaction styles"> | <img src="https://raw.githubusercontent.com/articles-adamziel-com/wordpress-playground/61a6cdc821cd75240b699d554e2bcbaf1a7927bd/blueprint-export-after-mobile.png" width="390" alt="Blueprint Export menu on mobile with shared hover and focus styles"> |

### Saved Playground actions

#### Desktop

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/articles-adamziel-com/wordpress-playground/61a6cdc821cd75240b699d554e2bcbaf1a7927bd/saved-playgrounds-before-desktop.png" width="720" alt="Saved Playground action menu on desktop before the shared interaction styles"> | <img src="https://raw.githubusercontent.com/articles-adamziel-com/wordpress-playground/61a6cdc821cd75240b699d554e2bcbaf1a7927bd/saved-playgrounds-after-desktop.png" width="720" alt="Saved Playground action menu on desktop with shared hover and focus styles"> |

#### Mobile

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/articles-adamziel-com/wordpress-playground/61a6cdc821cd75240b699d554e2bcbaf1a7927bd/saved-playgrounds-before-mobile.png" width="390" alt="Saved Playground action menu on mobile before the shared interaction styles"> | <img src="https://raw.githubusercontent.com/articles-adamziel-com/wordpress-playground/61a6cdc821cd75240b699d554e2bcbaf1a7927bd/saved-playgrounds-after-mobile.png" width="390" alt="Saved Playground action menu on mobile with shared hover and focus styles"> |

### Site Settings: Apply is available

#### Desktop

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/articles-adamziel-com/wordpress-playground/61a6cdc821cd75240b699d554e2bcbaf1a7927bd/site-settings-available-before-desktop.png" width="720" alt="Site Settings action menu on desktop before using the shared menu states"> | <img src="https://raw.githubusercontent.com/articles-adamziel-com/wordpress-playground/61a6cdc821cd75240b699d554e2bcbaf1a7927bd/site-settings-available-after-desktop.png" width="720" alt="Site Settings action menu on desktop using the shared hover and focus states"> |

#### Mobile

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/articles-adamziel-com/wordpress-playground/61a6cdc821cd75240b699d554e2bcbaf1a7927bd/site-settings-available-before-mobile.png" width="390" alt="Site Settings action menu on mobile before using the shared menu states"> | <img src="https://raw.githubusercontent.com/articles-adamziel-com/wordpress-playground/61a6cdc821cd75240b699d554e2bcbaf1a7927bd/site-settings-available-after-mobile.png" width="390" alt="Site Settings action menu on mobile using the shared hover and focus states"> |

### Site Settings: a fresh Playground is required

#### Desktop

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/articles-adamziel-com/wordpress-playground/61a6cdc821cd75240b699d554e2bcbaf1a7927bd/site-settings-unavailable-before-desktop.png" width="720" alt="Site Settings menu with Apply unavailable on desktop before using the shared menu states"> | <img src="https://raw.githubusercontent.com/articles-adamziel-com/wordpress-playground/61a6cdc821cd75240b699d554e2bcbaf1a7927bd/site-settings-unavailable-after-desktop.png" width="720" alt="Site Settings menu with Apply unavailable on desktop using the shared focus state"> |

#### Mobile

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/articles-adamziel-com/wordpress-playground/61a6cdc821cd75240b699d554e2bcbaf1a7927bd/site-settings-unavailable-before-mobile.png" width="390" alt="Site Settings menu with Apply unavailable on mobile before using the shared menu states"> | <img src="https://raw.githubusercontent.com/articles-adamziel-com/wordpress-playground/61a6cdc821cd75240b699d554e2bcbaf1a7927bd/site-settings-unavailable-after-mobile.png" width="390" alt="Site Settings menu with Apply unavailable on mobile using the shared focus state"> |

## Testing

Open the Blueprint Export, Saved Playground actions, and Site Settings menus on
desktop and mobile. Confirm ordinary choices share the same resting, hover, and
focus states. Confirm disabled choices remain muted, Delete remains red, and
the Site Settings menu keeps its spacing and wrapping. Use Arrow Up, Arrow
Down, Home, and End to move through each menu.
