### PR TITLE
[Website] Drop the Dock operation toast to the Dock only when the pane leaves no room

### DIFF
--- a/packages/playground/website/src/components/dock/dock-positioning.spec.ts
+++ b/packages/playground/website/src/components/dock/dock-positioning.spec.ts
@@ -135,6 +135,24 @@ describe('Dock positioning', () => {
 		).toEqual({ bottom: '504px', left: '308px' });
 	});
 
+	it('drops the toast above the Dock when a tall pane leaves no room above it', () => {
+		expect(
+			getDockOperationToastStyle({
+				isMobile: false,
+				dockSize: { width: 800, height: 80 },
+				toolsHeight: 60,
+				isCollapsed: false,
+				dockCenter: null,
+				viewportSize: { width: 1200, height: 800 },
+				paneHeight: 680,
+				toastHeight: 62,
+				paneOpen: true,
+				isEditorSection: true,
+				isWideSection: false,
+			})
+		).toEqual({ bottom: '92px', left: '600px' });
+	});
+
 	it('keeps operation notices above the visible collapsed Dock row', () => {
 		expect(
 			getDockOperationToastStyle({

--- a/packages/playground/website/src/components/dock/dock-positioning.spec.ts
+++ b/packages/playground/website/src/components/dock/dock-positioning.spec.ts
@@ -135,7 +135,7 @@ describe('Dock positioning', () => {
 		).toEqual({ bottom: '504px', left: '308px' });
 	});
 
-	it('drops the toast above the Dock when a tall pane leaves no room above it', () => {
+	it('lifts the toast above the Dock when a tall pane leaves no room above it', () => {
 		expect(
 			getDockOperationToastStyle({
 				isMobile: false,
@@ -150,7 +150,25 @@ describe('Dock positioning', () => {
 				isEditorSection: true,
 				isWideSection: false,
 			})
-		).toEqual({ bottom: '92px', left: '600px' });
+		).toEqual({ bottom: '104px', left: '600px' });
+	});
+
+	it('lifts the toast off the pane on mobile', () => {
+		expect(
+			getDockOperationToastStyle({
+				isMobile: true,
+				dockSize: { width: 390, height: 72 },
+				toolsHeight: 0,
+				isCollapsed: false,
+				dockCenter: null,
+				viewportSize: { width: 390, height: 844 },
+				paneHeight: 700,
+				toastHeight: 62,
+				paneOpen: true,
+				isEditorSection: false,
+				isWideSection: false,
+			})
+		).toEqual({ bottom: '96px', left: '195px' });
 	});
 
 	it('keeps operation notices above the visible collapsed Dock row', () => {

--- a/packages/playground/website/src/components/dock/dock-positioning.ts
+++ b/packages/playground/website/src/components/dock/dock-positioning.ts
@@ -72,7 +72,7 @@ export function getDockPaneStyle({
 	};
 }
 
-/** Keeps a global operation failure with the visible Dock surface. */
+/** Places a global operation toast above the pane, or above the Dock if it won't fit. */
 export function getDockOperationToastStyle({
 	isMobile,
 	dockSize,
@@ -108,12 +108,19 @@ export function getDockOperationToastStyle({
 		toolsHeight,
 		isCollapsed,
 	});
-	const desiredBottom =
-		visibleDockHeight +
-		DOCK_PANE_GAP +
-		(!isMobile && paneOpen ? paneHeight + DOCK_PANE_GAP : 0);
-	// Editor panes and mobile panes can consume all available space. Keep the
-	// toast reachable at the viewport edge instead of placing it off-screen.
+	const aboveDock = visibleDockHeight + DOCK_PANE_GAP;
+	const abovePane =
+		!isMobile && paneOpen
+			? aboveDock + paneHeight + DOCK_PANE_GAP
+			: aboveDock;
+	// Prefer sitting above the pane, but only while there's room between the
+	// pane's top edge and the top of the viewport. When there isn't — a
+	// full-height editor pane, or mobile — drop to just above the Dock and let
+	// the toast overlay the pane's lower edge instead of its toolbar.
+	const fitsAbovePane =
+		abovePane + toastHeight + DOCK_PANE_GAP <= viewportSize.height;
+	const desiredBottom = fitsAbovePane ? abovePane : aboveDock;
+	// Final guard so the toast never sits off-screen.
 	const maxBottom = Math.max(
 		DOCK_PANE_GAP,
 		viewportSize.height - DOCK_PANE_GAP - toastHeight

--- a/packages/playground/website/src/components/dock/dock-positioning.ts
+++ b/packages/playground/website/src/components/dock/dock-positioning.ts
@@ -72,7 +72,11 @@ export function getDockPaneStyle({
 	};
 }
 
-/** Places a global operation toast above the pane, or above the Dock if it won't fit. */
+/**
+ * Places a global operation toast above an open pane when there's room above it
+ * (desktop only). Otherwise — no pane, a full-height pane, or mobile — it sits
+ * just above the Dock.
+ */
 export function getDockOperationToastStyle({
 	isMobile,
 	dockSize,

--- a/packages/playground/website/src/components/dock/dock-positioning.ts
+++ b/packages/playground/website/src/components/dock/dock-positioning.ts
@@ -109,17 +109,19 @@ export function getDockOperationToastStyle({
 		isCollapsed,
 	});
 	const aboveDock = visibleDockHeight + DOCK_PANE_GAP;
-	const abovePane =
-		!isMobile && paneOpen
-			? aboveDock + paneHeight + DOCK_PANE_GAP
-			: aboveDock;
-	// Prefer sitting above the pane, but only while there's room between the
-	// pane's top edge and the top of the viewport. When there isn't — a
-	// full-height editor pane, or mobile — drop to just above the Dock and let
-	// the toast overlay the pane's lower edge instead of its toolbar.
+	const roomAbovePane = !isMobile && paneOpen;
+	const abovePane = roomAbovePane
+		? aboveDock + paneHeight + DOCK_PANE_GAP
+		: aboveDock;
 	const fitsAbovePane =
+		roomAbovePane &&
 		abovePane + toastHeight + DOCK_PANE_GAP <= viewportSize.height;
-	const desiredBottom = fitsAbovePane ? abovePane : aboveDock;
+	// Prefer sitting above the pane. When there's no room — a full-height
+	// editor pane, or mobile — the toast overlays the pane's lower edge, so
+	// lift it a gap off the pane's bottom edge instead of aligning with it.
+	const desiredBottom = fitsAbovePane
+		? abovePane
+		: aboveDock + (paneOpen ? DOCK_PANE_GAP : 0);
 	// Final guard so the toast never sits off-screen.
 	const maxBottom = Math.max(
 		DOCK_PANE_GAP,

--- a/packages/playground/website/src/components/dock/style.module.css
+++ b/packages/playground/website/src/components/dock/style.module.css
@@ -1276,7 +1276,7 @@
 	border: 1px solid var(--error-toast-border);
 	border-radius: 11px;
 	bottom: 12px;
-	box-shadow: 0 15px 36px rgba(226, 111, 86, 0.26);
+	box-shadow: 0 6px 20px rgba(28, 16, 12, 0.16);
 	color: #ffffff;
 	display: flex;
 	font-size: 14px;
@@ -1297,7 +1297,7 @@
 .dock-operation-toast-success {
 	background: var(--success-toast-background);
 	border-color: var(--success-toast-border);
-	box-shadow: 0 15px 36px rgba(51, 240, 120, 0.22);
+	box-shadow: 0 6px 20px rgba(16, 40, 26, 0.18);
 }
 
 .dock-operation-toast-success .dock-operation-toast-message {

--- a/packages/playground/website/src/styles.css
+++ b/packages/playground/website/src/styles.css
@@ -198,8 +198,8 @@ html {
 
 	/* Success, warning, error, and destructive states. */
 	--success-on-dark: #c7ffdb;
-	--success-toast-background: #20482e;
-	--success-toast-border: #3b8a5e;
+	--success-toast-background: #2e5540;
+	--success-toast-border: #457a5c;
 	--warning: #fff972;
 	--warning-highlight: #fffcb5;
 	--warning-surface: #fffdd6;


### PR DESCRIPTION
Follow-up to #4143.

## What it does

Improves how the Dock operation toast (Run / rename / save feedback) is placed and styled:

1. **Placement** — sits above the pane when there's room, and drops to **just above the Dock** only when there isn't (a full-height editor pane, or mobile). When it drops, it's lifted a gap off the pane's bottom edge rather than clamping over the pane's toolbar or aligning flush with the pane.
2. **Appearance** — lighter, less saturated success fill and a subtler neutral shadow, in place of the heavy colored glow.

| Desktop — full-height editor pane | Mobile |
| --- | --- |
| ![Desktop: toast lifted just above the Dock, clear of the toolbar](https://raw.githubusercontent.com/WordPress/wordpress-playground/adamziel/blueprint-notice-assets/dock-toast-desktop-drop.png) | ![Mobile: toast lifted just above the Dock](https://raw.githubusercontent.com/WordPress/wordpress-playground/adamziel/blueprint-notice-assets/dock-toast-mobile-drop.png) |

(Screenshots use the Run action's toast — the same shared Dock operation toast.) When a pane is short enough to leave room above it, the toast sits above the pane instead (unit-tested below).

## Rationale

`getDockOperationToastStyle` always placed the toast above the pane (`dockHeight + gap + paneHeight + gap`). For a full-height editor pane that overflows the viewport, so it clamped to the top edge — directly over the Export / Run buttons the user just clicked (surfaced by #4143). And when it did land near the Dock, its bottom edge aligned flush with the pane's.

## Implementation

Prefer above the pane; fall back to above the Dock, lifted off the pane's bottom edge, only when there's no room:

```ts
const aboveDock = visibleDockHeight + DOCK_PANE_GAP;
const roomAbovePane = !isMobile && paneOpen;
const abovePane = roomAbovePane
  ? aboveDock + paneHeight + DOCK_PANE_GAP
  : aboveDock;
const fitsAbovePane =
  roomAbovePane && abovePane + toastHeight + DOCK_PANE_GAP <= viewportSize.height;
const desiredBottom = fitsAbovePane
  ? abovePane
  : aboveDock + (paneOpen ? DOCK_PANE_GAP : 0);
```

The background is softened via the `--success-toast-background` / `--success-toast-border` tokens in `styles.css` and the shadow in `dock/style.module.css`. No `dock.tsx` changes — it already measures and passes `paneHeight` / `paneOpen`.

## Testing instructions

```bash
nx test playground-website --testFile=dock-positioning.spec.ts
```

Covers the three placements:

- short pane, room above → **above the pane** (`bottom: 504px`)
- full-height pane, no room → **above the Dock, lifted** (`bottom: 104px`)
- mobile → **above the Dock, lifted** (`bottom: 96px`)

Manual: open the Blueprint editor (a full-height pane) → **Run** — the toast sits just above the Dock, clear of the toolbar (desktop + mobile above).
