### PR TITLE
[Website] Keep background startup work from racing ZIP imports

### DIFF
--- a/packages/playground/client/src/blueprints-v1-handler.spec.ts
+++ b/packages/playground/client/src/blueprints-v1-handler.spec.ts
@@ -271,6 +271,29 @@ describe('BlueprintsV1Handler', () => {
 		vi.useRealTimers();
 	});
 
+	it('does not prefetch updates for WordPress files that will be replaced', async () => {
+		mocks.resolveRuntimeConfiguration.mockResolvedValue({
+			phpVersion: '8.4',
+			wpVersion: 'latest',
+			intl: false,
+			networking: true,
+		});
+		vi.useFakeTimers();
+		vi.stubGlobal('requestIdleCallback', undefined);
+		const iframe = createIframe();
+		const handler = new BlueprintsV1Handler({
+			iframe,
+			remoteUrl: 'http://example.com/remote.html',
+			blueprint: {},
+			willReplaceWordPressFiles: true,
+		});
+
+		await handler.bootPlayground(iframe, createProgressTracker());
+		await vi.runAllTimersAsync();
+
+		expect(mocks.playground.prefetchUpdateChecks).not.toHaveBeenCalled();
+	});
+
 	it('does not treat wp-admin-prefixed frontend paths as admin landings', async () => {
 		mocks.resolveRuntimeConfiguration.mockResolvedValue({
 			phpVersion: '8.4',

--- a/packages/playground/client/src/blueprints-v1-handler.ts
+++ b/packages/playground/client/src/blueprints-v1-handler.ts
@@ -39,6 +39,7 @@ export class BlueprintsV1Handler {
 			onClientConnected,
 			pathAliases,
 			disableProgressBar,
+			willReplaceWordPressFiles,
 		} = this.options;
 		const executionProgress = progressTracker!.stage(0.5);
 		const downloadProgress = progressTracker!.stage();
@@ -148,6 +149,7 @@ export class BlueprintsV1Handler {
 		const wpMajor = parseFloat(runtimeConfiguration.wpVersion);
 		const isLegacyWpVersion = Number.isFinite(wpMajor) && wpMajor < 5.1;
 		const shouldPrefetchUpdateChecks =
+			!willReplaceWordPressFiles &&
 			runtimeConfiguration.networking &&
 			!isLegacyWpVersion &&
 			resolvedWordPressInstallMode === 'download-and-install';

--- a/packages/playground/client/src/index.spec.ts
+++ b/packages/playground/client/src/index.spec.ts
@@ -64,6 +64,28 @@ describe('startPlaygroundWeb', () => {
 		expect(iframe.src).toContain('existing=1');
 	});
 
+	it('marks remote boots whose WordPress files will be replaced', async () => {
+		const playground = { connected: true };
+		mocks.BlueprintsV1Handler.mockImplementation(() => ({
+			bootPlayground: mocks.bootPlaygroundV1,
+		}));
+		mocks.bootPlaygroundV1.mockResolvedValue(playground);
+		const iframe = createIframe();
+
+		await startPlaygroundWeb({
+			iframe,
+			remoteUrl: 'http://localhost/remote.html',
+			progressTracker: createProgressTracker(),
+			willReplaceWordPressFiles: true,
+		});
+
+		expect(
+			new URL(iframe.src).searchParams.has(
+				'wordpress-files-will-be-replaced'
+			)
+		).toBe(true);
+	});
+
 	it('routes Blueprint v2 declarations through the v2 handler', async () => {
 		const playground = { connected: true };
 		mocks.BlueprintsV2Handler.mockImplementation(() => ({

--- a/packages/playground/client/src/index.ts
+++ b/packages/playground/client/src/index.ts
@@ -55,12 +55,23 @@ import { BlueprintsV1Handler } from './blueprints-v1-handler';
 import { BlueprintsV2Handler } from './blueprints-v2-handler';
 
 const WITH_ADMIN_TRANSITIONS_PARAM = 'with-admin-transitions';
+const WORDPRESS_FILES_WILL_BE_REPLACED_PARAM =
+	'wordpress-files-will-be-replaced';
 
 export interface StartPlaygroundOptions {
 	iframe: HTMLIFrameElement;
 	remoteUrl: string;
 	progressTracker?: ProgressTracker;
 	disableProgressBar?: boolean;
+	/**
+	 * Indicates that the installed WordPress files will be replaced immediately
+	 * after boot. Update prefetching and automatic static-file backfilling are
+	 * skipped for the throwaway installation. The caller must backfill the
+	 * replacement when needed.
+	 *
+	 * @internal
+	 */
+	willReplaceWordPressFiles?: boolean;
 	blueprint?: BlueprintV1;
 	/**
 	 * PHP extensions to install before the runtime starts.
@@ -171,8 +182,13 @@ export async function startPlaygroundWeb(
 
 	const remoteUrlWithoutLegacyRunner = new URL(remoteUrl, remoteOrigin);
 	remoteUrlWithoutLegacyRunner.searchParams.delete('blueprints-runner');
+	remoteUrlWithoutLegacyRunner.searchParams.delete(
+		WORDPRESS_FILES_WILL_BE_REPLACED_PARAM
+	);
 	remoteUrl = setQueryParams(remoteUrlWithoutLegacyRunner.toString(), {
 		progressbar: !disableProgressBar,
+		[WORDPRESS_FILES_WILL_BE_REPLACED_PARAM]:
+			options.willReplaceWordPressFiles,
 		[WITH_ADMIN_TRANSITIONS_PARAM]: new URL(
 			globalThis.location.href
 		).searchParams.has(WITH_ADMIN_TRANSITIONS_PARAM)

--- a/packages/playground/remote/src/lib/boot-playground-remote.ts
+++ b/packages/playground/remote/src/lib/boot-playground-remote.ts
@@ -37,6 +37,8 @@ import workerEntryPointUrl from './playground-worker-endpoint-blueprints.ts?work
 // resolved by the browser at runtime to reflect the current origin.
 const origin = new URL('/', (import.meta || {}).url).origin;
 const WITH_ADMIN_TRANSITIONS_PARAM = 'with-admin-transitions';
+const WORDPRESS_FILES_WILL_BE_REPLACED_PARAM =
+	'wordpress-files-will-be-replaced';
 
 function getWorkerUrl(): string {
 	const query = new URL(document.location.href).searchParams;
@@ -509,6 +511,12 @@ export async function bootPlaygroundRemote() {
 			} catch (e) {
 				setAPIError(e as Error);
 				throw e;
+			}
+
+			if (query.has(WORDPRESS_FILES_WILL_BE_REPLACED_PARAM)) {
+				// The caller will replace WordPress files, then explicitly backfill
+				// the imported filesystem.
+				return;
 			}
 
 			/**

--- a/packages/playground/website/playwright/e2e/opfs.spec.ts
+++ b/packages/playground/website/playwright/e2e/opfs.spec.ts
@@ -427,8 +427,7 @@ async function saveSiteViaDockPane(
 	// If a custom name is provided, update it
 	if (customName) {
 		const nameInput = pane.getByLabel('Playground name');
-		await nameInput.fill('');
-		await nameInput.type(customName);
+		await nameInput.fill(customName);
 	}
 
 	if (storageType === 'opfs') {

--- a/packages/playground/website/src/lib/state/redux/boot-site-client.spec.ts
+++ b/packages/playground/website/src/lib/state/redux/boot-site-client.spec.ts
@@ -909,6 +909,11 @@ describe('bootSiteClient', () => {
 		await initialization.finished;
 		await vi.waitFor(() => expect(calls).toHaveLength(2));
 
+		expect(startPlaygroundWeb).toHaveBeenCalledWith(
+			expect.objectContaining({
+				willReplaceWordPressFiles: true,
+			})
+		);
 		expect(calls).toEqual(['import ZIP', 'copy to OPFS']);
 	});
 });

--- a/packages/playground/website/src/lib/state/redux/boot-site-client.ts
+++ b/packages/playground/website/src/lib/state/redux/boot-site-client.ts
@@ -43,7 +43,10 @@ import {
 } from './error-utils';
 import { PHPMYADMIN_PATH_ALIAS } from '@wp-playground/tools';
 import { phpExtensionQueryArgsToExtensionsArray } from '../url/php-extension-query';
-import { runSiteFirstBootInitializer } from './site-first-boot-initializer';
+import {
+	hasSiteFirstBootInitializer,
+	runSiteFirstBootInitializer,
+} from './site-first-boot-initializer';
 import { captureAndPersistSiteThumbnail } from './capture-site-thumbnail';
 import { getPlaygroundDefinedPHPConstants } from './playground-defined-php-constants';
 
@@ -255,6 +258,11 @@ export function bootSiteClient(
 				corsProxy: corsProxyUrl,
 				gitAdditionalHeadersCallback: createGitAuthHeaders(),
 				pathAliases: [PHPMYADMIN_PATH_ALIAS],
+				// First-boot initialization owns the WordPress filesystem until it
+				// has imported and backfilled the replacement.
+				willReplaceWordPressFiles: hasSiteFirstBootInitializer(
+					site.slug
+				),
 			});
 		} catch (e) {
 			if (signal.aborted) {

--- a/packages/playground/website/src/lib/state/redux/site-first-boot-initializer.ts
+++ b/packages/playground/website/src/lib/state/redux/site-first-boot-initializer.ts
@@ -46,6 +46,11 @@ export function registerSiteFirstBootInitializer(
 	};
 }
 
+/** Returns whether a site has work waiting for its first runtime boot. */
+export function hasSiteFirstBootInitializer(siteSlug: string) {
+	return pendingInitializers.has(siteSlug);
+}
+
 /** Runs and consumes a site's pending first-boot initializer, if any. */
 export async function runSiteFirstBootInitializer(
 	siteSlug: string,

--- a/packages/playground/website/src/lib/state/redux/site-management-api-middleware.ts
+++ b/packages/playground/website/src/lib/state/redux/site-management-api-middleware.ts
@@ -908,6 +908,9 @@ export function createSitesAPI(
 						{ wordPressFilesZip },
 						{ tracker }
 					);
+					// Startup backfilling was suppressed for the throwaway install.
+					// Complete the imported filesystem before refreshing or persisting it.
+					await playground.backfillStaticFilesRemovedFromMinifiedBuild();
 					await playground.goTo('/').catch((error) => {
 						logger.error('Failed to refresh imported site', error);
 						throw error;


### PR DESCRIPTION
ZIP imports now declare before boot that they will replace the installed
WordPress files.

The client carries that intent on the `remote.html` URL. The throwaway
installation never starts automatic static-file backfilling or WordPress
update-check prefetching. After the import, one explicit backfill completes the
imported filesystem before the page refreshes and the initial OPFS copy starts.

No cancellation path or filesystem mutex is needed because the conflicting
work is never scheduled. Existing callers omit the intent, so their boot timing
and callbacks are unchanged.

The OPFS save helper now fills custom site names in one operation. Its previous
clear-then-type sequence could lose leading characters under parallel load and
fail before the ZIP import began.

## Testing

- While viewing a saved Playground with no temporary Playground, import a ZIP
  and confirm the imported site remains available after switching away and
  back.
- Repeated the saved-site ZIP import 30 times with three Chromium workers. All
  30 runs passed without retries.
