### PR TITLE
[Website] Keep ZIP drop listeners active through rerenders

### DIFF
--- a/packages/playground/website/src/components/site-manager/index.tsx
+++ b/packages/playground/website/src/components/site-manager/index.tsx
@@ -57,7 +57,7 @@ export const SiteManager = forwardRef<HTMLDivElement, SiteManagerProps>(
 		const [lastSavedPlaygroundsPanel, setLastSavedPlaygroundsPanel] =
 			useState<'new' | 'playgrounds'>('playgrounds');
 		const [sharePanelMounted, setSharePanelMounted] = useState(false);
-		const closeSavePane = useCallback(
+		const closeDockPane = useCallback(
 			() => dispatch(setDockPaneOpen(false)),
 			[dispatch]
 		);
@@ -86,7 +86,7 @@ export const SiteManager = forwardRef<HTMLDivElement, SiteManagerProps>(
 				isVisible && activeSite ? (
 					<SaveSiteModal
 						asPane
-						onClose={closeSavePane}
+						onClose={closeDockPane}
 						onCloseBlockedChange={onPaneCloseBlockedChange}
 					/>
 				) : null;
@@ -117,7 +117,7 @@ export const SiteManager = forwardRef<HTMLDivElement, SiteManagerProps>(
 									? activeSection
 									: lastSavedPlaygroundsPanel
 							}
-							onClose={() => dispatch(setDockPaneOpen(false))}
+							onClose={closeDockPane}
 							onPaneHeaderChange={onNewPlaygroundHeaderChange}
 						/>
 					</div>


### PR DESCRIPTION
The Saved Playgrounds panel now receives a stable close callback. Renders
during a drag no longer remove and reinstall its document-level drop listeners
before the drop.

The separate ZIP startup race remains isolated in #4213.

## Testing

- Repeated the page-drop import through its drag-enter, drag-leave, drag-over,
  and drop sequence; every drop reached the ZIP importer.
