### PR TITLE
Support filtered saved-site ZIP exports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54315,7 +54315,10 @@
 		},
 		"packages/playground/website": {
 			"name": "@wp-playground/website",
-			"version": "0.0.1"
+			"version": "0.0.1",
+			"dependencies": {
+				"ignore": "7.0.6"
+			}
 		},
 		"packages/playground/website-extras": {
 			"name": "@wp-playground/website-extras",
@@ -54354,6 +54357,15 @@
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
+			}
+		},
+		"packages/playground/website/node_modules/ignore": {
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+			"integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4"
 			}
 		},
 		"packages/playground/wordpress": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,7 @@
 				"file-saver": "^2.0.5",
 				"fs-ext-extra-prebuilt": "2.2.7",
 				"fs-extra": "11.1.1",
+				"ignore": "7.0.6",
 				"ini": "4.1.2",
 				"jsonc-parser": "3.3.1",
 				"modern-screenshot": "4.7.0",
@@ -6259,6 +6260,16 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/@eslint/eslintrc/node_modules/ignore": {
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+			"integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4"
+			}
+		},
 		"node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -11998,6 +12009,16 @@
 				"url": "https://github.com/chalk/chalk?sponsor=1"
 			}
 		},
+		"node_modules/@nx/js/node_modules/ignore": {
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+			"integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4"
+			}
+		},
 		"node_modules/@nx/js/node_modules/jsonc-parser": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
@@ -17275,16 +17296,6 @@
 			"peerDependencies": {
 				"eslint": "^8.57.0 || ^9.0.0",
 				"typescript": ">=4.8.4 <6.0.0"
-			}
-		},
-		"node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
-			"version": "7.0.5",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-			"integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 4"
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
@@ -24469,6 +24480,15 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/copy-webpack-plugin/node_modules/ignore": {
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+			"integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4"
+			}
+		},
 		"node_modules/copy-webpack-plugin/node_modules/slash": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
@@ -27743,6 +27763,16 @@
 				"node": ">=10.13.0"
 			}
 		},
+		"node_modules/eslint/node_modules/ignore": {
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+			"integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4"
+			}
+		},
 		"node_modules/eslint/node_modules/json-schema-traverse": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -29886,6 +29916,15 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/globby/node_modules/ignore": {
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+			"integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4"
+			}
+		},
 		"node_modules/globrex": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
@@ -31012,9 +31051,9 @@
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/ignore": {
-			"version": "5.3.2",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
-			"integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+			"integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
 			"license": "MIT",
 			"engines": {
 				"node": ">= 4"
@@ -32131,6 +32170,15 @@
 			"resolved": "https://registry.npmjs.org/diff3/-/diff3-0.0.3.tgz",
 			"integrity": "sha512-iSq8ngPOt0K53A6eVr4d5Kn6GNrM2nQZtC740pzIriHtn4pOQ2lyzEXQMBeVcWERN0ye7fhBsk9PbLLQOnUx/g==",
 			"license": "MIT"
+		},
+		"node_modules/isomorphic-git/node_modules/ignore": {
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+			"integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4"
+			}
 		},
 		"node_modules/isomorphic-git/node_modules/pify": {
 			"version": "4.0.1",
@@ -41679,16 +41727,6 @@
 			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/nx/node_modules/ignore": {
-			"version": "7.0.5",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-			"integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 4"
-			}
 		},
 		"node_modules/nx/node_modules/is-interactive": {
 			"version": "1.0.0",
@@ -54315,10 +54353,7 @@
 		},
 		"packages/playground/website": {
 			"name": "@wp-playground/website",
-			"version": "0.0.1",
-			"dependencies": {
-				"ignore": "7.0.6"
-			}
+			"version": "0.0.1"
 		},
 		"packages/playground/website-extras": {
 			"name": "@wp-playground/website-extras",
@@ -54357,15 +54392,6 @@
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
-			}
-		},
-		"packages/playground/website/node_modules/ignore": {
-			"version": "7.0.6",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
-			"integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 4"
 			}
 		},
 		"packages/playground/wordpress": {

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
 		"file-saver": "^2.0.5",
 		"fs-ext-extra-prebuilt": "2.2.7",
 		"fs-extra": "11.1.1",
+		"ignore": "7.0.6",
 		"ini": "4.1.2",
 		"jsonc-parser": "3.3.1",
 		"modern-screenshot": "4.7.0",

--- a/packages/playground/website/package.json
+++ b/packages/playground/website/package.json
@@ -2,5 +2,8 @@
 	"version": "0.0.1",
 	"type": "commonjs",
 	"private": true,
-	"name": "@wp-playground/website"
+	"name": "@wp-playground/website",
+	"dependencies": {
+		"ignore": "7.0.6"
+	}
 }

--- a/packages/playground/website/package.json
+++ b/packages/playground/website/package.json
@@ -2,8 +2,5 @@
 	"version": "0.0.1",
 	"type": "commonjs",
 	"private": true,
-	"name": "@wp-playground/website",
-	"dependencies": {
-		"ignore": "7.0.6"
-	}
+	"name": "@wp-playground/website"
 }

--- a/packages/playground/website/src/lib/state/opfs/opfs-site-storage.spec.ts
+++ b/packages/playground/website/src/lib/state/opfs/opfs-site-storage.spec.ts
@@ -239,6 +239,55 @@ describe('opfsSiteStorage', () => {
 		);
 		expect(archive.files.has('wp-runtime.json')).toBe(true);
 		expect(archive.directories.has('wp-content/empty-cache/')).toBe(true);
+		expect(archive.directories.get('wp-content/empty-cache/')).toBe(0o755);
+	});
+
+	it('applies ordered exclusion patterns when exporting saved site files', async () => {
+		const sitesRoot = await getSitesRoot(opfsRoot);
+		const siteDirectory = await writeSiteMetadata(
+			sitesRoot,
+			'site-patterns',
+			'patterns'
+		);
+		const wpAdmin = await siteDirectory.getDirectoryHandle('wp-admin', {
+			create: true,
+		});
+		wpAdmin.setFile('index.php', 'exclude admin');
+		const wpAdminEntries = vi.spyOn(wpAdmin, 'entries');
+		const wpContent = await siteDirectory.getDirectoryHandle('wp-content', {
+			create: true,
+		});
+		const plugins = await wpContent.getDirectoryHandle('plugins', {
+			create: true,
+		});
+		plugins.setFile('hello.php', 'include plugin');
+		const cache = await wpContent.getDirectoryHandle('cache', {
+			create: true,
+		});
+		cache.setFile('cached.html', 'exclude cache');
+		const cacheEntries = vi.spyOn(cache, 'entries');
+
+		const zipFile = await storage.exportSavedSiteAsZip('patterns', {
+			excludePatterns: [
+				'/*',
+				'!/wp-content/',
+				'!/wp-content/**',
+				'/wp-content/cache/',
+				'/wp-content/cache/**',
+			],
+		});
+		const archive = await readZipEntries(zipFile!);
+
+		expect(archive.files.has('wp-runtime.json')).toBe(false);
+		expect(archive.files.has('wp-admin/index.php')).toBe(false);
+		expect(wpAdminEntries).not.toHaveBeenCalled();
+		expect(archive.directories.has('wp-content/')).toBe(true);
+		expect(archive.files.get('wp-content/plugins/hello.php')).toBe(
+			'include plugin'
+		);
+		expect(archive.directories.has('wp-content/cache/')).toBe(false);
+		expect(archive.files.has('wp-content/cache/cached.html')).toBe(false);
+		expect(cacheEntries).not.toHaveBeenCalled();
 	});
 
 	it('does not export directories without saved Playground metadata', async () => {
@@ -358,10 +407,13 @@ async function readZipEntries(zipFile: Blob) {
 	try {
 		const entries = await reader.getEntries();
 		const files = new Map<string, string>();
-		const directories = new Set<string>();
+		const directories = new Map<string, number>();
 		for (const entry of entries) {
 			if (entry.directory) {
-				directories.add(entry.filename);
+				directories.set(
+					entry.filename,
+					(entry.externalFileAttributes >>> 16) & 0o777
+				);
 			} else {
 				files.set(
 					entry.filename,

--- a/packages/playground/website/src/lib/state/opfs/opfs-site-storage.spec.ts
+++ b/packages/playground/website/src/lib/state/opfs/opfs-site-storage.spec.ts
@@ -267,13 +267,6 @@ describe('opfsSiteStorage', () => {
 		cache.setFile('cached.html', 'exclude cache');
 		const cacheEntries = vi.spyOn(cache, 'entries');
 
-		expect(
-			JSON.parse(await readOpfsFile(siteDirectory, 'wp-runtime.json'))
-		).toMatchObject({ slug: 'patterns' });
-		expect(await readOpfsFile(wpAdmin, 'index.php')).toBe('exclude admin');
-		expect(await readOpfsFile(plugins, 'hello.php')).toBe('include plugin');
-		expect(await readOpfsFile(cache, 'cached.html')).toBe('exclude cache');
-
 		const zipFile = await storage.exportSavedSiteAsZip('patterns', {
 			excludePatterns: [
 				'/*',
@@ -432,14 +425,6 @@ async function readZipEntries(zipFile: Blob) {
 	} finally {
 		await reader.close();
 	}
-}
-
-async function readOpfsFile(
-	directory: MemoryDirectoryHandle,
-	fileName: string
-) {
-	const fileHandle = await directory.getFileHandle(fileName);
-	return (await fileHandle.getFile()).text();
 }
 
 async function getSitesRoot(opfsRoot: MemoryDirectoryHandle) {

--- a/packages/playground/website/src/lib/state/opfs/opfs-site-storage.spec.ts
+++ b/packages/playground/website/src/lib/state/opfs/opfs-site-storage.spec.ts
@@ -267,6 +267,13 @@ describe('opfsSiteStorage', () => {
 		cache.setFile('cached.html', 'exclude cache');
 		const cacheEntries = vi.spyOn(cache, 'entries');
 
+		expect(
+			JSON.parse(await readOpfsFile(siteDirectory, 'wp-runtime.json'))
+		).toMatchObject({ slug: 'patterns' });
+		expect(await readOpfsFile(wpAdmin, 'index.php')).toBe('exclude admin');
+		expect(await readOpfsFile(plugins, 'hello.php')).toBe('include plugin');
+		expect(await readOpfsFile(cache, 'cached.html')).toBe('exclude cache');
+
 		const zipFile = await storage.exportSavedSiteAsZip('patterns', {
 			excludePatterns: [
 				'/*',
@@ -425,6 +432,14 @@ async function readZipEntries(zipFile: Blob) {
 	} finally {
 		await reader.close();
 	}
+}
+
+async function readOpfsFile(
+	directory: MemoryDirectoryHandle,
+	fileName: string
+) {
+	const fileHandle = await directory.getFileHandle(fileName);
+	return (await fileHandle.getFile()).text();
 }
 
 async function getSitesRoot(opfsRoot: MemoryDirectoryHandle) {

--- a/packages/playground/website/src/lib/state/opfs/opfs-site-storage.ts
+++ b/packages/playground/website/src/lib/state/opfs/opfs-site-storage.ts
@@ -15,6 +15,7 @@ import type { OriginalUrlParams } from '../original-url-params';
 import { logger } from '@php-wasm/logger';
 import { joinPaths } from '@php-wasm/util';
 import { BlobReader, BlobWriter, ZipWriter } from '@zip.js/zip.js';
+import ignore from 'ignore';
 import {
 	type ExtraLibrary,
 	type PHPConstants,
@@ -39,6 +40,8 @@ export {
 
 // TODO: Decide on metadata filename
 const SITE_METADATA_FILENAME = 'wp-runtime.json';
+// 0o40755 = 0o40000 | 0o755; ZIP stores it in externalFileAttributes' upper 16 bits.
+const ZIP_DIRECTORY_EXTERNAL_FILE_ATTRIBUTES = 0o40755 << 16;
 
 // Use a symbol to mark legacy site metadata to avoid serializing it to JSON.
 // @TODO: Remove this backcompat code after 2024-12-01.
@@ -66,6 +69,14 @@ type StoredSiteChanges = {
 	metadata?: SiteMetadataChanges;
 	originalUrlParams?: OriginalUrlParams;
 };
+
+export interface ExportSavedSiteAsZipOptions {
+	/**
+	 * Gitignore-style exclusion patterns applied relative to the saved site root.
+	 * Patterns starting with `!` re-include paths.
+	 */
+	excludePatterns?: readonly string[];
+}
 
 let opfsSitesRoot: FileSystemDirectoryHandle | undefined = undefined;
 try {
@@ -217,12 +228,15 @@ class OpfsSiteStorage {
 	 * half-written or mismatched files is just corrupt output with a nicer file
 	 * extension.
 	 */
-	async exportSavedSiteAsZip(slug: string): Promise<Blob | undefined> {
+	async exportSavedSiteAsZip(
+		slug: string,
+		options: ExportSavedSiteAsZipOptions = {}
+	): Promise<Blob | undefined> {
 		const siteDirectory = await this.getSavedSiteDirectory(slug);
 		if (!siteDirectory) {
 			return undefined;
 		}
-		return await zipDirectory(siteDirectory);
+		return await zipDirectory(siteDirectory, options.excludePatterns);
 	}
 
 	/**
@@ -547,10 +561,14 @@ function isMissingOpfsEntry(error: unknown) {
  * callers can use the Blob directly, and converting it copies the whole archive
  * for no useful reason.
  */
-async function zipDirectory(directory: FileSystemDirectoryHandle) {
+async function zipDirectory(
+	directory: FileSystemDirectoryHandle,
+	excludePatterns: readonly string[] = []
+) {
 	const zipWriter = new ZipWriter(new BlobWriter('application/zip'));
+	const pathMatcher = ignore().add(excludePatterns);
 	try {
-		await addDirectoryEntries(zipWriter, directory, '');
+		await addDirectoryEntries(zipWriter, directory, '', pathMatcher);
 		return await zipWriter.close();
 	} catch (error) {
 		await zipWriter.close().catch(() => undefined);
@@ -568,7 +586,8 @@ async function zipDirectory(directory: FileSystemDirectoryHandle) {
 async function addDirectoryEntries(
 	zipWriter: ZipWriter<Blob>,
 	directory: FileSystemDirectoryHandle,
-	relativeDirPath: string
+	relativeDirPath: string,
+	pathMatcher: ReturnType<typeof ignore>
 ) {
 	for await (const [name, entry] of directory.entries()) {
 		const relativePath = relativeDirPath
@@ -576,11 +595,25 @@ async function addDirectoryEntries(
 			: name;
 
 		if (entry.kind === 'directory') {
-			await zipWriter.add(`${relativePath}/`, undefined, {
+			const archivePath = `${relativePath}/`;
+			// Descendants cannot be re-included while their parent remains ignored.
+			if (pathMatcher.ignores(archivePath)) {
+				continue;
+			}
+			await zipWriter.add(archivePath, undefined, {
 				directory: true,
+				externalFileAttributes: ZIP_DIRECTORY_EXTERNAL_FILE_ATTRIBUTES,
 			});
-			await addDirectoryEntries(zipWriter, entry, relativePath);
+			await addDirectoryEntries(
+				zipWriter,
+				entry,
+				relativePath,
+				pathMatcher
+			);
 		} else {
+			if (pathMatcher.ignores(relativePath)) {
+				continue;
+			}
 			await zipWriter.add(
 				relativePath,
 				new BlobReader(await entry.getFile())

--- a/packages/playground/website/src/lib/state/opfs/opfs-site-storage.ts
+++ b/packages/playground/website/src/lib/state/opfs/opfs-site-storage.ts
@@ -15,6 +15,7 @@ import type { OriginalUrlParams } from '../original-url-params';
 import { logger } from '@php-wasm/logger';
 import { joinPaths } from '@php-wasm/util';
 import { BlobReader, BlobWriter, ZipWriter } from '@zip.js/zip.js';
+import type { Ignore } from 'ignore';
 import ignore from 'ignore';
 import {
 	type ExtraLibrary,
@@ -587,7 +588,7 @@ async function addDirectoryEntries(
 	zipWriter: ZipWriter<Blob>,
 	directory: FileSystemDirectoryHandle,
 	relativeDirPath: string,
-	pathMatcher: ReturnType<typeof ignore>
+	pathMatcher: Ignore
 ) {
 	for await (const [name, entry] of directory.entries()) {
 		const relativePath = relativeDirPath


### PR DESCRIPTION
## What

Adds saved OPFS site ZIP exports with optional gitignore-style exclusion patterns, subtree pruning, stable directory permissions, and focused coverage.

## Why

This establishes the storage-layer capability independently of the hosted API, so it can be reviewed and tested without client, routing, or deployment changes.

## Stack

- 1 of 3
- Base: `trunk`
- Next: #4219

## Checks

- `npm exec nx test playground-website`
- `npm exec nx lint playground-website`
- `npm exec nx typecheck playground-website`
- `npm exec nx build playground-website`
