### PR TITLE
[PHP-WASM] Include dot entries in mounted directory scans

### DIFF
--- a/packages/php-wasm/node/src/lib/load-runtime.ts
+++ b/packages/php-wasm/node/src/lib/load-runtime.ts
@@ -206,6 +206,19 @@ export async function loadNodeRuntime(
 				}
 			: {}),
 		onRuntimeInitialized: (phpRuntime: PHPRuntime) => {
+			// Node.js omits "." and ".." from readdirSync(), unlike MEMFS and native PHP.
+			const nodeFs = phpRuntime.FS.filesystems.NODEFS;
+			const originalNodeFsReaddir = nodeFs.node_ops.readdir;
+			nodeFs.node_ops.readdir = (node: any) => {
+				const entries = originalNodeFsReaddir.call(
+					nodeFs.node_ops,
+					node
+				);
+				return entries.includes('.')
+					? entries
+					: ['.', '..', ...entries];
+			};
+
 			/**
 			 * When users mount a directory using the `mount` function,
 			 * the directory becomes accessible in the Emscripten's filesystem.

--- a/packages/php-wasm/node/src/test/mount.spec.ts
+++ b/packages/php-wasm/node/src/test/mount.spec.ts
@@ -62,6 +62,27 @@ describe('Mounting', () => {
 		}
 	});
 
+	it('Should include dot entries when PHP scans an empty mounted directory', async () => {
+		const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'temp-'));
+		const unmount = await php.mount(
+			directoryMountPoint,
+			createNodeFsMountHandler(tempDir)
+		);
+
+		try {
+			const result = await php.run({
+				code: `<?php
+					echo json_encode(scandir('${directoryMountPoint}'));
+				`,
+			});
+
+			expect(JSON.parse(result.text)).toEqual(['.', '..']);
+		} finally {
+			unmount();
+			fs.rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
 	[
 		{
 			filePath: testFilePath,


### PR DESCRIPTION
PHP's `scandir()` now returns `.` and `..` for NODEFS-mounted directories,
matching native PHP and Playground's MEMFS directories.

Node's `readdirSync()` omits these entries. `loadNodeRuntime()` adds them while
configuring NODEFS and preserves them if a future Emscripten release starts
returning them itself.

## Testing

Mount an empty host directory and confirm `scandir()` returns `[".", ".."]` in
both Asyncify and JSPI runtimes.
