### PR TITLE
[Website] Center the Dock refresh button between the frame and URL field

### DIFF
--- a/packages/playground/website/src/components/address-bar/style.module.css
+++ b/packages/playground/website/src/components/address-bar/style.module.css
@@ -4,7 +4,6 @@
 	transition: opacity 0.5s ease;
 	width: 100%;
 	align-items: center;
-	gap: 8px;
 }
 
 .refresh-button {
@@ -13,6 +12,7 @@
 	justify-content: center;
 	width: 32px;
 	height: 32px;
+	margin-inline: 4px;
 	padding: 5px;
 	background: transparent;
 	border: none;

--- a/packages/playground/website/src/components/dock/style.module.css
+++ b/packages/playground/website/src/components/dock/style.module.css
@@ -1258,7 +1258,7 @@
 .dock-body {
 	display: flex;
 	flex-direction: column;
-	gap: 6px;
+	gap: 8px;
 	/* One 8px frame all around. The measure that matters is the ink touching
 	   each edge: the toggle pill (full-row, bordered) at the top, the tool
 	   buttons at the sides and bottom — all of them clear the dock's edge by


### PR DESCRIPTION
Centers the Dock refresh button within the space beside the URL field. Its 32px target now has 4px on either side between the Dock's inner edge and URL field, moving the entire target 4px right without moving the field. The desktop row also matches the Dock's 8px frame so the control sits midway between the top edge and tool row.

## Before and after

| | Before | After |
| --- | --- | --- |
| Desktop | ![Before: the desktop Dock refresh button sits left and low within the surrounding space](https://raw.githubusercontent.com/articles-adamziel-com/wordpress-playground/650abe774e0d0fecfed87b92334bc8e140f5778d/before-desktop.png) | ![After: the desktop Dock refresh button is centered between the inner edge, URL field, top edge, and tool row](https://raw.githubusercontent.com/articles-adamziel-com/wordpress-playground/92630ec68f0e283d6389ebea6b04ae3cf65c0436/after-desktop.png) |
| Mobile | ![Before: the mobile Dock refresh button sits against the inner edge](https://raw.githubusercontent.com/articles-adamziel-com/wordpress-playground/650abe774e0d0fecfed87b92334bc8e140f5778d/before-mobile.png) | ![After: the mobile Dock refresh button has equal space before the URL field](https://raw.githubusercontent.com/articles-adamziel-com/wordpress-playground/92630ec68f0e283d6389ebea6b04ae3cf65c0436/after-mobile.png) |

## Testing

Open Playground at desktop and mobile widths. Check that the refresh button has equal space on both sides and that the desktop address row is centered above the tool row.
