### PR TITLE
[Website] Center the mobile Dock refresh button between the edge and URL field

### DIFF
--- a/packages/playground/website/src/components/address-bar/style.module.css
+++ b/packages/playground/website/src/components/address-bar/style.module.css
@@ -36,6 +36,14 @@
 	cursor: default;
 }
 
+@media (max-width: 1024px) {
+	/* The full-width mobile Dock has two inline insets. Center the refresh target
+	   between the outer Dock edge and URL field instead of the inner inset. */
+	.refresh-button {
+		margin-inline: -4px 12px;
+	}
+}
+
 .input-container {
 	position: relative;
 	display: flex;


### PR DESCRIPTION
Follow-up to #4225.

Moves the mobile Dock refresh target 8px toward the outer edge without moving the URL field. The 32px target now has 12px on both sides between the full-width Dock edge and the URL field.

The desktop Dock layout above 1024px keeps the alignment from #4225.


### Before / after

| | Before | After |
| --- | --- | --- |
| Desktop | ![Desktop before](https://raw.githubusercontent.com/articles-adamziel-com/wordpress-playground/3c07a34d7dac6250f0667e08f07c1a15ab81f2ec/follow-up-before-desktop.png) | ![Desktop after](https://raw.githubusercontent.com/articles-adamziel-com/wordpress-playground/3c07a34d7dac6250f0667e08f07c1a15ab81f2ec/follow-up-after-desktop.png) |
| Mobile | ![Mobile before](https://raw.githubusercontent.com/articles-adamziel-com/wordpress-playground/3c07a34d7dac6250f0667e08f07c1a15ab81f2ec/follow-up-before-mobile.png) | ![Mobile after](https://raw.githubusercontent.com/articles-adamziel-com/wordpress-playground/3c07a34d7dac6250f0667e08f07c1a15ab81f2ec/follow-up-after-mobile.png) |

### Testing

- Open Playground at desktop and mobile widths.
- Above 1024px, confirm the desktop refresh target stays aligned as in #4225.
- At 1024px or narrower, confirm the refresh target sits midway between the Dock edge and URL field.
