### PR TITLE
[Website] Relay sendmail streams through web client subscriptions

### DIFF
--- a/packages/playground/remote/src/lib/boot-playground-remote.ts
+++ b/packages/playground/remote/src/lib/boot-playground-remote.ts
@@ -130,6 +130,10 @@ export async function bootPlaygroundRemote() {
 	);
 
 	const wpFrame = document.querySelector('#wp') as HTMLIFrameElement;
+	type PHPEventListener = Parameters<
+		PlaygroundWorkerEndpoint['addEventListener']
+	>[1];
+
 	const phpRemoteApi: PHPRemoteApi = {
 		async onDownloadProgress(fn) {
 			return phpWorkerApi.onDownloadProgress(fn);
@@ -154,6 +158,26 @@ export async function bootPlaygroundRemote() {
 		},
 		async removeEventListener(event, listener) {
 			return await phpWorkerApi.removeEventListener(event, listener);
+		},
+		async subscribeToPHPEvent(event, listener) {
+			/**
+			 * Keep the relay in this iframe instead of passing the parent callback
+			 * proxy into the worker. This gives each Comlink hop a local callback and
+			 * lets transferable event payloads cross both boundaries.
+			 *
+			 * The worker stores the exact relay under the returned ID because callback
+			 * identity does not survive another Comlink call.
+			 */
+			const relay: PHPEventListener = (phpEvent) => listener(phpEvent);
+			return await phpWorkerApi.__internal_subscribeToPHPEvent(
+				event,
+				relay
+			);
+		},
+		async unsubscribeFromPHPEvent(subscriptionId) {
+			await phpWorkerApi.__internal_unsubscribeFromPHPEvent(
+				subscriptionId
+			);
 		},
 		async setProgress(options: ProgressBarOptions) {
 			if (!bar) {

--- a/packages/playground/remote/src/lib/playground-client.ts
+++ b/packages/playground/remote/src/lib/playground-client.ts
@@ -69,6 +69,15 @@ export interface WebClientMixin extends ProgressReceiver {
 	replayFSJournal: PlaygroundWorkerEndpoint['replayFSJournal'];
 	addEventListener: PlaygroundWorkerEndpoint['addEventListener'];
 	removeEventListener: PlaygroundWorkerEndpoint['removeEventListener'];
+	/**
+	 * Subscribes to PHP events through both the worker and iframe boundaries.
+	 * @returns An ID accepted by unsubscribeFromPHPEvent().
+	 */
+	subscribeToPHPEvent(
+		eventType: Parameters<PlaygroundWorkerEndpoint['addEventListener']>[0],
+		listener: Parameters<PlaygroundWorkerEndpoint['addEventListener']>[1]
+	): Promise<number>;
+	unsubscribeFromPHPEvent(subscriptionId: number): Promise<void>;
 	backfillStaticFilesRemovedFromMinifiedBuild: PlaygroundWorkerEndpoint['backfillStaticFilesRemovedFromMinifiedBuild'];
 	hasCachedStaticFilesRemovedFromMinifiedBuild: PlaygroundWorkerEndpoint['hasCachedStaticFilesRemovedFromMinifiedBuild'];
 

--- a/packages/playground/remote/src/lib/playground-worker-endpoint.ts
+++ b/packages/playground/remote/src/lib/playground-worker-endpoint.ts
@@ -63,6 +63,8 @@ import { WordPressFetchNetworkTransport } from './wordpress-fetch-network-transp
 
 let activeRequestHandler: PHPRequestHandler | undefined;
 const WITH_ADMIN_TRANSITIONS_PARAM = 'with-admin-transitions';
+type PHPEventType = Parameters<PHPWorker['addEventListener']>[0];
+type PHPEventListener = Parameters<PHPWorker['addEventListener']>[1];
 
 export interface MountDescriptor {
 	mountpoint: string;
@@ -123,6 +125,11 @@ export abstract class PlaygroundWorkerEndpoint extends PHPWorker {
 
 	private networkTransport: WordPressFetchNetworkTransport | undefined;
 	private requestHandler: PHPRequestHandler | undefined;
+	private phpEventSubscriptions = new Map<
+		number,
+		{ eventType: PHPEventType; relay: PHPEventListener }
+	>();
+	private nextPHPEventSubscriptionId = 1;
 
 	protected downloadMonitor: EmscriptenDownloadMonitor;
 	protected memoizedFetch: ReturnType<typeof createMemoizedFetch>;
@@ -134,6 +141,34 @@ export abstract class PlaygroundWorkerEndpoint extends PHPWorker {
 		const monitoredFetch = (input: RequestInfo | URL, init?: RequestInit) =>
 			this.downloadMonitor.monitorFetch(fetch(input, init));
 		this.memoizedFetch = createMemoizedFetch(monitoredFetch);
+	}
+
+	/**
+	 * Registers and removes the listener within this worker. Passing the listener
+	 * back through Comlink for removal would create a different function proxy.
+	 * @internal
+	 */
+	__internal_subscribeToPHPEvent(
+		eventType: PHPEventType,
+		listener: PHPEventListener
+	) {
+		const relay: PHPEventListener = (event) => listener(event);
+		this.addEventListener(eventType, relay);
+		const subscriptionId = this.nextPHPEventSubscriptionId++;
+		this.phpEventSubscriptions.set(subscriptionId, {
+			eventType,
+			relay,
+		});
+		return subscriptionId;
+	}
+
+	__internal_unsubscribeFromPHPEvent(subscriptionId: number) {
+		const subscription = this.phpEventSubscriptions.get(subscriptionId);
+		if (!subscription) {
+			return;
+		}
+		this.removeEventListener(subscription.eventType, subscription.relay);
+		this.phpEventSubscriptions.delete(subscriptionId);
 	}
 
 	protected computeSiteUrl(scope: string) {
@@ -239,10 +274,15 @@ export abstract class PlaygroundWorkerEndpoint extends PHPWorker {
 				 * The remote runtime has no mail server. Capture sendmail stdin as an
 				 * event through a null transport; consumers must relay the message if
 				 * they want it delivered.
+				 *
+				 * Dispatch directly through the worker endpoint. HTTP requests acquire
+				 * PHP instances without going through PHPWorker.acquirePHPInstance().
 				 */
 				php.setCommandSpawnHandler(
 					'sendmail',
-					sendmailSpawnHandler(php)
+					sendmailSpawnHandler({
+						dispatchEvent: (event) => this.dispatchEvent(event),
+					})
 				);
 
 				if (!isPrimary) {

--- a/packages/playground/remote/src/lib/sendmail-transport.spec.ts
+++ b/packages/playground/remote/src/lib/sendmail-transport.spec.ts
@@ -1,20 +1,31 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { EmscriptenDownloadMonitor } from '@php-wasm/progress';
+import { phpEventStdinTransfer } from '@php-wasm/util';
 
 const bootRequestHandlerMock = vi.hoisted(() => vi.fn());
+const sendmailSpawnHandlerMock = vi.hoisted(() =>
+	vi.fn<(eventTarget: { dispatchEvent(event: unknown): void }) => () => void>(
+		() => vi.fn()
+	)
+);
 
 vi.mock('@wp-playground/wordpress', async (importOriginal) => ({
 	...(await importOriginal<Record<string, unknown>>()),
 	bootRequestHandler: bootRequestHandlerMock,
 }));
+vi.mock('@php-wasm/util', async (importOriginal) => ({
+	...(await importOriginal<Record<string, unknown>>()),
+	sendmailSpawnHandler: sendmailSpawnHandlerMock,
+}));
 
 describe('remote sendmail transport', () => {
 	afterEach(() => {
 		bootRequestHandlerMock.mockReset();
+		sendmailSpawnHandlerMock.mockClear();
 		vi.unstubAllGlobals();
 	});
 
-	it('registers sendmail capture when a PHP instance is created', async () => {
+	it('routes sendmail events from created PHP instances through the endpoint', async () => {
 		vi.stubGlobal('caches', { open: vi.fn(async () => ({})) });
 		vi.stubGlobal('location', { href: 'http://playground.test/' });
 		const setCommandSpawnHandler = vi.fn();
@@ -47,6 +58,8 @@ describe('remote sendmail transport', () => {
 			}
 		}
 		const endpoint = new TestEndpoint({} as EmscriptenDownloadMonitor);
+		const listener = vi.fn();
+		endpoint.addEventListener('sendmail.spawned', listener);
 
 		await endpoint.createRequestHandlerForTest();
 
@@ -55,5 +68,16 @@ describe('remote sendmail transport', () => {
 			'sendmail',
 			expect.any(Function)
 		);
+
+		const event = {
+			type: 'sendmail.spawned',
+			stdin: new ReadableStream<Uint8Array>(),
+			[phpEventStdinTransfer]: true,
+		} as const;
+		const eventTarget = sendmailSpawnHandlerMock.mock.calls[0][0];
+		eventTarget.dispatchEvent(event);
+
+		expect(listener).toHaveBeenCalledOnce();
+		expect(listener).toHaveBeenCalledWith(event);
 	});
 });

--- a/packages/playground/website/playwright/e2e/sendmail-event.spec.ts
+++ b/packages/playground/website/playwright/e2e/sendmail-event.spec.ts
@@ -1,0 +1,75 @@
+import { test, expect } from '../playground-fixtures.ts';
+
+test('forwards sendmail streams from HTTP requests through the web client', async ({
+	website,
+}) => {
+	await website.goto('./?storage=temp');
+	await website.page.waitForFunction(() =>
+		Boolean((window as any).playground)
+	);
+
+	const result = await website.page.evaluate(async () => {
+		const playground = (window as any).playground;
+		let eventCount = 0;
+		let resolveMessage!: (message: string) => void;
+		const message = new Promise<string>((resolve) => {
+			resolveMessage = resolve;
+		});
+		const subscriptionId = await playground.subscribeToPHPEvent(
+			'sendmail.spawned',
+			async (event: { stdin: ReadableStream<Uint8Array> }) => {
+				eventCount++;
+				resolveMessage(await new Response(event.stdin).text());
+			}
+		);
+
+		await playground.writeFile(
+			'/wordpress/sendmail-event.php',
+			`<?php
+			$result = mail(
+				'recipient@test.com',
+				'Captured email subject',
+				'Captured email body.',
+				'From: sender@test.com'
+			);
+			echo $result ? 'SENT' : 'FAILED';
+			`
+		);
+		const response = await playground.request({
+			url: '/sendmail-event.php',
+		});
+		const rawMessage = await message;
+		await playground.unsubscribeFromPHPEvent(subscriptionId);
+
+		let resolveSecondMessage!: () => void;
+		const secondMessage = new Promise<void>((resolve) => {
+			resolveSecondMessage = resolve;
+		});
+		const secondSubscriptionId = await playground.subscribeToPHPEvent(
+			'sendmail.spawned',
+			async (event: { stdin: ReadableStream<Uint8Array> }) => {
+				await new Response(event.stdin).arrayBuffer();
+				resolveSecondMessage();
+			}
+		);
+		const secondResponse = await playground.request({
+			url: '/sendmail-event.php',
+		});
+		await secondMessage;
+		await playground.unsubscribeFromPHPEvent(secondSubscriptionId);
+		await new Promise((resolve) => setTimeout(resolve, 50));
+
+		return {
+			eventCount,
+			rawMessage,
+			responseText: response.text,
+			secondResponseText: secondResponse.text,
+		};
+	});
+
+	expect(result.responseText).toBe('SENT');
+	expect(result.secondResponseText).toBe('SENT');
+	expect(result.eventCount).toBe(1);
+	expect(result.rawMessage).toContain('Subject: Captured email subject');
+	expect(result.rawMessage).toContain('Captured email body.');
+});


### PR DESCRIPTION
Routes `sendmailSpawnHandler()` events directly through `PlaygroundWorkerEndpoint` so mail emitted by PHP instances serving HTTP requests reaches web clients without registering wildcard listeners on every PHP object.

Adds `subscribeToPHPEvent()` and `unsubscribeFromPHPEvent()` to the web client. The iframe relays each event locally and the worker owns numeric subscription IDs, so transferable stdin streams cross both Comlink boundaries and cleanup removes the exact worker callback.

This provides the transport needed by #4103. That PR can subscribe and parse messages without changing the universal `PHPWorker` lifecycle.

## Testing

Subscribe from the Playground web client, run `mail()` from a PHP file requested over HTTP, and confirm the raw message arrives once. Unsubscribe, send another message, and confirm the removed listener stays silent.
