### PR TITLE
Lazy-load ignore for filtered site exports

### DIFF
--- a/packages/playground/website/src/lib/state/opfs/opfs-site-storage.ts
+++ b/packages/playground/website/src/lib/state/opfs/opfs-site-storage.ts
@@ -16,7 +16,6 @@ import { logger } from '@php-wasm/logger';
 import { joinPaths } from '@php-wasm/util';
 import { BlobReader, BlobWriter, ZipWriter } from '@zip.js/zip.js';
 import type { Ignore } from 'ignore';
-import ignore from 'ignore';
 import {
 	type ExtraLibrary,
 	type PHPConstants,
@@ -567,7 +566,9 @@ async function zipDirectory(
 	excludePatterns: readonly string[] = []
 ) {
 	const zipWriter = new ZipWriter(new BlobWriter('application/zip'));
-	const pathMatcher = ignore().add(excludePatterns);
+	const pathMatcher = excludePatterns.length
+		? (await import('ignore')).default().add(excludePatterns)
+		: undefined;
 	try {
 		await addDirectoryEntries(zipWriter, directory, '', pathMatcher);
 		return await zipWriter.close();
@@ -588,7 +589,7 @@ async function addDirectoryEntries(
 	zipWriter: ZipWriter<Blob>,
 	directory: FileSystemDirectoryHandle,
 	relativeDirPath: string,
-	pathMatcher: Ignore
+	pathMatcher: Ignore | undefined
 ) {
 	for await (const [name, entry] of directory.entries()) {
 		const relativePath = relativeDirPath
@@ -598,7 +599,7 @@ async function addDirectoryEntries(
 		if (entry.kind === 'directory') {
 			const archivePath = `${relativePath}/`;
 			// Descendants cannot be re-included while their parent remains ignored.
-			if (pathMatcher.ignores(archivePath)) {
+			if (pathMatcher?.ignores(archivePath)) {
 				continue;
 			}
 			await zipWriter.add(archivePath, undefined, {
@@ -612,7 +613,7 @@ async function addDirectoryEntries(
 				pathMatcher
 			);
 		} else {
-			if (pathMatcher.ignores(relativePath)) {
+			if (pathMatcher?.ignores(relativePath)) {
 				continue;
 			}
 			await zipWriter.add(


### PR DESCRIPTION
## What

Lazy-loads the `ignore` package when exporting a saved OPFS site, and only constructs a path matcher when exclusion patterns are present.

## Why

PR #4217 added `ignore` to support gitignore-style saved-site export exclusions. The package was statically included in the shared OPFS storage chunk even though the default export path does not use exclusion rules. This change evaluates the suggested dynamic import on top of #4220.

## Benchmarking

Measurements compare production builds of PR #4220 at `a9045ecbd` and this branch. Gzip uses level 9 and Brotli uses quality 11.

| Measurement | Before | Lazy-loaded | Difference |
|---|---:|---:|---:|
| Default OPFS chunk, raw | 705,374 B | 700,854 B | −4,520 B |
| Default OPFS chunk, gzip | 174,813 B | 172,806 B | −2,007 B (−1.15%) |
| Default OPFS chunk, Brotli | 143,681 B | 141,780 B | −1,901 B |
| Filtered export, gzip total | 174,813 B | 175,190 B | +377 B and one request |

Vite emits `ignore` as a separate 4,929 B raw / 2,384 B gzip / 2,184 B Brotli chunk. The normal website and API documents continue to preload the shared OPFS chunk but do not preload the `ignore` chunk, so the package is not loaded or evaluated until exclusion rules are supplied.

Filtered exports pay one additional request on first use and 377 B more gzip in total because of the chunk boundary and dynamic-import wrapper. The offline asset manifest still includes the separate chunk, preserving filtered exports offline; a service-worker installation may therefore fetch and cache it in the background even though the module is not evaluated until exclusions are used.

## Stack

- Base: #4220

## Checks

- `npm exec nx test playground-website --testFile=opfs-site-storage.spec.ts --skip-nx-cache` (62 files, 370 tests passed)
- `npm exec nx lint playground-website --skip-nx-cache`
- `npm exec nx typecheck playground-website --skip-nx-cache`
- `npm exec nx run playground-website:build:standalone`
- `git diff --check`
