### PR TITLE
[Website] Position WordPress notices above the floating Dock

### DIFF
--- a/packages/playground/remote/src/lib/boot-playground-remote.ts
+++ b/packages/playground/remote/src/lib/boot-playground-remote.ts
@@ -132,6 +132,7 @@ export async function bootPlaygroundRemote() {
 
 	const wpFrame = document.querySelector('#wp') as HTMLIFrameElement;
 	const webMCPBridge = createWebMCPFrameBridge(wpFrame);
+	let editorNoticeBottomOffset: number | undefined;
 	const phpRemoteApi: PHPRemoteApi = {
 		async onDownloadProgress(fn) {
 			return phpWorkerApi.onDownloadProgress(fn);
@@ -382,6 +383,15 @@ export async function bootPlaygroundRemote() {
 				sandbox: wpFrame.getAttribute('sandbox'),
 			});
 		},
+		async setEditorNoticeBottomOffset(bottom) {
+			editorNoticeBottomOffset =
+				typeof bottom === 'number' &&
+				Number.isFinite(bottom) &&
+				bottom > 0
+					? bottom
+					: undefined;
+			postEditorNoticeBottomOffset();
+		},
 		async setIframeSandboxFlags(flags: string[]) {
 			wpFrame.setAttribute('sandbox', flags.join(' '));
 		},
@@ -576,6 +586,17 @@ export async function bootPlaygroundRemote() {
 			}
 		},
 	};
+	wpFrame.addEventListener('load', postEditorNoticeBottomOffset);
+
+	function postEditorNoticeBottomOffset() {
+		wpFrame.contentWindow?.postMessage(
+			{
+				type: 'playground-editor-notice-bottom-offset',
+				bottom: editorNoticeBottomOffset,
+			},
+			'*'
+		);
+	}
 
 	await phpWorkerApi.isConnected();
 

--- a/packages/playground/remote/src/lib/playground-client.ts
+++ b/packages/playground/remote/src/lib/playground-client.ts
@@ -59,6 +59,14 @@ export interface WebClientMixin extends ProgressReceiver {
 	captureSiteThumbnail(): Promise<SiteThumbnail>;
 
 	/**
+	 * Sets the bottom offset for WordPress editor notices.
+	 *
+	 * @internal Used by the Playground website to keep notices clear of its
+	 * floating Dock.
+	 */
+	setEditorNoticeBottomOffset(bottom: number | undefined): Promise<void>;
+
+	/**
 	 * Sets the iframe sandbox flags.
 	 * @param flags The iframe sandbox flags.
 	 */

--- a/packages/playground/remote/src/lib/playground-mu-plugin/0-playground.php
+++ b/packages/playground/remote/src/lib/playground-mu-plugin/0-playground.php
@@ -46,6 +46,109 @@ add_action('admin_head', function () {
 });
 
 /**
+ * Keeps editor snackbars above the floating Playground Dock.
+ *
+ * The Dock lives two iframe layers above WordPress. Playground's scoped
+ * requests share its origin, so wp-admin can read the Dock geometry without
+ * introducing a second host-side state channel. Embedded or isolated contexts
+ * that cannot reach the Dock keep WordPress's native notice positioning.
+ */
+add_action('admin_footer', function () {
+	?>
+	<style>
+		html.playground-dock-overlaps-admin-notices
+			body.wp-admin .components-snackbar-list {
+			bottom: var(--playground-dock-notice-bottom);
+		}
+	</style>
+	<script>
+		(function () {
+			let ancestorWindow = window;
+			let frameLeft = 0;
+			let frameTop = 0;
+			let dock;
+
+			while (ancestorWindow !== ancestorWindow.parent) {
+				try {
+					const frame = ancestorWindow.frameElement;
+					if (!frame) {
+						return;
+					}
+					const frameRect = frame.getBoundingClientRect();
+					frameLeft += frameRect.left;
+					frameTop += frameRect.top;
+					ancestorWindow = ancestorWindow.parent;
+					dock = ancestorWindow.document.querySelector(
+						'[data-playground-dock]'
+					);
+					if (dock) {
+						break;
+					}
+				} catch {
+					return;
+				}
+			}
+
+			if (!dock) {
+				return;
+			}
+
+			const root = document.documentElement;
+			const updateNoticePosition = function () {
+				const dockRect = dock.getBoundingClientRect();
+				const frameBottom = frameTop + window.innerHeight;
+				const frameCenter = frameLeft + window.innerWidth / 2;
+				const overlap = frameBottom - dockRect.top;
+				const overlapsNotices =
+					dockRect.width > 0 &&
+					dockRect.height > 0 &&
+					overlap > 0 &&
+					dockRect.left < frameCenter &&
+					dockRect.right > frameCenter;
+
+				root.classList.toggle(
+					'playground-dock-overlaps-admin-notices',
+					overlapsNotices
+				);
+				if (overlapsNotices) {
+					root.style.setProperty(
+						'--playground-dock-notice-bottom',
+						`${overlap + 12}px`
+					);
+				} else {
+					root.style.removeProperty(
+						'--playground-dock-notice-bottom'
+					);
+				}
+			};
+
+			const resizeObserver = new ResizeObserver(updateNoticePosition);
+			resizeObserver.observe(dock);
+			const mutationObserver = new MutationObserver(updateNoticePosition);
+			mutationObserver.observe(dock, {
+				attributes: true,
+				attributeFilter: ['class', 'style'],
+			});
+			window.addEventListener('resize', updateNoticePosition);
+			ancestorWindow.addEventListener('resize', updateNoticePosition);
+			dock.addEventListener('transitionend', updateNoticePosition);
+			dock.addEventListener('animationend', updateNoticePosition);
+
+			window.addEventListener('pagehide', function () {
+				resizeObserver.disconnect();
+				mutationObserver.disconnect();
+				ancestorWindow.removeEventListener('resize', updateNoticePosition);
+				dock.removeEventListener('transitionend', updateNoticePosition);
+				dock.removeEventListener('animationend', updateNoticePosition);
+			}, { once: true });
+
+			updateNoticePosition();
+		})();
+	</script>
+	<?php
+});
+
+/**
  * Opt Playground pages into browser-native cross-document View Transitions.
  *
  * This lets the browser keep the outgoing page visible until the incoming page

--- a/packages/playground/remote/src/lib/playground-mu-plugin/0-playground.php
+++ b/packages/playground/remote/src/lib/playground-mu-plugin/0-playground.php
@@ -48,10 +48,9 @@ add_action('admin_head', function () {
 /**
  * Keeps editor snackbars above the floating Playground Dock.
  *
- * The Dock lives two iframe layers above WordPress. Playground's scoped
- * requests share its origin, so wp-admin can read the Dock geometry without
- * introducing a second host-side state channel. Embedded or isolated contexts
- * that cannot reach the Dock keep WordPress's native notice positioning.
+ * The host measures the Dock and relays its bottom offset through the
+ * Playground client. postMessage crosses the iframe boundary even when the
+ * host, remote, and WordPress documents cannot inspect each other's DOM.
  */
 add_action('admin_footer', function () {
 	?>
@@ -63,86 +62,36 @@ add_action('admin_footer', function () {
 	</style>
 	<script>
 		(function () {
-			let ancestorWindow = window;
-			let frameLeft = 0;
-			let frameTop = 0;
-			let dock;
-
-			while (ancestorWindow !== ancestorWindow.parent) {
-				try {
-					const frame = ancestorWindow.frameElement;
-					if (!frame) {
-						return;
-					}
-					const frameRect = frame.getBoundingClientRect();
-					frameLeft += frameRect.left;
-					frameTop += frameRect.top;
-					ancestorWindow = ancestorWindow.parent;
-					dock = ancestorWindow.document.querySelector(
-						'[data-playground-dock]'
-					);
-					if (dock) {
-						break;
-					}
-				} catch {
+			const root = document.documentElement;
+			window.addEventListener('message', function (event) {
+				// The remote may be cross-origin, so its window identity is the
+				// trust boundary for this presentation-only message.
+				if (
+					event.source !== window.parent ||
+					event.data?.type !== 'playground-editor-notice-bottom-offset'
+				) {
 					return;
 				}
-			}
-
-			if (!dock) {
-				return;
-			}
-
-			const root = document.documentElement;
-			const updateNoticePosition = function () {
-				const dockRect = dock.getBoundingClientRect();
-				const frameBottom = frameTop + window.innerHeight;
-				const frameCenter = frameLeft + window.innerWidth / 2;
-				const overlap = frameBottom - dockRect.top;
-				const overlapsNotices =
-					dockRect.width > 0 &&
-					dockRect.height > 0 &&
-					overlap > 0 &&
-					dockRect.left < frameCenter &&
-					dockRect.right > frameCenter;
-
+				const bottom = event.data.bottom;
+				const hasBottomOffset =
+					typeof bottom === 'number' &&
+					Number.isFinite(bottom) &&
+					bottom > 0;
 				root.classList.toggle(
 					'playground-dock-overlaps-admin-notices',
-					overlapsNotices
+					hasBottomOffset
 				);
-				if (overlapsNotices) {
+				if (hasBottomOffset) {
 					root.style.setProperty(
 						'--playground-dock-notice-bottom',
-						`${overlap + 12}px`
+						`${bottom}px`
 					);
 				} else {
 					root.style.removeProperty(
 						'--playground-dock-notice-bottom'
 					);
 				}
-			};
-
-			const resizeObserver = new ResizeObserver(updateNoticePosition);
-			resizeObserver.observe(dock);
-			const mutationObserver = new MutationObserver(updateNoticePosition);
-			mutationObserver.observe(dock, {
-				attributes: true,
-				attributeFilter: ['class', 'style'],
 			});
-			window.addEventListener('resize', updateNoticePosition);
-			ancestorWindow.addEventListener('resize', updateNoticePosition);
-			dock.addEventListener('transitionend', updateNoticePosition);
-			dock.addEventListener('animationend', updateNoticePosition);
-
-			window.addEventListener('pagehide', function () {
-				resizeObserver.disconnect();
-				mutationObserver.disconnect();
-				ancestorWindow.removeEventListener('resize', updateNoticePosition);
-				dock.removeEventListener('transitionend', updateNoticePosition);
-				dock.removeEventListener('animationend', updateNoticePosition);
-			}, { once: true });
-
-			updateNoticePosition();
 		})();
 	</script>
 	<?php

--- a/packages/playground/website/src/components/dock/dock.tsx
+++ b/packages/playground/website/src/components/dock/dock.tsx
@@ -64,6 +64,7 @@ import { DockTogglePill } from './dock-toggle-pill';
 import {
 	DOCK_DRAG_EDGE,
 	DOCK_OPERATION_TOAST_MIN_HEIGHT,
+	DOCK_PANE_GAP,
 	getDockOperationToastStyle,
 	getDockPaneStyle,
 } from './dock-positioning';
@@ -230,6 +231,7 @@ export function Dock({
 	const paneCopy = PANE_COPY[section];
 	const paneTitle = paneCopy.title;
 	const isMobile = useIsMobileDock();
+	const activeClient = clientInfo?.client;
 	const isEditorSection =
 		section === 'blueprint' || section === 'files' || section === 'mail';
 	// Logs and Terminal hold long monospace records, so they get a wider pane.
@@ -343,6 +345,61 @@ export function Dock({
 		}
 		return () => observer.disconnect();
 	}, []);
+
+	useEffect(() => {
+		const dock = dockRef.current;
+		if (!activeClient || !dock) {
+			return;
+		}
+
+		const updateEditorNoticePosition = () => {
+			const dockRect = dock.getBoundingClientRect();
+			const viewportCenter = window.innerWidth / 2;
+			const overlap = window.innerHeight - dockRect.top;
+			const overlapsNotices =
+				!isMobile &&
+				!isFullWidth &&
+				dockRect.width > 0 &&
+				dockRect.height > 0 &&
+				overlap > 0 &&
+				dockRect.left < viewportCenter &&
+				dockRect.right > viewportCenter;
+			void activeClient.setEditorNoticeBottomOffset(
+				overlapsNotices ? overlap + DOCK_PANE_GAP : undefined
+			);
+		};
+
+		let resizeObserver: ResizeObserver | undefined;
+		if (typeof ResizeObserver !== 'undefined') {
+			resizeObserver = new ResizeObserver(updateEditorNoticePosition);
+			resizeObserver.observe(dock);
+		}
+		const mutationObserver = new MutationObserver(
+			updateEditorNoticePosition
+		);
+		mutationObserver.observe(dock, {
+			attributes: true,
+			attributeFilter: ['class', 'style'],
+		});
+		window.addEventListener('resize', updateEditorNoticePosition);
+		dock.addEventListener('transitionend', updateEditorNoticePosition);
+		dock.addEventListener('animationend', updateEditorNoticePosition);
+		updateEditorNoticePosition();
+
+		return () => {
+			resizeObserver?.disconnect();
+			mutationObserver.disconnect();
+			window.removeEventListener('resize', updateEditorNoticePosition);
+			dock.removeEventListener(
+				'transitionend',
+				updateEditorNoticePosition
+			);
+			dock.removeEventListener(
+				'animationend',
+				updateEditorNoticePosition
+			);
+		};
+	}, [activeClient, isFullWidth, isMobile]);
 
 	useEffect(() => {
 		/** Keeps floating geometry inside the live viewport. */
@@ -1272,10 +1329,8 @@ export function Dock({
 					</button>
 				</div>
 			)}
-			{/* The web MU-plugin uses this stable hook to keep WordPress notices clear. */}
 			<nav
 				ref={dockRef}
-				data-playground-dock=""
 				className={classNames(css.dock, {
 					[css.dockCollapsed]: isCollapsed,
 					[css.dockFull]: !isMobile && isFullWidth,

--- a/packages/playground/website/src/components/dock/dock.tsx
+++ b/packages/playground/website/src/components/dock/dock.tsx
@@ -1272,8 +1272,10 @@ export function Dock({
 					</button>
 				</div>
 			)}
+			{/* The web MU-plugin uses this stable hook to keep WordPress notices clear. */}
 			<nav
 				ref={dockRef}
+				data-playground-dock=""
 				className={classNames(css.dock, {
 					[css.dockCollapsed]: isCollapsed,
 					[css.dockFull]: !isMobile && isFullWidth,


### PR DESCRIPTION
WordPress editor notices now stay above the floating Dock. The website measures the Dock and passes its bottom offset through the Playground client; the remote frame relays it to WordPress with `postMessage`, so no frame needs cross-origin DOM access.

| Before | After |
| --- | --- |
| ![WordPress notice hidden by the floating Dock](https://raw.githubusercontent.com/WordPress/wordpress-playground/refs/heads/adamziel/move-notices-above-dock-screencasts/pr-media/before.gif) | ![WordPress notice positioned above the floating Dock](https://raw.githubusercontent.com/WordPress/wordpress-playground/refs/heads/adamziel/move-notices-above-dock-screencasts/pr-media/after.gif) |

## Testing

In the Site Editor or Post Editor, trigger a notice and switch the Dock between full-width, floating, and collapsed modes. Repeat with the website and `remote.html` on different origins. Confirm that the notice stays clear of the Dock and returns to WordPress's native spacing when the iframe is resized.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved WordPress editor notice positioning when the Playground Dock overlaps the notices.
  - Editor notices now automatically adjust their bottom offset as the Dock moves, resizes, or changes state.
  - Positioning updates remain accurate during viewport resizing and Dock animations.
  - Added validation to prevent invalid positioning values from affecting the editor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->