### PR TITLE
Fix doc screenshots skill Markdown

### DIFF
--- a/.agents/skills/doc-screenshots/SKILL.md
+++ b/.agents/skills/doc-screenshots/SKILL.md
@@ -17,68 +17,33 @@ to spec. Do not reimplement the drawing by hand.
 
 ## Workflow
 
-1.  **Capture.** Take screenshots at `deviceScaleFactor: 2`. Never eyeball
-    coordinates: record every target's bounding box programmatically and save
-    the boxes to JSON — including _regions_ (panels, sidebars, block trees),
-    not just buttons; eyeballed region outlines are the most common
-    quality-gate failure. With Playwright:
+1. **Capture.** Take screenshots at `deviceScaleFactor: 2`. Never eyeball coordinates: record every target's bounding box programmatically and save the boxes to JSON — including _regions_ (panels, sidebars, block trees), not just buttons; eyeballed region outlines are the most common quality-gate failure. With Playwright:
 
-        ```js
-        const page = await browser.newPage({ viewport: { width: 1440, height: 900 }, deviceScaleFactor: 2 });
-        // ... navigate, prepare UI state ...
-        const box = await page.locator('button:has-text("Export")').boundingBox();
-        await page.screenshot({ path: 'shot.png' });
-        ```
+    ```js
+    const viewport = { width: 1440, height: 900 };
+    const page = await browser.newPage({ viewport, deviceScaleFactor: 2 });
+    // ... navigate, prepare UI state ...
+    const box = await page.locator('button:has-text("Export")').boundingBox();
+    await page.screenshot({ path: 'shot.png' });
+    ```
 
-        **Iframes:** Playwright's `locator(...).boundingBox()` already returns
-        main-viewport coordinates, even inside nested iframes (Playground nests
-        main page → `remote.html` wrapper → the WordPress scope frame) — use
-        the boxes as-is, no offsets. Only raw `getBoundingClientRect()` inside a
-        frame's own `evaluate()` (or the Chrome DevTools MCP tools) needs the
-        enclosing iframe's box offset added.
+    **Iframes:** Playwright's `locator(...).boundingBox()` already returns main-viewport coordinates, even inside nested iframes (Playground nests main page → `remote.html` wrapper → the WordPress scope frame) — use the boxes as-is, no offsets. Only raw `getBoundingClientRect()` inside a frame's own `evaluate()` (or the Chrome DevTools MCP tools) needs the enclosing iframe's box offset added.
 
-        **WordPress modals:** editor screens open welcome guides ("Edit your
-        site" → Get started) whose overlay swallows clicks; some have no
-        `aria-label="Close"` button. Dismiss with an Escape loop — while
-        `.components-modal__screen-overlay` exists, press Escape on the frame's
-        body, wait ~1s — and retry the blocked click between attempts. The modal
-        can appear _after_ the page looks loaded, so dismiss lazily around the
-        click, not once up front.
+    **WordPress modals:** Editor screens open welcome guides ("Edit your site" → Get started) whose overlay swallows clicks; some have no `aria-label="Close"` button. Dismiss with an Escape loop — while `.components-modal__screen-overlay` exists, press Escape on the frame's body, wait ~1s — and retry the blocked click between attempts. The modal can appear _after_ the page looks loaded, so dismiss lazily around the click, not once up front.
 
-        Prefer driving the browser from Node with the repo's own
-        `node_modules/playwright`; otherwise `pip install playwright &&
+    Prefer driving the browser from Node with the repo's own `node_modules/playwright`; otherwise run `pip install playwright && playwright install chromium`, or use the Chrome DevTools MCP capture tools.
 
-    playwright install chromium`, or use the Chrome DevTools MCP capture
-    tools.
+    Before capturing, clean up dev-environment artifacts such as update nags, debug badges, and plugin notices. They must not appear in docs imagery.
 
-        Before capturing, clean up dev-environment artifacts: update nags, debug
-        badges, plugin notices. They must not appear in docs imagery.
+2. **Author the config.** All geometry is in CSS px relative to the screenshot's top-left. Write a config JSON using the schema in the script's docstring; read it first. Runnable examples of both modes are in `examples/` and share the bundled `sample-shot.webp`. Then run:
 
-2.  **Author the config.** All geometry is in CSS px relative to the
-    screenshot's top-left. Write a config JSON (schema in the script's
-    docstring — read it; runnable examples of both modes are in `examples/`,
-    sharing the bundled `sample-shot.webp`) and run:
+    ```bash
+    python .agents/skills/doc-screenshots/scripts/annotate.py config.json --crops crops/
+    ```
 
-        ```bash
-        python .agents/skills/doc-screenshots/scripts/annotate.py config.json --crops crops/
-        ```
+    The script needs Python with Pillow. If no suitable interpreter is active, create a virtual environment in the session scratchpad with `python3 -m venv <scratchpad>/venv && <scratchpad>/venv/bin/pip install Pillow`, then call that interpreter directly. The script validates the config up front and exits with a readable `config error:` message on bad input; `output` must be a `.webp` path.
 
-        The script needs Python with Pillow. If no suitable interpreter is
-        active, create a venv in the session scratchpad (`python3 -m venv
-
-    <scratchpad>/venv && <scratchpad>/venv/bin/pip install Pillow`) and call
-that interpreter directly. The script validates the config up front and
-exits with a readable `config error:`message on bad input;`output`    must be a`.webp` path.
-
-3.  **Quality gate — actually look.** Read the rendered WEBP at full size,
-    plus the zoomed crops the script saves of every arrowhead and outline
-    (named `<output-stem>-NN-<spot>.png`, so one crops dir can serve all
-    configs of a batch).
-    Check: tip gaps even (5–7px short of each outline), halos unbroken,
-    no arrow crosses another arrow or a sibling annotation, no card text
-    overflow warnings on stderr, artifacts removed. Also sanity-check
-    legibility at docs width (~860px) and mobile (~343px) — if labels become
-    unreadable, simplify rather than shrink. Fix and re-render until clean.
+3. **Quality gate — actually look.** Read the rendered WEBP at full size, plus the zoomed crops the script saves of every arrowhead and outline (named `<output-stem>-NN-<spot>.png`, so one crops directory can serve every config in a batch). Check that tip gaps are even (5–7px short of each outline), halos are unbroken, no arrow crosses another arrow or a sibling annotation, stderr has no card-text overflow warnings, and artifacts are removed. Also sanity-check legibility at docs width (~860px) and mobile (~343px); if labels become unreadable, simplify rather than shrink. Fix and re-render until clean.
 
 ## Choosing the annotation mode
 

--- a/.agents/skills/doc-screenshots/SKILL.md
+++ b/.agents/skills/doc-screenshots/SKILL.md
@@ -31,7 +31,7 @@ to spec. Do not reimplement the drawing by hand.
 
     **WordPress modals:** Editor screens open welcome guides ("Edit your site" → Get started) whose overlay swallows clicks; some have no `aria-label="Close"` button. Dismiss with an Escape loop — while `.components-modal__screen-overlay` exists, press Escape on the frame's body, wait ~1s — and retry the blocked click between attempts. The modal can appear _after_ the page looks loaded, so dismiss lazily around the click, not once up front.
 
-    Prefer driving the browser from Node with the repo's own `node_modules/playwright`; otherwise run `pip install playwright && playwright install chromium`, or use the Chrome DevTools MCP capture tools.
+    Prefer driving the browser from Node with the repo's own `node_modules/playwright`; otherwise run `python3 -m pip install playwright && python3 -m playwright install chromium`, or use the Chrome DevTools MCP capture tools.
 
     Before capturing, clean up dev-environment artifacts such as update nags, debug badges, and plugin notices. They must not appear in docs imagery.
 
@@ -41,7 +41,7 @@ to spec. Do not reimplement the drawing by hand.
     python .agents/skills/doc-screenshots/scripts/annotate.py config.json --crops crops/
     ```
 
-    The script needs Python with Pillow. If no suitable interpreter is active, create a virtual environment in the session scratchpad with `python3 -m venv <scratchpad>/venv && <scratchpad>/venv/bin/pip install Pillow`, then call that interpreter directly. The script validates the config up front and exits with a readable `config error:` message on bad input; `output` must be a `.webp` path.
+    The script needs Python with Pillow. If no suitable interpreter is active, create a virtual environment in the session scratchpad with `python3 -m venv <scratchpad>/venv && <scratchpad>/venv/bin/python -m pip install Pillow`, then call that interpreter directly. The script validates the config up front and exits with a readable `config error:` message on bad input; `output` must be a `.webp` path.
 
 3. **Quality gate — actually look.** Read the rendered WEBP at full size, plus the zoomed crops the script saves of every arrowhead and outline (named `<output-stem>-NN-<spot>.png`, so one crops directory can serve every config in a batch). Check that tip gaps are even (5–7px short of each outline), halos are unbroken, no arrow crosses another arrow or a sibling annotation, stderr has no card-text overflow warnings, and artifacts are removed. Also sanity-check legibility at docs width (~860px) and mobile (~343px); if labels become unreadable, simplify rather than shrink. Fix and re-render until clean.
 

--- a/.agents/skills/doc-screenshots/SKILL.md
+++ b/.agents/skills/doc-screenshots/SKILL.md
@@ -5,15 +5,9 @@ description: Annotate UI screenshots with documentation callouts in Fellyph's es
 
 # Documentation Screenshot Annotations
 
-Produce annotated UI screenshots in one specific house style: uniform-width
-orange (#e8590c) arrows with white halos, double-stroke blue outlines around
-targets, and (for overviews) a row of numbered callout cards over a dimmed
-screenshot. Never use stock arrow shapes, stroked polylines, or ad-hoc styles.
+Produce annotated UI screenshots in one specific house style: uniform-width orange (#e8590c) arrows with white halos, double-stroke blue outlines around targets, and (for overviews) a row of numbered callout cards over a dimmed screenshot. Never use stock arrow shapes, stroked polylines, or ad-hoc styles.
 
-The geometry engine lives in `scripts/annotate.py`. Your job is to produce
-accurate coordinates and a config JSON; the script renders everything
-(supersampling, Bézier ribbons, halos, cards, shadows, WEBP export) exactly
-to spec. Do not reimplement the drawing by hand.
+The geometry engine lives in `scripts/annotate.py`. Your job is to produce accurate coordinates and a config JSON; the script renders everything (supersampling, Bézier ribbons, halos, cards, shadows, WEBP export) exactly to spec. Do not reimplement the drawing by hand.
 
 ## Workflow
 
@@ -47,52 +41,23 @@ to spec. Do not reimplement the drawing by hand.
 
 ## Choosing the annotation mode
 
-- **Pointing at specific controls** (a dialog walkthrough, "click here"):
-  use `outlines` + free `arrows`. No dim, no cards. One arrow per target,
-  tail starting from empty space, arriving straight onto the outline.
-- **Overview with a legend** ("these are the three persistence controls"):
-  use `cards` + `outlines` + `dim`. Cards get `target` indexes and the
-  script auto-draws vertical arrows from each card's bottom edge onto its
-  outline. Set `dim.region` to the area holding the documented controls so
-  they stay at full brightness while the rest dims 24% toward #28313b.
-- Add `chrome_bar` (44px bar, traffic lights, URL pill) only when browser
-  context matters to the reader.
+- **Pointing at specific controls** (a dialog walkthrough, "click here"): use `outlines` + free `arrows`. No dim, no cards. One arrow per target, tail starting from empty space, arriving straight onto the outline.
+- **Overview with a legend** ("these are the three persistence controls"): use `cards` + `outlines` + `dim`. Cards get `target` indexes and the script auto-draws vertical arrows from each card's bottom edge onto its outline. Set `dim.region` to the area holding the documented controls so they stay at full brightness while the rest dims 24% toward #28313b.
+- Add `chrome_bar` (44px bar, traffic lights, URL pill) only when browser context matters to the reader.
 
 ## Placement rules the script cannot decide for you
 
-- Arrow endpoints: the tip must stop 5–7px short of the target's outline
-  (for card arrows the script handles the 6px gap; for free arrows, place
-  `to` accordingly). Both tangents are axis-parallel — pick `axis` so the
-  arrow leaves and arrives straight, giving the calm S-curve.
-- Arrows must never cross each other or overlap another annotation. If a
-  layout forces a crossing, move the tail, flip the axis, or reorder cards
-  so each card sits roughly above its target.
-- Outlines must enclose the whole control including secondary lines (a
-  row's timestamp, a button's icon), not just the text node you queried
-  for. Pad 6–10px, radius 10–14 for rounded rects; plain circles r≈25 for
-  icon-only buttons.
-- Card copy: title 2–3 words, subtitle one short clause. The script warns
-  on stderr if text overflows its card — treat that as a hard failure.
+- Arrow endpoints: the tip must stop 5–7px short of the target's outline (for card arrows the script handles the 6px gap; for free arrows, place `to` accordingly). Both tangents are axis-parallel — pick `axis` so the arrow leaves and arrives straight, giving the calm S-curve.
+- Arrows must never cross each other or overlap another annotation. If a layout forces a crossing, move the tail, flip the axis, or reorder cards so each card sits roughly above its target.
+- Outlines must enclose the whole control including secondary lines (a row's timestamp, a button's icon), not just the text node you queried for. Pad 6–10px, radius 10–14 for rounded rects; plain circles r≈25 for icon-only buttons.
+- Card copy: title 2–3 words, subtitle one short clause. The script warns on stderr if text overflows its card — treat that as a hard failure.
 
 ## Style constants (already baked into the script — do not override)
 
-Arrows are orange #e8590c on pure white halos; outlines, badges and cards stay blue #3858e9. The shaft is a uniform 9px line (constant
-top to bottom, round caps) ending in an open chevron head — two 16px
-diagonal strokes of the same width sweeping back from the tip at ±35°;
-halo expanded 3.2px per side. Outline = white width 9 on
-the bbox expanded 2.5px, blue width 4 on the exact bbox. Canvas #f6f7f7,
-36px margins, rounded frame with 1px #dcdcde border and soft shadow. Cards:
-white, radius 16, 1px #ccced0 border, double shadow, blue badge r22,
-Helvetica Neue (27px bold title #101517 / 19px subtitle #2c3338). Export is
-WEBP quality ~89 after a single LANCZOS downsample from the supersampled
-canvas.
+Arrows are orange #e8590c on pure white halos; outlines, badges and cards stay blue #3858e9. The shaft is a uniform 9px line (constant top to bottom, round caps) ending in an open chevron head — two 16px diagonal strokes of the same width sweeping back from the tip at ±35°; halo expanded 3.2px per side. Outline = white width 9 on the bbox expanded 2.5px, blue width 4 on the exact bbox. Canvas #f6f7f7, 36px margins, rounded frame with 1px #dcdcde border and soft shadow. Cards: white, radius 16, 1px #ccced0 border, double shadow, blue badge r22, Helvetica Neue (27px bold title #101517 / 19px subtitle #2c3338). Export is WEBP quality ~89 after a single LANCZOS downsample from the supersampled canvas.
 
-Reference outputs in this style: an action walkthrough
-(free arrows onto dialog controls) and an overview legend (three cards over
-a dimmed page) — match their look, spacing and restraint.
+Reference outputs in this style: an action walkthrough (free arrows onto dialog controls) and an overview legend (three cards over a dimmed page) — match their look, spacing and restraint.
 
 ## Repo layout
 
-The source of truth is `.agents/skills/doc-screenshots/`. `.claude/skills`
-is a committed symlink to `../.agents/skills`, so Claude Code loads the same
-files — edit only under `.agents/skills/` and never create a separate copy.
+The source of truth is `.agents/skills/doc-screenshots/`. `.claude/skills` is a committed symlink to `../.agents/skills`, so Claude Code loads the same files — edit only under `.agents/skills/` and never create a separate copy.


### PR DESCRIPTION
## What

Repair malformed Markdown in the `doc-screenshots` skill's Workflow section so its instructions render correctly and commands remain copyable. Additionally, remove the line wrapping from other lines to be consistent in raw form.

## Problems fixed

- Fenced JavaScript and shell examples were over-indented inside numbered list items, causing them to be parsed as malformed nested content instead of normal fenced code blocks.
- The Playwright installation command was split by a blank line across separate Markdown paragraphs.
- The virtual-environment and Pillow installation command was also split across paragraphs.
- Inline code lacked required surrounding spacing, producing text such as `` `config error:`message `` and `` `output` must be a`.webp` ``.

## What was not the issue

Ordinary prose wrapping was not the underlying bug, and skill files are not categorically forbidden from containing wrapped prose. The edited paragraphs are kept unwrapped to follow this repository's Markdown convention, but the functional problem was malformed Markdown structure and broken commands.

## Impact

This changes only the skill instructions. The annotation script, examples, and runtime behavior are unchanged.

## Checks

- `quick_validate.py .agents/skills/doc-screenshots`
- `prettier --check .agents/skills/doc-screenshots/SKILL.md`
- `git diff --check`


## Created screenshots

<img width="767" height="2043" alt="Screenshot 2026-08-03 at 18 09 49" src="https://github.com/user-attachments/assets/ad433cd2-6a5b-4367-ae38-6b160c2d569b" />
