### PR TITLE
Prevent storage E2E retries from canceling CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,45 +277,36 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                # Keep three balanced shards for regular tests. Storage tests
+                # Keep three balanced shards for non-storage tests. Storage tests
                 # have their own unsharded lane because OPFS is browser-scoped.
                 # That lane uses one worker, so Playwright can retry only the
                 # failed test without allowing storage tests to overlap.
                 include:
                     - browser: 'chromium'
-                      test_group: 'regular'
                       shard: '1/3'
                       shard_name: '1-of-3'
                     - browser: 'chromium'
-                      test_group: 'regular'
                       shard: '2/3'
                       shard_name: '2-of-3'
                     - browser: 'chromium'
-                      test_group: 'regular'
                       shard: '3/3'
                       shard_name: '3-of-3'
                     - browser: 'firefox'
-                      test_group: 'regular'
                       shard: '1/3'
                       shard_name: '1-of-3'
                     - browser: 'firefox'
-                      test_group: 'regular'
                       shard: '2/3'
                       shard_name: '2-of-3'
                     - browser: 'firefox'
-                      test_group: 'regular'
                       shard: '3/3'
                       shard_name: '3-of-3'
                     - browser: 'webkit'
-                      test_group: 'regular'
                       shard: '1/3'
                       shard_name: '1-of-3'
                     - browser: 'webkit'
-                      test_group: 'regular'
                       shard: '2/3'
                       shard_name: '2-of-3'
                     - browser: 'webkit'
-                      test_group: 'regular'
                       shard: '3/3'
                       shard_name: '3-of-3'
                     - browser: 'chromium'
@@ -346,27 +337,27 @@ jobs:
               run: sudo npx playwright install ${{ matrix.browser }} --with-deps
             - name: Build app for E2E tests
               run: CORS_PROXY_URL=http://127.0.0.1:5263/cors-proxy.php? npx nx e2e:playwright:prepare-app-deploy-and-offline-mode playground-website
-            - name: Run Playwright ${{ matrix.test_group }} tests - ${{ matrix.browser }}${{ matrix.shard && format(' (shard {0})', matrix.shard) || '' }}
+            - name: Run Playwright${{ matrix.test_group && format(' {0}', matrix.test_group) || '' }} tests - ${{ matrix.browser }}${{ matrix.shard && format(' (shard {0})', matrix.shard) || '' }}
               run: |
                   SHARD_ARG=""
                   if [ -n "${{ matrix.shard }}" ]; then
                     SHARD_ARG="--shard=${{ matrix.shard }}"
                   fi
                   if [ "${{ matrix.browser }}" = "firefox" ]; then
-                    sudo -E HOME=/root XDG_RUNTIME_DIR=/root CI=true PLAYWRIGHT_TEST_GROUP=${{ matrix.test_group }} npx playwright test --config=packages/playground/website/playwright/playwright.ci.config.ts --project=${{ matrix.browser }} $SHARD_ARG
+                    sudo -E HOME=/root XDG_RUNTIME_DIR=/root CI=true PLAYWRIGHT_TEST_GROUP=${{ matrix.test_group || 'regular' }} npx playwright test --config=packages/playground/website/playwright/playwright.ci.config.ts --project=${{ matrix.browser }} $SHARD_ARG
                   else
-                    sudo CI=true PLAYWRIGHT_TEST_GROUP=${{ matrix.test_group }} npx playwright test --config=packages/playground/website/playwright/playwright.ci.config.ts --project=${{ matrix.browser }} $SHARD_ARG
+                    sudo CI=true PLAYWRIGHT_TEST_GROUP=${{ matrix.test_group || 'regular' }} npx playwright test --config=packages/playground/website/playwright/playwright.ci.config.ts --project=${{ matrix.browser }} $SHARD_ARG
                   fi
             - uses: actions/upload-artifact@v4
               if: ${{ !cancelled() }}
               with:
-                  name: playwright-report-${{ matrix.browser }}-${{ matrix.test_group }}${{ matrix.shard_name && format('-shard-{0}', matrix.shard_name) || '' }}
+                  name: playwright-report-${{ matrix.browser }}${{ matrix.test_group && format('-{0}', matrix.test_group) || '' }}${{ matrix.shard_name && format('-shard-{0}', matrix.shard_name) || '' }}
                   path: packages/playground/website/playwright-report/
                   if-no-files-found: ignore
             - uses: actions/upload-artifact@v4
               if: ${{ !cancelled() }}
               with:
-                  name: playwright-snapshots-${{ matrix.browser }}-${{ matrix.test_group }}${{ matrix.shard_name && format('-shard-{0}', matrix.shard_name) || '' }}
+                  name: playwright-snapshots-${{ matrix.browser }}${{ matrix.test_group && format('-{0}', matrix.test_group) || '' }}${{ matrix.shard_name && format('-shard-{0}', matrix.shard_name) || '' }}
                   path: packages/playground/website/playwright/e2e/deployment.spec.ts-snapshots/
                   if-no-files-found: ignore
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,36 +277,53 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                # 3 shards per browser for balanced parallel execution
-                # (4 shards caused uneven distribution due to serial test files)
+                # Keep three balanced shards for regular tests. Storage tests
+                # have their own unsharded lane because OPFS is browser-scoped.
+                # That lane uses one worker, so Playwright can retry only the
+                # failed test without allowing storage tests to overlap.
                 include:
                     - browser: 'chromium'
+                      test_group: 'regular'
                       shard: '1/3'
                       shard_name: '1-of-3'
                     - browser: 'chromium'
+                      test_group: 'regular'
                       shard: '2/3'
                       shard_name: '2-of-3'
                     - browser: 'chromium'
+                      test_group: 'regular'
                       shard: '3/3'
                       shard_name: '3-of-3'
                     - browser: 'firefox'
+                      test_group: 'regular'
                       shard: '1/3'
                       shard_name: '1-of-3'
                     - browser: 'firefox'
+                      test_group: 'regular'
                       shard: '2/3'
                       shard_name: '2-of-3'
                     - browser: 'firefox'
+                      test_group: 'regular'
                       shard: '3/3'
                       shard_name: '3-of-3'
                     - browser: 'webkit'
+                      test_group: 'regular'
                       shard: '1/3'
                       shard_name: '1-of-3'
                     - browser: 'webkit'
+                      test_group: 'regular'
                       shard: '2/3'
                       shard_name: '2-of-3'
                     - browser: 'webkit'
+                      test_group: 'regular'
                       shard: '3/3'
                       shard_name: '3-of-3'
+                    - browser: 'chromium'
+                      test_group: 'storage'
+                    - browser: 'firefox'
+                      test_group: 'storage'
+                    - browser: 'webkit'
+                      test_group: 'storage'
         steps:
             - name: Free up runner disk space
               shell: bash
@@ -329,27 +346,27 @@ jobs:
               run: sudo npx playwright install ${{ matrix.browser }} --with-deps
             - name: Build app for E2E tests
               run: CORS_PROXY_URL=http://127.0.0.1:5263/cors-proxy.php? npx nx e2e:playwright:prepare-app-deploy-and-offline-mode playground-website
-            - name: Run Playwright tests - ${{ matrix.browser }}${{ matrix.shard && format(' (shard {0})', matrix.shard) || '' }}
+            - name: Run Playwright ${{ matrix.test_group }} tests - ${{ matrix.browser }}${{ matrix.shard && format(' (shard {0})', matrix.shard) || '' }}
               run: |
                   SHARD_ARG=""
                   if [ -n "${{ matrix.shard }}" ]; then
                     SHARD_ARG="--shard=${{ matrix.shard }}"
                   fi
                   if [ "${{ matrix.browser }}" = "firefox" ]; then
-                    sudo -E HOME=/root XDG_RUNTIME_DIR=/root CI=true npx playwright test --config=packages/playground/website/playwright/playwright.ci.config.ts --project=${{ matrix.browser }} $SHARD_ARG
+                    sudo -E HOME=/root XDG_RUNTIME_DIR=/root CI=true PLAYWRIGHT_TEST_GROUP=${{ matrix.test_group }} npx playwright test --config=packages/playground/website/playwright/playwright.ci.config.ts --project=${{ matrix.browser }} $SHARD_ARG
                   else
-                    sudo CI=true npx playwright test --config=packages/playground/website/playwright/playwright.ci.config.ts --project=${{ matrix.browser }} $SHARD_ARG
+                    sudo CI=true PLAYWRIGHT_TEST_GROUP=${{ matrix.test_group }} npx playwright test --config=packages/playground/website/playwright/playwright.ci.config.ts --project=${{ matrix.browser }} $SHARD_ARG
                   fi
             - uses: actions/upload-artifact@v4
               if: ${{ !cancelled() }}
               with:
-                  name: playwright-report-${{ matrix.browser }}${{ matrix.shard_name && format('-shard-{0}', matrix.shard_name) || '' }}
+                  name: playwright-report-${{ matrix.browser }}-${{ matrix.test_group }}${{ matrix.shard_name && format('-shard-{0}', matrix.shard_name) || '' }}
                   path: packages/playground/website/playwright-report/
                   if-no-files-found: ignore
             - uses: actions/upload-artifact@v4
               if: ${{ !cancelled() }}
               with:
-                  name: playwright-snapshots-${{ matrix.browser }}${{ matrix.shard_name && format('-shard-{0}', matrix.shard_name) || '' }}
+                  name: playwright-snapshots-${{ matrix.browser }}-${{ matrix.test_group }}${{ matrix.shard_name && format('-shard-{0}', matrix.shard_name) || '' }}
                   path: packages/playground/website/playwright/e2e/deployment.spec.ts-snapshots/
                   if-no-files-found: ignore
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,7 @@ npx nx build <package-name>              # Build specific package
 npm test                                 # Run all tests
 npx nx test <package-name>               # Test specific package
 npx nx e2e playground-website            # Run end-to-end tests
+npx nx run playground-website:e2e:playwright:ci # Run regular tests, then one-worker storage tests
 
 # Running a single test file
 npx nx test <package-name> --testFile=<test-file-name>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,8 +54,8 @@ npx nx build <package-name>              # Build specific package
 # Testing
 npm test                                 # Run all tests
 npx nx test <package-name>               # Test specific package
-npx nx e2e playground-website            # Run end-to-end tests
-npx nx run playground-website:e2e:playwright:ci # Run regular tests, then one-worker storage tests
+npx nx e2e playground-website            # Run website Cypress E2E tests
+npx nx run playground-website:e2e:playwright:ci # Run website Playwright E2E tests
 
 # Running a single test file
 npx nx test <package-name> --testFile=<test-file-name>

--- a/packages/playground/website/playwright/e2e/opfs.spec.ts
+++ b/packages/playground/website/playwright/e2e/opfs.spec.ts
@@ -127,16 +127,17 @@ Theme Name: Close Race Theme
 	return Buffer.from(zipBytes!);
 }
 
-// OPFS tests must run serially because OPFS storage is shared at the browser
-// level, so tests would interfere with each other's saved sites if run in parallel.
-test.describe.configure({ mode: 'serial' });
+// OPFS is shared by tests in one browser. Default mode keeps this file ordered
+// while retrying only the failed test. CI also selects this file into the
+// one-worker storage lane configured in playwright.ci.config.ts.
+test.describe.configure({ mode: 'default' });
 
 /**
  * Returns a URL that opts this test out of default browser storage.
  *
  * `storage=temp` is what makes the site temporary. The random value keeps
  * repeated navigations from reusing a temporary site created earlier in this
- * serial OPFS test file.
+ * ordered OPFS test file.
  */
 function getTemporaryPlaygroundUrl(hash = '') {
 	return `./?storage=temp&random=${Math.random().toString(36).slice(2)}${hash}`;
@@ -2024,11 +2025,8 @@ PHP;
 	);
 });
 
-// Missing site modal tests in a separate describe block to avoid state pollution
+// Missing site modal tests in a separate describe block to avoid state pollution.
 test.describe('Missing site modal', () => {
-	// These tests also need serial mode since they use OPFS
-	test.describe.configure({ mode: 'serial' });
-
 	test('should show modal when loading non-existent site slug', async ({
 		website,
 		wordpress,

--- a/packages/playground/website/playwright/e2e/opfs.spec.ts
+++ b/packages/playground/website/playwright/e2e/opfs.spec.ts
@@ -128,8 +128,7 @@ Theme Name: Close Race Theme
 }
 
 // OPFS is shared by tests in one browser. Default mode keeps this file ordered
-// while retrying only the failed test. Each test includes the `@storage` tag so
-// CI routes it to the one-worker storage lane.
+// while retrying only the failed test.
 test.describe.configure({ mode: 'default' });
 
 /**
@@ -535,7 +534,8 @@ async function openPlaygroundPath(page: Page, path: string) {
 		path
 	);
 }
-test('should retry pending OPFS cleanup after another tab releases storage @storage', async ({
+// `@storage` routes this browser-scoped test to the one-worker CI lane.
+test('@storage should retry pending OPFS cleanup after another tab releases storage', async ({
 	website,
 	context,
 	browserName,
@@ -595,7 +595,8 @@ test('should retry pending OPFS cleanup after another tab releases storage @stor
 	expect(storedSite.hasOldResetSentinel).toBe(false);
 });
 
-test('should start a new Playground after an initial OPFS sync was interrupted @storage', async ({
+// `@storage` routes this browser-scoped test to the one-worker CI lane.
+test('@storage should start a new Playground after an initial OPFS sync was interrupted', async ({
 	website,
 	browserName,
 }) => {
@@ -631,7 +632,8 @@ test('should start a new Playground after an initial OPFS sync was interrupted @
 	await website.waitForNestedIframes();
 });
 
-test('should switch between sites @storage', async ({
+// `@storage` routes this browser-scoped test to the one-worker CI lane.
+test('@storage should switch between sites', async ({
 	website,
 	browserName,
 }) => {
@@ -697,7 +699,8 @@ test('should switch between sites @storage', async ({
 	await expect(getPlaygroundTitle(website.page)).toContainText(firstSiteName);
 });
 
-test('should preserve PHP constants when saving a temporary site to OPFS @storage', async ({
+// `@storage` routes this browser-scoped test to the one-worker CI lane.
+test('@storage should preserve PHP constants when saving a temporary site to OPFS', async ({
 	website,
 	browserName,
 	wordpress,
@@ -764,7 +767,8 @@ test('should preserve PHP constants when saving a temporary site to OPFS @storag
 	await expect(wordpress.locator('body')).toContainText('E2E_TEST_VALUE');
 });
 
-test('should rename a saved Playground and persist after reload @storage', async ({
+// `@storage` routes this browser-scoped test to the one-worker CI lane.
+test('@storage should rename a saved Playground and persist after reload', async ({
 	website,
 	browserName,
 }) => {
@@ -817,7 +821,8 @@ test('should rename a saved Playground and persist after reload @storage', async
 	await website.closePlaygroundsPane();
 });
 
-test('should wait for a temporary OPFS metadata lock @storage', async ({
+// `@storage` routes this browser-scoped test to the one-worker CI lane.
+test('@storage should wait for a temporary OPFS metadata lock', async ({
 	website,
 	browserName,
 }) => {
@@ -879,7 +884,8 @@ test('should wait for a temporary OPFS metadata lock @storage', async ({
 		.toBe(newName);
 });
 
-test('should preserve metadata changes made in different tabs @storage', async ({
+// `@storage` routes this browser-scoped test to the one-worker CI lane.
+test('@storage should preserve metadata changes made in different tabs', async ({
 	website,
 	context,
 	browserName,
@@ -935,7 +941,8 @@ test('should preserve metadata changes made in different tabs @storage', async (
 	expect(persistedMetadata.runtimeConfiguration.networking).toBe(false);
 });
 
-test('should show the Store permanently pane with the save controls @storage', async ({
+// `@storage` routes this browser-scoped test to the one-worker CI lane.
+test('@storage should show the Store permanently pane with the save controls', async ({
 	website,
 	browserName,
 }) => {
@@ -967,7 +974,8 @@ test('should show the Store permanently pane with the save controls @storage', a
 	await expect(pane).not.toBeVisible();
 });
 
-test('should close the Store permanently pane without saving @storage', async ({
+// `@storage` routes this browser-scoped test to the one-worker CI lane.
+test('@storage should close the Store permanently pane without saving', async ({
 	website,
 	browserName,
 }) => {
@@ -1002,7 +1010,8 @@ test('should close the Store permanently pane without saving @storage', async ({
 	);
 });
 
-test('should have playground name input text selected by default @storage', async ({
+// `@storage` routes this browser-scoped test to the one-worker CI lane.
+test('@storage should have playground name input text selected by default', async ({
 	website,
 	browserName,
 }) => {
@@ -1038,7 +1047,8 @@ test('should have playground name input text selected by default @storage', asyn
 	await pane.getByRole('button', { name: 'Cancel' }).click();
 });
 
-test('should save site with custom name @storage', async ({
+// `@storage` routes this browser-scoped test to the one-worker CI lane.
+test('@storage should save site with custom name', async ({
 	website,
 	browserName,
 }) => {
@@ -1070,7 +1080,8 @@ test('should save site with custom name @storage', async ({
 	await website.closePlaygroundsPane();
 });
 
-test('should not persist the Store permanently pane through page refresh @storage', async ({
+// `@storage` routes this browser-scoped test to the one-worker CI lane.
+test('@storage should not persist the Store permanently pane through page refresh', async ({
 	website,
 	browserName,
 }) => {
@@ -1094,7 +1105,8 @@ test('should not persist the Store permanently pane through page refresh @storag
 	await expect(pane).toHaveCount(0);
 });
 
-test('should display OPFS storage option as selected by default @storage', async ({
+// `@storage` routes this browser-scoped test to the one-worker CI lane.
+test('@storage should display OPFS storage option as selected by default', async ({
 	website,
 	browserName,
 }) => {
@@ -1117,7 +1129,8 @@ test('should display OPFS storage option as selected by default @storage', async
 	await pane.getByRole('button', { name: 'Cancel' }).click();
 });
 
-test('should import ZIP into a fresh temporary site without browser storage @storage', async ({
+// `@storage` routes this browser-scoped test to the one-worker CI lane.
+test('@storage should import ZIP into a fresh temporary site without browser storage', async ({
 	website,
 	browserName,
 	context,
@@ -1185,7 +1198,8 @@ test('should import ZIP into a fresh temporary site without browser storage @sto
 		.toBe(marker);
 });
 
-test('should remove the saved site created for a failed ZIP import @storage', async ({
+// `@storage` routes this browser-scoped test to the one-worker CI lane.
+test('@storage should remove the saved site created for a failed ZIP import', async ({
 	website,
 	browserName,
 }) => {
@@ -1229,7 +1243,8 @@ test('should remove the saved site created for a failed ZIP import @storage', as
 		.toEqual(storedSiteSlugsBeforeImport);
 });
 
-test('should import a ZIP dropped on the page @storage', async ({
+// `@storage` routes this browser-scoped test to the one-worker CI lane.
+test('@storage should import a ZIP dropped on the page', async ({
 	website,
 	wordpress,
 	browserName,
@@ -1265,7 +1280,8 @@ test('should import a ZIP dropped on the page @storage', async ({
 	await expect(wordpress.locator('body')).toContainText(marker);
 });
 
-test('should show an inline error for a non-ZIP drop @storage', async ({
+// `@storage` routes this browser-scoped test to the one-worker CI lane.
+test('@storage should show an inline error for a non-ZIP drop', async ({
 	website,
 	browserName,
 }) => {
@@ -1293,7 +1309,8 @@ test('should show an inline error for a non-ZIP drop @storage', async ({
 	).toBeVisible();
 });
 
-test('should notify when a ZIP import loads before autosave finishes @storage', async ({
+// `@storage` routes this browser-scoped test to the one-worker CI lane.
+test('@storage should notify when a ZIP import loads before autosave finishes', async ({
 	website,
 	browserName,
 }) => {
@@ -1413,7 +1430,8 @@ test('should notify when a ZIP import loads before autosave finishes @storage', 
 		.toEqual({ plugin: true, theme: true });
 });
 
-test('should import ZIP into a new saved site when a saved site exists @storage', async ({
+// `@storage` routes this browser-scoped test to the one-worker CI lane.
+test('@storage should import ZIP into a new saved site when a saved site exists', async ({
 	website,
 	wordpress,
 	browserName,
@@ -1505,7 +1523,8 @@ test('should import ZIP into a new saved site when a saved site exists @storage'
 	);
 });
 
-test('should create a saved site when importing ZIP while on a saved site with no existing temporary site @storage', async ({
+// `@storage` routes this browser-scoped test to the one-worker CI lane.
+test('@storage should create a saved site when importing ZIP while on a saved site with no existing temporary site', async ({
 	website,
 	wordpress,
 	browserName,
@@ -1608,7 +1627,8 @@ test('should create a saved site when importing ZIP while on a saved site with n
 	);
 });
 
-test('should persist an imported ZIP saved site after switching away and back @storage', async ({
+// `@storage` routes this browser-scoped test to the one-worker CI lane.
+test('@storage should persist an imported ZIP saved site after switching away and back', async ({
 	website,
 	wordpress,
 	browserName,
@@ -1698,7 +1718,8 @@ test('should persist an imported ZIP saved site after switching away and back @s
 	await expect(wordpress.locator('body')).toContainText(importedMarker);
 });
 
-test('should retain files omitted from a legacy ZIP export @storage', async ({
+// `@storage` routes this browser-scoped test to the one-worker CI lane.
+test('@storage should retain files omitted from a legacy ZIP export', async ({
 	website,
 	wordpress,
 	browserName,
@@ -1802,7 +1823,8 @@ test('should retain files omitted from a legacy ZIP export @storage', async ({
 	);
 });
 
-test('should re-import an exported ZIP without switching sites @storage', async ({
+// `@storage` routes this browser-scoped test to the one-worker CI lane.
+test('@storage should re-import an exported ZIP without switching sites', async ({
 	website,
 	context,
 	browserName,
@@ -1903,7 +1925,8 @@ test('should re-import an exported ZIP without switching sites @storage', async 
 	expect(importedSite.slug).not.toBe(occupiedSiteSlug);
 });
 
-test('should preserve a customized default-theme background through export and import @storage', async ({
+// `@storage` routes this browser-scoped test to the one-worker CI lane.
+test('@storage should preserve a customized default-theme background through export and import', async ({
 	website,
 	wordpress,
 	browserName,
@@ -2035,7 +2058,8 @@ PHP;
 
 // Missing site modal tests in a separate describe block to avoid state pollution.
 test.describe('Missing site modal', () => {
-	test('should show modal when loading non-existent site slug @storage', async ({
+	// `@storage` routes this browser-scoped test to the one-worker CI lane.
+	test('@storage should show modal when loading non-existent site slug', async ({
 		website,
 		wordpress,
 		browserName,
@@ -2062,7 +2086,8 @@ test.describe('Missing site modal', () => {
 		).toBeVisible({ timeout: 30000 });
 	});
 
-	test('should dismiss modal when clicking dismiss button @storage', async ({
+	// `@storage` routes this browser-scoped test to the one-worker CI lane.
+	test('@storage should dismiss modal when clicking dismiss button', async ({
 		website,
 		wordpress,
 		browserName,

--- a/packages/playground/website/playwright/e2e/opfs.spec.ts
+++ b/packages/playground/website/playwright/e2e/opfs.spec.ts
@@ -1,17 +1,9 @@
-import { test as baseTest, expect } from '../playground-fixtures.ts';
+import { test, expect } from '../playground-fixtures.ts';
 import type { Blueprint } from '@wp-playground/blueprints';
 import type { BrowserContext, Page } from '@playwright/test';
 import { encodeZip, collectBytes } from '@php-wasm/stream-compression';
 import { getDirectoryNameForSlug } from '../../src/lib/state/opfs/opfs-site-path';
 import { readFile } from 'node:fs/promises';
-
-// Every test in this file touches browser-wide OPFS, so CI must route all of
-// them to the one-worker storage lane. Keep the usual APIs used in this file
-// while adding `@storage` to each test declaration.
-const test = Object.assign(storageTest, {
-	describe: baseTest.describe,
-	skip: baseTest.skip,
-});
 
 /**
  * Creates a minimal WordPress export ZIP file for testing imports.
@@ -136,7 +128,8 @@ Theme Name: Close Race Theme
 }
 
 // OPFS is shared by tests in one browser. Default mode keeps this file ordered
-// while retrying only the failed test.
+// while retrying only the failed test. Each test includes the `@storage` tag so
+// CI routes it to the one-worker storage lane.
 test.describe.configure({ mode: 'default' });
 
 /**
@@ -542,7 +535,7 @@ async function openPlaygroundPath(page: Page, path: string) {
 		path
 	);
 }
-test('should retry pending OPFS cleanup after another tab releases storage', async ({
+test('should retry pending OPFS cleanup after another tab releases storage @storage', async ({
 	website,
 	context,
 	browserName,
@@ -602,7 +595,7 @@ test('should retry pending OPFS cleanup after another tab releases storage', asy
 	expect(storedSite.hasOldResetSentinel).toBe(false);
 });
 
-test('should start a new Playground after an initial OPFS sync was interrupted', async ({
+test('should start a new Playground after an initial OPFS sync was interrupted @storage', async ({
 	website,
 	browserName,
 }) => {
@@ -638,7 +631,10 @@ test('should start a new Playground after an initial OPFS sync was interrupted',
 	await website.waitForNestedIframes();
 });
 
-test('should switch between sites', async ({ website, browserName }) => {
+test('should switch between sites @storage', async ({
+	website,
+	browserName,
+}) => {
 	test.skip(
 		browserName !== 'chromium',
 		`This test relies on OPFS which isn't available in Playwright's flavor of ${browserName}.`
@@ -701,7 +697,7 @@ test('should switch between sites', async ({ website, browserName }) => {
 	await expect(getPlaygroundTitle(website.page)).toContainText(firstSiteName);
 });
 
-test('should preserve PHP constants when saving a temporary site to OPFS', async ({
+test('should preserve PHP constants when saving a temporary site to OPFS @storage', async ({
 	website,
 	browserName,
 	wordpress,
@@ -768,7 +764,7 @@ test('should preserve PHP constants when saving a temporary site to OPFS', async
 	await expect(wordpress.locator('body')).toContainText('E2E_TEST_VALUE');
 });
 
-test('should rename a saved Playground and persist after reload', async ({
+test('should rename a saved Playground and persist after reload @storage', async ({
 	website,
 	browserName,
 }) => {
@@ -821,7 +817,7 @@ test('should rename a saved Playground and persist after reload', async ({
 	await website.closePlaygroundsPane();
 });
 
-test('should wait for a temporary OPFS metadata lock', async ({
+test('should wait for a temporary OPFS metadata lock @storage', async ({
 	website,
 	browserName,
 }) => {
@@ -883,7 +879,7 @@ test('should wait for a temporary OPFS metadata lock', async ({
 		.toBe(newName);
 });
 
-test('should preserve metadata changes made in different tabs', async ({
+test('should preserve metadata changes made in different tabs @storage', async ({
 	website,
 	context,
 	browserName,
@@ -939,7 +935,7 @@ test('should preserve metadata changes made in different tabs', async ({
 	expect(persistedMetadata.runtimeConfiguration.networking).toBe(false);
 });
 
-test('should show the Store permanently pane with the save controls', async ({
+test('should show the Store permanently pane with the save controls @storage', async ({
 	website,
 	browserName,
 }) => {
@@ -971,7 +967,7 @@ test('should show the Store permanently pane with the save controls', async ({
 	await expect(pane).not.toBeVisible();
 });
 
-test('should close the Store permanently pane without saving', async ({
+test('should close the Store permanently pane without saving @storage', async ({
 	website,
 	browserName,
 }) => {
@@ -1006,7 +1002,7 @@ test('should close the Store permanently pane without saving', async ({
 	);
 });
 
-test('should have playground name input text selected by default', async ({
+test('should have playground name input text selected by default @storage', async ({
 	website,
 	browserName,
 }) => {
@@ -1042,7 +1038,10 @@ test('should have playground name input text selected by default', async ({
 	await pane.getByRole('button', { name: 'Cancel' }).click();
 });
 
-test('should save site with custom name', async ({ website, browserName }) => {
+test('should save site with custom name @storage', async ({
+	website,
+	browserName,
+}) => {
 	test.skip(
 		browserName !== 'chromium',
 		`This test relies on OPFS which isn't available in Playwright's flavor of ${browserName}.`
@@ -1071,7 +1070,7 @@ test('should save site with custom name', async ({ website, browserName }) => {
 	await website.closePlaygroundsPane();
 });
 
-test('should not persist the Store permanently pane through page refresh', async ({
+test('should not persist the Store permanently pane through page refresh @storage', async ({
 	website,
 	browserName,
 }) => {
@@ -1095,7 +1094,7 @@ test('should not persist the Store permanently pane through page refresh', async
 	await expect(pane).toHaveCount(0);
 });
 
-test('should display OPFS storage option as selected by default', async ({
+test('should display OPFS storage option as selected by default @storage', async ({
 	website,
 	browserName,
 }) => {
@@ -1118,7 +1117,7 @@ test('should display OPFS storage option as selected by default', async ({
 	await pane.getByRole('button', { name: 'Cancel' }).click();
 });
 
-test('should import ZIP into a fresh temporary site without browser storage', async ({
+test('should import ZIP into a fresh temporary site without browser storage @storage', async ({
 	website,
 	browserName,
 	context,
@@ -1186,7 +1185,7 @@ test('should import ZIP into a fresh temporary site without browser storage', as
 		.toBe(marker);
 });
 
-test('should remove the saved site created for a failed ZIP import', async ({
+test('should remove the saved site created for a failed ZIP import @storage', async ({
 	website,
 	browserName,
 }) => {
@@ -1230,7 +1229,7 @@ test('should remove the saved site created for a failed ZIP import', async ({
 		.toEqual(storedSiteSlugsBeforeImport);
 });
 
-test('should import a ZIP dropped on the page', async ({
+test('should import a ZIP dropped on the page @storage', async ({
 	website,
 	wordpress,
 	browserName,
@@ -1266,7 +1265,7 @@ test('should import a ZIP dropped on the page', async ({
 	await expect(wordpress.locator('body')).toContainText(marker);
 });
 
-test('should show an inline error for a non-ZIP drop', async ({
+test('should show an inline error for a non-ZIP drop @storage', async ({
 	website,
 	browserName,
 }) => {
@@ -1294,7 +1293,7 @@ test('should show an inline error for a non-ZIP drop', async ({
 	).toBeVisible();
 });
 
-test('should notify when a ZIP import loads before autosave finishes', async ({
+test('should notify when a ZIP import loads before autosave finishes @storage', async ({
 	website,
 	browserName,
 }) => {
@@ -1414,7 +1413,7 @@ test('should notify when a ZIP import loads before autosave finishes', async ({
 		.toEqual({ plugin: true, theme: true });
 });
 
-test('should import ZIP into a new saved site when a saved site exists', async ({
+test('should import ZIP into a new saved site when a saved site exists @storage', async ({
 	website,
 	wordpress,
 	browserName,
@@ -1506,7 +1505,7 @@ test('should import ZIP into a new saved site when a saved site exists', async (
 	);
 });
 
-test('should create a saved site when importing ZIP while on a saved site with no existing temporary site', async ({
+test('should create a saved site when importing ZIP while on a saved site with no existing temporary site @storage', async ({
 	website,
 	wordpress,
 	browserName,
@@ -1609,7 +1608,7 @@ test('should create a saved site when importing ZIP while on a saved site with n
 	);
 });
 
-test('should persist an imported ZIP saved site after switching away and back', async ({
+test('should persist an imported ZIP saved site after switching away and back @storage', async ({
 	website,
 	wordpress,
 	browserName,
@@ -1699,7 +1698,7 @@ test('should persist an imported ZIP saved site after switching away and back', 
 	await expect(wordpress.locator('body')).toContainText(importedMarker);
 });
 
-test('should retain files omitted from a legacy ZIP export', async ({
+test('should retain files omitted from a legacy ZIP export @storage', async ({
 	website,
 	wordpress,
 	browserName,
@@ -1803,7 +1802,7 @@ test('should retain files omitted from a legacy ZIP export', async ({
 	);
 });
 
-test('should re-import an exported ZIP without switching sites', async ({
+test('should re-import an exported ZIP without switching sites @storage', async ({
 	website,
 	context,
 	browserName,
@@ -1904,7 +1903,7 @@ test('should re-import an exported ZIP without switching sites', async ({
 	expect(importedSite.slug).not.toBe(occupiedSiteSlug);
 });
 
-test('should preserve a customized default-theme background through export and import', async ({
+test('should preserve a customized default-theme background through export and import @storage', async ({
 	website,
 	wordpress,
 	browserName,
@@ -2036,7 +2035,7 @@ PHP;
 
 // Missing site modal tests in a separate describe block to avoid state pollution.
 test.describe('Missing site modal', () => {
-	test('should show modal when loading non-existent site slug', async ({
+	test('should show modal when loading non-existent site slug @storage', async ({
 		website,
 		wordpress,
 		browserName,
@@ -2063,7 +2062,7 @@ test.describe('Missing site modal', () => {
 		).toBeVisible({ timeout: 30000 });
 	});
 
-	test('should dismiss modal when clicking dismiss button', async ({
+	test('should dismiss modal when clicking dismiss button @storage', async ({
 		website,
 		wordpress,
 		browserName,
@@ -2097,7 +2096,3 @@ test.describe('Missing site modal', () => {
 		await expect(dialog).not.toBeVisible();
 	});
 });
-
-function storageTest(title: string, body: Parameters<typeof baseTest>[2]) {
-	baseTest(title, { tag: '@storage' }, body);
-}

--- a/packages/playground/website/playwright/e2e/opfs.spec.ts
+++ b/packages/playground/website/playwright/e2e/opfs.spec.ts
@@ -1,9 +1,17 @@
-import { test, expect } from '../playground-fixtures.ts';
+import { test as baseTest, expect } from '../playground-fixtures.ts';
 import type { Blueprint } from '@wp-playground/blueprints';
 import type { BrowserContext, Page } from '@playwright/test';
 import { encodeZip, collectBytes } from '@php-wasm/stream-compression';
 import { getDirectoryNameForSlug } from '../../src/lib/state/opfs/opfs-site-path';
 import { readFile } from 'node:fs/promises';
+
+// Every test in this file touches browser-wide OPFS, so CI must route all of
+// them to the one-worker storage lane. Keep the usual APIs used in this file
+// while adding `@storage` to each test declaration.
+const test = Object.assign(storageTest, {
+	describe: baseTest.describe,
+	skip: baseTest.skip,
+});
 
 /**
  * Creates a minimal WordPress export ZIP file for testing imports.
@@ -128,8 +136,7 @@ Theme Name: Close Race Theme
 }
 
 // OPFS is shared by tests in one browser. Default mode keeps this file ordered
-// while retrying only the failed test. CI also selects this file into the
-// one-worker storage lane configured in playwright.ci.config.ts.
+// while retrying only the failed test.
 test.describe.configure({ mode: 'default' });
 
 /**
@@ -1057,7 +1064,9 @@ test('should save site with custom name', async ({ website, browserName }) => {
 	// Verify the name also appears in the Playgrounds pane.
 	await website.openPlaygroundsPane();
 	await expect(
-		website.page.locator('[class*="siteRowName"]', { hasText: customName })
+		website.page.locator('[class*="siteRowName"]', {
+			hasText: customName,
+		})
 	).toBeVisible();
 	await website.closePlaygroundsPane();
 });
@@ -2088,3 +2097,7 @@ test.describe('Missing site modal', () => {
 		await expect(dialog).not.toBeVisible();
 	});
 });
+
+function storageTest(title: string, body: Parameters<typeof baseTest>[2]) {
+	baseTest(title, { tag: '@storage' }, body);
+}

--- a/packages/playground/website/playwright/e2e/opfs.spec.ts
+++ b/packages/playground/website/playwright/e2e/opfs.spec.ts
@@ -127,10 +127,6 @@ Theme Name: Close Race Theme
 	return Buffer.from(zipBytes!);
 }
 
-// OPFS is shared by tests in one browser. Default mode keeps this file ordered
-// while retrying only the failed test.
-test.describe.configure({ mode: 'default' });
-
 /**
  * Returns a URL that opts this test out of default browser storage.
  *
@@ -534,1418 +530,1446 @@ async function openPlaygroundPath(page: Page, path: string) {
 		path
 	);
 }
-// `@storage` routes this browser-scoped test to the one-worker CI lane.
-test('@storage should retry pending OPFS cleanup after another tab releases storage', async ({
-	website,
-	context,
-	browserName,
-}) => {
-	test.skip(
-		browserName !== 'chromium',
-		`This test relies on OPFS which isn't available in Playwright's flavor of ${browserName}.`
-	);
 
-	await simulateOpfsCleanupBlockedByAnotherTab(context);
-	const slug = `pending-cleanup-${Date.now()}`;
-	await website.page.goto(getTemporaryPlaygroundUrl());
-	await website.page.waitForFunction(() => !!navigator.storage?.getDirectory);
-	await writePendingOpfsResetSite(website.page, slug);
+// OPFS is browser-scoped, so `@storage` routes this suite to the one-worker CI lane.
+test.describe('OPFS', { tag: '@storage' }, () => {
+	// Default mode retries only the failed test instead of replaying the suite.
+	test.describe.configure({ mode: 'default' });
 
-	const lockPage = await context.newPage();
-	await lockPage.goto(getTemporaryPlaygroundUrl());
-	await lockPage.evaluate(() => {
-		(window as any).simulateOpfsCleanupLockForThisTab();
+	test('should retry pending OPFS cleanup after another tab releases storage', async ({
+		website,
+		context,
+		browserName,
+	}) => {
+		test.skip(
+			browserName !== 'chromium',
+			`This test relies on OPFS which isn't available in Playwright's flavor of ${browserName}.`
+		);
+
+		await simulateOpfsCleanupBlockedByAnotherTab(context);
+		const slug = `pending-cleanup-${Date.now()}`;
+		await website.page.goto(getTemporaryPlaygroundUrl());
+		await website.page.waitForFunction(
+			() => !!navigator.storage?.getDirectory
+		);
+		await writePendingOpfsResetSite(website.page, slug);
+
+		const lockPage = await context.newPage();
+		await lockPage.goto(getTemporaryPlaygroundUrl());
+		await lockPage.evaluate(() => {
+			(window as any).simulateOpfsCleanupLockForThisTab();
+		});
+
+		await website.page.goto(
+			`./?site-slug=${encodeURIComponent(slug)}&random=${Date.now()}`
+		);
+		await expect
+			.poll(() =>
+				website.page.evaluate(
+					(failureCountKey) =>
+						Number(localStorage.getItem(failureCountKey) || '0'),
+					OPFS_CLEANUP_FAILURE_COUNT_KEY
+				)
+			)
+			.toBeGreaterThan(0);
+
+		// This mirrors the user closing another Playground tab that still holds on
+		// to the old OPFS files. The next automatic retry should finish cleanup and boot.
+		await lockPage.close({ runBeforeUnload: true });
+		await expect
+			.poll(() =>
+				website.page.evaluate(
+					(lockHolderKey) => localStorage.getItem(lockHolderKey),
+					OPFS_CLEANUP_LOCK_HOLDER_KEY
+				)
+			)
+			.toBeNull();
+
+		await expect(website.wordpress().locator('body')).toContainText(
+			'cleanup retry ready',
+			{ timeout: 120000 }
+		);
+		await expect(
+			website.page.getByText('Close other Playground tabs, then reload')
+		).not.toBeVisible();
+
+		const storedSite = await readPendingResetSiteState(website.page, slug);
+		expect(storedSite.metadata.opfsSiteRemovalPending).toBeUndefined();
+		expect(storedSite.hasOldResetSentinel).toBe(false);
 	});
 
-	await website.page.goto(
-		`./?site-slug=${encodeURIComponent(slug)}&random=${Date.now()}`
-	);
-	await expect
-		.poll(() =>
-			website.page.evaluate(
-				(failureCountKey) =>
-					Number(localStorage.getItem(failureCountKey) || '0'),
-				OPFS_CLEANUP_FAILURE_COUNT_KEY
+	test('should start a new Playground after an initial OPFS sync was interrupted', async ({
+		website,
+		browserName,
+	}) => {
+		test.skip(
+			browserName !== 'chromium',
+			`This test relies on OPFS which isn't available in Playwright's flavor of ${browserName}.`
+		);
+
+		const interruptedSiteSlug = `interrupted-initial-sync-${Date.now()}`;
+		await website.page.goto(getTemporaryPlaygroundUrl());
+		await website.page.waitForFunction(
+			() => !!navigator.storage?.getDirectory
+		);
+		await writeInterruptedInitialOpfsSite(
+			website.page,
+			interruptedSiteSlug
+		);
+
+		await website.page.goto(
+			`./?site-slug=${encodeURIComponent(interruptedSiteSlug)}`
+		);
+		await expect(
+			website.page.getByText('Start a new Playground to continue')
+		).toBeVisible();
+
+		await website.page
+			.getByRole('button', { name: 'Start a new Playground' })
+			.click();
+
+		await expect
+			.poll(
+				async () => (await getActivePlaygroundSite(website.page))?.slug,
+				{
+					timeout: 15000,
+				}
 			)
-		)
-		.toBeGreaterThan(0);
+			.not.toBe(interruptedSiteSlug);
+		await expect(
+			website.page.getByText('Start a new Playground to continue')
+		).not.toBeVisible();
+		await website.waitForNestedIframes();
+	});
 
-	// This mirrors the user closing another Playground tab that still holds on
-	// to the old OPFS files. The next automatic retry should finish cleanup and boot.
-	await lockPage.close({ runBeforeUnload: true });
-	await expect
-		.poll(() =>
-			website.page.evaluate(
-				(lockHolderKey) => localStorage.getItem(lockHolderKey),
-				OPFS_CLEANUP_LOCK_HOLDER_KEY
-			)
-		)
-		.toBeNull();
+	test('should switch between sites', async ({ website, browserName }) => {
+		test.skip(
+			browserName !== 'chromium',
+			`This test relies on OPFS which isn't available in Playwright's flavor of ${browserName}.`
+		);
 
-	await expect(website.wordpress().locator('body')).toContainText(
-		'cleanup retry ready',
-		{ timeout: 120000 }
-	);
-	await expect(
-		website.page.getByText('Close other Playground tabs, then reload')
-	).not.toBeVisible();
+		await website.goto(getTemporaryPlaygroundUrl());
 
-	const storedSite = await readPendingResetSiteState(website.page, slug);
-	expect(storedSite.metadata.opfsSiteRemovalPending).toBeUndefined();
-	expect(storedSite.hasOldResetSentinel).toBe(false);
-});
+		await website.ensureSiteManagerIsOpen();
 
-// `@storage` routes this browser-scoped test to the one-worker CI lane.
-test('@storage should start a new Playground after an initial OPFS sync was interrupted', async ({
-	website,
-	browserName,
-}) => {
-	test.skip(
-		browserName !== 'chromium',
-		`This test relies on OPFS which isn't available in Playwright's flavor of ${browserName}.`
-	);
+		// Store the temporary site from the Dock.
+		const firstSiteName = 'Switching Test Site';
+		await saveSiteViaDockPane(website.page, { customName: firstSiteName });
 
-	const interruptedSiteSlug = `interrupted-initial-sync-${Date.now()}`;
-	await website.page.goto(getTemporaryPlaygroundUrl());
-	await website.page.waitForFunction(() => !!navigator.storage?.getDirectory);
-	await writeInterruptedInitialOpfsSite(website.page, interruptedSiteSlug);
+		await expect(getPlaygroundTitle(website.page)).not.toContainText(
+			'Unsaved Playground',
+			{
+				// Saving the site takes a while on CI
+				timeout: 90000,
+			}
+		);
+		await expect(getPlaygroundTitle(website.page)).toContainText(
+			firstSiteName
+		);
 
-	await website.page.goto(
-		`./?site-slug=${encodeURIComponent(interruptedSiteSlug)}`
-	);
-	await expect(
-		website.page.getByText('Start a new Playground to continue')
-	).toBeVisible();
-
-	await website.page
-		.getByRole('button', { name: 'Start a new Playground' })
-		.click();
-
-	await expect
-		.poll(async () => (await getActivePlaygroundSite(website.page))?.slug, {
-			timeout: 15000,
-		})
-		.not.toBe(interruptedSiteSlug);
-	await expect(
-		website.page.getByText('Start a new Playground to continue')
-	).not.toBeVisible();
-	await website.waitForNestedIframes();
-});
-
-// `@storage` routes this browser-scoped test to the one-worker CI lane.
-test('@storage should switch between sites', async ({
-	website,
-	browserName,
-}) => {
-	test.skip(
-		browserName !== 'chromium',
-		`This test relies on OPFS which isn't available in Playwright's flavor of ${browserName}.`
-	);
-
-	await website.goto(getTemporaryPlaygroundUrl());
-
-	await website.ensureSiteManagerIsOpen();
-
-	// Store the temporary site from the Dock.
-	const firstSiteName = 'Switching Test Site';
-	await saveSiteViaDockPane(website.page, { customName: firstSiteName });
-
-	await expect(getPlaygroundTitle(website.page)).not.toContainText(
-		'Unsaved Playground',
-		{
-			// Saving the site takes a while on CI
-			timeout: 90000,
-		}
-	);
-	await expect(getPlaygroundTitle(website.page)).toContainText(firstSiteName);
-
-	// Start another saved Playground, then switch back to the first one.
-	await website.openDockPane('New Playground');
-	await website.page
-		.getByRole('button', {
-			name: 'Vanilla WordPress - New Playground',
-			exact: true,
-		})
-		.click();
-	await website.waitForNestedIframes();
-	await website.ensureSiteManagerIsOpen();
-
-	await expect(getPlaygroundTitle(website.page)).not.toContainText(
-		firstSiteName
-	);
-	await expect(
-		website.page.getByRole('button', { name: 'Autosaved' })
-	).toBeVisible({ timeout: 120000 });
-	await expect
-		.poll(() =>
-			website.page.evaluate(() => {
-				const activeSite = (window as any).playgroundSites
-					.list()
-					.find((site: any) => site.isActive);
-				return activeSite
-					? `${activeSite.storage}:${activeSite.persistence}`
-					: null;
+		// Start another saved Playground, then switch back to the first one.
+		await website.openDockPane('New Playground');
+		await website.page
+			.getByRole('button', {
+				name: 'Vanilla WordPress - New Playground',
+				exact: true,
 			})
-		)
-		.toBe('opfs:autosave');
-
-	await website.openPlaygroundsPane();
-	await website.page
-		.locator('[class*="siteRowContent"]')
-		.filter({ hasText: firstSiteName })
-		.click();
-	await website.ensureSiteManagerIsOpen();
-
-	await expect(getPlaygroundTitle(website.page)).toContainText(firstSiteName);
-});
-
-// `@storage` routes this browser-scoped test to the one-worker CI lane.
-test('@storage should preserve PHP constants when saving a temporary site to OPFS', async ({
-	website,
-	browserName,
-	wordpress,
-}) => {
-	test.skip(
-		browserName !== 'chromium',
-		`This test relies on OPFS which isn't available in Playwright's flavor of ${browserName}.`
-	);
-
-	// Start a site with a specific PHP constant.
-	const blueprint: Blueprint = {
-		landingPage: '/index.php',
-		constants: { E2E_TEST_CONSTANT: 'E2E_TEST_VALUE' },
-		steps: [
-			{
-				step: 'writeFile',
-				path: '/wordpress/index.php',
-				data: '<?php echo E2E_TEST_CONSTANT;',
-			},
-		],
-	};
-	await website.goto(
-		getTemporaryPlaygroundUrl(`#${JSON.stringify(blueprint)}`)
-	);
-
-	await website.ensureSiteManagerIsOpen();
-
-	// Store the temporary site from the Dock.
-	await saveSiteViaDockPane(website.page);
-
-	await expect(getPlaygroundTitle(website.page)).not.toContainText(
-		'Unsaved Playground',
-		{
-			// Saving the site takes a while on CI
-			timeout: 90000,
-		}
-	);
-
-	const storedPlaygroundTitleText = await getPlaygroundTitle(
-		website.page
-	).textContent();
-	await expect(storedPlaygroundTitleText).not.toBeNull();
-	await expect(storedPlaygroundTitleText).not.toMatch('Unsaved Playground');
-
-	// Create another Playground, then switch back.
-	await website.openDockPane('New Playground');
-	await website.page
-		.getByRole('button', {
-			name: 'Vanilla WordPress - New Playground',
-			exact: true,
-		})
-		.click();
-	await website.waitForNestedIframes();
-
-	// Open the Playgrounds pane again to switch back to the stored site.
-	await website.openPlaygroundsPane();
-
-	// Switch back to the stored site and confirm the PHP constant is still present.
-	await website.page
-		.locator('[class*="siteRowContent"]')
-		.filter({ hasText: storedPlaygroundTitleText! })
-		.click();
-
-	await expect(wordpress.locator('body')).toContainText('E2E_TEST_VALUE');
-});
-
-// `@storage` routes this browser-scoped test to the one-worker CI lane.
-test('@storage should rename a saved Playground and persist after reload', async ({
-	website,
-	browserName,
-}) => {
-	test.skip(
-		browserName !== 'chromium',
-		`This test relies on OPFS which isn't available in Playwright's flavor of ${browserName}.`
-	);
-
-	await website.goto(getTemporaryPlaygroundUrl());
-	await website.ensureSiteManagerIsOpen();
-
-	// Save the temporary site to OPFS so rename is available
-	await saveSiteViaDockPane(website.page);
-
-	await expect(getPlaygroundTitle(website.page)).not.toContainText(
-		'Unsaved Playground',
-		{
-			timeout: 90000,
-		}
-	);
-
-	await website.ensureSiteManagerIsOpen();
-
-	// Rename from the Site Settings header.
-	await website.page
-		.getByRole('button', { name: 'Rename Playground' })
-		.click();
-
-	const newName = 'My Renamed Playground';
-	const nameInput = website.page.getByRole('textbox', {
-		name: 'Rename Playground',
-	});
-	await nameInput.fill(newName);
-	await nameInput.press('Enter');
-
-	await expect(getPlaygroundTitle(website.page)).toContainText(newName);
-
-	await expect(nameInput).not.toBeVisible();
-
-	// Reload and verify the name persists
-	await website.page.reload();
-	await website.ensureSiteManagerIsOpen();
-	await expect(getPlaygroundTitle(website.page)).toContainText(newName);
-
-	// Verify the name is also updated in the Playgrounds pane.
-	await website.openPlaygroundsPane();
-	await expect(
-		website.page.locator('[class*="siteRowName"]', { hasText: newName })
-	).toBeVisible();
-	await website.closePlaygroundsPane();
-});
-
-// `@storage` routes this browser-scoped test to the one-worker CI lane.
-test('@storage should wait for a temporary OPFS metadata lock', async ({
-	website,
-	browserName,
-}) => {
-	test.skip(
-		browserName !== 'chromium',
-		`This test relies on OPFS which isn't available in Playwright's flavor of ${browserName}.`
-	);
-
-	await website.goto(getTemporaryPlaygroundUrl());
-	await website.page.waitForFunction(() =>
-		Boolean((window as any).playgroundSites?.getClient())
-	);
-	await website.page.evaluate(() =>
-		(window as any).playgroundSites.saveInBrowser()
-	);
-	const site = await getActivePlaygroundSite(website.page);
-	const newName = 'Renamed after OPFS lock';
-
-	await website.page.evaluate(
-		async ({ dirName, newName, slug }) => {
-			const root = await navigator.storage.getDirectory();
-			const sites = await root.getDirectoryHandle('sites');
-			const siteDirectory = await sites.getDirectoryHandle(dirName);
-			const metadataFile =
-				await siteDirectory.getFileHandle('wp-runtime.json');
-			const writable = await metadataFile.createWritable({
-				keepExistingData: true,
-			});
-			const releaseLock = new Promise<void>((resolve, reject) => {
-				setTimeout(async () => {
-					try {
-						await writable.close();
-						resolve();
-					} catch (error) {
-						reject(error);
-					}
-				}, 200);
-			});
-
-			try {
-				await (window as any).playgroundSites.rename(newName, slug);
-			} finally {
-				await releaseLock;
-			}
-		},
-		{
-			dirName: getDirectoryNameForSlug(site.slug),
-			newName,
-			slug: site.slug,
-		}
-	);
-
-	await website.page.reload();
-	await website.page.waitForFunction(() =>
-		Boolean((window as any).playgroundSites?.getClient())
-	);
-	await expect
-		.poll(async () => (await getActivePlaygroundSite(website.page))?.name)
-		.toBe(newName);
-});
-
-// `@storage` routes this browser-scoped test to the one-worker CI lane.
-test('@storage should preserve metadata changes made in different tabs', async ({
-	website,
-	context,
-	browserName,
-}) => {
-	test.skip(
-		browserName !== 'chromium',
-		`This test relies on OPFS which isn't available in Playwright's flavor of ${browserName}.`
-	);
-
-	await website.goto(getTemporaryPlaygroundUrl());
-	await website.page.waitForFunction(() =>
-		Boolean((window as any).playgroundSites?.getClient())
-	);
-	await website.page.evaluate(() =>
-		(window as any).playgroundSites.saveInBrowser()
-	);
-	const site = await getActivePlaygroundSite(website.page);
-
-	const secondTab = await context.newPage();
-	await secondTab.goto(
-		new URL(
-			`./?site-slug=${encodeURIComponent(site.slug)}`,
-			website.page.url()
-		).href
-	);
-	await secondTab.waitForFunction(() =>
-		Boolean((window as any).playgroundSites)
-	);
-	await secondTab.evaluate(() => (window as any).playgroundSites.isReady());
-
-	const newName = 'Renamed in the first tab';
-	await website.page.evaluate(
-		({ name, slug }) => (window as any).playgroundSites.rename(name, slug),
-		{ name: newName, slug: site.slug }
-	);
-	await website.page.evaluate(() =>
-		(window as any).playgroundSites.setPhpVersion('8.2')
-	);
-	await secondTab.evaluate(() =>
-		(window as any).playgroundSites.setNetworking(false)
-	);
-
-	const persistedMetadata = await website.page.evaluate(async (dirName) => {
-		const root = await navigator.storage.getDirectory();
-		const sites = await root.getDirectoryHandle('sites');
-		const siteDirectory = await sites.getDirectoryHandle(dirName);
-		const metadataFile =
-			await siteDirectory.getFileHandle('wp-runtime.json');
-		return JSON.parse(await (await metadataFile.getFile()).text());
-	}, getDirectoryNameForSlug(site.slug));
-	expect(persistedMetadata.name).toBe(newName);
-	expect(persistedMetadata.runtimeConfiguration.phpVersion).toBe('8.2');
-	expect(persistedMetadata.runtimeConfiguration.networking).toBe(false);
-});
-
-// `@storage` routes this browser-scoped test to the one-worker CI lane.
-test('@storage should show the Store permanently pane with the save controls', async ({
-	website,
-	browserName,
-}) => {
-	test.skip(
-		browserName !== 'chromium',
-		`This test relies on OPFS which isn't available in Playwright's flavor of ${browserName}.`
-	);
-
-	await website.goto(getTemporaryPlaygroundUrl());
-	await website.ensureSiteManagerIsOpen();
-
-	const pane = await openStorePermanentlyPane(website.page);
-
-	// Verify the playground name input exists and has default value
-	const nameInput = pane.getByLabel('Playground name');
-	await expect(nameInput).toBeVisible();
-	await expect(nameInput).toHaveValue(/.+/);
-
-	// Verify storage location radio buttons exist
-	await expect(pane.getByText('Storage location')).toBeVisible();
-	await expect(pane.getByText('Save in browser storage')).toBeVisible();
-	await expect(pane.getByText('Save in a local directory')).toBeVisible();
-
-	// Verify action buttons exist
-	await expect(pane.getByRole('button', { name: 'Save' })).toBeVisible();
-	await expect(pane.getByRole('button', { name: 'Cancel' })).toBeVisible();
-
-	await pane.getByRole('button', { name: 'Cancel' }).click();
-	await expect(pane).not.toBeVisible();
-});
-
-// `@storage` routes this browser-scoped test to the one-worker CI lane.
-test('@storage should close the Store permanently pane without saving', async ({
-	website,
-	browserName,
-}) => {
-	test.skip(
-		browserName !== 'chromium',
-		`This test relies on OPFS which isn't available in Playwright's flavor of ${browserName}.`
-	);
-
-	await website.goto(getTemporaryPlaygroundUrl());
-	await website.ensureSiteManagerIsOpen();
-
-	const pane = await openStorePermanentlyPane(website.page);
-
-	// Close without saving using Cancel button
-	await pane.getByRole('button', { name: 'Cancel' }).click();
-	await expect(pane).not.toBeVisible();
-
-	// Verify the site is still temporary
-	await expect(getPlaygroundTitle(website.page)).toContainText(
-		'Unsaved Playground'
-	);
-
-	await openStorePermanentlyPane(website.page);
-
-	// Close using ESC key
-	await website.page.keyboard.press('Escape');
-	await expect(pane).not.toBeVisible();
-
-	// Verify the site is still temporary
-	await expect(getPlaygroundTitle(website.page)).toContainText(
-		'Unsaved Playground'
-	);
-});
-
-// `@storage` routes this browser-scoped test to the one-worker CI lane.
-test('@storage should have playground name input text selected by default', async ({
-	website,
-	browserName,
-}) => {
-	test.skip(
-		browserName !== 'chromium',
-		`This test relies on OPFS which isn't available in Playwright's flavor of ${browserName}.`
-	);
-
-	await website.goto(getTemporaryPlaygroundUrl());
-	await website.ensureSiteManagerIsOpen();
-
-	const pane = await openStorePermanentlyPane(website.page);
-
-	const nameInput = pane.getByLabel('Playground name');
-
-	// Verify the input is focused
-	await expect(nameInput).toBeFocused();
-
-	await expect
-		.poll(() =>
-			nameInput.evaluate(
-				(input: HTMLInputElement) =>
-					input.selectionStart === 0 &&
-					input.selectionEnd === input.value.length
-			)
-		)
-		.toBe(true);
-
-	// Type to replace the selected text
-	await website.page.keyboard.type('New Name');
-	await expect(nameInput).toHaveValue('New Name');
-
-	await pane.getByRole('button', { name: 'Cancel' }).click();
-});
-
-// `@storage` routes this browser-scoped test to the one-worker CI lane.
-test('@storage should save site with custom name', async ({
-	website,
-	browserName,
-}) => {
-	test.skip(
-		browserName !== 'chromium',
-		`This test relies on OPFS which isn't available in Playwright's flavor of ${browserName}.`
-	);
-
-	await website.goto(getTemporaryPlaygroundUrl());
-	await website.ensureSiteManagerIsOpen();
-
-	const customName = 'My Custom Playground Name';
-
-	// Save with custom name using the helper
-	await saveSiteViaDockPane(website.page, { customName });
-
-	// Verify the site was saved with the custom name
-	await expect(getPlaygroundTitle(website.page)).toContainText(customName, {
-		timeout: 90000,
-	});
-
-	// Verify the name also appears in the Playgrounds pane.
-	await website.openPlaygroundsPane();
-	await expect(
-		website.page.locator('[class*="siteRowName"]', {
-			hasText: customName,
-		})
-	).toBeVisible();
-	await website.closePlaygroundsPane();
-});
-
-// `@storage` routes this browser-scoped test to the one-worker CI lane.
-test('@storage should not persist the Store permanently pane through page refresh', async ({
-	website,
-	browserName,
-}) => {
-	test.skip(
-		browserName !== 'chromium',
-		`This test relies on OPFS which isn't available in Playwright's flavor of ${browserName}.`
-	);
-
-	await website.goto(getTemporaryPlaygroundUrl());
-	await website.ensureSiteManagerIsOpen();
-
-	const pane = await openStorePermanentlyPane(website.page);
-
-	// Dock pane state is not encoded in the URL.
-	expect(website.page.url()).not.toContain('modal=save-site');
-
-	// Reload the page
-	await website.page.reload();
-	await website.waitForPlaygroundShell();
-
-	await expect(pane).toHaveCount(0);
-});
-
-// `@storage` routes this browser-scoped test to the one-worker CI lane.
-test('@storage should display OPFS storage option as selected by default', async ({
-	website,
-	browserName,
-}) => {
-	test.skip(
-		browserName !== 'chromium',
-		`This test relies on OPFS which isn't available in Playwright's flavor of ${browserName}.`
-	);
-
-	await website.goto(getTemporaryPlaygroundUrl());
-	await website.ensureSiteManagerIsOpen();
-
-	const pane = await openStorePermanentlyPane(website.page);
-
-	// Verify OPFS option is selected by default
-	const opfsRadio = pane.getByRole('radio', {
-		name: /Save in browser storage/,
-	});
-	await expect(opfsRadio).toBeChecked();
-
-	await pane.getByRole('button', { name: 'Cancel' }).click();
-});
-
-// `@storage` routes this browser-scoped test to the one-worker CI lane.
-test('@storage should import ZIP into a fresh temporary site without browser storage', async ({
-	website,
-	browserName,
-	context,
-}) => {
-	test.skip(
-		browserName !== 'chromium',
-		'This test controls OPFS availability in Chromium.'
-	);
-	await context.addInitScript(() => {
-		Object.defineProperty(StorageManager.prototype, 'getDirectory', {
-			configurable: true,
-			value: undefined,
-		});
-	});
-
-	await website.goto(getTemporaryPlaygroundUrl());
-	const siteBeforeImport = await getActivePlaygroundSite(website.page);
-	expect(siteBeforeImport?.storage).toBe('temporary');
-
-	await website.openDockPane('New Playground');
-	await website.page
-		.getByRole('tab', { name: 'Import zip', exact: true })
-		.click();
-
-	const marker = 'TEMPORARY_ZIP_IMPORT_MARKER';
-	const markerPath = 'wp-content/temporary-zip-import-marker.txt';
-	const zipBuffer = await createTestWordPressZip(
-		marker,
-		'wp-content/index.php',
-		[new File([marker], markerPath)]
-	);
-	await website.page
-		.locator('input[type="file"][accept*=".zip"]')
-		.setInputFiles({
-			name: 'temporary-playground.zip',
-			mimeType: 'application/zip',
-			buffer: zipBuffer,
-		});
-
-	await expect(
-		website.page
-			.getByRole('group', { name: 'Operation succeeded' })
-			.filter({ hasText: 'Playground imported' })
-	).toBeVisible({ timeout: 120000 });
-	await expect(
-		website.page.getByRole('alert').filter({
-			hasText: 'Playground imported',
-		})
-	).toHaveCount(0);
-	const siteAfterImport = await getActivePlaygroundSite(website.page);
-	expect(siteAfterImport).toMatchObject({
-		storage: 'temporary',
-	});
-	expect(siteAfterImport.slug).not.toBe(siteBeforeImport.slug);
-	await expect
-		.poll(async () => {
-			return await website.page.evaluate(async (relativePath) => {
-				const playground = (window as any).playgroundSites.getClient();
-				const documentRoot = await playground.documentRoot;
-				return await playground.readFileAsText(
-					`${documentRoot}/${relativePath}`
-				);
-			}, markerPath);
-		})
-		.toBe(marker);
-});
-
-// `@storage` routes this browser-scoped test to the one-worker CI lane.
-test('@storage should remove the saved site created for a failed ZIP import', async ({
-	website,
-	browserName,
-}) => {
-	test.skip(
-		browserName !== 'chromium',
-		`This test relies on OPFS which isn't available in Playwright's flavor of ${browserName}.`
-	);
-
-	await website.goto(getTemporaryPlaygroundUrl());
-	const activeSiteBeforeImport = await getActivePlaygroundSite(website.page);
-	const storedSiteSlugsBeforeImport = await getStoredPlaygroundSiteSlugs(
-		website.page
-	);
-	expect(storedSiteSlugsBeforeImport).not.toBeNull();
-
-	const importFailed = await website.page.evaluate(async () => {
-		try {
-			await (window as any).playgroundSites.createNewSiteFromZip(
-				new File(['not a zip archive'], 'invalid-playground.zip', {
-					type: 'application/zip',
+			.click();
+		await website.waitForNestedIframes();
+		await website.ensureSiteManagerIsOpen();
+
+		await expect(getPlaygroundTitle(website.page)).not.toContainText(
+			firstSiteName
+		);
+		await expect(
+			website.page.getByRole('button', { name: 'Autosaved' })
+		).toBeVisible({ timeout: 120000 });
+		await expect
+			.poll(() =>
+				website.page.evaluate(() => {
+					const activeSite = (window as any).playgroundSites
+						.list()
+						.find((site: any) => site.isActive);
+					return activeSite
+						? `${activeSite.storage}:${activeSite.persistence}`
+						: null;
 				})
-			);
-			return false;
-		} catch {
-			return true;
-		}
+			)
+			.toBe('opfs:autosave');
+
+		await website.openPlaygroundsPane();
+		await website.page
+			.locator('[class*="siteRowContent"]')
+			.filter({ hasText: firstSiteName })
+			.click();
+		await website.ensureSiteManagerIsOpen();
+
+		await expect(getPlaygroundTitle(website.page)).toContainText(
+			firstSiteName
+		);
 	});
-	expect(importFailed).toBe(true);
 
-	await expect
-		.poll(() => getStoredPlaygroundSiteSlugs(website.page))
-		.toEqual(storedSiteSlugsBeforeImport);
-	await expect
-		.poll(async () => (await getActivePlaygroundSite(website.page))?.slug)
-		.toBe(activeSiteBeforeImport.slug);
+	test('should preserve PHP constants when saving a temporary site to OPFS', async ({
+		website,
+		browserName,
+		wordpress,
+	}) => {
+		test.skip(
+			browserName !== 'chromium',
+			`This test relies on OPFS which isn't available in Playwright's flavor of ${browserName}.`
+		);
 
-	await website.page.reload();
-	await website.waitForPlaygroundShell();
-	await expect
-		.poll(() => getStoredPlaygroundSiteSlugs(website.page))
-		.toEqual(storedSiteSlugsBeforeImport);
-});
+		// Start a site with a specific PHP constant.
+		const blueprint: Blueprint = {
+			landingPage: '/index.php',
+			constants: { E2E_TEST_CONSTANT: 'E2E_TEST_VALUE' },
+			steps: [
+				{
+					step: 'writeFile',
+					path: '/wordpress/index.php',
+					data: '<?php echo E2E_TEST_CONSTANT;',
+				},
+			],
+		};
+		await website.goto(
+			getTemporaryPlaygroundUrl(`#${JSON.stringify(blueprint)}`)
+		);
 
-// `@storage` routes this browser-scoped test to the one-worker CI lane.
-test('@storage should import a ZIP dropped on the page', async ({
-	website,
-	wordpress,
-	browserName,
-}) => {
-	test.skip(
-		browserName !== 'chromium',
-		`This test relies on OPFS which isn't available in Playwright's flavor of ${browserName}.`
-	);
+		await website.ensureSiteManagerIsOpen();
 
-	await website.goto(getTemporaryPlaygroundUrl());
-	const sourceSite = await getActivePlaygroundSite(website.page);
-	expect(sourceSite?.slug).toBeTruthy();
-	const sourceSiteSlug = sourceSite.slug;
+		// Store the temporary site from the Dock.
+		await saveSiteViaDockPane(website.page);
 
-	await website.openDockPane('New Playground');
-	await website.page
-		.getByRole('tab', { name: 'Import zip', exact: true })
-		.click();
+		await expect(getPlaygroundTitle(website.page)).not.toContainText(
+			'Unsaved Playground',
+			{
+				// Saving the site takes a while on CI
+				timeout: 90000,
+			}
+		);
 
-	const marker = 'PAGE_DROP_ZIP_IMPORT_MARKER';
-	const markerPath = 'wp-content/page-drop-zip-import-marker.php';
-	const zipBuffer = await createTestWordPressZip(marker, markerPath);
-	await dropZipFile(website.page, 'page-drop-import.zip', zipBuffer);
+		const storedPlaygroundTitleText = await getPlaygroundTitle(
+			website.page
+		).textContent();
+		await expect(storedPlaygroundTitleText).not.toBeNull();
+		await expect(storedPlaygroundTitleText).not.toMatch(
+			'Unsaved Playground'
+		);
 
-	await expect(
-		website.page.getByText('Playground imported', { exact: true })
-	).toBeVisible({ timeout: 120000 });
-	await waitForActivePlaygroundSiteSlug(
-		website.page,
-		(slug) => slug !== sourceSiteSlug
-	);
-	await openPlaygroundPath(website.page, `/${markerPath}`);
-	await expect(wordpress.locator('body')).toContainText(marker);
-});
+		// Create another Playground, then switch back.
+		await website.openDockPane('New Playground');
+		await website.page
+			.getByRole('button', {
+				name: 'Vanilla WordPress - New Playground',
+				exact: true,
+			})
+			.click();
+		await website.waitForNestedIframes();
 
-// `@storage` routes this browser-scoped test to the one-worker CI lane.
-test('@storage should show an inline error for a non-ZIP drop', async ({
-	website,
-	browserName,
-}) => {
-	test.skip(
-		browserName !== 'chromium',
-		`This test relies on OPFS which isn't available in Playwright's flavor of ${browserName}.`
-	);
+		// Open the Playgrounds pane again to switch back to the stored site.
+		await website.openPlaygroundsPane();
 
-	await website.goto(getTemporaryPlaygroundUrl());
-	await website.openDockPane('New Playground');
-	await website.page
-		.getByRole('tab', { name: 'Import zip', exact: true })
-		.click();
-	await dropZipFile(
-		website.page,
-		'not-a-playground-export.txt',
-		Buffer.from('not a zip archive'),
-		false
-	);
+		// Switch back to the stored site and confirm the PHP constant is still present.
+		await website.page
+			.locator('[class*="siteRowContent"]')
+			.filter({ hasText: storedPlaygroundTitleText! })
+			.click();
 
-	await expect(
-		website.page.getByRole('alert').filter({
-			hasText: 'Choose a WordPress Playground .zip export.',
-		})
-	).toBeVisible();
-});
-
-// `@storage` routes this browser-scoped test to the one-worker CI lane.
-test('@storage should notify when a ZIP import loads before autosave finishes', async ({
-	website,
-	browserName,
-}) => {
-	test.skip(
-		browserName !== 'chromium',
-		`This test relies on OPFS which isn't available in Playwright's flavor of ${browserName}.`
-	);
-
-	await website.goto(getTemporaryPlaygroundUrl());
-	const sourceSite = await getActivePlaygroundSite(website.page);
-	expect(sourceSite?.slug).toBeTruthy();
-	await website.openDockPane('New Playground');
-	await website.page
-		.getByRole('tab', { name: 'Import zip', exact: true })
-		.click();
-
-	const zipBuffer = await createPluginThemeExportZip();
-	const fileInput = website.page.locator(
-		'input[type="file"][accept*=".zip"]'
-	);
-	const pane = website.page.getByRole('dialog', {
-		name: 'New Playground pane',
+		await expect(wordpress.locator('body')).toContainText('E2E_TEST_VALUE');
 	});
-	const importProgress = website.page.getByRole('progressbar', {
-		name: 'WordPress import progress',
-	});
-	const autosaveProgress = website.page.getByRole('progressbar', {
-		name: 'Autosave progress',
-	});
-	const importNotice = website.page
-		.getByRole('group', { name: 'Operation succeeded' })
-		.filter({ hasText: 'Playground imported' });
-	const importProgressStarted = expect(importProgress).toBeVisible({
-		timeout: 120000,
-	});
-	const notifyWhileAutosaving = (async () => {
-		await expect(autosaveProgress).toBeVisible({ timeout: 120000 });
-		const importedSite = await getActivePlaygroundSite(website.page);
-		expect(importedSite).toMatchObject({
-			storage: 'opfs',
-			persistence: 'autosave',
+
+	test('should rename a saved Playground and persist after reload', async ({
+		website,
+		browserName,
+	}) => {
+		test.skip(
+			browserName !== 'chromium',
+			`This test relies on OPFS which isn't available in Playwright's flavor of ${browserName}.`
+		);
+
+		await website.goto(getTemporaryPlaygroundUrl());
+		await website.ensureSiteManagerIsOpen();
+
+		// Save the temporary site to OPFS so rename is available
+		await saveSiteViaDockPane(website.page);
+
+		await expect(getPlaygroundTitle(website.page)).not.toContainText(
+			'Unsaved Playground',
+			{
+				timeout: 90000,
+			}
+		);
+
+		await website.ensureSiteManagerIsOpen();
+
+		// Rename from the Site Settings header.
+		await website.page
+			.getByRole('button', { name: 'Rename Playground' })
+			.click();
+
+		const newName = 'My Renamed Playground';
+		const nameInput = website.page.getByRole('textbox', {
+			name: 'Rename Playground',
 		});
-		await setActivePlaygroundSite(website.page, sourceSite.slug);
-		await expect(importNotice).toBeVisible();
-		expect(
-			await getInitialOpfsSyncPending(website.page, importedSite.slug)
-		).toBe(true);
-		return importedSite;
-	})();
-	const importProgressAdvanced = expect
-		.poll(
-			async () => {
-				return (
-					Number(await importProgress.getAttribute('aria-valuenow')) >
-					0
-				);
+		await nameInput.fill(newName);
+		await nameInput.press('Enter');
+
+		await expect(getPlaygroundTitle(website.page)).toContainText(newName);
+
+		await expect(nameInput).not.toBeVisible();
+
+		// Reload and verify the name persists
+		await website.page.reload();
+		await website.ensureSiteManagerIsOpen();
+		await expect(getPlaygroundTitle(website.page)).toContainText(newName);
+
+		// Verify the name is also updated in the Playgrounds pane.
+		await website.openPlaygroundsPane();
+		await expect(
+			website.page.locator('[class*="siteRowName"]', { hasText: newName })
+		).toBeVisible();
+		await website.closePlaygroundsPane();
+	});
+
+	test('should wait for a temporary OPFS metadata lock', async ({
+		website,
+		browserName,
+	}) => {
+		test.skip(
+			browserName !== 'chromium',
+			`This test relies on OPFS which isn't available in Playwright's flavor of ${browserName}.`
+		);
+
+		await website.goto(getTemporaryPlaygroundUrl());
+		await website.page.waitForFunction(() =>
+			Boolean((window as any).playgroundSites?.getClient())
+		);
+		await website.page.evaluate(() =>
+			(window as any).playgroundSites.saveInBrowser()
+		);
+		const site = await getActivePlaygroundSite(website.page);
+		const newName = 'Renamed after OPFS lock';
+
+		await website.page.evaluate(
+			async ({ dirName, newName, slug }) => {
+				const root = await navigator.storage.getDirectory();
+				const sites = await root.getDirectoryHandle('sites');
+				const siteDirectory = await sites.getDirectoryHandle(dirName);
+				const metadataFile =
+					await siteDirectory.getFileHandle('wp-runtime.json');
+				const writable = await metadataFile.createWritable({
+					keepExistingData: true,
+				});
+				const releaseLock = new Promise<void>((resolve, reject) => {
+					setTimeout(async () => {
+						try {
+							await writable.close();
+							resolve();
+						} catch (error) {
+							reject(error);
+						}
+					}, 200);
+				});
+
+				try {
+					await (window as any).playgroundSites.rename(newName, slug);
+				} finally {
+					await releaseLock;
+				}
 			},
 			{
-				intervals: [16],
-				timeout: 120000,
+				dirName: getDirectoryNameForSlug(site.slug),
+				newName,
+				slug: site.slug,
 			}
-		)
-		.toBe(true);
-	await fileInput.setInputFiles({
-		name: 'playground-export-with-plugin-and-theme.zip',
-		mimeType: 'application/zip',
-		buffer: zipBuffer,
+		);
+
+		await website.page.reload();
+		await website.page.waitForFunction(() =>
+			Boolean((window as any).playgroundSites?.getClient())
+		);
+		await expect
+			.poll(
+				async () => (await getActivePlaygroundSite(website.page))?.name
+			)
+			.toBe(newName);
 	});
-	await expect(pane).not.toBeVisible();
-	await importProgressStarted;
-	await expect(autosaveProgress).toHaveCount(0);
-	await importProgressAdvanced;
-	await expect(importProgress).toHaveCount(0, { timeout: 120000 });
-	const importedSite = await notifyWhileAutosaving;
 
-	// Reopen the retained import runtime before its background sync finishes.
-	// setActiveSite() must not wait for a second client-added event.
-	await setActivePlaygroundSite(website.page, importedSite.slug);
-	expect((await getActivePlaygroundSite(website.page)).slug).toBe(
-		importedSite.slug
-	);
-	await setActivePlaygroundSite(website.page, sourceSite.slug);
+	test('should preserve metadata changes made in different tabs', async ({
+		website,
+		context,
+		browserName,
+	}) => {
+		test.skip(
+			browserName !== 'chromium',
+			`This test relies on OPFS which isn't available in Playwright's flavor of ${browserName}.`
+		);
 
-	const newPlaygroundButton = website.page.getByRole('button', {
-		name: 'New Playground',
-		exact: true,
+		await website.goto(getTemporaryPlaygroundUrl());
+		await website.page.waitForFunction(() =>
+			Boolean((window as any).playgroundSites?.getClient())
+		);
+		await website.page.evaluate(() =>
+			(window as any).playgroundSites.saveInBrowser()
+		);
+		const site = await getActivePlaygroundSite(website.page);
+
+		const secondTab = await context.newPage();
+		await secondTab.goto(
+			new URL(
+				`./?site-slug=${encodeURIComponent(site.slug)}`,
+				website.page.url()
+			).href
+		);
+		await secondTab.waitForFunction(() =>
+			Boolean((window as any).playgroundSites)
+		);
+		await secondTab.evaluate(() =>
+			(window as any).playgroundSites.isReady()
+		);
+
+		const newName = 'Renamed in the first tab';
+		await website.page.evaluate(
+			({ name, slug }) =>
+				(window as any).playgroundSites.rename(name, slug),
+			{ name: newName, slug: site.slug }
+		);
+		await website.page.evaluate(() =>
+			(window as any).playgroundSites.setPhpVersion('8.2')
+		);
+		await secondTab.evaluate(() =>
+			(window as any).playgroundSites.setNetworking(false)
+		);
+
+		const persistedMetadata = await website.page.evaluate(
+			async (dirName) => {
+				const root = await navigator.storage.getDirectory();
+				const sites = await root.getDirectoryHandle('sites');
+				const siteDirectory = await sites.getDirectoryHandle(dirName);
+				const metadataFile =
+					await siteDirectory.getFileHandle('wp-runtime.json');
+				return JSON.parse(await (await metadataFile.getFile()).text());
+			},
+			getDirectoryNameForSlug(site.slug)
+		);
+		expect(persistedMetadata.name).toBe(newName);
+		expect(persistedMetadata.runtimeConfiguration.phpVersion).toBe('8.2');
+		expect(persistedMetadata.runtimeConfiguration.networking).toBe(false);
 	});
-	await expect(newPlaygroundButton).toBeEnabled();
 
-	// A full page load discards the retained runtime. Let its background sync
-	// finish before verifying that the imported files survive a cold boot.
-	await waitForInitialOpfsSync(website.page, importedSite.slug);
-	await website.goto(`./?site-slug=${encodeURIComponent(importedSite.slug)}`);
+	test('should show the Store permanently pane with the save controls', async ({
+		website,
+		browserName,
+	}) => {
+		test.skip(
+			browserName !== 'chromium',
+			`This test relies on OPFS which isn't available in Playwright's flavor of ${browserName}.`
+		);
 
-	await expect
-		.poll(
-			() =>
-				website.page.evaluate(async () => {
+		await website.goto(getTemporaryPlaygroundUrl());
+		await website.ensureSiteManagerIsOpen();
+
+		const pane = await openStorePermanentlyPane(website.page);
+
+		// Verify the playground name input exists and has default value
+		const nameInput = pane.getByLabel('Playground name');
+		await expect(nameInput).toBeVisible();
+		await expect(nameInput).toHaveValue(/.+/);
+
+		// Verify storage location radio buttons exist
+		await expect(pane.getByText('Storage location')).toBeVisible();
+		await expect(pane.getByText('Save in browser storage')).toBeVisible();
+		await expect(pane.getByText('Save in a local directory')).toBeVisible();
+
+		// Verify action buttons exist
+		await expect(pane.getByRole('button', { name: 'Save' })).toBeVisible();
+		await expect(
+			pane.getByRole('button', { name: 'Cancel' })
+		).toBeVisible();
+
+		await pane.getByRole('button', { name: 'Cancel' }).click();
+		await expect(pane).not.toBeVisible();
+	});
+
+	test('should close the Store permanently pane without saving', async ({
+		website,
+		browserName,
+	}) => {
+		test.skip(
+			browserName !== 'chromium',
+			`This test relies on OPFS which isn't available in Playwright's flavor of ${browserName}.`
+		);
+
+		await website.goto(getTemporaryPlaygroundUrl());
+		await website.ensureSiteManagerIsOpen();
+
+		const pane = await openStorePermanentlyPane(website.page);
+
+		// Close without saving using Cancel button
+		await pane.getByRole('button', { name: 'Cancel' }).click();
+		await expect(pane).not.toBeVisible();
+
+		// Verify the site is still temporary
+		await expect(getPlaygroundTitle(website.page)).toContainText(
+			'Unsaved Playground'
+		);
+
+		await openStorePermanentlyPane(website.page);
+
+		// Close using ESC key
+		await website.page.keyboard.press('Escape');
+		await expect(pane).not.toBeVisible();
+
+		// Verify the site is still temporary
+		await expect(getPlaygroundTitle(website.page)).toContainText(
+			'Unsaved Playground'
+		);
+	});
+
+	test('should have playground name input text selected by default', async ({
+		website,
+		browserName,
+	}) => {
+		test.skip(
+			browserName !== 'chromium',
+			`This test relies on OPFS which isn't available in Playwright's flavor of ${browserName}.`
+		);
+
+		await website.goto(getTemporaryPlaygroundUrl());
+		await website.ensureSiteManagerIsOpen();
+
+		const pane = await openStorePermanentlyPane(website.page);
+
+		const nameInput = pane.getByLabel('Playground name');
+
+		// Verify the input is focused
+		await expect(nameInput).toBeFocused();
+
+		await expect
+			.poll(() =>
+				nameInput.evaluate(
+					(input: HTMLInputElement) =>
+						input.selectionStart === 0 &&
+						input.selectionEnd === input.value.length
+				)
+			)
+			.toBe(true);
+
+		// Type to replace the selected text
+		await website.page.keyboard.type('New Name');
+		await expect(nameInput).toHaveValue('New Name');
+
+		await pane.getByRole('button', { name: 'Cancel' }).click();
+	});
+
+	test('should save site with custom name', async ({
+		website,
+		browserName,
+	}) => {
+		test.skip(
+			browserName !== 'chromium',
+			`This test relies on OPFS which isn't available in Playwright's flavor of ${browserName}.`
+		);
+
+		await website.goto(getTemporaryPlaygroundUrl());
+		await website.ensureSiteManagerIsOpen();
+
+		const customName = 'My Custom Playground Name';
+
+		// Save with custom name using the helper
+		await saveSiteViaDockPane(website.page, { customName });
+
+		// Verify the site was saved with the custom name
+		await expect(getPlaygroundTitle(website.page)).toContainText(
+			customName,
+			{
+				timeout: 90000,
+			}
+		);
+
+		// Verify the name also appears in the Playgrounds pane.
+		await website.openPlaygroundsPane();
+		await expect(
+			website.page.locator('[class*="siteRowName"]', {
+				hasText: customName,
+			})
+		).toBeVisible();
+		await website.closePlaygroundsPane();
+	});
+
+	test('should not persist the Store permanently pane through page refresh', async ({
+		website,
+		browserName,
+	}) => {
+		test.skip(
+			browserName !== 'chromium',
+			`This test relies on OPFS which isn't available in Playwright's flavor of ${browserName}.`
+		);
+
+		await website.goto(getTemporaryPlaygroundUrl());
+		await website.ensureSiteManagerIsOpen();
+
+		const pane = await openStorePermanentlyPane(website.page);
+
+		// Dock pane state is not encoded in the URL.
+		expect(website.page.url()).not.toContain('modal=save-site');
+
+		// Reload the page
+		await website.page.reload();
+		await website.waitForPlaygroundShell();
+
+		await expect(pane).toHaveCount(0);
+	});
+
+	test('should display OPFS storage option as selected by default', async ({
+		website,
+		browserName,
+	}) => {
+		test.skip(
+			browserName !== 'chromium',
+			`This test relies on OPFS which isn't available in Playwright's flavor of ${browserName}.`
+		);
+
+		await website.goto(getTemporaryPlaygroundUrl());
+		await website.ensureSiteManagerIsOpen();
+
+		const pane = await openStorePermanentlyPane(website.page);
+
+		// Verify OPFS option is selected by default
+		const opfsRadio = pane.getByRole('radio', {
+			name: /Save in browser storage/,
+		});
+		await expect(opfsRadio).toBeChecked();
+
+		await pane.getByRole('button', { name: 'Cancel' }).click();
+	});
+
+	test('should import ZIP into a fresh temporary site without browser storage', async ({
+		website,
+		browserName,
+		context,
+	}) => {
+		test.skip(
+			browserName !== 'chromium',
+			'This test controls OPFS availability in Chromium.'
+		);
+		await context.addInitScript(() => {
+			Object.defineProperty(StorageManager.prototype, 'getDirectory', {
+				configurable: true,
+				value: undefined,
+			});
+		});
+
+		await website.goto(getTemporaryPlaygroundUrl());
+		const siteBeforeImport = await getActivePlaygroundSite(website.page);
+		expect(siteBeforeImport?.storage).toBe('temporary');
+
+		await website.openDockPane('New Playground');
+		await website.page
+			.getByRole('tab', { name: 'Import zip', exact: true })
+			.click();
+
+		const marker = 'TEMPORARY_ZIP_IMPORT_MARKER';
+		const markerPath = 'wp-content/temporary-zip-import-marker.txt';
+		const zipBuffer = await createTestWordPressZip(
+			marker,
+			'wp-content/index.php',
+			[new File([marker], markerPath)]
+		);
+		await website.page
+			.locator('input[type="file"][accept*=".zip"]')
+			.setInputFiles({
+				name: 'temporary-playground.zip',
+				mimeType: 'application/zip',
+				buffer: zipBuffer,
+			});
+
+		await expect(
+			website.page
+				.getByRole('group', { name: 'Operation succeeded' })
+				.filter({ hasText: 'Playground imported' })
+		).toBeVisible({ timeout: 120000 });
+		await expect(
+			website.page.getByRole('alert').filter({
+				hasText: 'Playground imported',
+			})
+		).toHaveCount(0);
+		const siteAfterImport = await getActivePlaygroundSite(website.page);
+		expect(siteAfterImport).toMatchObject({
+			storage: 'temporary',
+		});
+		expect(siteAfterImport.slug).not.toBe(siteBeforeImport.slug);
+		await expect
+			.poll(async () => {
+				return await website.page.evaluate(async (relativePath) => {
 					const playground = (
 						window as any
 					).playgroundSites.getClient();
-					if (!playground) {
-						return { plugin: false, theme: false };
-					}
 					const documentRoot = await playground.documentRoot;
-					return {
-						plugin: await playground.fileExists(
-							`${documentRoot}/wp-content/plugins/close-race-plugin/close-race-plugin.php`
-						),
-						theme: await playground.fileExists(
-							`${documentRoot}/wp-content/themes/close-race-theme/style.css`
-						),
-					};
-				}),
-			{ timeout: 90000 }
-		)
-		.toEqual({ plugin: true, theme: true });
-});
-
-// `@storage` routes this browser-scoped test to the one-worker CI lane.
-test('@storage should import ZIP into a new saved site when a saved site exists', async ({
-	website,
-	wordpress,
-	browserName,
-}) => {
-	test.skip(
-		browserName !== 'chromium',
-		`This test relies on OPFS which isn't available in Playwright's flavor of ${browserName}.`
-	);
-
-	// Start with a blueprint that writes a distinctive marker to distinguish the saved site
-	const savedSiteMarker = 'SAVED_SITE_CONTENT_MARKER_12345';
-	const blueprint: Blueprint = {
-		landingPage: '/test-marker.php',
-		steps: [
-			{
-				step: 'writeFile',
-				path: '/wordpress/test-marker.php',
-				data: `<?php echo '${savedSiteMarker}';`,
-			},
-		],
-	};
-	await website.goto(
-		getTemporaryPlaygroundUrl(`#${JSON.stringify(blueprint)}`)
-	);
-
-	// Verify the marker is present
-	await expect(wordpress.locator('body')).toContainText(savedSiteMarker);
-
-	await website.ensureSiteManagerIsOpen();
-
-	// Save the site with a custom name
-	const savedSiteName = 'ZIP Import Test Site';
-	await saveSiteViaDockPane(website.page, { customName: savedSiteName });
-
-	// Wait for the site to be saved (title should change from "Temporary Playground")
-	await expect(getPlaygroundTitle(website.page)).toContainText(
-		savedSiteName,
-		{ timeout: 90000 }
-	);
-
-	// Open the New pane where ZIP imports start.
-	await website.openDockPane('New Playground');
-	await website.page
-		.getByRole('tab', { name: 'Import zip', exact: true })
-		.click();
-
-	// Create a test ZIP with imported content marker
-	const importedMarker = 'IMPORTED_CONTENT_MARKER_67890';
-	const zipBuffer = await createTestWordPressZip(importedMarker);
-
-	// Find the hidden file input and upload the ZIP
-	const fileInput = website.page.locator(
-		'input[type="file"][accept*=".zip"]'
-	);
-
-	// Upload the ZIP file
-	await fileInput.setInputFiles({
-		name: 'test-import.zip',
-		mimeType: 'application/zip',
-		buffer: zipBuffer,
+					return await playground.readFileAsText(
+						`${documentRoot}/${relativePath}`
+					);
+				}, markerPath);
+			})
+			.toBe(marker);
 	});
-	await expect(
-		website.page.getByText('Playground imported', { exact: true })
-	).toBeVisible({ timeout: 120000 });
 
-	// The import should switch us to a new saved Playground by default.
-	await expect(getPlaygroundTitle(website.page)).not.toContainText(
-		savedSiteName,
-		{ timeout: 30000 }
-	);
-	await expect(getPlaygroundTitle(website.page)).not.toContainText(
-		'Unsaved Playground'
-	);
+	test('should remove the saved site created for a failed ZIP import', async ({
+		website,
+		browserName,
+	}) => {
+		test.skip(
+			browserName !== 'chromium',
+			`This test relies on OPFS which isn't available in Playwright's flavor of ${browserName}.`
+		);
 
-	// Now verify the saved site still has the original content.
-	// Open the Playgrounds pane and switch to the saved site.
-	await website.openPlaygroundsPane();
+		await website.goto(getTemporaryPlaygroundUrl());
+		const activeSiteBeforeImport = await getActivePlaygroundSite(
+			website.page
+		);
+		const storedSiteSlugsBeforeImport = await getStoredPlaygroundSiteSlugs(
+			website.page
+		);
+		expect(storedSiteSlugsBeforeImport).not.toBeNull();
 
-	await website.page
-		.getByRole('button', { name: `Open ${savedSiteName}`, exact: true })
-		.click();
-	await website.ensureSiteManagerIsOpen();
+		const importFailed = await website.page.evaluate(async () => {
+			try {
+				await (window as any).playgroundSites.createNewSiteFromZip(
+					new File(['not a zip archive'], 'invalid-playground.zip', {
+						type: 'application/zip',
+					})
+				);
+				return false;
+			} catch {
+				return true;
+			}
+		});
+		expect(importFailed).toBe(true);
 
-	// Wait for the saved site to load - this verifies the saved site wasn't overwritten
-	// by the ZIP import (which went to a new saved site instead)
-	await expect(getPlaygroundTitle(website.page)).toContainText(
-		savedSiteName,
-		{ timeout: 30000 }
-	);
-});
+		await expect
+			.poll(() => getStoredPlaygroundSiteSlugs(website.page))
+			.toEqual(storedSiteSlugsBeforeImport);
+		await expect
+			.poll(
+				async () => (await getActivePlaygroundSite(website.page))?.slug
+			)
+			.toBe(activeSiteBeforeImport.slug);
 
-// `@storage` routes this browser-scoped test to the one-worker CI lane.
-test('@storage should create a saved site when importing ZIP while on a saved site with no existing temporary site', async ({
-	website,
-	wordpress,
-	browserName,
-}) => {
-	test.skip(
-		browserName !== 'chromium',
-		`This test relies on OPFS which isn't available in Playwright's flavor of ${browserName}.`
-	);
-
-	// First, create and save a site
-	const savedSiteMarker = 'SAVED_ONLY_MARKER_AAAAA';
-	const blueprint: Blueprint = {
-		landingPage: '/saved-only-marker.php',
-		steps: [
-			{
-				step: 'writeFile',
-				path: '/wordpress/saved-only-marker.php',
-				data: `<?php echo '${savedSiteMarker}';`,
-			},
-		],
-	};
-	await website.goto(
-		getTemporaryPlaygroundUrl(`#${JSON.stringify(blueprint)}`)
-	);
-	await expect(wordpress.locator('body')).toContainText(savedSiteMarker);
-
-	await website.ensureSiteManagerIsOpen();
-
-	// Save the site
-	const savedSiteName = 'Direct Slug Test Site';
-	await saveSiteViaDockPane(website.page, { customName: savedSiteName });
-
-	await expect(getPlaygroundTitle(website.page)).toContainText(
-		savedSiteName,
-		{ timeout: 90000 }
-	);
-
-	// Get the site slug from the URL
-	const urlAfterSave = website.page.url();
-	const urlObj = new URL(urlAfterSave);
-	const siteSlug = urlObj.searchParams.get('site-slug');
-	expect(siteSlug).toBeTruthy();
-
-	// Now reload the page directly with the site-slug parameter.
-	// This simulates starting fresh with just the saved site (no temporary site).
-	await website.page.goto(`./?site-slug=${siteSlug}`);
-	await website.waitForNestedIframes();
-	await website.ensureSiteManagerIsOpen();
-
-	// Verify we're on the saved site
-	await expect(getPlaygroundTitle(website.page)).toContainText(savedSiteName);
-
-	// Open the New pane where ZIP imports start.
-	await website.openDockPane('New Playground');
-	await website.page
-		.getByRole('tab', { name: 'Import zip', exact: true })
-		.click();
-
-	// Create a test ZIP
-	const importedMarker = 'FRESH_IMPORT_MARKER_BBBBB';
-	const zipBuffer = await createTestWordPressZip(importedMarker);
-
-	// Find the file input
-	const fileInput = website.page.locator(
-		'input[type="file"][accept*=".zip"]'
-	);
-
-	// Upload the ZIP file
-	await fileInput.setInputFiles({
-		name: 'test-import-direct.zip',
-		mimeType: 'application/zip',
-		buffer: zipBuffer,
+		await website.page.reload();
+		await website.waitForPlaygroundShell();
+		await expect
+			.poll(() => getStoredPlaygroundSiteSlugs(website.page))
+			.toEqual(storedSiteSlugsBeforeImport);
 	});
-	await expect(
-		website.page.getByText('Playground imported', { exact: true })
-	).toBeVisible({ timeout: 120000 });
 
-	// The import should trigger creation of a new saved site by default.
-	await expect(getPlaygroundTitle(website.page)).not.toContainText(
-		savedSiteName,
-		{ timeout: 30000 }
-	);
-	await expect(getPlaygroundTitle(website.page)).not.toContainText(
-		'Unsaved Playground'
-	);
+	test('should import a ZIP dropped on the page', async ({
+		website,
+		wordpress,
+		browserName,
+	}) => {
+		test.skip(
+			browserName !== 'chromium',
+			`This test relies on OPFS which isn't available in Playwright's flavor of ${browserName}.`
+		);
 
-	// Verify the saved site is still intact by switching to it
-	await website.openPlaygroundsPane();
+		await website.goto(getTemporaryPlaygroundUrl());
+		const sourceSite = await getActivePlaygroundSite(website.page);
+		expect(sourceSite?.slug).toBeTruthy();
+		const sourceSiteSlug = sourceSite.slug;
 
-	await website.page
-		.getByRole('button', { name: `Open ${savedSiteName}`, exact: true })
-		.click();
-	await website.ensureSiteManagerIsOpen();
+		await website.openDockPane('New Playground');
+		await website.page
+			.getByRole('tab', { name: 'Import zip', exact: true })
+			.click();
 
-	// Wait for the saved site to load - this verifies the saved site wasn't overwritten
-	// by the ZIP import (which went to a new saved site instead)
-	await expect(getPlaygroundTitle(website.page)).toContainText(
-		savedSiteName,
-		{ timeout: 30000 }
-	);
-});
+		const marker = 'PAGE_DROP_ZIP_IMPORT_MARKER';
+		const markerPath = 'wp-content/page-drop-zip-import-marker.php';
+		const zipBuffer = await createTestWordPressZip(marker, markerPath);
+		await dropZipFile(website.page, 'page-drop-import.zip', zipBuffer);
 
-// `@storage` routes this browser-scoped test to the one-worker CI lane.
-test('@storage should persist an imported ZIP saved site after switching away and back', async ({
-	website,
-	wordpress,
-	browserName,
-}) => {
-	test.skip(
-		browserName !== 'chromium',
-		`This test relies on OPFS which isn't available in Playwright's flavor of ${browserName}.`
-	);
+		await expect(
+			website.page.getByText('Playground imported', { exact: true })
+		).toBeVisible({ timeout: 120000 });
+		await waitForActivePlaygroundSiteSlug(
+			website.page,
+			(slug) => slug !== sourceSiteSlug
+		);
+		await openPlaygroundPath(website.page, `/${markerPath}`);
+		await expect(wordpress.locator('body')).toContainText(marker);
+	});
 
-	const savedSiteMarker = 'ZIP_IMPORT_PERSISTENCE_SOURCE';
-	const blueprint: Blueprint = {
-		landingPage: '/saved-site-marker.php',
-		steps: [
-			{
-				step: 'writeFile',
-				path: '/wordpress/saved-site-marker.php',
-				data: `<?php echo '${savedSiteMarker}';`,
-			},
-		],
-	};
-	await website.goto(
-		getTemporaryPlaygroundUrl(`#${JSON.stringify(blueprint)}`)
-	);
-	await expect(wordpress.locator('body')).toContainText(savedSiteMarker);
+	test('should show an inline error for a non-ZIP drop', async ({
+		website,
+		browserName,
+	}) => {
+		test.skip(
+			browserName !== 'chromium',
+			`This test relies on OPFS which isn't available in Playwright's flavor of ${browserName}.`
+		);
 
-	await website.ensureSiteManagerIsOpen();
-	const savedSiteName = 'ZIP Import Persistence Source';
-	await saveSiteViaDockPane(website.page, { customName: savedSiteName });
-	await expect(getPlaygroundTitle(website.page)).toContainText(
-		savedSiteName,
-		{ timeout: 90000 }
-	);
-	const savedSite = await getActivePlaygroundSite(website.page);
-	expect(savedSite?.slug).toBeTruthy();
-	const savedSiteSlug = savedSite.slug;
+		await website.goto(getTemporaryPlaygroundUrl());
+		await website.openDockPane('New Playground');
+		await website.page
+			.getByRole('tab', { name: 'Import zip', exact: true })
+			.click();
+		await dropZipFile(
+			website.page,
+			'not-a-playground-export.txt',
+			Buffer.from('not a zip archive'),
+			false
+		);
 
-	await website.openDockPane('New Playground');
-	await website.page
-		.getByRole('tab', { name: 'Import zip', exact: true })
-		.click();
+		await expect(
+			website.page.getByRole('alert').filter({
+				hasText: 'Choose a WordPress Playground .zip export.',
+			})
+		).toBeVisible();
+	});
 
-	const importedMarker = 'ZIP_IMPORT_PERSISTED_MARKER';
-	const importedMarkerPath = 'imported-marker.php';
-	const zipBuffer = await createTestWordPressZip(
-		importedMarker,
-		importedMarkerPath
-	);
+	test('should notify when a ZIP import loads before autosave finishes', async ({
+		website,
+		browserName,
+	}) => {
+		test.skip(
+			browserName !== 'chromium',
+			`This test relies on OPFS which isn't available in Playwright's flavor of ${browserName}.`
+		);
 
-	await website.page
-		.locator('input[type="file"][accept*=".zip"]')
-		.setInputFiles({
-			name: 'test-import-persistence.zip',
+		await website.goto(getTemporaryPlaygroundUrl());
+		const sourceSite = await getActivePlaygroundSite(website.page);
+		expect(sourceSite?.slug).toBeTruthy();
+		await website.openDockPane('New Playground');
+		await website.page
+			.getByRole('tab', { name: 'Import zip', exact: true })
+			.click();
+
+		const zipBuffer = await createPluginThemeExportZip();
+		const fileInput = website.page.locator(
+			'input[type="file"][accept*=".zip"]'
+		);
+		const pane = website.page.getByRole('dialog', {
+			name: 'New Playground pane',
+		});
+		const importProgress = website.page.getByRole('progressbar', {
+			name: 'WordPress import progress',
+		});
+		const autosaveProgress = website.page.getByRole('progressbar', {
+			name: 'Autosave progress',
+		});
+		const importNotice = website.page
+			.getByRole('group', { name: 'Operation succeeded' })
+			.filter({ hasText: 'Playground imported' });
+		const importProgressStarted = expect(importProgress).toBeVisible({
+			timeout: 120000,
+		});
+		const notifyWhileAutosaving = (async () => {
+			await expect(autosaveProgress).toBeVisible({ timeout: 120000 });
+			const importedSite = await getActivePlaygroundSite(website.page);
+			expect(importedSite).toMatchObject({
+				storage: 'opfs',
+				persistence: 'autosave',
+			});
+			await setActivePlaygroundSite(website.page, sourceSite.slug);
+			await expect(importNotice).toBeVisible();
+			expect(
+				await getInitialOpfsSyncPending(website.page, importedSite.slug)
+			).toBe(true);
+			return importedSite;
+		})();
+		const importProgressAdvanced = expect
+			.poll(
+				async () => {
+					return (
+						Number(
+							await importProgress.getAttribute('aria-valuenow')
+						) > 0
+					);
+				},
+				{
+					intervals: [16],
+					timeout: 120000,
+				}
+			)
+			.toBe(true);
+		await fileInput.setInputFiles({
+			name: 'playground-export-with-plugin-and-theme.zip',
 			mimeType: 'application/zip',
 			buffer: zipBuffer,
 		});
+		await expect(pane).not.toBeVisible();
+		await importProgressStarted;
+		await expect(autosaveProgress).toHaveCount(0);
+		await importProgressAdvanced;
+		await expect(importProgress).toHaveCount(0, { timeout: 120000 });
+		const importedSite = await notifyWhileAutosaving;
 
-	await expect(
-		website.page.getByText('Playground imported', { exact: true })
-	).toBeVisible({ timeout: 120000 });
-	const importedSite = await waitForActivePlaygroundSiteSlug(
-		website.page,
-		(slug) => slug !== savedSiteSlug
-	);
-	expect(importedSite?.slug).toBeTruthy();
-	const importedSiteSlug = importedSite.slug;
-	await waitForInitialOpfsSync(website.page, importedSiteSlug);
-	// Discard the import runtime before requesting the marker. The fresh runtime
-	// must load the imported file from persisted OPFS state.
-	await website.goto(`./?site-slug=${encodeURIComponent(importedSiteSlug)}`);
-	await openPlaygroundPath(website.page, `/${importedMarkerPath}`);
-	await expect(wordpress.locator('body')).toContainText(importedMarker);
+		// Reopen the retained import runtime before its background sync finishes.
+		// setActiveSite() must not wait for a second client-added event.
+		await setActivePlaygroundSite(website.page, importedSite.slug);
+		expect((await getActivePlaygroundSite(website.page)).slug).toBe(
+			importedSite.slug
+		);
+		await setActivePlaygroundSite(website.page, sourceSite.slug);
 
-	await setActivePlaygroundSite(website.page, savedSiteSlug);
-	await website.waitForNestedIframes();
-	await expect(getPlaygroundTitle(website.page)).toContainText(
-		savedSiteName,
-		{ timeout: 30000 }
-	);
-
-	await setActivePlaygroundSite(website.page, importedSiteSlug);
-	await website.waitForNestedIframes();
-	await openPlaygroundPath(website.page, `/${importedMarkerPath}`);
-	await expect(wordpress.locator('body')).toContainText(importedMarker);
-
-	await website.goto(`./?site-slug=${encodeURIComponent(importedSiteSlug)}`);
-	await openPlaygroundPath(website.page, `/${importedMarkerPath}`);
-	await expect(wordpress.locator('body')).toContainText(importedMarker);
-});
-
-// `@storage` routes this browser-scoped test to the one-worker CI lane.
-test('@storage should retain files omitted from a legacy ZIP export', async ({
-	website,
-	wordpress,
-	browserName,
-}) => {
-	test.skip(
-		browserName !== 'chromium',
-		`This test relies on OPFS which isn't available in Playwright's flavor of ${browserName}.`
-	);
-
-	await website.goto(getTemporaryPlaygroundUrl());
-	const sourceSite = await getActivePlaygroundSite(website.page);
-	expect(sourceSite?.slug).toBeTruthy();
-	const sourceSiteSlug = sourceSite.slug;
-
-	await website.openDockPane('New Playground');
-	await website.page
-		.getByRole('tab', { name: 'Import zip', exact: true })
-		.click();
-
-	const legacyMarker = 'LEGACY_ZIP_IMPORT_MARKER';
-	const legacyMarkerPath = 'wp-content/plugins/legacy-zip-import-marker.php';
-	const zipBuffer = await createTestWordPressZip(
-		legacyMarker,
-		legacyMarkerPath,
-		[
-			new File(
-				[JSON.stringify({ siteUrl: 'http://playground-domain/' })],
-				'playground-export.json'
-			),
-		]
-	);
-	let importDialogAccepted = false;
-	const acceptImportDialog = async (dialog: { accept(): Promise<void> }) => {
-		await dialog.accept();
-		importDialogAccepted = true;
-	};
-	website.page.on('dialog', acceptImportDialog);
-	await website.page
-		.locator('input[type="file"][accept*=".zip"]')
-		.setInputFiles({
-			name: 'legacy-playground-export.zip',
-			mimeType: 'application/zip',
-			buffer: zipBuffer,
+		const newPlaygroundButton = website.page.getByRole('button', {
+			name: 'New Playground',
+			exact: true,
 		});
+		await expect(newPlaygroundButton).toBeEnabled();
 
-	await expect
-		.poll(
-			() =>
-				website.page.evaluate(
-					async ({ originalSlug, markerPath }) => {
-						const sitesAPI = (window as any).playgroundSites;
-						if (!sitesAPI) {
-							return { marker: false, defaultTheme: false };
-						}
-						const activeSite = sitesAPI
-							.list()
-							.find((site: any) => site.isActive);
-						const playground = sitesAPI.getClient();
-						if (
-							!activeSite ||
-							activeSite.slug === originalSlug ||
-							!playground
-						) {
-							return { marker: false, defaultTheme: false };
+		// A full page load discards the retained runtime. Let its background sync
+		// finish before verifying that the imported files survive a cold boot.
+		await waitForInitialOpfsSync(website.page, importedSite.slug);
+		await website.goto(
+			`./?site-slug=${encodeURIComponent(importedSite.slug)}`
+		);
+
+		await expect
+			.poll(
+				() =>
+					website.page.evaluate(async () => {
+						const playground = (
+							window as any
+						).playgroundSites.getClient();
+						if (!playground) {
+							return { plugin: false, theme: false };
 						}
 						const documentRoot = await playground.documentRoot;
 						return {
-							marker: await playground.fileExists(
-								`${documentRoot}/${markerPath}`
+							plugin: await playground.fileExists(
+								`${documentRoot}/wp-content/plugins/close-race-plugin/close-race-plugin.php`
 							),
-							defaultTheme: await playground.fileExists(
-								`${documentRoot}/wp-content/themes/twentytwentyfive/theme.json`
+							theme: await playground.fileExists(
+								`${documentRoot}/wp-content/themes/close-race-theme/style.css`
 							),
 						};
-					},
-					{
-						originalSlug: sourceSiteSlug,
-						markerPath: legacyMarkerPath,
-					}
+					}),
+				{ timeout: 90000 }
+			)
+			.toEqual({ plugin: true, theme: true });
+	});
+
+	test('should import ZIP into a new saved site when a saved site exists', async ({
+		website,
+		wordpress,
+		browserName,
+	}) => {
+		test.skip(
+			browserName !== 'chromium',
+			`This test relies on OPFS which isn't available in Playwright's flavor of ${browserName}.`
+		);
+
+		// Start with a blueprint that writes a distinctive marker to distinguish the saved site
+		const savedSiteMarker = 'SAVED_SITE_CONTENT_MARKER_12345';
+		const blueprint: Blueprint = {
+			landingPage: '/test-marker.php',
+			steps: [
+				{
+					step: 'writeFile',
+					path: '/wordpress/test-marker.php',
+					data: `<?php echo '${savedSiteMarker}';`,
+				},
+			],
+		};
+		await website.goto(
+			getTemporaryPlaygroundUrl(`#${JSON.stringify(blueprint)}`)
+		);
+
+		// Verify the marker is present
+		await expect(wordpress.locator('body')).toContainText(savedSiteMarker);
+
+		await website.ensureSiteManagerIsOpen();
+
+		// Save the site with a custom name
+		const savedSiteName = 'ZIP Import Test Site';
+		await saveSiteViaDockPane(website.page, { customName: savedSiteName });
+
+		// Wait for the site to be saved (title should change from "Temporary Playground")
+		await expect(getPlaygroundTitle(website.page)).toContainText(
+			savedSiteName,
+			{ timeout: 90000 }
+		);
+
+		// Open the New pane where ZIP imports start.
+		await website.openDockPane('New Playground');
+		await website.page
+			.getByRole('tab', { name: 'Import zip', exact: true })
+			.click();
+
+		// Create a test ZIP with imported content marker
+		const importedMarker = 'IMPORTED_CONTENT_MARKER_67890';
+		const zipBuffer = await createTestWordPressZip(importedMarker);
+
+		// Find the hidden file input and upload the ZIP
+		const fileInput = website.page.locator(
+			'input[type="file"][accept*=".zip"]'
+		);
+
+		// Upload the ZIP file
+		await fileInput.setInputFiles({
+			name: 'test-import.zip',
+			mimeType: 'application/zip',
+			buffer: zipBuffer,
+		});
+		await expect(
+			website.page.getByText('Playground imported', { exact: true })
+		).toBeVisible({ timeout: 120000 });
+
+		// The import should switch us to a new saved Playground by default.
+		await expect(getPlaygroundTitle(website.page)).not.toContainText(
+			savedSiteName,
+			{ timeout: 30000 }
+		);
+		await expect(getPlaygroundTitle(website.page)).not.toContainText(
+			'Unsaved Playground'
+		);
+
+		// Now verify the saved site still has the original content.
+		// Open the Playgrounds pane and switch to the saved site.
+		await website.openPlaygroundsPane();
+
+		await website.page
+			.getByRole('button', { name: `Open ${savedSiteName}`, exact: true })
+			.click();
+		await website.ensureSiteManagerIsOpen();
+
+		// Wait for the saved site to load - this verifies the saved site wasn't overwritten
+		// by the ZIP import (which went to a new saved site instead)
+		await expect(getPlaygroundTitle(website.page)).toContainText(
+			savedSiteName,
+			{ timeout: 30000 }
+		);
+	});
+
+	test('should create a saved site when importing ZIP while on a saved site with no existing temporary site', async ({
+		website,
+		wordpress,
+		browserName,
+	}) => {
+		test.skip(
+			browserName !== 'chromium',
+			`This test relies on OPFS which isn't available in Playwright's flavor of ${browserName}.`
+		);
+
+		// First, create and save a site
+		const savedSiteMarker = 'SAVED_ONLY_MARKER_AAAAA';
+		const blueprint: Blueprint = {
+			landingPage: '/saved-only-marker.php',
+			steps: [
+				{
+					step: 'writeFile',
+					path: '/wordpress/saved-only-marker.php',
+					data: `<?php echo '${savedSiteMarker}';`,
+				},
+			],
+		};
+		await website.goto(
+			getTemporaryPlaygroundUrl(`#${JSON.stringify(blueprint)}`)
+		);
+		await expect(wordpress.locator('body')).toContainText(savedSiteMarker);
+
+		await website.ensureSiteManagerIsOpen();
+
+		// Save the site
+		const savedSiteName = 'Direct Slug Test Site';
+		await saveSiteViaDockPane(website.page, { customName: savedSiteName });
+
+		await expect(getPlaygroundTitle(website.page)).toContainText(
+			savedSiteName,
+			{ timeout: 90000 }
+		);
+
+		// Get the site slug from the URL
+		const urlAfterSave = website.page.url();
+		const urlObj = new URL(urlAfterSave);
+		const siteSlug = urlObj.searchParams.get('site-slug');
+		expect(siteSlug).toBeTruthy();
+
+		// Now reload the page directly with the site-slug parameter.
+		// This simulates starting fresh with just the saved site (no temporary site).
+		await website.page.goto(`./?site-slug=${siteSlug}`);
+		await website.waitForNestedIframes();
+		await website.ensureSiteManagerIsOpen();
+
+		// Verify we're on the saved site
+		await expect(getPlaygroundTitle(website.page)).toContainText(
+			savedSiteName
+		);
+
+		// Open the New pane where ZIP imports start.
+		await website.openDockPane('New Playground');
+		await website.page
+			.getByRole('tab', { name: 'Import zip', exact: true })
+			.click();
+
+		// Create a test ZIP
+		const importedMarker = 'FRESH_IMPORT_MARKER_BBBBB';
+		const zipBuffer = await createTestWordPressZip(importedMarker);
+
+		// Find the file input
+		const fileInput = website.page.locator(
+			'input[type="file"][accept*=".zip"]'
+		);
+
+		// Upload the ZIP file
+		await fileInput.setInputFiles({
+			name: 'test-import-direct.zip',
+			mimeType: 'application/zip',
+			buffer: zipBuffer,
+		});
+		await expect(
+			website.page.getByText('Playground imported', { exact: true })
+		).toBeVisible({ timeout: 120000 });
+
+		// The import should trigger creation of a new saved site by default.
+		await expect(getPlaygroundTitle(website.page)).not.toContainText(
+			savedSiteName,
+			{ timeout: 30000 }
+		);
+		await expect(getPlaygroundTitle(website.page)).not.toContainText(
+			'Unsaved Playground'
+		);
+
+		// Verify the saved site is still intact by switching to it
+		await website.openPlaygroundsPane();
+
+		await website.page
+			.getByRole('button', { name: `Open ${savedSiteName}`, exact: true })
+			.click();
+		await website.ensureSiteManagerIsOpen();
+
+		// Wait for the saved site to load - this verifies the saved site wasn't overwritten
+		// by the ZIP import (which went to a new saved site instead)
+		await expect(getPlaygroundTitle(website.page)).toContainText(
+			savedSiteName,
+			{ timeout: 30000 }
+		);
+	});
+
+	test('should persist an imported ZIP saved site after switching away and back', async ({
+		website,
+		wordpress,
+		browserName,
+	}) => {
+		test.skip(
+			browserName !== 'chromium',
+			`This test relies on OPFS which isn't available in Playwright's flavor of ${browserName}.`
+		);
+
+		const savedSiteMarker = 'ZIP_IMPORT_PERSISTENCE_SOURCE';
+		const blueprint: Blueprint = {
+			landingPage: '/saved-site-marker.php',
+			steps: [
+				{
+					step: 'writeFile',
+					path: '/wordpress/saved-site-marker.php',
+					data: `<?php echo '${savedSiteMarker}';`,
+				},
+			],
+		};
+		await website.goto(
+			getTemporaryPlaygroundUrl(`#${JSON.stringify(blueprint)}`)
+		);
+		await expect(wordpress.locator('body')).toContainText(savedSiteMarker);
+
+		await website.ensureSiteManagerIsOpen();
+		const savedSiteName = 'ZIP Import Persistence Source';
+		await saveSiteViaDockPane(website.page, { customName: savedSiteName });
+		await expect(getPlaygroundTitle(website.page)).toContainText(
+			savedSiteName,
+			{ timeout: 90000 }
+		);
+		const savedSite = await getActivePlaygroundSite(website.page);
+		expect(savedSite?.slug).toBeTruthy();
+		const savedSiteSlug = savedSite.slug;
+
+		await website.openDockPane('New Playground');
+		await website.page
+			.getByRole('tab', { name: 'Import zip', exact: true })
+			.click();
+
+		const importedMarker = 'ZIP_IMPORT_PERSISTED_MARKER';
+		const importedMarkerPath = 'imported-marker.php';
+		const zipBuffer = await createTestWordPressZip(
+			importedMarker,
+			importedMarkerPath
+		);
+
+		await website.page
+			.locator('input[type="file"][accept*=".zip"]')
+			.setInputFiles({
+				name: 'test-import-persistence.zip',
+				mimeType: 'application/zip',
+				buffer: zipBuffer,
+			});
+
+		await expect(
+			website.page.getByText('Playground imported', { exact: true })
+		).toBeVisible({ timeout: 120000 });
+		const importedSite = await waitForActivePlaygroundSiteSlug(
+			website.page,
+			(slug) => slug !== savedSiteSlug
+		);
+		expect(importedSite?.slug).toBeTruthy();
+		const importedSiteSlug = importedSite.slug;
+		await waitForInitialOpfsSync(website.page, importedSiteSlug);
+		// Discard the import runtime before requesting the marker. The fresh runtime
+		// must load the imported file from persisted OPFS state.
+		await website.goto(
+			`./?site-slug=${encodeURIComponent(importedSiteSlug)}`
+		);
+		await openPlaygroundPath(website.page, `/${importedMarkerPath}`);
+		await expect(wordpress.locator('body')).toContainText(importedMarker);
+
+		await setActivePlaygroundSite(website.page, savedSiteSlug);
+		await website.waitForNestedIframes();
+		await expect(getPlaygroundTitle(website.page)).toContainText(
+			savedSiteName,
+			{ timeout: 30000 }
+		);
+
+		await setActivePlaygroundSite(website.page, importedSiteSlug);
+		await website.waitForNestedIframes();
+		await openPlaygroundPath(website.page, `/${importedMarkerPath}`);
+		await expect(wordpress.locator('body')).toContainText(importedMarker);
+
+		await website.goto(
+			`./?site-slug=${encodeURIComponent(importedSiteSlug)}`
+		);
+		await openPlaygroundPath(website.page, `/${importedMarkerPath}`);
+		await expect(wordpress.locator('body')).toContainText(importedMarker);
+	});
+
+	test('should retain files omitted from a legacy ZIP export', async ({
+		website,
+		wordpress,
+		browserName,
+	}) => {
+		test.skip(
+			browserName !== 'chromium',
+			`This test relies on OPFS which isn't available in Playwright's flavor of ${browserName}.`
+		);
+
+		await website.goto(getTemporaryPlaygroundUrl());
+		const sourceSite = await getActivePlaygroundSite(website.page);
+		expect(sourceSite?.slug).toBeTruthy();
+		const sourceSiteSlug = sourceSite.slug;
+
+		await website.openDockPane('New Playground');
+		await website.page
+			.getByRole('tab', { name: 'Import zip', exact: true })
+			.click();
+
+		const legacyMarker = 'LEGACY_ZIP_IMPORT_MARKER';
+		const legacyMarkerPath =
+			'wp-content/plugins/legacy-zip-import-marker.php';
+		const zipBuffer = await createTestWordPressZip(
+			legacyMarker,
+			legacyMarkerPath,
+			[
+				new File(
+					[JSON.stringify({ siteUrl: 'http://playground-domain/' })],
+					'playground-export.json'
 				),
-			{ timeout: 120000 }
-		)
-		.toEqual({ marker: true, defaultTheme: true });
-	await expect
-		.poll(
-			async () =>
-				importDialogAccepted ||
-				(await website.page
-					.getByText('Playground imported', { exact: true })
-					.isVisible()),
-			{ timeout: 120000 }
-		)
-		.toBe(true);
-	website.page.off('dialog', acceptImportDialog);
+			]
+		);
+		let importDialogAccepted = false;
+		const acceptImportDialog = async (dialog: {
+			accept(): Promise<void>;
+		}) => {
+			await dialog.accept();
+			importDialogAccepted = true;
+		};
+		website.page.on('dialog', acceptImportDialog);
+		await website.page
+			.locator('input[type="file"][accept*=".zip"]')
+			.setInputFiles({
+				name: 'legacy-playground-export.zip',
+				mimeType: 'application/zip',
+				buffer: zipBuffer,
+			});
 
-	await website.waitForNestedIframes();
-	await openPlaygroundPath(website.page, '/');
-	await expect(wordpress.locator('body')).toBeVisible();
-	await expect(wordpress.locator('body')).not.toContainText(
-		'There has been a critical error'
-	);
-});
+		await expect
+			.poll(
+				() =>
+					website.page.evaluate(
+						async ({ originalSlug, markerPath }) => {
+							const sitesAPI = (window as any).playgroundSites;
+							if (!sitesAPI) {
+								return { marker: false, defaultTheme: false };
+							}
+							const activeSite = sitesAPI
+								.list()
+								.find((site: any) => site.isActive);
+							const playground = sitesAPI.getClient();
+							if (
+								!activeSite ||
+								activeSite.slug === originalSlug ||
+								!playground
+							) {
+								return { marker: false, defaultTheme: false };
+							}
+							const documentRoot = await playground.documentRoot;
+							return {
+								marker: await playground.fileExists(
+									`${documentRoot}/${markerPath}`
+								),
+								defaultTheme: await playground.fileExists(
+									`${documentRoot}/wp-content/themes/twentytwentyfive/theme.json`
+								),
+							};
+						},
+						{
+							originalSlug: sourceSiteSlug,
+							markerPath: legacyMarkerPath,
+						}
+					),
+				{ timeout: 120000 }
+			)
+			.toEqual({ marker: true, defaultTheme: true });
+		await expect
+			.poll(
+				async () =>
+					importDialogAccepted ||
+					(await website.page
+						.getByText('Playground imported', { exact: true })
+						.isVisible()),
+				{ timeout: 120000 }
+			)
+			.toBe(true);
+		website.page.off('dialog', acceptImportDialog);
 
-// `@storage` routes this browser-scoped test to the one-worker CI lane.
-test('@storage should re-import an exported ZIP without switching sites', async ({
-	website,
-	context,
-	browserName,
-}) => {
-	test.skip(
-		browserName !== 'chromium',
-		`This test relies on OPFS which isn't available in Playwright's flavor of ${browserName}.`
-	);
+		await website.waitForNestedIframes();
+		await openPlaygroundPath(website.page, '/');
+		await expect(wordpress.locator('body')).toBeVisible();
+		await expect(wordpress.locator('body')).not.toContainText(
+			'There has been a critical error'
+		);
+	});
 
-	const blueprint: Blueprint = {
-		meta: {
-			title: 'ZIP Reimport Regression',
-			author: 'wordpress',
-		},
-		steps: [],
-	};
-	const sourceUrl = getTemporaryPlaygroundUrl(
-		`#${JSON.stringify(blueprint)}`
-	);
-	await website.goto(sourceUrl);
-	const sourceSiteSlug = await website.page.evaluate(() =>
-		(window as any).playgroundSites.createNewSavedSite(
-			undefined,
-			undefined,
-			{
-				persistence: 'autosave',
-				updateUrl: false,
-			}
-		)
-	);
+	test('should re-import an exported ZIP without switching sites', async ({
+		website,
+		context,
+		browserName,
+	}) => {
+		test.skip(
+			browserName !== 'chromium',
+			`This test relies on OPFS which isn't available in Playwright's flavor of ${browserName}.`
+		);
 
-	// Occupy the next slug after this tab loaded. Its Redux snapshot will not
-	// include this site, but both tabs share OPFS.
-	const secondTab = await context.newPage();
-	await secondTab.goto(new URL(sourceUrl, website.page.url()).href);
-	await secondTab.waitForFunction(() =>
-		Boolean((window as any).playgroundSites?.getClient())
-	);
-	const occupiedSiteSlug = await secondTab.evaluate(
-		(slugToKeep) =>
+		const blueprint: Blueprint = {
+			meta: {
+				title: 'ZIP Reimport Regression',
+				author: 'wordpress',
+			},
+			steps: [],
+		};
+		const sourceUrl = getTemporaryPlaygroundUrl(
+			`#${JSON.stringify(blueprint)}`
+		);
+		await website.goto(sourceUrl);
+		const sourceSiteSlug = await website.page.evaluate(() =>
 			(window as any).playgroundSites.createNewSavedSite(
 				undefined,
 				undefined,
 				{
+					persistence: 'autosave',
 					updateUrl: false,
-					excludeFromPruning: [slugToKeep],
 				}
-			),
-		sourceSiteSlug
-	);
-	await secondTab.close();
+			)
+		);
 
-	expect(occupiedSiteSlug).not.toBe(sourceSiteSlug);
-	expect((await getActivePlaygroundSite(website.page))?.slug).toBe(
-		sourceSiteSlug
-	);
+		// Occupy the next slug after this tab loaded. Its Redux snapshot will not
+		// include this site, but both tabs share OPFS.
+		const secondTab = await context.newPage();
+		await secondTab.goto(new URL(sourceUrl, website.page.url()).href);
+		await secondTab.waitForFunction(() =>
+			Boolean((window as any).playgroundSites?.getClient())
+		);
+		const occupiedSiteSlug = await secondTab.evaluate(
+			(slugToKeep) =>
+				(window as any).playgroundSites.createNewSavedSite(
+					undefined,
+					undefined,
+					{
+						updateUrl: false,
+						excludeFromPruning: [slugToKeep],
+					}
+				),
+			sourceSiteSlug
+		);
+		await secondTab.close();
 
-	await website.openDockPane('Export');
-	const downloadPromise = website.page.waitForEvent('download');
-	await website.page
-		.getByRole('dialog', { name: 'Export pane' })
-		.getByRole('button', { name: 'Download as .zip' })
-		.click();
-	const download = await downloadPromise;
-	const downloadPath = await download.path();
-	expect(downloadPath).toBeTruthy();
-	const zipBuffer = await readFile(downloadPath!);
+		expect(occupiedSiteSlug).not.toBe(sourceSiteSlug);
+		expect((await getActivePlaygroundSite(website.page))?.slug).toBe(
+			sourceSiteSlug
+		);
 
-	// Downloading must not change the active site before the ZIP is imported.
-	expect((await getActivePlaygroundSite(website.page))?.slug).toBe(
-		sourceSiteSlug
-	);
+		await website.openDockPane('Export');
+		const downloadPromise = website.page.waitForEvent('download');
+		await website.page
+			.getByRole('dialog', { name: 'Export pane' })
+			.getByRole('button', { name: 'Download as .zip' })
+			.click();
+		const download = await downloadPromise;
+		const downloadPath = await download.path();
+		expect(downloadPath).toBeTruthy();
+		const zipBuffer = await readFile(downloadPath!);
 
-	await website.openDockPane('New Playground');
-	await website.page
-		.getByRole('tab', { name: 'Import zip', exact: true })
-		.click();
-	const acceptImportDialog = async (dialog: { accept(): Promise<void> }) => {
-		await dialog.accept();
-	};
-	website.page.on('dialog', acceptImportDialog);
-	await website.page
-		.locator('input[type="file"][accept*=".zip"]')
-		.setInputFiles({
-			name: 'zip-reimport-regression.zip',
-			mimeType: 'application/zip',
-			buffer: zipBuffer,
-		});
+		// Downloading must not change the active site before the ZIP is imported.
+		expect((await getActivePlaygroundSite(website.page))?.slug).toBe(
+			sourceSiteSlug
+		);
 
-	await expect(
-		website.page.getByText('Playground imported', { exact: true })
-	).toBeVisible({ timeout: 120000 });
-	const importedSite = await waitForActivePlaygroundSiteSlug(
-		website.page,
-		(slug) => slug !== sourceSiteSlug
-	);
-	website.page.off('dialog', acceptImportDialog);
-	expect(importedSite.slug).not.toBe(occupiedSiteSlug);
-});
+		await website.openDockPane('New Playground');
+		await website.page
+			.getByRole('tab', { name: 'Import zip', exact: true })
+			.click();
+		const acceptImportDialog = async (dialog: {
+			accept(): Promise<void>;
+		}) => {
+			await dialog.accept();
+		};
+		website.page.on('dialog', acceptImportDialog);
+		await website.page
+			.locator('input[type="file"][accept*=".zip"]')
+			.setInputFiles({
+				name: 'zip-reimport-regression.zip',
+				mimeType: 'application/zip',
+				buffer: zipBuffer,
+			});
 
-// `@storage` routes this browser-scoped test to the one-worker CI lane.
-test('@storage should preserve a customized default-theme background through export and import', async ({
-	website,
-	wordpress,
-	browserName,
-}) => {
-	test.skip(
-		browserName !== 'chromium',
-		`This test relies on OPFS which isn't available in Playwright's flavor of ${browserName}.`
-	);
+		await expect(
+			website.page.getByText('Playground imported', { exact: true })
+		).toBeVisible({ timeout: 120000 });
+		const importedSite = await waitForActivePlaygroundSiteSlug(
+			website.page,
+			(slug) => slug !== sourceSiteSlug
+		);
+		website.page.off('dialog', acceptImportDialog);
+		expect(importedSite.slug).not.toBe(occupiedSiteSlug);
+	});
 
-	const purpleBackground = '#7f54b3';
-	const purpleBackgroundRgb = 'rgb(127, 84, 179)';
-	// Keep the customization in stock-theme files, which older imports replaced
-	// with pristine files from the new runtime.
-	const blueprint: Blueprint = {
-		landingPage: '/',
-		steps: [
-			{
-				step: 'runPHP',
-				code: `<?php
+	test('should preserve a customized default-theme background through export and import', async ({
+		website,
+		wordpress,
+		browserName,
+	}) => {
+		test.skip(
+			browserName !== 'chromium',
+			`This test relies on OPFS which isn't available in Playwright's flavor of ${browserName}.`
+		);
+
+		const purpleBackground = '#7f54b3';
+		const purpleBackgroundRgb = 'rgb(127, 84, 179)';
+		// Keep the customization in stock-theme files, which older imports replaced
+		// with pristine files from the new runtime.
+		const blueprint: Blueprint = {
+			landingPage: '/',
+			steps: [
+				{
+					step: 'runPHP',
+					code: `<?php
 					$functions_path = '/wordpress/wp-content/themes/twentytwentyfive/functions.php';
 					$customization = <<<'PHP'
 add_action('wp_head', function() {
@@ -1960,164 +1984,167 @@ PHP;
 						FILE_APPEND
 					);
 				`,
-			},
-			{
-				step: 'activateTheme',
-				themeFolderName: 'twentytwentyfive',
-			},
-		],
-	};
-	await website.goto(
-		getTemporaryPlaygroundUrl(`#${JSON.stringify(blueprint)}`)
-	);
-	await expect(wordpress.locator('body')).toHaveCSS(
-		'background-color',
-		purpleBackgroundRgb
-	);
-	const sourceSite = await getActivePlaygroundSite(website.page);
-	expect(sourceSite?.slug).toBeTruthy();
-	const sourceSiteSlug = sourceSite.slug;
-
-	await website.openDockPane('Export');
-	const downloadPromise = website.page.waitForEvent('download');
-	await website.page
-		.getByRole('dialog', { name: 'Export pane' })
-		.getByRole('button', { name: 'Download as .zip' })
-		.click();
-	const download = await downloadPromise;
-	const downloadPath = await download.path();
-	expect(downloadPath).toBeTruthy();
-	const zipBuffer = await readFile(downloadPath!);
-
-	await website.openDockPane('New Playground');
-	await website.page
-		.getByRole('tab', { name: 'Import zip', exact: true })
-		.click();
-	let importDialogAccepted = false;
-	const acceptImportDialog = async (dialog: { accept(): Promise<void> }) => {
-		await dialog.accept();
-		importDialogAccepted = true;
-	};
-	website.page.on('dialog', acceptImportDialog);
-	await website.page
-		.locator('input[type="file"][accept*=".zip"]')
-		.setInputFiles({
-			name: 'brewcommerce-purple-export.zip',
-			mimeType: 'application/zip',
-			buffer: zipBuffer,
-		});
-	const importedSite = await waitForActivePlaygroundSiteSlug(
-		website.page,
-		(slug) => slug !== sourceSiteSlug
-	);
-	expect(importedSite?.slug).toBeTruthy();
-	const importedSiteSlug = importedSite.slug;
-	await expect
-		.poll(() =>
-			website.page.evaluate(async (background) => {
-				const sitesAPI = (window as any).playgroundSites;
-				const playground = sitesAPI?.getClient();
-				if (!playground) {
-					return false;
-				}
-				const documentRoot = await playground.documentRoot;
-				return (
-					await playground.readFileAsText(
-						`${documentRoot}/wp-content/themes/twentytwentyfive/functions.php`
-					)
-				).includes(background);
-			}, purpleBackground)
-		)
-		.toBe(true);
-	await expect
-		.poll(
-			async () =>
-				importDialogAccepted ||
-				(await website.page
-					.getByText('Playground imported', { exact: true })
-					.isVisible()),
-			{ timeout: 120000 }
-		)
-		.toBe(true);
-	website.page.off('dialog', acceptImportDialog);
-
-	await waitForInitialOpfsSync(website.page, importedSiteSlug);
-	// Reboot the imported site so the final assertion reads the customization
-	// from persisted OPFS state rather than the import runtime.
-	await website.goto(`./?site-slug=${encodeURIComponent(importedSiteSlug)}`);
-	await waitForActivePlaygroundSiteSlug(
-		website.page,
-		(slug) => slug === importedSiteSlug
-	);
-	await openPlaygroundPath(website.page, '/');
-	await expect(wordpress.locator('body')).toHaveCSS(
-		'background-color',
-		purpleBackgroundRgb
-	);
-});
-
-// Missing site modal tests in a separate describe block to avoid state pollution.
-test.describe('Missing site modal', () => {
-	// `@storage` routes this browser-scoped test to the one-worker CI lane.
-	test('@storage should show modal when loading non-existent site slug', async ({
-		website,
-		wordpress,
-		browserName,
-		context,
-	}) => {
-		test.skip(
-			browserName !== 'chromium',
-			`This test relies on OPFS which isn't available in Playwright's flavor of ${browserName}.`
+				},
+				{
+					step: 'activateTheme',
+					themeFolderName: 'twentytwentyfive',
+				},
+			],
+		};
+		await website.goto(
+			getTemporaryPlaygroundUrl(`#${JSON.stringify(blueprint)}`)
 		);
+		await expect(wordpress.locator('body')).toHaveCSS(
+			'background-color',
+			purpleBackgroundRgb
+		);
+		const sourceSite = await getActivePlaygroundSite(website.page);
+		expect(sourceSite?.slug).toBeTruthy();
+		const sourceSiteSlug = sourceSite.slug;
 
-		// Clear all storage to ensure clean state
-		await context.clearCookies();
+		await website.openDockPane('Export');
+		const downloadPromise = website.page.waitForEvent('download');
+		await website.page
+			.getByRole('dialog', { name: 'Export pane' })
+			.getByRole('button', { name: 'Download as .zip' })
+			.click();
+		const download = await downloadPromise;
+		const downloadPath = await download.path();
+		expect(downloadPath).toBeTruthy();
+		const zipBuffer = await readFile(downloadPath!);
 
-		// Use a unique temporary slug so the missing-site prompt is expected.
-		// Missing saved-site URLs create a new autosaved site by default.
-		const uniqueSlug = `missing-modal-test-${Date.now()}`;
-		await website.goto(`./?storage=temp&site-slug=${uniqueSlug}`);
+		await website.openDockPane('New Playground');
+		await website.page
+			.getByRole('tab', { name: 'Import zip', exact: true })
+			.click();
+		let importDialogAccepted = false;
+		const acceptImportDialog = async (dialog: {
+			accept(): Promise<void>;
+		}) => {
+			await dialog.accept();
+			importDialogAccepted = true;
+		};
+		website.page.on('dialog', acceptImportDialog);
+		await website.page
+			.locator('input[type="file"][accept*=".zip"]')
+			.setInputFiles({
+				name: 'brewcommerce-purple-export.zip',
+				mimeType: 'application/zip',
+				buffer: zipBuffer,
+			});
+		const importedSite = await waitForActivePlaygroundSiteSlug(
+			website.page,
+			(slug) => slug !== sourceSiteSlug
+		);
+		expect(importedSite?.slug).toBeTruthy();
+		const importedSiteSlug = importedSite.slug;
+		await expect
+			.poll(() =>
+				website.page.evaluate(async (background) => {
+					const sitesAPI = (window as any).playgroundSites;
+					const playground = sitesAPI?.getClient();
+					if (!playground) {
+						return false;
+					}
+					const documentRoot = await playground.documentRoot;
+					return (
+						await playground.readFileAsText(
+							`${documentRoot}/wp-content/themes/twentytwentyfive/functions.php`
+						)
+					).includes(background);
+				}, purpleBackground)
+			)
+			.toBe(true);
+		await expect
+			.poll(
+				async () =>
+					importDialogAccepted ||
+					(await website.page
+						.getByText('Playground imported', { exact: true })
+						.isVisible()),
+				{ timeout: 120000 }
+			)
+			.toBe(true);
+		website.page.off('dialog', acceptImportDialog);
 
-		// The modal should appear early, even before WordPress fully loads
-		await expect(
-			website.page.getByRole('dialog', {
-				name: 'This is a dialog window which overlays the main content of the page. It offers the user a choice between using an Unsaved Playground and a persistent Playground that is saved to browser storage.',
-			})
-		).toBeVisible({ timeout: 30000 });
+		await waitForInitialOpfsSync(website.page, importedSiteSlug);
+		// Reboot the imported site so the final assertion reads the customization
+		// from persisted OPFS state rather than the import runtime.
+		await website.goto(
+			`./?site-slug=${encodeURIComponent(importedSiteSlug)}`
+		);
+		await waitForActivePlaygroundSiteSlug(
+			website.page,
+			(slug) => slug === importedSiteSlug
+		);
+		await openPlaygroundPath(website.page, '/');
+		await expect(wordpress.locator('body')).toHaveCSS(
+			'background-color',
+			purpleBackgroundRgb
+		);
 	});
 
-	// `@storage` routes this browser-scoped test to the one-worker CI lane.
-	test('@storage should dismiss modal when clicking dismiss button', async ({
-		website,
-		wordpress,
-		browserName,
-		context,
-	}) => {
-		test.skip(
-			browserName !== 'chromium',
-			`This test relies on OPFS which isn't available in Playwright's flavor of ${browserName}.`
-		);
+	// Missing site modal tests in a separate describe block to avoid state pollution.
+	test.describe('Missing site modal', () => {
+		test('should show modal when loading non-existent site slug', async ({
+			website,
+			wordpress,
+			browserName,
+			context,
+		}) => {
+			test.skip(
+				browserName !== 'chromium',
+				`This test relies on OPFS which isn't available in Playwright's flavor of ${browserName}.`
+			);
 
-		// Clear storage
-		await context.clearCookies();
+			// Clear all storage to ensure clean state
+			await context.clearCookies();
 
-		const uniqueSlug = `dismiss-modal-test-${Date.now()}`;
-		await website.goto(`./?storage=temp&site-slug=${uniqueSlug}`);
+			// Use a unique temporary slug so the missing-site prompt is expected.
+			// Missing saved-site URLs create a new autosaved site by default.
+			const uniqueSlug = `missing-modal-test-${Date.now()}`;
+			await website.goto(`./?storage=temp&site-slug=${uniqueSlug}`);
 
-		// Wait for modal
-		const dialog = website.page.getByRole('dialog', {
-			name: 'This is a dialog window which overlays the main content of the page. It offers the user a choice between using an Unsaved Playground and a persistent Playground that is saved to browser storage.',
+			// The modal should appear early, even before WordPress fully loads
+			await expect(
+				website.page.getByRole('dialog', {
+					name: 'This is a dialog window which overlays the main content of the page. It offers the user a choice between using an Unsaved Playground and a persistent Playground that is saved to browser storage.',
+				})
+			).toBeVisible({ timeout: 30000 });
 		});
-		await expect(dialog).toBeVisible({ timeout: 30000 });
 
-		// Click dismiss button
-		await dialog
-			.getByRole('button', {
-				name: 'Keep using an Unsaved Playground',
-			})
-			.click();
+		test('should dismiss modal when clicking dismiss button', async ({
+			website,
+			wordpress,
+			browserName,
+			context,
+		}) => {
+			test.skip(
+				browserName !== 'chromium',
+				`This test relies on OPFS which isn't available in Playwright's flavor of ${browserName}.`
+			);
 
-		// Modal should close
-		await expect(dialog).not.toBeVisible();
+			// Clear storage
+			await context.clearCookies();
+
+			const uniqueSlug = `dismiss-modal-test-${Date.now()}`;
+			await website.goto(`./?storage=temp&site-slug=${uniqueSlug}`);
+
+			// Wait for modal
+			const dialog = website.page.getByRole('dialog', {
+				name: 'This is a dialog window which overlays the main content of the page. It offers the user a choice between using an Unsaved Playground and a persistent Playground that is saved to browser storage.',
+			});
+			await expect(dialog).toBeVisible({ timeout: 30000 });
+
+			// Click dismiss button
+			await dialog
+				.getByRole('button', {
+					name: 'Keep using an Unsaved Playground',
+				})
+				.click();
+
+			// Modal should close
+			await expect(dialog).not.toBeVisible();
+		});
 	});
 });

--- a/packages/playground/website/playwright/e2e/website-ui.spec.ts
+++ b/packages/playground/website/playwright/e2e/website-ui.spec.ts
@@ -1265,9 +1265,9 @@ test.describe('Database panel', () => {
 });
 
 // Test browser-saved Playgrounds by default and explicit temporary opt-outs.
+// The tag routes this group to the one-worker CI storage lane.
 test.describe('Default Playground storage', { tag: '@storage' }, () => {
 	// Default mode prevents storage overlap while retrying only the failed test.
-	// The tag routes this group to the one-worker CI storage lane.
 	test.describe.configure({ mode: 'default' });
 
 	test('should create and finish autosaving a Playground from the root URL', async ({

--- a/packages/playground/website/playwright/e2e/website-ui.spec.ts
+++ b/packages/playground/website/playwright/e2e/website-ui.spec.ts
@@ -1265,7 +1265,7 @@ test.describe('Database panel', () => {
 });
 
 // Test browser-saved Playgrounds by default and explicit temporary opt-outs.
-// The tag routes this group to the one-worker CI storage lane.
+// The `@storage` tag routes this group to the one-worker CI storage lane.
 test.describe('Default Playground storage', { tag: '@storage' }, () => {
 	// Default mode prevents storage overlap while retrying only the failed test.
 	test.describe.configure({ mode: 'default' });

--- a/packages/playground/website/playwright/e2e/website-ui.spec.ts
+++ b/packages/playground/website/playwright/e2e/website-ui.spec.ts
@@ -1265,8 +1265,10 @@ test.describe('Database panel', () => {
 });
 
 // Test browser-saved Playgrounds by default and explicit temporary opt-outs.
-test.describe('Default Playground storage', () => {
-	test.describe.configure({ mode: 'serial' });
+test.describe('Default Playground storage', { tag: '@storage' }, () => {
+	// Default mode prevents storage overlap while retrying only the failed test.
+	// The tag routes this group to the one-worker CI storage lane.
+	test.describe.configure({ mode: 'default' });
 
 	test('should create and finish autosaving a Playground from the root URL', async ({
 		website,

--- a/packages/playground/website/playwright/playwright.ci.config.ts
+++ b/packages/playground/website/playwright/playwright.ci.config.ts
@@ -6,10 +6,10 @@ import playwrightConfig from './playwright.config';
  * The dedicated CI lane uses one worker and Playwright's default mode, which
  * retries only a failed test instead of replaying an entire serial group.
  *
- * `opfs.spec.ts` is entirely storage-sensitive. The tag selects the storage
- * describe nested inside the otherwise parallel `website-ui.spec.ts` file.
+ * Every storage-sensitive test carries the `@storage` tag, so the CI routing
+ * does not need to know which files contain storage tests.
  */
-const storageTests = /(?:opfs\.spec\.ts|@storage)/;
+const storageTests = /@storage/;
 const testGroup = process.env.PLAYWRIGHT_TEST_GROUP;
 const testGroupOptions =
 	testGroup === 'storage'

--- a/packages/playground/website/playwright/playwright.ci.config.ts
+++ b/packages/playground/website/playwright/playwright.ci.config.ts
@@ -15,6 +15,8 @@ const testGroupOptions = getTestGroupOptions(process.env.PLAYWRIGHT_TEST_GROUP);
 function getTestGroupOptions(testGroup: string | undefined) {
 	switch (testGroup) {
 		case 'storage':
+			// Storage tests share browser-scoped OPFS, so one worker prevents
+			// them from changing the same storage concurrently.
 			return { grep: storageTests, workers: 1 };
 		case 'regular':
 			return { grepInvert: storageTests };

--- a/packages/playground/website/playwright/playwright.ci.config.ts
+++ b/packages/playground/website/playwright/playwright.ci.config.ts
@@ -10,13 +10,25 @@ import playwrightConfig from './playwright.config';
  * does not need to know which files contain storage tests.
  */
 const storageTests = /@storage/;
-const testGroup = process.env.PLAYWRIGHT_TEST_GROUP;
-const testGroupOptions =
-	testGroup === 'storage'
-		? { grep: storageTests, workers: 1 }
-		: testGroup === 'regular'
-			? { grepInvert: storageTests }
-			: {};
+const testGroupOptions = getTestGroupOptions(process.env.PLAYWRIGHT_TEST_GROUP);
+
+function getTestGroupOptions(testGroup: string | undefined) {
+	switch (testGroup) {
+		case 'storage':
+			return { grep: storageTests, workers: 1 };
+		case 'regular':
+			return { grepInvert: storageTests };
+		case undefined:
+			// The Nx full-suite target does not select a group. One worker keeps
+			// its storage tests from overlapping while still running every test.
+			return { workers: 1 };
+		default:
+			throw new Error(
+				`Unsupported PLAYWRIGHT_TEST_GROUP: ${JSON.stringify(testGroup)}. ` +
+					'Expected "regular" or "storage".'
+			);
+	}
+}
 
 /**
  * See https://playwright.dev/docs/test-configuration.

--- a/packages/playground/website/playwright/playwright.ci.config.ts
+++ b/packages/playground/website/playwright/playwright.ci.config.ts
@@ -1,11 +1,29 @@
 import { defineConfig } from '@playwright/test';
 import playwrightConfig from './playwright.config';
 
+/*
+ * OPFS is browser-scoped, so storage tests must not overlap in one browser.
+ * The dedicated CI lane uses one worker and Playwright's default mode, which
+ * retries only a failed test instead of replaying an entire serial group.
+ *
+ * `opfs.spec.ts` is entirely storage-sensitive. The tag selects the storage
+ * describe nested inside the otherwise parallel `website-ui.spec.ts` file.
+ */
+const storageTests = /(?:opfs\.spec\.ts|@storage)/;
+const testGroup = process.env.PLAYWRIGHT_TEST_GROUP;
+const testGroupOptions =
+	testGroup === 'storage'
+		? { grep: storageTests, workers: 1 }
+		: testGroup === 'regular'
+			? { grepInvert: storageTests }
+			: {};
+
 /**
  * See https://playwright.dev/docs/test-configuration.
  */
 export default defineConfig({
 	...playwrightConfig,
+	...testGroupOptions,
 	use: {
 		...playwrightConfig.use,
 		baseURL: 'http://127.0.0.1/',

--- a/packages/playground/website/playwright/playwright.ci.config.ts
+++ b/packages/playground/website/playwright/playwright.ci.config.ts
@@ -18,10 +18,6 @@ function getTestGroupOptions(testGroup: string | undefined) {
 			return { grep: storageTests, workers: 1 };
 		case 'regular':
 			return { grepInvert: storageTests };
-		case undefined:
-			// The Nx full-suite target does not select a group. One worker keeps
-			// its storage tests from overlapping while still running every test.
-			return { workers: 1 };
 		default:
 			throw new Error(
 				`Unsupported PLAYWRIGHT_TEST_GROUP: ${JSON.stringify(testGroup)}. ` +

--- a/packages/playground/website/project.json
+++ b/packages/playground/website/project.json
@@ -178,7 +178,8 @@
 			"executor": "nx:run-commands",
 			"options": {
 				"commands": [
-					"npx playwright test --config=packages/playground/website/playwright/playwright.ci.config.ts"
+					"PLAYWRIGHT_TEST_GROUP=regular npx playwright test --config=packages/playground/website/playwright/playwright.ci.config.ts",
+					"PLAYWRIGHT_TEST_GROUP=storage npx playwright test --config=packages/playground/website/playwright/playwright.ci.config.ts"
 				],
 				"parallel": false
 			}


### PR DESCRIPTION
## Why this change is needed

@adamziel reported that flaky end-to-end tests were causing more CI jobs to be
canceled.

The canceled jobs shared the same pattern: one storage test failed late in a
Playwright serial group, so Playwright retried the whole group from its first
test. In one case, a 33-test storage group restarted more than once and the job
reached the existing 30-minute limit before it could finish. The OPFS tests had
the same retry behavior.

Adding another ordinary shard would not help because Playwright keeps a serial
group together. Increasing the timeout or reducing the three retries would
also leave the whole-group replay in place.

Examples:

- https://github.com/WordPress/wordpress-playground/actions/runs/30863319632/job/91858108020
- https://github.com/WordPress/wordpress-playground/actions/runs/30860081972/job/91848066181

## Why this approach

The storage tests must not run at the same time because they share browser
storage. A dedicated storage lane with one worker preserves that isolation.
Using Playwright's default test mode inside that lane means a failure retries
only the failed test instead of replaying every earlier test in its group.

This directly addresses the cancellation pattern while keeping the existing
30-minute job timeout and three retries.

## What this changes

- Changes the OPFS tests and default-storage tests from serial mode to default
  mode, allowing Playwright to retry one failed test.
- Adds `@storage` to the top-level OPFS suite and the default-storage group.
  CI routes tests only by this tag, so it does not need file-path rules.
- Keeps three ordinary shards per browser and excludes storage tests from them.
- Adds one unsharded storage lane per browser with `workers: 1`.
- Runs the Nx CI-style target as two sequential groups: ordinary tests use the
  normal three workers, then storage tests use one worker. Missing or unsupported
  group values produce a clear error.
- Gives only the three storage matrix entries a `storage` test group. Entries
  without a group use the ordinary-test behavior, so the matrix does not repeat
  a `regular` label nine times.
- Adds a `-storage` suffix only to storage artifacts. Ordinary artifact names
  remain unchanged.

The tradeoff is three additional install/build runners, one per browser. This
is the same job-count increase as changing from three to four ordinary shards,
but it removes the whole-group retry amplification that caused the cancellations.

## Verification

- Collected all Chromium tests with the tag-only selector and confirmed that
  each test is in exactly one lane: 182 ordinary tests and 59 storage tests.
  The ordinary shards contain 61, 61, and 60 tests.
- Confirmed the top-level OPFS suite contributes all 26 tagged tests.
- Confirmed the Nx target resolves to two sequential commands with explicit
  groups, and a missing or unsupported group exits with a clear error.
- Ran all 59 Chromium storage tests locally with one worker; all passed.
- The full CI run passed for Chromium, Firefox, and WebKit storage lanes.
- Ran the Chromium storage lane two more times after it first passed. All three
  attempts passed. Two attempts had one flaky ZIP-import test, and Playwright
  retried only that test instead of restarting the storage suite. This confirms
  the new retry scope works as intended.
- Confirmed the simplified matrix has 12 entries: 9 without a group and 3 with
  the `storage` group.
- Ran the website typecheck, lint, formatting checks, YAML parsing, and workflow
  validation.

The repetitions also exposed a separate race in two ZIP-import tests. PR #4213
addresses that underlying race. It remains separate so this PR stays focused on
making retries safe and preventing CI cancellations.
