### PR TITLE
[Website] Add Gutenberg branch setting

### DIFF
--- a/packages/docs/site/docs/developers/06-apis/query-api/01-index.md
+++ b/packages/docs/site/docs/developers/06-apis/query-api/01-index.md
@@ -49,6 +49,11 @@ You can go ahead and try it out. The Playground will automatically install the t
 | `mcp-port`         | `7999`                | Sets the WebSocket port used by the MCP bridge to communicate with the MCP server. For example, `mcp-port=8080`.                                                                                                                                                                                                                                                                                                                                                            |
 | `overlay`          |                       | Opens a Playground tool on page load. Supports `new` for the Dock's **New** pane. For example, `?overlay=new`. `blueprints` is kept as a compatibility alias that opens the same **New** pane, so `?overlay=blueprints` still works. The parameter is removed from the URL when the pane is closed.                                                                                                                                                                         |
 
+The **Gutenberg Branch** control in **Site Settings** provides shortcuts for
+`trunk`, `wp/next`, and `wp/latest`. WordPress Core branch artifacts are not
+available through a `core-branch` parameter; use the **WordPress Version**
+control for release, beta, and trunk builds instead.
+
 For example, the following code embeds a Playground with a preinstalled Gutenberg plugin and opens the post editor:
 
 ```html

--- a/packages/docs/site/docs/developers/06-apis/sites-api/01-index.md
+++ b/packages/docs/site/docs/developers/06-apis/sites-api/01-index.md
@@ -59,6 +59,7 @@ createNewTemporarySite(
 	settings?: {
 		phpVersion?: string; // e.g. '8.4'
 		wpVersion?: string; // e.g. '6.8', 'latest', 'nightly', 'beta'
+		gutenbergBranch?: string; // e.g. 'trunk', 'wp/next', 'wp/latest'
 		networking?: boolean;
 		language?: string; // e.g. 'pl_PL'
 		multisite?: boolean;
@@ -66,7 +67,7 @@ createNewTemporarySite(
 ): Promise<string>;
 ```
 
-Each setting corresponds to an equivalent [Query API](/developers/apis/query-api) parameter of the same name, with `phpVersion` mapped to `php` and `wpVersion` mapped to `wp`. Other Query API options like `plugin`, `theme`, or `blueprint-url` are not accepted here.
+Each setting corresponds to an equivalent [Query API](/developers/apis/query-api) parameter of the same name, with `phpVersion` mapped to `php`, `wpVersion` mapped to `wp`, and `gutenbergBranch` mapped to `gutenberg-branch`. Other Query API options like `plugin`, `theme`, or `blueprint-url` are not accepted here.
 
 ### `createNewSavedSite(slug?, settings?, options?)`
 
@@ -78,6 +79,7 @@ createNewSavedSite(
 	settings?: {
 		phpVersion?: string;
 		wpVersion?: string;
+		gutenbergBranch?: string;
 		networking?: boolean;
 		language?: string;
 		multisite?: boolean;

--- a/packages/docs/site/docs/main/quick-start-guide.md
+++ b/packages/docs/site/docs/main/quick-start-guide.md
@@ -92,7 +92,7 @@ This restores the files and database from the ZIP into a new Playground.
 
 ## Use a specific WordPress or PHP version
 
-Open **Site Settings** from the Dock to choose WordPress, PHP, language, multisite, and networking options.
+Open **Site Settings** from the Dock to choose WordPress, Gutenberg branch, PHP, language, multisite, and networking options.
 
 ![The Site Settings pane](/img/dock/dock-site-settings.webp)
 

--- a/packages/docs/site/docs/main/web-instance.md
+++ b/packages/docs/site/docs/main/web-instance.md
@@ -86,7 +86,7 @@ Open **Site Settings** to change runtime and WordPress setup options.
 
 ![The Site Settings pane](/img/dock/dock-site-settings.webp)
 
-PHP version and networking can be applied to an existing stored Playground. WordPress version, language, and multisite change the WordPress installation itself, so they require a fresh Playground.
+PHP version and networking can be applied to an existing stored Playground. WordPress version, Gutenberg branch, language, and multisite change the WordPress installation itself, so they require a fresh Playground.
 
 Running an edited Blueprint keeps stored and autosaved Playgrounds. It discards a temporary Playground because the new run starts from a fresh setup.
 

--- a/packages/playground/website/src/components/site-manager/site-settings-form/active-site-settings-form.spec.tsx
+++ b/packages/playground/website/src/components/site-manager/site-settings-form/active-site-settings-form.spec.tsx
@@ -66,6 +66,7 @@ vi.mock('./temporary-site-settings-form', () => ({
 const formData: SiteFormData = {
 	phpVersion: '8.3',
 	wpVersion: 'latest',
+	gutenbergBranch: '',
 	language: '',
 	withNetworking: true,
 	multisite: false,

--- a/packages/playground/website/src/components/site-manager/site-settings-form/setup-form-values.ts
+++ b/packages/playground/website/src/components/site-manager/site-settings-form/setup-form-values.ts
@@ -19,10 +19,13 @@ export function getSetupFormDefaultValues(
 	const runtimeConf = siteInfo.metadata?.runtimeConfiguration || {};
 	const language = searchParams.language;
 	const multisite = searchParams.multisite;
+	const gutenbergBranch = searchParams['gutenberg-branch'];
 	return {
 		// @TODO: Handle an unsupported PHP version coming up here.
 		phpVersion: runtimeConf?.phpVersion as any,
 		wpVersion: runtimeConf?.wpVersion as any,
+		gutenbergBranch:
+			typeof gutenbergBranch === 'string' ? gutenbergBranch : '',
 		withNetworking: runtimeConf?.networking,
 		language: typeof language === 'string' ? language : '',
 		multisite: multisite === 'yes',
@@ -40,6 +43,7 @@ export function getSiteSettingsFromFormData(data: SiteFormData): SiteSettings {
 	return {
 		phpVersion: data.phpVersion,
 		wpVersion: data.wpVersion,
+		gutenbergBranch: data.gutenbergBranch,
 		networking: data.withNetworking,
 		language: data.language,
 		multisite: data.multisite,

--- a/packages/playground/website/src/components/site-manager/site-settings-form/site-settings-action-footer.spec.tsx
+++ b/packages/playground/website/src/components/site-manager/site-settings-form/site-settings-action-footer.spec.tsx
@@ -15,6 +15,7 @@ import type {
 const defaults: SiteFormData = {
 	phpVersion: '8.3',
 	wpVersion: 'latest',
+	gutenbergBranch: '',
 	language: '',
 	withNetworking: true,
 	multisite: false,

--- a/packages/playground/website/src/components/site-manager/site-settings-form/site-settings-actions.spec.ts
+++ b/packages/playground/website/src/components/site-manager/site-settings-form/site-settings-actions.spec.ts
@@ -5,6 +5,7 @@ import { getFreshPlaygroundReason } from './site-settings-actions';
 const defaults: SiteFormData = {
 	phpVersion: '8.3',
 	wpVersion: '6.8',
+	gutenbergBranch: '',
 	language: '',
 	withNetworking: true,
 	multisite: false,
@@ -31,6 +32,15 @@ describe('getFreshPlaygroundReason', () => {
 				defaults
 			)
 		).toBe('Changing WordPress version requires a fresh Playground.');
+	});
+
+	it('requires a fresh Playground for a Gutenberg branch change', () => {
+		expect(
+			getFreshPlaygroundReason(
+				{ ...defaults, gutenbergBranch: 'trunk' },
+				defaults
+			)
+		).toBe('Changing Gutenberg branch requires a fresh Playground.');
 	});
 
 	it('names every setting that prevents applying to the current Playground', () => {

--- a/packages/playground/website/src/components/site-manager/site-settings-form/site-settings-actions.ts
+++ b/packages/playground/website/src/components/site-manager/site-settings-form/site-settings-actions.ts
@@ -10,6 +10,7 @@ const siteSettingActions: Record<keyof SiteFormData, SiteSettingAction> = {
 	phpVersion: { action: 'apply' },
 	withNetworking: { action: 'apply' },
 	wpVersion: { action: 'fresh', label: 'WordPress version' },
+	gutenbergBranch: { action: 'fresh', label: 'Gutenberg branch' },
 	language: { action: 'fresh', label: 'language' },
 	multisite: { action: 'fresh', label: 'multisite' },
 };

--- a/packages/playground/website/src/components/site-manager/site-settings-form/unconnected-site-settings-form.tsx
+++ b/packages/playground/website/src/components/site-manager/site-settings-form/unconnected-site-settings-form.tsx
@@ -20,9 +20,17 @@ import {
 import { getWordPressVersionOptions } from './wordpress-version-options';
 
 type ConfigurableFields = Record<
-	keyof SiteFormData & ('wpVersion' | 'language' | 'multisite'),
+	keyof SiteFormData &
+		('wpVersion' | 'gutenbergBranch' | 'language' | 'multisite'),
 	boolean
 >;
+
+const GutenbergBranchOptions = [
+	{ label: 'No branch preview', value: '' },
+	{ label: 'Gutenberg trunk', value: 'trunk' },
+	{ label: 'WordPress next (wp/next)', value: 'wp/next' },
+	{ label: 'WordPress latest (wp/latest)', value: 'wp/latest' },
+];
 
 export interface SiteSettingsFormProps {
 	onSubmit: (data: any) => void;
@@ -38,6 +46,7 @@ export interface SiteSettingsFormProps {
 export interface SiteFormData {
 	phpVersion: AllPHPVersion;
 	wpVersion: string;
+	gutenbergBranch: string;
 	language: string;
 	withNetworking: boolean;
 	multisite: boolean;
@@ -57,6 +66,7 @@ export function UnconnectedSiteSettingsForm({
 	defaultValues = {},
 	enabledFields = {
 		wpVersion: true,
+		gutenbergBranch: true,
 		language: true,
 		multisite: true,
 	},
@@ -65,6 +75,7 @@ export function UnconnectedSiteSettingsForm({
 		() => ({
 			phpVersion: RecommendedPHPVersion as AllPHPVersion,
 			wpVersion: 'latest',
+			gutenbergBranch: '',
 			language: '',
 			withNetworking: true,
 			multisite: false,
@@ -171,6 +182,25 @@ export function UnconnectedSiteSettingsForm({
 		];
 	}, [forcedPhpVersion]);
 
+	const gutenbergBranchOptions = useMemo(() => {
+		if (
+			!mergedDefaults.gutenbergBranch ||
+			GutenbergBranchOptions.some(
+				({ value }) => value === mergedDefaults.gutenbergBranch
+			)
+		) {
+			return GutenbergBranchOptions;
+		}
+		return [
+			GutenbergBranchOptions[0],
+			{
+				label: `${mergedDefaults.gutenbergBranch} (current branch)`,
+				value: mergedDefaults.gutenbergBranch,
+			},
+			...GutenbergBranchOptions.slice(1),
+		];
+	}, [mergedDefaults.gutenbergBranch]);
+
 	return (
 		<form
 			onSubmit={handleSubmit(onSubmit)}
@@ -220,6 +250,27 @@ export function UnconnectedSiteSettingsForm({
 								/>
 							)}
 						</div>
+					)}
+				/>
+
+				<Controller
+					control={control}
+					name="gutenbergBranch"
+					disabled={!enabledFields.gutenbergBranch}
+					render={({ field: { onChange, ...rest } }) => (
+						<SelectControl
+							size="compact"
+							__nextHasNoMarginBottom={true}
+							label="Gutenberg Branch"
+							labelPosition="side"
+							disabled={!enabledFields.gutenbergBranch}
+							className={css.addSiteInput}
+							options={gutenbergBranchOptions}
+							onChange={(value, extra) => {
+								onChange(extra?.event);
+							}}
+							{...rest}
+						/>
 					)}
 				/>
 

--- a/packages/playground/website/src/components/site-manager/site-settings-form/use-site-settings-submission.spec.tsx
+++ b/packages/playground/website/src/components/site-manager/site-settings-form/use-site-settings-submission.spec.tsx
@@ -9,6 +9,7 @@ import { useSiteSettingsSubmission } from './use-site-settings-submission';
 const formData: SiteFormData = {
 	phpVersion: '8.3',
 	wpVersion: 'latest',
+	gutenbergBranch: '',
 	language: '',
 	withNetworking: true,
 	multisite: false,

--- a/packages/playground/website/src/lib/state/redux/site-management-api-middleware.ts
+++ b/packages/playground/website/src/lib/state/redux/site-management-api-middleware.ts
@@ -56,6 +56,7 @@ import { PlaygroundRoute, redirectTo } from '../url/router';
 export interface SiteSettings {
 	phpVersion?: AllPHPVersion;
 	wpVersion?: string;
+	gutenbergBranch?: string;
 	networking?: boolean;
 	language?: string;
 	multisite?: boolean;
@@ -1159,6 +1160,16 @@ function getSetupUrlForNewSite(
 		}
 		if (settings.wpVersion !== undefined) {
 			url.searchParams.set('wp', settings.wpVersion);
+		}
+		if (settings.gutenbergBranch !== undefined) {
+			url.searchParams.delete('gutenberg-branch');
+			if (settings.gutenbergBranch) {
+				url.searchParams.delete('gutenberg-pr');
+				url.searchParams.set(
+					'gutenberg-branch',
+					settings.gutenbergBranch
+				);
+			}
 		}
 		if (settings.networking !== undefined) {
 			url.searchParams.set(


### PR DESCRIPTION
## What changed

- Add a Gutenberg Branch selector to Site Settings with shortcuts for `trunk`, `wp/next`, and `wp/latest`.
- Carry the selected branch through the Sites API to the existing `gutenberg-branch` Query API parameter.
- Treat changing the branch as an installation-level setting that creates a fresh Playground.
- Preserve custom branch values from existing setup URLs and document the new UI/Sites API option.

## Why

The Query API already supports Gutenberg branch previews, but Site Settings only exposed WordPress, PHP, language, networking, and multisite controls. Users had to edit the URL manually to preview the maintained Gutenberg branches.

WordPress Core branch previews are intentionally not exposed because `wordpress-develop` does not publish matching branch artifacts; the existing WordPress Version control continues to cover release, beta, and trunk builds.

## User impact

Developers can choose the main Gutenberg development channels directly from Site Settings. Applying a branch creates a fresh Playground and installs the selected Gutenberg artifact.

## Before and after

### Before

Site Settings had no Gutenberg branch selector, so branch previews required manually editing the Query API URL.

<img width="900" alt="Site Settings before the change, without a Gutenberg Branch selector" src="https://github.com/user-attachments/assets/36920339-d433-43e0-ba95-c24c1e7aaace" />

### After

Site Settings includes a Gutenberg Branch dropdown with `trunk`, `wp/next`, and `wp/latest` shortcuts.

<img width="900" alt="Site Settings after the change, with the Gutenberg Branch selector" src="https://github.com/user-attachments/assets/290614bc-0761-4518-a3de-c57cd50ad347" />

## Validation

- `npm exec nx test playground-website` (370 tests)
- `npm exec nx typecheck playground-website`
- `npm exec nx lint playground-website`
- Manual browser verification with `wp/next`: branch download completed, selection persisted, and Gutenberg was active.
