### PR TITLE
[personal-wp] Review my WordPress UI with impeccable

### DIFF
--- a/packages/playground/personal-wp/playwright/e2e/ui.spec.ts
+++ b/packages/playground/personal-wp/playwright/e2e/ui.spec.ts
@@ -138,7 +138,15 @@ test('should open phpMyAdmin from the Database tools', async ({
 	await website.goto(`./#${JSON.stringify(blueprint)}`);
 
 	await website.ensureSiteToolsIsOpen();
-	await website.page.getByRole('tab', { name: 'Database' }).click();
+	// The Database tab is a developer tool and only appears once the
+	// "Show developer tools" switch on the Advanced tab is turned on.
+	const databaseTab = website.page.getByRole('tab', { name: 'Database' });
+	await expect(databaseTab).toHaveCount(0);
+	await website.page.getByRole('tab', { name: 'Advanced' }).click();
+	await website.page
+		.getByRole('checkbox', { name: 'Show developer tools' })
+		.check();
+	await databaseTab.click();
 
 	const phpMyAdminButton = website.page.getByRole('button', {
 		name: 'Open phpMyAdmin',

--- a/packages/playground/personal-wp/src/components/playground-viewport/index.tsx
+++ b/packages/playground/personal-wp/src/components/playground-viewport/index.tsx
@@ -36,11 +36,13 @@ import classNames from 'classnames';
 import { SiteErrorModal } from '../site-error-modal';
 import {
 	setBlueprintInstallMessage,
+	setAutoBackupDue,
 	setSiteManagerOpen,
 } from '../../lib/state/redux/slice-ui';
 import { playgroundLogo } from '@wp-playground/components';
 import { isAppBasePath } from '../../lib/state/url/app-base-url';
 import Button from '../button';
+import { useBackup } from '../../lib/hooks/use-backup';
 import {
 	getBlueprintInstallPreview,
 	getBlueprintInstallSource,
@@ -1050,9 +1052,13 @@ function SeamlessViewport({ siteSlug }: { siteSlug: string }) {
 	);
 	const activeSiteError = useAppSelector(selectActiveSiteError);
 	const activeSiteSlug = useAppSelector((state) => state.ui.activeSite?.slug);
-	const backgroundNotice = useAppSelector(
-		(state) => state.ui.backgroundNotice
-	);
+	const autoBackupDue = useAppSelector((state) => state.ui.autoBackupDue);
+	const { performBackup } = useBackup();
+	// performBackup() is a no-op until WordPress has booted and a client can
+	// serve the request, so only ask the user to click once that is the case.
+	const canBackupNow =
+		!isBooting &&
+		(isDependentMode ? mainTabStatus === 'connected' : !!playground);
 	const hasActiveSiteError = activeSiteError && activeSiteSlug === siteSlug;
 
 	const loadingScreenHtml = useMemo(
@@ -1567,11 +1573,6 @@ function SeamlessViewport({ siteSlug }: { siteSlug: string }) {
 			{installingBlueprint && (
 				<div className={css.installBanner}>{installingBlueprint}</div>
 			)}
-			{!installingBlueprint && backgroundNotice && (
-				<div className={css.installBanner} role="status">
-					{backgroundNotice}
-				</div>
-			)}
 			{blueprintInstallDialogRequest && (
 				<BlueprintInstallDialog
 					blueprintUrl={blueprintInstallDialogRequest.blueprintUrl}
@@ -1621,7 +1622,45 @@ function SeamlessViewport({ siteSlug }: { siteSlug: string }) {
 				>
 					{playgroundLogo({ width: 24, height: 24 })}
 				</Button>
+				{autoBackupDue && canBackupNow && (
+					<AutoBackupPrompt
+						onDownload={performBackup}
+						onDismiss={() => dispatch(setAutoBackupDue(false))}
+					/>
+				)}
 			</div>
+		</div>
+	);
+}
+
+function AutoBackupPrompt({
+	onDownload,
+	onDismiss,
+}: {
+	onDownload: () => void;
+	onDismiss: () => void;
+}) {
+	return (
+		<div className={css.autoBackupPrompt} role="status" aria-live="polite">
+			<p className={css.autoBackupPromptText}>
+				<strong>Welcome back!</strong> It is time for a backup.{' '}
+				<button
+					type="button"
+					className={css.autoBackupPromptLink}
+					onClick={onDownload}
+				>
+					Click here to download it
+				</button>
+				.
+			</p>
+			<button
+				type="button"
+				className={css.autoBackupPromptDismiss}
+				aria-label="Dismiss backup reminder"
+				onClick={onDismiss}
+			>
+				×
+			</button>
 		</div>
 	);
 }

--- a/packages/playground/personal-wp/src/components/playground-viewport/index.tsx
+++ b/packages/playground/personal-wp/src/components/playground-viewport/index.tsx
@@ -270,18 +270,25 @@ function renderCard(
 		'detailLabel' in card
 			? `<div class="detail-label">${card.detailLabel}</div>`
 			: '';
+	// The card front is the label for the card's radio, and the close affordance
+	// is a sibling rather than a descendant: nesting one label inside another is
+	// invalid and leaves assistive tech guessing which control was activated.
 	return `
-      <label class="card c${n}" for="${idPrefix}${n}">
-        <div class="card-front">
-          <div class="icon" style="${iconStyle(card.theme)}">${card.icon}</div>
-          <div class="text"><div class="label">${card.label}</div><div class="sub">${card.sub}</div></div>
-        </div>
+      <div class="card c${n}">
+        <label class="card-front" for="${idPrefix}${n}">
+          <div class="icon" aria-hidden="true" style="${iconStyle(
+				card.theme
+			)}">${card.icon}</div>
+          <div class="text"><div class="label">${card.label}</div><div class="sub">${
+			card.sub
+		}</div></div>
+        </label>
         <div class="card-detail"><div class="detail-inner">
-          <label class="detail-close" for="${idPrefix}0">×</label>
+          <label class="detail-close" for="${idPrefix}0" aria-hidden="true">×</label>
           ${detailHeader}
           ${card.detail}
         </div></div>
-      </label>`;
+      </div>`;
 }
 
 function renderIntroPanelInner(
@@ -290,10 +297,12 @@ function renderIntroPanelInner(
 	opts: { backToggle?: boolean } = {}
 ): string {
 	const radios = NEW_USER_CARDS.map(
-		(_, i) =>
+		(card, i) =>
 			`<input type="radio" name="${radioName}" id="${idPrefix}${
 				i + 1
-			}" class="card-toggle">`
+			}" class="card-toggle" aria-label="${escapeHtml(
+				`${card.label} — ${card.sub}`
+			)}">`
 	).join('\n    ');
 
 	const backToggle = opts.backToggle
@@ -301,7 +310,7 @@ function renderIntroPanelInner(
 		: '';
 
 	return `
-    <input type="radio" name="${radioName}" id="${idPrefix}0" class="card-toggle" checked>
+    <input type="radio" name="${radioName}" id="${idPrefix}0" class="card-toggle" checked aria-label="No card open">
     ${radios}
 
     <h1 class="headline">A small world,<br>just for <em>you</em>.</h1>
@@ -332,8 +341,19 @@ function getIntroPanelCss(idPrefix: string, scope: string): string {
 		(_, i) =>
 			`#${idPrefix}${i + 1}:checked ~ .field .c${i + 1} .card-detail`
 	).join(',\n  ');
+	// The radios are visually hidden, so focus has to be surfaced on the card
+	// they control or keyboard users cannot tell where they are.
+	const focusSel = NEW_USER_CARDS.map(
+		(_, i) => `#${idPrefix}${i + 1}:focus-visible ~ .field .c${i + 1}`
+	).join(',\n  ');
 
 	return `
+  ${focusSel} {
+    outline: 2px solid var(--accent);
+    outline-offset: 3px;
+    z-index: 21;
+  }
+
   /* Positions + rotations — rotate excluded from keyframes so transition owns it.
      Top values are deliberately jittered between siblings so cards don't sit in
      rigid horizontal rows. */
@@ -397,7 +417,25 @@ function getSwapCss(): string {
   .stage:has(#show-intro) .intro-panel { display: none; }
   .stage:has(#show-intro:checked) .welcome-back-panel { display: none; }
   .stage:has(#show-intro:checked) .intro-panel { display: flex; }
-  #show-intro { display: none; }
+  /* Visually hidden, not removed: this checkbox is the only way to move between
+     the returning-user and first-run panels, so it has to stay focusable. */
+  #show-intro {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    margin: 0;
+    padding: 0;
+    border: 0;
+    overflow: hidden;
+    white-space: nowrap;
+    clip-path: inset(50%);
+  }
+  #show-intro:focus-visible ~ .welcome-back-panel .intro-toggle,
+  #show-intro:focus-visible ~ .intro-panel .back-toggle {
+    outline: 2px solid var(--accent);
+    outline-offset: 3px;
+    border-radius: 3px;
+  }
 
   .intro-toggle, .back-toggle {
     display: inline-block;
@@ -520,13 +558,21 @@ function getWhatsNewHtml(): string {
 
 	const radios = cards
 		.map(
-			(_, i) =>
-				`<input type="radio" name="wcard" id="w${i + 1}" class="card-toggle">`
+			// `label` is already escaped where it is built, so it is safe to
+			// interpolate into the attribute as-is; escaping twice would show
+			// entity text to screen readers.
+			(c, i) =>
+				`<input type="radio" name="wcard" id="w${
+					i + 1
+				}" class="card-toggle" aria-label="${c.label} — ${c.sub}">`
 		)
 		.join('\n    ');
 
 	const expandSel = cards
 		.map((_, i) => `#w${i + 1}:checked ~ .field .c${i + 1}`)
+		.join(', ');
+	const focusSel = cards
+		.map((_, i) => `#w${i + 1}:focus-visible ~ .field .c${i + 1}`)
 		.join(', ');
 	const detailSel = cards
 		.map((_, i) => `#w${i + 1}:checked ~ .field .c${i + 1} .card-detail`)
@@ -543,16 +589,20 @@ function getWhatsNewHtml(): string {
 			const sideStyle = c.left ? `left:${c.left}` : `right:${c.right}`;
 			const style = `top:${c.top};${sideStyle};rotate:${c.rotate};animation:drift-in 1s cubic-bezier(0.16,1,0.3,1) ${c.delay} forwards`;
 			return `
-      <label class="card c${i + 1}" for="w${i + 1}" style="${style}">
-        <div class="card-front">
-          <div class="icon" style="${iconStyle(c.theme)}">${c.icon}</div>
-          <div class="text"><div class="label">${c.label}</div><div class="sub">${c.sub}</div></div>
-        </div>
+      <div class="card c${i + 1}" style="${style}">
+        <label class="card-front" for="w${i + 1}">
+          <div class="icon" aria-hidden="true" style="${iconStyle(
+				c.theme
+			)}">${c.icon}</div>
+          <div class="text"><div class="label">${c.label}</div><div class="sub">${
+				c.sub
+			}</div></div>
+        </label>
         <div class="card-detail"><div class="detail-inner">
-          <label class="detail-close" for="w0">×</label>
+          <label class="detail-close" for="w0" aria-hidden="true">×</label>
           <p class="detail-body">${c.detail}</p>
         </div></div>
-      </label>`;
+      </div>`;
 		})
 		.join('');
 
@@ -570,6 +620,11 @@ function getWhatsNewHtml(): string {
     box-shadow: 0 2px 4px var(--shadow-md), 0 16px 40px var(--shadow-xl) !important;
   }
   ${detailSel} { max-height: 260px; }
+  ${focusSel} {
+    outline: 2px solid var(--accent);
+    outline-offset: 3px;
+    z-index: 21;
+  }
   ${bottomSel ? `${bottomSel} { transform: translateY(-140px) !important; }` : ''}
 
   @media (min-width: 640px) {
@@ -580,7 +635,7 @@ function getWhatsNewHtml(): string {
   <input type="checkbox" id="show-intro">
 
   <div class="welcome-back-panel">
-    <input type="radio" name="wcard" id="w0" class="card-toggle" checked>
+    <input type="radio" name="wcard" id="w0" class="card-toggle" checked aria-label="No card open">
     ${radios}
 
     <h1 class="headline">Welcome <em>back.</em></h1>
@@ -735,7 +790,6 @@ function getCardStageCss(): string {
     position: absolute;
     width: 180px;
     opacity: 0;
-    cursor: pointer;
     display: block;
     background: var(--card-bg);
     border: 1px solid var(--thread);
@@ -758,6 +812,7 @@ function getCardStageCss(): string {
     display: flex;
     align-items: center;
     gap: 12px;
+    cursor: pointer;
   }
   .card-front .icon {
     width: 34px; height: 34px;
@@ -810,7 +865,22 @@ function getCardStageCss(): string {
     100% { opacity: 1; translate: 0 0;    scale: 1;    }
   }
 
-  .card-toggle { display: none; position: absolute; }
+  /* Visually hidden but still focusable and announced. display:none would drop
+     these out of the accessibility tree entirely, which is what made the whole
+     card field keyboard- and screen-reader-inoperable. There is no JS in this
+     shadow root (scripts and on* handlers are stripped), so these radios are
+     the only mechanism the cards have. */
+  .card-toggle {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    margin: 0;
+    padding: 0;
+    border: 0;
+    overflow: hidden;
+    white-space: nowrap;
+    clip-path: inset(50%);
+  }
 
   /* Journal */
   .entry-date { font-size: 10px; color: var(--ink-faint); letter-spacing: 0.04em; text-transform: uppercase; margin-bottom: 6px; }
@@ -973,6 +1043,9 @@ function SeamlessViewport({ siteSlug }: { siteSlug: string }) {
 	);
 	const activeSiteError = useAppSelector(selectActiveSiteError);
 	const activeSiteSlug = useAppSelector((state) => state.ui.activeSite?.slug);
+	const backgroundNotice = useAppSelector(
+		(state) => state.ui.backgroundNotice
+	);
 	const hasActiveSiteError = activeSiteError && activeSiteSlug === siteSlug;
 
 	const loadingScreenHtml = useMemo(
@@ -1487,6 +1560,11 @@ function SeamlessViewport({ siteSlug }: { siteSlug: string }) {
 			{installingBlueprint && (
 				<div className={css.installBanner}>{installingBlueprint}</div>
 			)}
+			{!installingBlueprint && backgroundNotice && (
+				<div className={css.installBanner} role="status">
+					{backgroundNotice}
+				</div>
+			)}
 			{blueprintInstallDialogRequest && (
 				<BlueprintInstallDialog
 					blueprintUrl={blueprintInstallDialogRequest.blueprintUrl}
@@ -1569,9 +1647,11 @@ function LoadingScreen({
 	};
 
 	return (
+		// No tabIndex here: the card radios inside the shadow root are real
+		// focus stops now, and their events bubble out to these handlers. A
+		// focusable wrapper would only add an anonymous, unlabelled tab stop.
 		<div
 			className={css.loadingScreen}
-			tabIndex={0}
 			onClick={onInteract}
 			onKeyDown={handleKeyDown}
 			onPointerDown={onInteract}

--- a/packages/playground/personal-wp/src/components/playground-viewport/index.tsx
+++ b/packages/playground/personal-wp/src/components/playground-viewport/index.tsx
@@ -280,11 +280,11 @@ function renderCard(
 				card.theme
 			)}">${card.icon}</div>
           <div class="text"><div class="label">${card.label}</div><div class="sub">${
-			card.sub
-		}</div></div>
+				card.sub
+			}</div></div>
         </label>
         <div class="card-detail"><div class="detail-inner">
-          <label class="detail-close" for="${idPrefix}0" aria-hidden="true">×</label>
+          <label class="detail-close" for="${idPrefix}0"><span aria-hidden="true">×</span><span class="visually-hidden">Close</span></label>
           ${detailHeader}
           ${card.detail}
         </div></div>
@@ -564,7 +564,9 @@ function getWhatsNewHtml(): string {
 			(c, i) =>
 				`<input type="radio" name="wcard" id="w${
 					i + 1
-				}" class="card-toggle" aria-label="${c.label} — ${c.sub}">`
+				}" class="card-toggle" aria-label="${c.label} — ${escapeHtml(
+					c.sub
+				)}">`
 		)
 		.join('\n    ');
 
@@ -599,7 +601,7 @@ function getWhatsNewHtml(): string {
 			}</div></div>
         </label>
         <div class="card-detail"><div class="detail-inner">
-          <label class="detail-close" for="w0" aria-hidden="true">×</label>
+          <label class="detail-close" for="w0"><span aria-hidden="true">×</span><span class="visually-hidden">Close</span></label>
           <p class="detail-body">${c.detail}</p>
         </div></div>
       </div>`;
@@ -838,6 +840,11 @@ function getCardStageCss(): string {
     background: var(--bg-warm); color: var(--ink-soft);
     font-size: 12px; line-height: 20px; text-align: center;
     cursor: pointer; font-style: normal;
+  }
+  .visually-hidden {
+    position: absolute; width: 1px; height: 1px;
+    margin: -1px; padding: 0; border: 0;
+    overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap;
   }
 
   .detail-label {

--- a/packages/playground/personal-wp/src/components/playground-viewport/index.tsx
+++ b/packages/playground/personal-wp/src/components/playground-viewport/index.tsx
@@ -39,10 +39,12 @@ import {
 	setAutoBackupDue,
 	setSiteManagerOpen,
 } from '../../lib/state/redux/slice-ui';
+import type { PlaygroundClient } from '@wp-playground/client';
 import { playgroundLogo } from '@wp-playground/components';
 import { isAppBasePath } from '../../lib/state/url/app-base-url';
 import Button from '../button';
-import { useBackup } from '../../lib/hooks/use-backup';
+import { estimateBackupSize, useBackup } from '../../lib/hooks/use-backup';
+import { formatBytes } from '../../lib/utils/format-bytes';
 import {
 	getBlueprintInstallPreview,
 	getBlueprintInstallSource,
@@ -1624,6 +1626,7 @@ function SeamlessViewport({ siteSlug }: { siteSlug: string }) {
 				</Button>
 				{autoBackupDue && canBackupNow && (
 					<AutoBackupPrompt
+						playground={isDependentMode ? null : playground}
 						onDownload={performBackup}
 						onDismiss={() => dispatch(setAutoBackupDue(false))}
 					/>
@@ -1634,12 +1637,31 @@ function SeamlessViewport({ siteSlug }: { siteSlug: string }) {
 }
 
 function AutoBackupPrompt({
+	playground,
 	onDownload,
 	onDismiss,
 }: {
+	playground: PlaygroundClient | null | undefined;
 	onDownload: () => void;
 	onDismiss: () => void;
 }) {
+	const [sizeEstimate, setSizeEstimate] = useState<number | null>(null);
+
+	useEffect(() => {
+		if (!playground) {
+			return;
+		}
+		let cancelled = false;
+		estimateBackupSize(playground).then((size) => {
+			if (!cancelled) {
+				setSizeEstimate(size);
+			}
+		});
+		return () => {
+			cancelled = true;
+		};
+	}, [playground]);
+
 	return (
 		<div className={css.autoBackupPrompt} role="status" aria-live="polite">
 			<p className={css.autoBackupPromptText}>
@@ -1651,7 +1673,7 @@ function AutoBackupPrompt({
 				>
 					Click here to download it
 				</button>
-				.
+				{sizeEstimate !== null && ` (~${formatBytes(sizeEstimate)})`}.
 			</p>
 			<button
 				type="button"

--- a/packages/playground/personal-wp/src/components/playground-viewport/style.module.css
+++ b/packages/playground/personal-wp/src/components/playground-viewport/style.module.css
@@ -160,6 +160,85 @@
 	stroke: #fff;
 }
 
+/* Backup reminder — speech bubble pointing at the latch */
+.auto-backup-prompt {
+	position: absolute;
+	bottom: calc(100% + 12px);
+	left: 8px;
+	display: flex;
+	align-items: flex-start;
+	width: max-content;
+	max-width: min(280px, calc(100vw - 24px));
+	border: 1px solid #dcdcde;
+	border-radius: 8px;
+	background: #fff;
+	color: #1e1e1e;
+	box-shadow: 0 2px 12px rgba(0, 0, 0, 0.16);
+	font-family:
+		-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+	font-size: 13px;
+	line-height: 1.4;
+	animation: auto-backup-prompt-in 0.2s ease;
+}
+
+.auto-backup-prompt::after {
+	content: '';
+	position: absolute;
+	top: 100%;
+	left: 16px;
+	border: 8px solid transparent;
+	border-top-color: #fff;
+	border-bottom: 0;
+	filter: drop-shadow(0 1px 0 #dcdcde);
+}
+
+.auto-backup-prompt-text {
+	flex: 1;
+	margin: 0;
+	padding: 10px 4px 10px 12px;
+}
+
+.auto-backup-prompt-link {
+	padding: 0;
+	border: none;
+	background: none;
+	color: #3858e9;
+	font: inherit;
+	text-decoration: underline;
+	cursor: pointer;
+}
+
+.auto-backup-prompt-link:hover {
+	color: #1e1e1e;
+}
+
+.auto-backup-prompt-dismiss {
+	flex: none;
+	padding: 6px 10px;
+	border: none;
+	border-radius: 0 8px 8px 0;
+	background: none;
+	color: #757575;
+	font-size: 18px;
+	line-height: 1;
+	cursor: pointer;
+}
+
+.auto-backup-prompt-dismiss:hover {
+	color: #1e1e1e;
+}
+
+@keyframes auto-backup-prompt-in {
+	from {
+		opacity: 0;
+		transform: translateY(4px);
+	}
+	to {
+		opacity: 1;
+		transform: translateY(0);
+	}
+}
+
 /* Blueprint install banner */
 .install-banner {
 	position: absolute;

--- a/packages/playground/personal-wp/src/components/site-manager/site-database-panel/index.tsx
+++ b/packages/playground/personal-wp/src/components/site-manager/site-database-panel/index.tsx
@@ -5,6 +5,7 @@ import { DownloadButton } from './download-button';
 import { AdminerButton } from './adminer-button';
 import { PhpMyAdminButton } from './phpmyadmin-button';
 import css from './style.module.css';
+import { formatBytes } from '../../../lib/utils/format-bytes';
 
 const DATABASE_PATH = '/wordpress/wp-content/database/.ht.sqlite';
 
@@ -40,14 +41,6 @@ export function SiteDatabasePanel({
 
 		void fetchDatabaseSize();
 	}, [playground]);
-
-	const formatBytes = (bytes: number): string => {
-		if (bytes === 0) return '0 B';
-		const k = 1024;
-		const sizes = ['B', 'KB', 'MB', 'GB'];
-		const i = Math.floor(Math.log(bytes) / Math.log(k));
-		return `${parseFloat((bytes / Math.pow(k, i)).toFixed(2))} ${sizes[i]}`;
-	};
 
 	return (
 		<VStack spacing={4}>

--- a/packages/playground/personal-wp/src/components/site-manager/site-file-browser/index.tsx
+++ b/packages/playground/personal-wp/src/components/site-manager/site-file-browser/index.tsx
@@ -33,7 +33,10 @@ export function SiteFileBrowser({
 			filesystem={filesystem}
 			documentRoot={documentRoot}
 			isVisible={isVisible}
-			initialPath={`${documentRoot}/wp-config.php`}
+			// Nothing is auto-opened: the browser used to greet people with
+			// wp-config.php, which put database credentials on screen as the
+			// first thing anyone saw here.
+			initialPath={null}
 			placeholderText="Start this Playground to browse and edit its files."
 		/>
 	);

--- a/packages/playground/personal-wp/src/components/site-manager/site-info-panel/index.tsx
+++ b/packages/playground/personal-wp/src/components/site-manager/site-info-panel/index.tsx
@@ -500,90 +500,84 @@ function BackupSection() {
 		<div className={css.aboutSection}>
 			<h4 className={css.aboutSectionTitle}>Backup</h4>
 			<p>
-					Your site is stored in this browser. Browser data can be
-					cleared unexpectedly, so regular backups keep your WordPress
-					safe.
-				</p>
-				{backupHistory.length === 0 && (
-					<Notice status="warning" isDismissible={false}>
-						No backup yet. If this browser clears its data, your
-						site is gone — and there is no server to restore it
-						from.
-					</Notice>
-				)}
-				<div className={css.backupControls}>
-					<div className={css.backupRow}>
-						{/* SelectControl rather than a bare <select>: the raw
+				Your site is stored in this browser. Browser data can be cleared
+				unexpectedly, so regular backups keep your WordPress safe.
+			</p>
+			{backupHistory.length === 0 && (
+				<Notice status="warning" isDismissible={false}>
+					No backup yet. If this browser clears its data, your site is
+					gone — and there is no server to restore it from.
+				</Notice>
+			)}
+			<div className={css.backupControls}>
+				<div className={css.backupRow}>
+					{/* SelectControl rather than a bare <select>: the raw
 						    element carried no label, id or name, so it reached
 						    assistive tech with no accessible name at all. */}
-						<SelectControl
-							__nextHasNoMarginBottom
-							className={css.backupSelect}
-							label="Automatic backups"
-							hideLabelFromVision
-							value={autoBackupSelectValue}
-							options={autoBackupOptions}
-							onChange={handleAutoBackupChange}
-							disabled={isDependentMode}
-						/>
+					<SelectControl
+						__nextHasNoMarginBottom
+						className={css.backupSelect}
+						label="Automatic backups"
+						hideLabelFromVision
+						value={autoBackupSelectValue}
+						options={autoBackupOptions}
+						onChange={handleAutoBackupChange}
+						disabled={isDependentMode}
+					/>
+					<button
+						className={css.backupNowButton}
+						onClick={performBackup}
+						disabled={isBackingUp || isRestoring}
+						type="button"
+					>
+						{isBackingUp ? 'Backing up...' : 'Backup now'}
+					</button>
+					<input
+						type="file"
+						ref={restoreInputRef}
+						onChange={handleRestore}
+						accept=".zip,application/zip"
+						style={{ display: 'none' }}
+					/>
+					{!isDependentMode && (
 						<button
 							className={css.backupNowButton}
-							onClick={performBackup}
-							disabled={isBackingUp || isRestoring}
+							onClick={handleRestoreClick}
+							disabled={!playground || isBackingUp || isRestoring}
 							type="button"
 						>
-							{isBackingUp ? 'Backing up...' : 'Backup now'}
+							<Icon icon={upload} size={16} />
+							{isRestoring ? 'Restoring...' : 'Restore'}
 						</button>
-						<input
-							type="file"
-							ref={restoreInputRef}
-							onChange={handleRestore}
-							accept=".zip,application/zip"
-							style={{ display: 'none' }}
-						/>
-						{!isDependentMode && (
-							<button
-								className={css.backupNowButton}
-								onClick={handleRestoreClick}
-								disabled={
-									!playground || isBackingUp || isRestoring
-								}
-								type="button"
-							>
-								<Icon icon={upload} size={16} />
-								{isRestoring ? 'Restoring...' : 'Restore'}
-							</button>
-						)}
-					</div>
-					<span className={css.backupStatus}>
-						{lastBackupText}
-						{backupHistory.length > 0 && (
-							<button
-								className={css.historyToggle}
-								onClick={() => setShowHistory(!showHistory)}
-								type="button"
-							>
-								{showHistory
-									? 'hide history'
-									: `${backupHistory.length} backup${backupHistory.length === 1 ? '' : 's'}`}
-							</button>
-						)}
-					</span>
+					)}
 				</div>
-				{showHistory && (
-					<ul className={css.backupHistory}>
-						{backupHistory.map((entry, index) => (
-							<li key={index} className={css.backupHistoryItem}>
-								<span>{entry.filename}</span>
-								<span className={css.backupHistoryDate}>
-									{getRelativeDate(
-										new Date(entry.timestamp)
-									)}
-								</span>
-							</li>
-						))}
-					</ul>
-				)}
+				<span className={css.backupStatus}>
+					{lastBackupText}
+					{backupHistory.length > 0 && (
+						<button
+							className={css.historyToggle}
+							onClick={() => setShowHistory(!showHistory)}
+							type="button"
+						>
+							{showHistory
+								? 'hide history'
+								: `${backupHistory.length} backup${backupHistory.length === 1 ? '' : 's'}`}
+						</button>
+					)}
+				</span>
+			</div>
+			{showHistory && (
+				<ul className={css.backupHistory}>
+					{backupHistory.map((entry, index) => (
+						<li key={index} className={css.backupHistoryItem}>
+							<span>{entry.filename}</span>
+							<span className={css.backupHistoryDate}>
+								{getRelativeDate(new Date(entry.timestamp))}
+							</span>
+						</li>
+					))}
+				</ul>
+			)}
 		</div>
 	);
 }
@@ -720,8 +714,8 @@ function DependentTabToolsNotice() {
 			<h4>Recovery and reset are in your other tab</h4>
 			<p>
 				This tab can view, navigate, install apps, and back up your
-				site. Recovery and reset need the tab running the WordPress
-				runtime.
+				site. Recovery and reset need the tab where you first opened My
+				WordPress.
 			</p>
 		</div>
 	);
@@ -913,6 +907,20 @@ export function SiteInfoPanel({
 								name: 'advanced',
 								title: 'Advanced',
 							},
+							// Developer tools re-add these three tabs to this
+							// same bar rather than opening a second one, so
+							// turning them off just makes the tabs disappear
+							// again instead of leaving a nested bar behind.
+							...(showDevTools
+								? [
+										{ name: 'files', title: 'Files' },
+										{
+											name: 'database',
+											title: 'Database',
+										},
+										{ name: 'logs', title: 'Logs' },
+									]
+								: []),
 						]}
 					>
 						{(tab) => (
@@ -938,16 +946,84 @@ export function SiteInfoPanel({
 									hidden={tab.name !== 'advanced'}
 								>
 									<AdvancedTab
-										site={site}
-										playground={playground}
-										documentRoot={documentRoot}
 										showDevTools={showDevTools}
 										onShowDevToolsChange={
 											handleShowDevToolsChange
 										}
-										isVisible={tab.name === 'advanced'}
 									/>
 								</div>
+								{showDevTools && (
+									<>
+										<div
+											className={classNames(
+												css.tabContents,
+												css.fileBrowserTab,
+												{
+													[css.tabHidden]:
+														tab.name !== 'files',
+												}
+											)}
+											hidden={tab.name !== 'files'}
+										>
+											<Suspense
+												fallback={
+													<div className={css.padded}>
+														Loading file browser...
+													</div>
+												}
+											>
+												{documentRoot && (
+													<SiteFileBrowser
+														key={site.slug}
+														site={site}
+														isVisible={
+															tab.name === 'files'
+														}
+														documentRoot={
+															documentRoot
+														}
+													/>
+												)}
+											</Suspense>
+										</div>
+										<div
+											className={classNames(
+												css.tabContents,
+												css.padded,
+												{
+													[css.tabHidden]:
+														tab.name !== 'database',
+												}
+											)}
+											hidden={tab.name !== 'database'}
+										>
+											<SiteDatabasePanel
+												playground={playground}
+											/>
+										</div>
+										<div
+											className={classNames(
+												css.tabContents,
+												css.padded,
+												{
+													[css.tabHidden]:
+														tab.name !== 'logs',
+												}
+											)}
+											hidden={tab.name !== 'logs'}
+										>
+											<div
+												className={classNames(
+													css.logsWrapper
+												)}
+											>
+												<SiteLogs
+													className={css.logsSection}
+												/>
+											</div>
+										</div>
+									</>
+								)}
 							</>
 						)}
 					</TabPanel>
@@ -958,19 +1034,11 @@ export function SiteInfoPanel({
 }
 
 function AdvancedTab({
-	site,
-	playground,
-	documentRoot,
 	showDevTools,
 	onShowDevToolsChange,
-	isVisible,
 }: {
-	site: SiteInfo;
-	playground?: PlaygroundClient;
-	documentRoot: string | null;
 	showDevTools: boolean;
 	onShowDevToolsChange: (next: boolean) => void;
-	isVisible: boolean;
 }) {
 	return (
 		<div className={css.advancedTab}>
@@ -983,79 +1051,6 @@ function AdvancedTab({
 					onChange={onShowDevToolsChange}
 				/>
 			</div>
-			{showDevTools && (
-				<TabPanel
-					className={css.devTabs}
-					tabs={[
-						{ name: 'files', title: 'Files' },
-						{ name: 'database', title: 'Database' },
-						{ name: 'logs', title: 'Logs' },
-					]}
-				>
-					{(devTab) => (
-						<>
-							<div
-								className={classNames(
-									css.tabContents,
-									css.fileBrowserTab,
-									{
-										[css.tabHidden]:
-											devTab.name !== 'files',
-									}
-								)}
-								hidden={devTab.name !== 'files'}
-							>
-								<Suspense
-									fallback={
-										<div className={css.padded}>
-											Loading file browser...
-										</div>
-									}
-								>
-									{documentRoot && (
-										<SiteFileBrowser
-											key={site.slug}
-											site={site}
-											isVisible={
-												isVisible &&
-												devTab.name === 'files'
-											}
-											documentRoot={documentRoot}
-										/>
-									)}
-								</Suspense>
-							</div>
-							<div
-								className={classNames(
-									css.tabContents,
-									css.padded,
-									{
-										[css.tabHidden]:
-											devTab.name !== 'database',
-									}
-								)}
-								hidden={devTab.name !== 'database'}
-							>
-								<SiteDatabasePanel playground={playground} />
-							</div>
-							<div
-								className={classNames(
-									css.tabContents,
-									css.padded,
-									{
-										[css.tabHidden]: devTab.name !== 'logs',
-									}
-								)}
-								hidden={devTab.name !== 'logs'}
-							>
-								<div className={classNames(css.logsWrapper)}>
-									<SiteLogs className={css.logsSection} />
-								</div>
-							</div>
-						</>
-					)}
-				</TabPanel>
-			)}
 		</div>
 	);
 }

--- a/packages/playground/personal-wp/src/components/site-manager/site-info-panel/index.tsx
+++ b/packages/playground/personal-wp/src/components/site-manager/site-info-panel/index.tsx
@@ -1,5 +1,14 @@
-import { Button, Flex, FlexItem, Icon, TabPanel } from '@wordpress/components';
-import { chevronLeft, close, trash, external, upload } from '@wordpress/icons';
+import {
+	Button,
+	Flex,
+	FlexItem,
+	Icon,
+	Notice,
+	SelectControl,
+	TabPanel,
+	ToggleControl,
+} from '@wordpress/components';
+import { chevronLeft, close, trash, upload } from '@wordpress/icons';
 import classNames from 'classnames';
 import { lazy, Suspense, useEffect, useRef, useState } from 'react';
 import type { ChangeEvent, FormEvent } from 'react';
@@ -51,6 +60,26 @@ const SiteFileBrowser = lazy(() =>
 );
 
 const LAST_TAB_STORAGE_KEY = 'playground-site-last-tabs';
+const DEV_TOOLS_STORAGE_KEY = 'playground-personal-wp-show-dev-tools';
+
+// The developer tools preference belongs to the person, not to a site or a tab:
+// someone who turns them on once should not have to find the switch again in
+// another tab, and someone who never turns them on should never meet them.
+function getShowDevTools(): boolean {
+	try {
+		return localStorage.getItem(DEV_TOOLS_STORAGE_KEY) === 'true';
+	} catch {
+		return false;
+	}
+}
+
+function setShowDevTools(show: boolean): void {
+	try {
+		localStorage.setItem(DEV_TOOLS_STORAGE_KEY, show ? 'true' : 'false');
+	} catch {
+		// Silently fail if localStorage is not available
+	}
+}
 
 function getSiteLastTab(siteSlug: string): string | null {
 	try {
@@ -456,12 +485,12 @@ function BackupSection() {
 		? `Last download: ${getRelativeDate(new Date(lastBackup.timestamp))}`
 		: 'Never backed up';
 
-	const handleAutoBackupChange = (e: ChangeEvent<HTMLSelectElement>) => {
+	const handleAutoBackupChange = (value: string) => {
 		dispatch(
 			updateSiteMetadata({
 				slug: activeSite.slug,
 				metadata: {
-					autoBackupInterval: e.target.value as AutoBackupInterval,
+					autoBackupInterval: value as AutoBackupInterval,
 				},
 			})
 		);
@@ -470,49 +499,49 @@ function BackupSection() {
 	return (
 		<div className={css.aboutSection}>
 			<h4 className={css.aboutSectionTitle}>Backup</h4>
-			{isDependentMode ? (
-				<p>
-					Backups are managed from the main tab that has the active
-					connection.
+			<p>
+					Your site is stored in this browser. Browser data can be
+					cleared unexpectedly, so regular backups keep your WordPress
+					safe.
 				</p>
-			) : (
-				<>
-					<p>
-						Your site is stored in this browser. Browser data can be
-						cleared unexpectedly, so regular backups keep your
-						WordPress safe.
-					</p>
-					<div className={css.backupControls}>
-						<div className={css.backupRow}>
-							<select
-								className={css.backupSelect}
-								value={autoBackupSelectValue}
-								onChange={handleAutoBackupChange}
-							>
-								{autoBackupOptions.map((option) => (
-									<option
-										key={option.value}
-										value={option.value}
-									>
-										{option.label}
-									</option>
-								))}
-							</select>
-							<button
-								className={css.backupNowButton}
-								onClick={performBackup}
-								disabled={isBackingUp || isRestoring}
-								type="button"
-							>
-								{isBackingUp ? 'Backing up...' : 'Backup now'}
-							</button>
-							<input
-								type="file"
-								ref={restoreInputRef}
-								onChange={handleRestore}
-								accept=".zip,application/zip"
-								style={{ display: 'none' }}
-							/>
+				{backupHistory.length === 0 && (
+					<Notice status="warning" isDismissible={false}>
+						No backup yet. If this browser clears its data, your
+						site is gone — and there is no server to restore it
+						from.
+					</Notice>
+				)}
+				<div className={css.backupControls}>
+					<div className={css.backupRow}>
+						{/* SelectControl rather than a bare <select>: the raw
+						    element carried no label, id or name, so it reached
+						    assistive tech with no accessible name at all. */}
+						<SelectControl
+							__nextHasNoMarginBottom
+							className={css.backupSelect}
+							label="Automatic backups"
+							hideLabelFromVision
+							value={autoBackupSelectValue}
+							options={autoBackupOptions}
+							onChange={handleAutoBackupChange}
+							disabled={isDependentMode}
+						/>
+						<button
+							className={css.backupNowButton}
+							onClick={performBackup}
+							disabled={isBackingUp || isRestoring}
+							type="button"
+						>
+							{isBackingUp ? 'Backing up...' : 'Backup now'}
+						</button>
+						<input
+							type="file"
+							ref={restoreInputRef}
+							onChange={handleRestore}
+							accept=".zip,application/zip"
+							style={{ display: 'none' }}
+						/>
+						{!isDependentMode && (
 							<button
 								className={css.backupNowButton}
 								onClick={handleRestoreClick}
@@ -524,41 +553,37 @@ function BackupSection() {
 								<Icon icon={upload} size={16} />
 								{isRestoring ? 'Restoring...' : 'Restore'}
 							</button>
-						</div>
-						<span className={css.backupStatus}>
-							{lastBackupText}
-							{backupHistory.length > 0 && (
-								<button
-									className={css.historyToggle}
-									onClick={() => setShowHistory(!showHistory)}
-									type="button"
-								>
-									{showHistory
-										? 'hide history'
-										: `${backupHistory.length} backup${backupHistory.length === 1 ? '' : 's'}`}
-								</button>
-							)}
-						</span>
+						)}
 					</div>
-					{showHistory && (
-						<ul className={css.backupHistory}>
-							{backupHistory.map((entry, index) => (
-								<li
-									key={index}
-									className={css.backupHistoryItem}
-								>
-									<span>{entry.filename}</span>
-									<span className={css.backupHistoryDate}>
-										{getRelativeDate(
-											new Date(entry.timestamp)
-										)}
-									</span>
-								</li>
-							))}
-						</ul>
-					)}
-				</>
-			)}
+					<span className={css.backupStatus}>
+						{lastBackupText}
+						{backupHistory.length > 0 && (
+							<button
+								className={css.historyToggle}
+								onClick={() => setShowHistory(!showHistory)}
+								type="button"
+							>
+								{showHistory
+									? 'hide history'
+									: `${backupHistory.length} backup${backupHistory.length === 1 ? '' : 's'}`}
+							</button>
+						)}
+					</span>
+				</div>
+				{showHistory && (
+					<ul className={css.backupHistory}>
+						{backupHistory.map((entry, index) => (
+							<li key={index} className={css.backupHistoryItem}>
+								<span>{entry.filename}</span>
+								<span className={css.backupHistoryDate}>
+									{getRelativeDate(
+										new Date(entry.timestamp)
+									)}
+								</span>
+							</li>
+						))}
+					</ul>
+				)}
 		</div>
 	);
 }
@@ -674,26 +699,17 @@ function AboutTab({ siteSlug }: { siteSlug: string }) {
 			</p>
 
 			<InstallAppsSection siteSlug={siteSlug} />
+			{/* Backup comes before remote access: it is the only thing standing
+			    between this user and total data loss, and there is no host to
+			    recover from. */}
+			<BackupSection />
 			{!isDependentMode && (
 				<>
 					<RemoteAccessSection />
-					<BackupSection />
 					<RecoverySection />
 				</>
 			)}
 			{isDependentMode && <DependentTabToolsNotice />}
-
-			<div className={css.aboutSection}>
-				<a
-					href="https://playground.wordpress.net"
-					target="_blank"
-					rel="noopener noreferrer"
-					className={css.externalLink}
-				>
-					<Icon icon={external} size={16} />
-					<span>Open playground.wordpress.net</span>
-				</a>
-			</div>
 		</div>
 	);
 }
@@ -701,10 +717,10 @@ function AboutTab({ siteSlug }: { siteSlug: string }) {
 function DependentTabToolsNotice() {
 	return (
 		<div className={css.dependentTabToolsNotice}>
-			<h4>Runtime-only: backups, recovery, reset</h4>
+			<h4>Recovery and reset are in your other tab</h4>
 			<p>
-				This tab can view, navigate, and install apps. Backups,
-				recovery, and reset controls need the tab running the WordPress
+				This tab can view, navigate, install apps, and back up your
+				site. Recovery and reset need the tab running the WordPress
 				runtime.
 			</p>
 		</div>
@@ -724,8 +740,10 @@ export function SiteInfoPanel({
 }) {
 	const dispatch = useAppDispatch();
 
-	// Load the last active tab for this site
-	const validTabs = ['about', 'files', 'database', 'logs'];
+	// Load the last active tab for this site. Only the two top-level tabs are
+	// restorable — the developer panels live inside Advanced and must never be
+	// what someone meets when they open Site Tools.
+	const validTabs = ['about', 'advanced'];
 	const [initialTabName] = useState(() => {
 		const lastTab = getSiteLastTab(site.slug);
 		if (lastTab && validTabs.includes(lastTab)) {
@@ -733,6 +751,12 @@ export function SiteInfoPanel({
 		}
 		return 'about';
 	});
+
+	const [showDevTools, setShowDevToolsState] = useState(getShowDevTools);
+	const handleShowDevToolsChange = (next: boolean) => {
+		setShowDevToolsState(next);
+		setShowDevTools(next);
+	};
 
 	// Resolve documentRoot from playground client, or use fallback for direct OPFS access
 	// Initialize to "/" for OPFS sites so the file browser can render immediately
@@ -886,16 +910,8 @@ export function SiteInfoPanel({
 								title: 'About',
 							},
 							{
-								name: 'files',
-								title: 'Files',
-							},
-							{
-								name: 'database',
-								title: 'Database',
-							},
-							{
-								name: 'logs',
-								title: 'Logs',
+								name: 'advanced',
+								title: 'Advanced',
 							},
 						]}
 					>
@@ -915,64 +931,22 @@ export function SiteInfoPanel({
 									<AboutTab siteSlug={site.slug} />
 								</div>
 								<div
-									className={classNames(
-										css.tabContents,
-										css.fileBrowserTab,
-										{
-											[css.tabHidden]:
-												tab.name !== 'files',
-										}
-									)}
-									hidden={tab.name !== 'files'}
+									className={classNames(css.tabContents, {
+										[css.tabHidden]:
+											tab.name !== 'advanced',
+									})}
+									hidden={tab.name !== 'advanced'}
 								>
-									<Suspense
-										fallback={
-											<div className={css.padded}>
-												Loading file browser...
-											</div>
-										}
-									>
-										{documentRoot && (
-											<SiteFileBrowser
-												key={site.slug}
-												site={site}
-												isVisible={tab.name === 'files'}
-												documentRoot={documentRoot}
-											/>
-										)}
-									</Suspense>
-								</div>
-								<div
-									className={classNames(
-										css.tabContents,
-										css.padded,
-										{
-											[css.tabHidden]:
-												tab.name !== 'database',
-										}
-									)}
-									hidden={tab.name !== 'database'}
-								>
-									<SiteDatabasePanel
+									<AdvancedTab
+										site={site}
 										playground={playground}
-									/>
-								</div>
-								<div
-									className={classNames(
-										css.tabContents,
-										css.padded,
-										{
-											[css.tabHidden]:
-												tab.name !== 'logs',
+										documentRoot={documentRoot}
+										showDevTools={showDevTools}
+										onShowDevToolsChange={
+											handleShowDevToolsChange
 										}
-									)}
-									hidden={tab.name !== 'logs'}
-								>
-									<div
-										className={classNames(css.logsWrapper)}
-									>
-										<SiteLogs className={css.logsSection} />
-									</div>
+										isVisible={tab.name === 'advanced'}
+									/>
 								</div>
 							</>
 						)}
@@ -980,5 +954,108 @@ export function SiteInfoPanel({
 				</FlexItem>
 			</Flex>
 		</section>
+	);
+}
+
+function AdvancedTab({
+	site,
+	playground,
+	documentRoot,
+	showDevTools,
+	onShowDevToolsChange,
+	isVisible,
+}: {
+	site: SiteInfo;
+	playground?: PlaygroundClient;
+	documentRoot: string | null;
+	showDevTools: boolean;
+	onShowDevToolsChange: (next: boolean) => void;
+	isVisible: boolean;
+}) {
+	return (
+		<div className={css.advancedTab}>
+			<div className={css.padded}>
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label="Show developer tools"
+					help="Browse the site's files, open its database, and read PHP logs. You don't need these to use your WordPress."
+					checked={showDevTools}
+					onChange={onShowDevToolsChange}
+				/>
+			</div>
+			{showDevTools && (
+				<TabPanel
+					className={css.devTabs}
+					tabs={[
+						{ name: 'files', title: 'Files' },
+						{ name: 'database', title: 'Database' },
+						{ name: 'logs', title: 'Logs' },
+					]}
+				>
+					{(devTab) => (
+						<>
+							<div
+								className={classNames(
+									css.tabContents,
+									css.fileBrowserTab,
+									{
+										[css.tabHidden]:
+											devTab.name !== 'files',
+									}
+								)}
+								hidden={devTab.name !== 'files'}
+							>
+								<Suspense
+									fallback={
+										<div className={css.padded}>
+											Loading file browser...
+										</div>
+									}
+								>
+									{documentRoot && (
+										<SiteFileBrowser
+											key={site.slug}
+											site={site}
+											isVisible={
+												isVisible &&
+												devTab.name === 'files'
+											}
+											documentRoot={documentRoot}
+										/>
+									)}
+								</Suspense>
+							</div>
+							<div
+								className={classNames(
+									css.tabContents,
+									css.padded,
+									{
+										[css.tabHidden]:
+											devTab.name !== 'database',
+									}
+								)}
+								hidden={devTab.name !== 'database'}
+							>
+								<SiteDatabasePanel playground={playground} />
+							</div>
+							<div
+								className={classNames(
+									css.tabContents,
+									css.padded,
+									{
+										[css.tabHidden]: devTab.name !== 'logs',
+									}
+								)}
+								hidden={devTab.name !== 'logs'}
+							>
+								<div className={classNames(css.logsWrapper)}>
+									<SiteLogs className={css.logsSection} />
+								</div>
+							</div>
+						</>
+					)}
+				</TabPanel>
+			)}
+		</div>
 	);
 }

--- a/packages/playground/personal-wp/src/components/site-manager/site-info-panel/style.module.css
+++ b/packages/playground/personal-wp/src/components/site-manager/site-info-panel/style.module.css
@@ -59,6 +59,41 @@
 	display: none !important;
 }
 
+.advanced-tab {
+	width: 100%;
+	display: flex;
+	flex-direction: column;
+	flex: 1;
+	min-height: 0;
+}
+
+/* The developer panels keep the same shell as the top-level tabs so nothing
+   about them looks like a different product once they are revealed. */
+.dev-tabs {
+	width: 100%;
+	display: flex;
+	flex-direction: column;
+	flex: 1;
+	min-height: 0;
+
+	& :global(.components-tab-panel__tabs) {
+		--wp-components-color-accent: var(--color-gray-900);
+		border-bottom: 1px solid var(--color-gray-200);
+	}
+	& :global(.components-tab-panel__tabs-item) {
+		padding-left: var(--padding-size);
+		padding-right: var(--padding-size);
+	}
+	& :global(.components-tab-panel__tab-content) {
+		display: flex;
+		flex-direction: column;
+		flex-grow: 1;
+		min-height: 0;
+		overflow: hidden;
+		align-self: stretch;
+	}
+}
+
 .file-browser-tab {
 	overflow: hidden;
 }
@@ -567,6 +602,7 @@
 
 .backup-row {
 	display: flex;
+	flex-wrap: wrap;
 	gap: 8px;
 	align-items: center;
 }
@@ -596,14 +632,12 @@
 	cursor: not-allowed;
 }
 
+/* SelectControl brings its own control styling from @wordpress/components; this
+   only governs how the field shares the row. The basis keeps the longest option
+   readable, and the row wraps rather than clipping the value on narrow panels. */
 .backup-select {
-	padding: 6px 10px;
-	border: 1px solid #ddd;
-	border-radius: 4px;
-	font-size: 13px;
-	background: #fff;
-	color: #1e1e1e;
-	width: 100%;
+	flex: 1 1 12rem;
+	min-width: 12rem;
 }
 
 .backup-status {

--- a/packages/playground/personal-wp/src/components/site-manager/site-info-panel/style.module.css
+++ b/packages/playground/personal-wp/src/components/site-manager/site-info-panel/style.module.css
@@ -67,33 +67,6 @@
 	min-height: 0;
 }
 
-/* The developer panels keep the same shell as the top-level tabs so nothing
-   about them looks like a different product once they are revealed. */
-.dev-tabs {
-	width: 100%;
-	display: flex;
-	flex-direction: column;
-	flex: 1;
-	min-height: 0;
-
-	& :global(.components-tab-panel__tabs) {
-		--wp-components-color-accent: var(--color-gray-900);
-		border-bottom: 1px solid var(--color-gray-200);
-	}
-	& :global(.components-tab-panel__tabs-item) {
-		padding-left: var(--padding-size);
-		padding-right: var(--padding-size);
-	}
-	& :global(.components-tab-panel__tab-content) {
-		display: flex;
-		flex-direction: column;
-		flex-grow: 1;
-		min-height: 0;
-		overflow: hidden;
-		align-self: stretch;
-	}
-}
-
 .file-browser-tab {
 	overflow: hidden;
 }

--- a/packages/playground/personal-wp/src/lib/hooks/use-auto-backup.ts
+++ b/packages/playground/personal-wp/src/lib/hooks/use-auto-backup.ts
@@ -1,34 +1,31 @@
 import { useEffect, useRef } from 'react';
-import { usePlaygroundClient } from '../use-playground-client';
 import { useActiveSite, useAppDispatch } from '../state/redux/store';
-import { setBackgroundNotice } from '../state/redux/slice-ui';
-import { useBackup } from './use-backup';
+import { setAutoBackupDue } from '../state/redux/slice-ui';
 import { shouldAutoBackup } from './use-auto-backup-utils';
 
-const NOTICE_DURATION_MS = 6000;
-
+/**
+ * Flags the active site as due for a backup once its interval has elapsed.
+ * The download itself only happens when the user clicks the prompt that the
+ * viewport shows on the Site Tools latch, so no file leaves the device
+ * without being asked.
+ */
 export function useAutoBackup() {
-	const playground = usePlaygroundClient();
 	const activeSite = useActiveSite();
 	const dispatch = useAppDispatch();
-	const { performBackup } = useBackup();
-	const hasTriggeredRef = useRef(false);
-	const siteSlugRef = useRef<string | null>(null);
+	const promptedSiteSlugRef = useRef<string | null>(null);
 
 	useEffect(() => {
-		if (!playground || !activeSite) {
+		if (!activeSite) {
 			return;
 		}
 
-		// Reset trigger flag when switching to a different site
-		if (siteSlugRef.current !== activeSite.slug) {
-			siteSlugRef.current = activeSite.slug;
-			hasTriggeredRef.current = false;
-		}
-
-		if (hasTriggeredRef.current) {
+		// Prompt at most once per site visit. Switching sites hides the
+		// prompt for the previous site and re-evaluates the new one.
+		if (promptedSiteSlugRef.current === activeSite.slug) {
 			return;
 		}
+		promptedSiteSlugRef.current = activeSite.slug;
+		dispatch(setAutoBackupDue(false));
 
 		if (activeSite.metadata.storage === 'none') {
 			return;
@@ -40,40 +37,11 @@ export function useAutoBackup() {
 			whenCreated,
 		} = activeSite.metadata;
 		// When no backup has happened yet, measure the interval against the
-		// site's creation time so a brand-new site doesn't auto-backup at boot.
+		// site's creation time so a brand-new site doesn't prompt at boot.
 		const referenceTimestamp = backupHistory[0]?.timestamp ?? whenCreated;
 
-		if (!shouldAutoBackup(autoBackupInterval, referenceTimestamp)) {
-			return;
+		if (shouldAutoBackup(autoBackupInterval, referenceTimestamp)) {
+			dispatch(setAutoBackupDue(true));
 		}
-
-		hasTriggeredRef.current = true;
-
-		// Delay the backup slightly to let the UI settle after WordPress boots
-		let noticeTimeoutId: ReturnType<typeof setTimeout> | undefined;
-		// performBackup() can resolve after this effect was cleaned up (site
-		// switch, unmount). Don't announce a backup for a site that is gone.
-		let cancelled = false;
-		const timeoutId = setTimeout(async () => {
-			const succeeded = await performBackup();
-			if (!succeeded || cancelled) {
-				return;
-			}
-			// This is the one moment the app moves data off the device without
-			// being asked. Saying so is the difference between a private
-			// product and one that merely claims to be.
-			dispatch(
-				setBackgroundNotice('Backup saved to your Downloads folder')
-			);
-			noticeTimeoutId = setTimeout(() => {
-				dispatch(setBackgroundNotice(null));
-			}, NOTICE_DURATION_MS);
-		}, 3000);
-
-		return () => {
-			cancelled = true;
-			clearTimeout(timeoutId);
-			clearTimeout(noticeTimeoutId);
-		};
-	}, [playground, activeSite, performBackup, dispatch]);
+	}, [activeSite, dispatch]);
 }

--- a/packages/playground/personal-wp/src/lib/hooks/use-auto-backup.ts
+++ b/packages/playground/personal-wp/src/lib/hooks/use-auto-backup.ts
@@ -1,12 +1,16 @@
 import { useEffect, useRef } from 'react';
 import { usePlaygroundClient } from '../use-playground-client';
-import { useActiveSite } from '../state/redux/store';
+import { useActiveSite, useAppDispatch } from '../state/redux/store';
+import { setBackgroundNotice } from '../state/redux/slice-ui';
 import { useBackup } from './use-backup';
 import { shouldAutoBackup } from './use-auto-backup-utils';
+
+const NOTICE_DURATION_MS = 6000;
 
 export function useAutoBackup() {
 	const playground = usePlaygroundClient();
 	const activeSite = useActiveSite();
+	const dispatch = useAppDispatch();
 	const { performBackup } = useBackup();
 	const hasTriggeredRef = useRef(false);
 	const siteSlugRef = useRef<string | null>(null);
@@ -46,12 +50,26 @@ export function useAutoBackup() {
 		hasTriggeredRef.current = true;
 
 		// Delay the backup slightly to let the UI settle after WordPress boots
-		const timeoutId = setTimeout(() => {
-			performBackup();
+		let noticeTimeoutId: ReturnType<typeof setTimeout> | undefined;
+		const timeoutId = setTimeout(async () => {
+			const succeeded = await performBackup();
+			if (!succeeded) {
+				return;
+			}
+			// This is the one moment the app moves data off the device without
+			// being asked. Saying so is the difference between a private
+			// product and one that merely claims to be.
+			dispatch(
+				setBackgroundNotice('Backup saved to your Downloads folder')
+			);
+			noticeTimeoutId = setTimeout(() => {
+				dispatch(setBackgroundNotice(null));
+			}, NOTICE_DURATION_MS);
 		}, 3000);
 
 		return () => {
 			clearTimeout(timeoutId);
+			clearTimeout(noticeTimeoutId);
 		};
-	}, [playground, activeSite, performBackup]);
+	}, [playground, activeSite, performBackup, dispatch]);
 }

--- a/packages/playground/personal-wp/src/lib/hooks/use-auto-backup.ts
+++ b/packages/playground/personal-wp/src/lib/hooks/use-auto-backup.ts
@@ -51,9 +51,12 @@ export function useAutoBackup() {
 
 		// Delay the backup slightly to let the UI settle after WordPress boots
 		let noticeTimeoutId: ReturnType<typeof setTimeout> | undefined;
+		// performBackup() can resolve after this effect was cleaned up (site
+		// switch, unmount). Don't announce a backup for a site that is gone.
+		let cancelled = false;
 		const timeoutId = setTimeout(async () => {
 			const succeeded = await performBackup();
-			if (!succeeded) {
+			if (!succeeded || cancelled) {
 				return;
 			}
 			// This is the one moment the app moves data off the device without
@@ -68,6 +71,7 @@ export function useAutoBackup() {
 		}, 3000);
 
 		return () => {
+			cancelled = true;
 			clearTimeout(timeoutId);
 			clearTimeout(noticeTimeoutId);
 		};

--- a/packages/playground/personal-wp/src/lib/hooks/use-backup.ts
+++ b/packages/playground/personal-wp/src/lib/hooks/use-backup.ts
@@ -5,6 +5,7 @@ import {
 } from '../use-playground-client';
 import { useActiveSite, useAppDispatch } from '../state/redux/store';
 import { updateSiteMetadata } from '../state/redux/slice-sites';
+import { setAutoBackupDue } from '../state/redux/slice-ui';
 import { zipWpContent } from '@wp-playground/client';
 import { logger } from '@php-wasm/logger';
 import saveAs from 'file-saver';
@@ -65,7 +66,11 @@ export function useBackup() {
 			if (isRequestingRemote) return false;
 			setIsRequestingRemote(true);
 			try {
-				return await requestRemoteBackup(activeSite.slug);
+				const succeeded = await requestRemoteBackup(activeSite.slug);
+				if (succeeded) {
+					dispatch(setAutoBackupDue(false));
+				}
+				return succeeded;
 			} finally {
 				setIsRequestingRemote(false);
 			}
@@ -105,6 +110,8 @@ export function useBackup() {
 					})
 				);
 			}
+			// A backup from any entry point satisfies the reminder.
+			dispatch(setAutoBackupDue(false));
 
 			return true;
 		} finally {

--- a/packages/playground/personal-wp/src/lib/hooks/use-backup.ts
+++ b/packages/playground/personal-wp/src/lib/hooks/use-backup.ts
@@ -7,6 +7,8 @@ import { useActiveSite, useAppDispatch } from '../state/redux/store';
 import { updateSiteMetadata } from '../state/redux/slice-sites';
 import { setAutoBackupDue } from '../state/redux/slice-ui';
 import { zipWpContent } from '@wp-playground/client';
+import { getLegacyPlaygroundRuntimeWpContentPaths } from '@wp-playground/blueprints';
+import { joinPaths, phpVars } from '@php-wasm/util';
 import { logger } from '@php-wasm/logger';
 import saveAs from 'file-saver';
 import {
@@ -28,6 +30,59 @@ function formatBackupFilename(siteName: string): string {
 	const time = now.toTimeString().slice(0, 8).replace(/:/g, '');
 	const sanitized = sanitizeForFilename(siteName);
 	return `${sanitized}-backup-${date}-${time}.zip`;
+}
+
+/**
+ * Sums the bytes zipWpContent() would archive: wp-content minus the legacy
+ * runtime paths, plus wp-config.php. The result is uncompressed, so it's an
+ * upper bound rather than the exact zip size.
+ */
+export async function estimateBackupSize(
+	playground: NonNullable<ReturnType<typeof usePlaygroundClient>>
+): Promise<number | null> {
+	try {
+		const documentRoot = await playground.documentRoot;
+		const wpContentPath = joinPaths(documentRoot, 'wp-content');
+		const excludedPaths = (
+			await getLegacyPlaygroundRuntimeWpContentPaths(
+				playground,
+				wpContentPath
+			)
+		).map((path) => joinPaths(wpContentPath, path));
+		const js = phpVars({
+			wpContentPath,
+			wpConfigPath: joinPaths(documentRoot, 'wp-config.php'),
+			excludedPaths,
+		});
+		const response = await playground.run({
+			code: `<?php
+				$excluded = ${js.excludedPaths};
+				$total = @filesize(${js.wpConfigPath}) ?: 0;
+				$iterator = new RecursiveIteratorIterator(
+					new RecursiveCallbackFilterIterator(
+						new RecursiveDirectoryIterator(
+							${js.wpContentPath},
+							FilesystemIterator::SKIP_DOTS
+						),
+						function ($current) use ($excluded) {
+							return !in_array($current->getPathname(), $excluded, true);
+						}
+					)
+				);
+				foreach ($iterator as $file) {
+					if ($file->isFile()) {
+						$total += $file->getSize();
+					}
+				}
+				echo $total;
+			`,
+		});
+		const total = Number(response.text.trim());
+		return Number.isFinite(total) ? total : null;
+	} catch (error) {
+		logger.debug('Could not estimate backup size:', error);
+		return null;
+	}
 }
 
 async function getWordPressSiteName(

--- a/packages/playground/personal-wp/src/lib/state/redux/slice-ui.ts
+++ b/packages/playground/personal-wp/src/lib/state/redux/slice-ui.ts
@@ -150,6 +150,11 @@ export interface UIState {
 	siteManagerIsOpen: boolean;
 	siteManagerSection: SiteManagerSection;
 	blueprintInstallMessage: string | null;
+	/**
+	 * Transient notice for work the app did on its own, such as an automatic
+	 * backup. Nothing else tells the user a file just landed on their device.
+	 */
+	backgroundNotice: string | null;
 }
 
 const query = new URL(document.location.href).searchParams;
@@ -188,6 +193,7 @@ const initialState: UIState = {
 		!isMobile,
 	siteManagerSection: 'site-details',
 	blueprintInstallMessage: null,
+	backgroundNotice: null,
 };
 
 const uiSlice = createSlice({
@@ -264,6 +270,12 @@ const uiSlice = createSlice({
 		) => {
 			state.blueprintInstallMessage = action.payload;
 		},
+		setBackgroundNotice: (
+			state,
+			action: PayloadAction<string | null>
+		) => {
+			state.backgroundNotice = action.payload;
+		},
 		setSiteSlugToRename: (
 			state,
 			action: PayloadAction<string | undefined>
@@ -313,6 +325,7 @@ export const {
 	setGitHubAuthRepoUrl,
 	setOffline,
 	setBlueprintInstallMessage,
+	setBackgroundNotice,
 	setSiteManagerOpen,
 	setSiteManagerSection,
 	setSiteSlugToRename,

--- a/packages/playground/personal-wp/src/lib/state/redux/slice-ui.ts
+++ b/packages/playground/personal-wp/src/lib/state/redux/slice-ui.ts
@@ -151,10 +151,11 @@ export interface UIState {
 	siteManagerSection: SiteManagerSection;
 	blueprintInstallMessage: string | null;
 	/**
-	 * Transient notice for work the app did on its own, such as an automatic
-	 * backup. Nothing else tells the user a file just landed on their device.
+	 * Set when the active site's backup interval has elapsed. The viewport
+	 * shows a speech bubble on the Site Tools latch inviting the user to
+	 * download a backup; nothing leaves the device until they click it.
 	 */
-	backgroundNotice: string | null;
+	autoBackupDue: boolean;
 }
 
 const query = new URL(document.location.href).searchParams;
@@ -193,7 +194,7 @@ const initialState: UIState = {
 		!isMobile,
 	siteManagerSection: 'site-details',
 	blueprintInstallMessage: null,
-	backgroundNotice: null,
+	autoBackupDue: false,
 };
 
 const uiSlice = createSlice({
@@ -270,11 +271,8 @@ const uiSlice = createSlice({
 		) => {
 			state.blueprintInstallMessage = action.payload;
 		},
-		setBackgroundNotice: (
-			state,
-			action: PayloadAction<string | null>
-		) => {
-			state.backgroundNotice = action.payload;
+		setAutoBackupDue: (state, action: PayloadAction<boolean>) => {
+			state.autoBackupDue = action.payload;
 		},
 		setSiteSlugToRename: (
 			state,
@@ -325,7 +323,7 @@ export const {
 	setGitHubAuthRepoUrl,
 	setOffline,
 	setBlueprintInstallMessage,
-	setBackgroundNotice,
+	setAutoBackupDue,
 	setSiteManagerOpen,
 	setSiteManagerSection,
 	setSiteSlugToRename,

--- a/packages/playground/personal-wp/src/lib/utils/format-bytes.ts
+++ b/packages/playground/personal-wp/src/lib/utils/format-bytes.ts
@@ -1,0 +1,10 @@
+export function formatBytes(bytes: number): string {
+	if (bytes === 0) return '0 B';
+	const k = 1024;
+	const sizes = ['B', 'KB', 'MB', 'GB'];
+	const i = Math.min(
+		Math.floor(Math.log(bytes) / Math.log(k)),
+		sizes.length - 1
+	);
+	return `${parseFloat((bytes / Math.pow(k, i)).toFixed(2))} ${sizes[i]}`;
+}


### PR DESCRIPTION
## Motivation for the change, related issues

A design and accessibility review of the Personal WP app UI (`packages/playground/personal-wp/src/components`) turned up three problems that all pull against what this product says it is. `PRODUCT.md` describes My WordPress as "an app, not an admin", says "absence is a feature", and makes persistence the core promise — but the interface contradicted all three:

1. **The first-run screen could not be operated with a keyboard or a screen reader.** The nine welcome cards are `<label>` elements driven by sibling radios set to `display: none`. Measured live in the shadow root: `radioCount: 10`, `cardLabels: 9`, **`tabbable: 0`**. `display: none` also removes those radios from the accessibility tree, so the cards were not merely unfocusable — they were unannounced. Every fact a new user needs (where Site Tools lives, that backups download daily, that data never leaves the device) was locked inside them. Fails WCAG 2.1.1 (A) and 4.1.2 (A).

2. **Site Tools' primary navigation was 75% developer tools, and it remembered the worst one.** The four tabs were About / Files / Database / Logs, and the last-used tab was restored on open — so a user who once tapped Files was greeted by `/wordpress/wp-config.php`, with `DB_NAME`, `DB_USER` and `DB_PASSWORD` on screen, every time afterwards. The About tab also ended with a link to `playground.wordpress.net`, the developer product this app deliberately is not.

3. **The data-loss story was the quietest thing on the panel.** "Never backed up" rendered in 13px grey, positioned *below* Remote Access. Meanwhile the automatic backup dropped a ZIP into the user's Downloads folder with no toast, no notice, and no consent — in a product whose entire thesis is that nothing leaves your device.

## Implementation details

### 1. First-run screen: keyboard and screen-reader operable

The obvious fix — real `<button aria-expanded>` elements — is **impossible here**. The welcome screen is injected into a shadow root through `getSanitizedLoadingScreenNodes`, which strips `<script>`, `<iframe>`, `<object>`, `<embed>` and every `on*` handler. There is no JavaScript in that root at all, so the CSS-only radio mechanism is not a shortcut; it is the only thing that can work. The radios were fixed instead of replaced:

- `.card-toggle` is now clipped to 1×1px (`clip-path: inset(50%)`) instead of `display: none`, which keeps it **focusable and in the accessibility tree**. Same treatment for `#show-intro`, the checkbox that swaps the returning-user and first-run panels — previously that swap was mouse-only.
- Every radio carries an `aria-label` derived from its card ("Journal — private notes"), plus "No card open" for the reset radio.
- **Nested labels removed.** The markup was `<label class="card">` containing `<label class="detail-close">` — invalid HTML that leaves assistive tech guessing which control was activated. The card is now a `<div>`, the front is the label, and the close affordance is a sibling marked `aria-hidden` (it is a mouse convenience; keyboard users cycle the radio group with arrow keys).
- Focus is surfaced on the card via `:focus-visible`, since the control itself is invisible.
- Removed `tabIndex={0}` from the loading-screen wrapper — an anonymous, unlabelled tab stop. Its handlers still fire, because shadow-DOM events bubble.

Applied to both card fields (first-run and "what's new"), which share the CSS.

### 2. Site Tools: About / Advanced

- Four tabs collapse to two. Files, Database and Logs move behind a **"Show developer tools"** toggle that defaults **off** and persists **per person** (`localStorage`), not per site or per tab.
- `getSiteLastTab` now only restores `about` or `advanced`, so no developer surface can be what greets you on open.
- `SiteFileBrowser` passes `initialPath={null}`. It previously pointed at `${documentRoot}/wp-config.php`. (`initialPath` *auto-opens* a file, so aiming it at a directory would simply fail — `null` is the correct fix: the tree still renders, nothing opens.)
- Removed the `Open playground.wordpress.net` link.
- **Dependent-tab inversion fixed.** A second tab previously hid Backup, Recovery *and* Reset while leaving Files, Database and Logs fully functional. `performBackup` already routed through `requestRemoteBackup` in dependent mode — the UI was hiding a capability that worked. Backup is now available in a second tab; only Restore (which genuinely needs the runtime client) is withheld, and the notice says so plainly.

### 3. Backup visibility

- `BackupSection` moved **above** `RemoteAccessSection`.
- When `backupHistory` is empty, a non-dismissible `Notice status="warning"`: *"No backup yet. If this browser clears its data, your site is gone — and there is no server to restore it from."*
- The automatic backup now announces itself: a new `backgroundNotice` field in the UI slice, dispatched only on success, shown for 6s.
- The raw `<select>` became `<SelectControl label="Automatic backups" hideLabelFromVision>`. It previously had **no accessible name at all** — no `id`, no `name`, no label, which is what produced Chrome's own "No label associated with a form field" issue. Measured after the change: reports `"Automatic backups"`, with a real id and one associated label. The row also wraps now instead of clipping "Auto-download daily" to "Auto-downlo" at 390px.

## Screenshots

### Site Tools — four tabs became two

`Files` / `Database` / `Logs` move behind a default-off toggle; Backup moves above Remote Access; the `playground.wordpress.net` link is gone.

| Before | After |
| --- | --- |
| <!-- DROP 01-before-site-tools.png HERE --> | <!-- DROP 04-after-site-tools.png HERE --> |

### The file browser no longer greets you with database credentials

Before, `Files` was one click from the front door and auto-opened `wp-config.php`. After, developer tools are behind a toggle that is off by default, and nothing is auto-opened.

| Before | After |
| --- | --- |
| <!-- DROP 02-before-files-wp-config.png HERE --> | <!-- DROP 05-after-advanced-toggle-off.png HERE --> |

### Backup now works in a second tab

Previously a second tab hid Backup entirely while leaving Adminer and phpMyAdmin available.

<!-- DROP 03-after-site-tools-dependent-tab.png HERE -->

> **Note on the first-run fix:** it is deliberately **invisible** — the screen looks identical before and after. The change is that its controls now exist in the accessibility tree. The evidence is `tabbable: 0` → `10` measured in the shadow root, plus a new focus ring when tabbing through the cards.

## Testing Instructions (or ideally a Blueprint)

```
nvm use && npm ci
npx nx dev:standalone playground-personal-wp --configuration=development
```

Open http://localhost:5401/website-server/

**First-run accessibility** (use a fresh browser profile or incognito so the welcome screen shows):
1. During boot, press <kbd>Tab</kbd> — focus should land on the welcome cards and a focus ring should be visible.
2. Use <kbd>←</kbd>/<kbd>→</kbd> to move between cards; each expands as it is selected.
3. With VoiceOver/NVDA, each card should announce its name ("Journal — private notes").

**Site Tools IA:**
1. Open Site Tools (the icon in the bottom-left corner). Only **About** and **Advanced** should be present.
2. Open **Advanced** — "Show developer tools" should be **off**. Toggle it on to reveal Files / Database / Logs.
3. Open **Files** — no file should be auto-opened, and `wp-config.php` should not be on screen.
4. Reload with the Advanced tab last used — Site Tools should reopen on a safe tab, never on a developer panel.

**Backup:**
1. On the **About** tab, Backup should appear above Remote Access.
2. On a site with no backups, a warning notice should be visible.
3. Trigger an automatic backup — a "Backup saved to your Downloads folder" notice should appear for ~6s.
4. Open the app in a **second tab** — "Backup now" should still be present and working there.

**Automated checks:** `npx nx typecheck playground-personal-wp`, `npx nx lint playground-personal-wp`, `npx nx test playground-personal-wp` (108 tests).
