### PR TITLE
[Website] Auto-prepend PHP scripts before snippet execution

### DIFF
--- a/packages/docs/site/docs/main/guides/php-code-snippets.md
+++ b/packages/docs/site/docs/main/guides/php-code-snippets.md
@@ -220,9 +220,9 @@ bootstraps can still share one runtime.
 
 `php-fragment` says the visible source omits its PHP opening tag. Playground
 adds the opener on the first line of the execution file, so PHP errors still
-point to the displayed line and the `name` attribute. A fragment containing
-`<?php` or `<?=` is rejected; remove `php-fragment` when the source is already
-a complete PHP file.
+point to the displayed line and the `name` attribute. A fragment starting with
+`<?php` or `<?=` is rejected; remove `php-fragment` when the source is already a
+complete PHP file.
 
 Without `php-fragment`, bootstrap-backed snippets must include their own PHP
 opening tag. `bootstrap` and `php-fragment` are independent, so fragments also

--- a/packages/docs/site/docs/main/guides/php-code-snippets.md
+++ b/packages/docs/site/docs/main/guides/php-code-snippets.md
@@ -195,28 +195,28 @@ the WordPress download and boot step:
 </php-snippet>
 ```
 
-### Hide repeated bootstrap code
+### Run hidden setup code before a snippet
 
-Use `bootstrap` when code must run before every execution but should not appear
+Use `run-before` when code must run before every execution but should not appear
 in the editable example. Point it at a complete PHP script by id or CSS
 selector:
 
 ```html
-<script id="wordpress-bootstrap" type="application/x-php">
+<script id="load-wordpress" type="application/x-php">
 	<?php
 	require_once '/wordpress/wp-load.php';
 </script>
 
-<php-snippet name="site-title.php" bootstrap="#wordpress-bootstrap" php-fragment>
+<php-snippet name="site-title.php" run-before="#load-wordpress" php-fragment>
 	<script type="application/x-php">
 		echo get_bloginfo( 'name' );
 	</script>
 </php-snippet>
 ```
 
-The bootstrap remains outside the visible editor and runs before every click,
+The referenced script remains outside the visible editor and runs before every click,
 including after the reader edits the snippet. Snippets with different
-bootstraps can still share one runtime.
+`run-before` scripts can still share one runtime.
 
 `php-fragment` says the visible source omits its PHP opening tag. Playground
 adds the opener on the first line of the execution file, so PHP errors still
@@ -224,8 +224,8 @@ point to the displayed line and the `name` attribute. A fragment starting with
 `<?php` or `<?=` is rejected; remove `php-fragment` when the source is already a
 complete PHP file.
 
-Without `php-fragment`, bootstrap-backed snippets must include their own PHP
-opening tag. `bootstrap` and `php-fragment` are independent, so fragments also
+Without `php-fragment`, snippets using `run-before` must include their own PHP
+opening tag. `run-before` and `php-fragment` are independent, so fragments also
 work without hidden setup code.
 
 ## Edit examples in place
@@ -501,7 +501,7 @@ fields.
 | Several runnable examples in one article              | `<php-snippet>`                 |
 | A tutorial step where readers should edit code inline | `<php-snippet>`                 |
 | Shared setup across examples                          | `<php-snippet blueprint="...">` |
-| Hidden PHP setup before every run                     | `<php-snippet bootstrap="...">` |
+| Hidden PHP setup before every run                     | `<php-snippet run-before="...">` |
 | PHP source without an opening tag                     | `<php-snippet php-fragment>`    |
 | A pure PHP language example                           | `<php-snippet wp="none">`       |
 | A runnable example that should not be edited          | `<php-snippet readonly>`        |

--- a/packages/docs/site/docs/main/guides/php-code-snippets.md
+++ b/packages/docs/site/docs/main/guides/php-code-snippets.md
@@ -195,6 +195,39 @@ the WordPress download and boot step:
 </php-snippet>
 ```
 
+### Hide repeated bootstrap code
+
+Use `bootstrap` when code must run before every execution but should not appear
+in the editable example. Point it at a complete PHP script by id or CSS
+selector:
+
+```html
+<script id="wordpress-bootstrap" type="application/x-php">
+	<?php
+	require_once '/wordpress/wp-load.php';
+</script>
+
+<php-snippet name="site-title.php" bootstrap="#wordpress-bootstrap" php-fragment>
+	<script type="application/x-php">
+		echo get_bloginfo( 'name' );
+	</script>
+</php-snippet>
+```
+
+The bootstrap remains outside the visible editor and runs before every click,
+including after the reader edits the snippet. Snippets with different
+bootstraps can still share one runtime.
+
+`php-fragment` says the visible source omits its PHP opening tag. Playground
+adds the opener on the first line of the execution file, so PHP errors still
+point to the displayed line and the `name` attribute. A fragment containing
+`<?php` or `<?=` is rejected; remove `php-fragment` when the source is already
+a complete PHP file.
+
+Without `php-fragment`, bootstrap-backed snippets must include their own PHP
+opening tag. `bootstrap` and `php-fragment` are independent, so fragments also
+work without hidden setup code.
+
 ## Edit examples in place
 
 Runnable snippets are editable by default. The edited code is kept only in the
@@ -468,6 +501,8 @@ fields.
 | Several runnable examples in one article              | `<php-snippet>`                 |
 | A tutorial step where readers should edit code inline | `<php-snippet>`                 |
 | Shared setup across examples                          | `<php-snippet blueprint="...">` |
+| Hidden PHP setup before every run                     | `<php-snippet bootstrap="...">` |
+| PHP source without an opening tag                     | `<php-snippet php-fragment>`    |
 | A pure PHP language example                           | `<php-snippet wp="none">`       |
 | A runnable example that should not be edited          | `<php-snippet readonly>`        |
 | A single full-page editor with a shareable URL        | Standalone PHP Playground       |

--- a/packages/docs/site/docs/main/guides/php-code-snippets.md
+++ b/packages/docs/site/docs/main/guides/php-code-snippets.md
@@ -217,15 +217,17 @@ not appear in the editable example:
 </php-snippet>
 ```
 
-The referenced script remains outside the visible editor and runs before every
-click, including after the reader edits the snippet. Snippets with different
-auto-prepended scripts can still share one runtime.
+The referenced script must start with `<?php`. It remains outside the visible
+editor and runs before every click, including after the reader edits the
+snippet. Snippets with different auto-prepended scripts can still share one
+runtime.
 
 `implicit-php-open-tag` adds the PHP opening tag omitted from the visible
 source. Playground adds it on the first line of the execution file, so PHP
-errors still point to the displayed line and the `name` attribute. Code
-starting with `<?php` or `<?=` is rejected; remove `implicit-php-open-tag` when
-the source is already a complete PHP file.
+errors still point to the displayed line. Diagnostics use a filesystem-safe
+form of the `name` attribute as the filename. Code starting with any PHP
+opening tag (`<?php`, `<?=`, or `<?`) is rejected; remove
+`implicit-php-open-tag` when the source is already a complete PHP file.
 
 Without `implicit-php-open-tag`, snippets using `auto-prepend-script` must
 include their own PHP opening tag. The two attributes are independent, so an

--- a/packages/docs/site/docs/main/guides/php-code-snippets.md
+++ b/packages/docs/site/docs/main/guides/php-code-snippets.md
@@ -195,11 +195,14 @@ the WordPress download and boot step:
 </php-snippet>
 ```
 
-### Run hidden setup code before a snippet
+### Automatically prepend a hidden PHP script
 
-Use `run-before` when code must run before every execution but should not appear
-in the editable example. Point it at a complete PHP script by id or CSS
-selector:
+`auto-prepend-script` mirrors PHP's
+[`auto_prepend_file`](https://www.php.net/manual/en/ini.core.php#ini.auto-prepend-file)
+`php.ini` directive: the referenced PHP script runs before the snippet's main
+file on every request. Unlike the PHP directive, the attribute takes the id or
+CSS selector of an inert PHP `<script>` element. Use it when setup code should
+not appear in the editable example:
 
 ```html
 <script id="load-wordpress" type="application/x-php">
@@ -207,16 +210,16 @@ selector:
 	require_once '/wordpress/wp-load.php';
 </script>
 
-<php-snippet name="site-title.php" run-before="#load-wordpress" php-fragment>
+<php-snippet name="site-title.php" auto-prepend-script="#load-wordpress" php-fragment>
 	<script type="application/x-php">
 		echo get_bloginfo( 'name' );
 	</script>
 </php-snippet>
 ```
 
-The referenced script remains outside the visible editor and runs before every click,
-including after the reader edits the snippet. Snippets with different
-`run-before` scripts can still share one runtime.
+The referenced script remains outside the visible editor and runs before every
+click, including after the reader edits the snippet. Snippets with different
+auto-prepended scripts can still share one runtime.
 
 `php-fragment` says the visible source omits its PHP opening tag. Playground
 adds the opener on the first line of the execution file, so PHP errors still
@@ -224,9 +227,9 @@ point to the displayed line and the `name` attribute. A fragment starting with
 `<?php` or `<?=` is rejected; remove `php-fragment` when the source is already a
 complete PHP file.
 
-Without `php-fragment`, snippets using `run-before` must include their own PHP
-opening tag. `run-before` and `php-fragment` are independent, so fragments also
-work without hidden setup code.
+Without `php-fragment`, snippets using `auto-prepend-script` must include their
+own PHP opening tag. `auto-prepend-script` and `php-fragment` are independent,
+so fragments also work without hidden setup code.
 
 ## Edit examples in place
 
@@ -496,17 +499,17 @@ fields.
 
 ## Which embed should you use?
 
-| Use case                                              | Use                             |
-| ----------------------------------------------------- | ------------------------------- |
-| Several runnable examples in one article              | `<php-snippet>`                 |
-| A tutorial step where readers should edit code inline | `<php-snippet>`                 |
-| Shared setup across examples                          | `<php-snippet blueprint="...">` |
-| Hidden PHP setup before every run                     | `<php-snippet run-before="...">` |
-| PHP source without an opening tag                     | `<php-snippet php-fragment>`    |
-| A pure PHP language example                           | `<php-snippet wp="none">`       |
-| A runnable example that should not be edited          | `<php-snippet readonly>`        |
-| A single full-page editor with a shareable URL        | Standalone PHP Playground       |
-| A complete WordPress site preview                     | Standard Playground iframe      |
+| Use case                                              | Use                                       |
+| ----------------------------------------------------- | ----------------------------------------- |
+| Several runnable examples in one article              | `<php-snippet>`                           |
+| A tutorial step where readers should edit code inline | `<php-snippet>`                           |
+| Shared setup across examples                          | `<php-snippet blueprint="...">`           |
+| Hidden PHP setup before every run                     | `<php-snippet auto-prepend-script="...">` |
+| PHP source without an opening tag                     | `<php-snippet php-fragment>`              |
+| A pure PHP language example                           | `<php-snippet wp="none">`                 |
+| A runnable example that should not be edited          | `<php-snippet readonly>`                  |
+| A single full-page editor with a shareable URL        | Standalone PHP Playground                 |
+| A complete WordPress site preview                     | Standard Playground iframe                |
 
 ## Troubleshooting
 

--- a/packages/docs/site/docs/main/guides/php-code-snippets.md
+++ b/packages/docs/site/docs/main/guides/php-code-snippets.md
@@ -210,7 +210,7 @@ not appear in the editable example:
 	require_once '/wordpress/wp-load.php';
 </script>
 
-<php-snippet name="site-title.php" auto-prepend-script="#load-wordpress" php-fragment>
+<php-snippet name="site-title.php" auto-prepend-script="#load-wordpress" implicit-php-open-tag>
 	<script type="application/x-php">
 		echo get_bloginfo( 'name' );
 	</script>
@@ -221,15 +221,15 @@ The referenced script remains outside the visible editor and runs before every
 click, including after the reader edits the snippet. Snippets with different
 auto-prepended scripts can still share one runtime.
 
-`php-fragment` says the visible source omits its PHP opening tag. Playground
-adds the opener on the first line of the execution file, so PHP errors still
-point to the displayed line and the `name` attribute. A fragment starting with
-`<?php` or `<?=` is rejected; remove `php-fragment` when the source is already a
-complete PHP file.
+`implicit-php-open-tag` adds the PHP opening tag omitted from the visible
+source. Playground adds it on the first line of the execution file, so PHP
+errors still point to the displayed line and the `name` attribute. Code
+starting with `<?php` or `<?=` is rejected; remove `implicit-php-open-tag` when
+the source is already a complete PHP file.
 
-Without `php-fragment`, snippets using `auto-prepend-script` must include their
-own PHP opening tag. `auto-prepend-script` and `php-fragment` are independent,
-so fragments also work without hidden setup code.
+Without `implicit-php-open-tag`, snippets using `auto-prepend-script` must
+include their own PHP opening tag. The two attributes are independent, so an
+implicit opening tag also works without an auto-prepended script.
 
 ## Edit examples in place
 
@@ -505,7 +505,7 @@ fields.
 | A tutorial step where readers should edit code inline | `<php-snippet>`                           |
 | Shared setup across examples                          | `<php-snippet blueprint="...">`           |
 | Hidden PHP setup before every run                     | `<php-snippet auto-prepend-script="...">` |
-| PHP source without an opening tag                     | `<php-snippet php-fragment>`              |
+| PHP source without an opening tag                     | `<php-snippet implicit-php-open-tag>`     |
 | A pure PHP language example                           | `<php-snippet wp="none">`                 |
 | A runnable example that should not be edited          | `<php-snippet readonly>`                  |
 | A single full-page editor with a shareable URL        | Standalone PHP Playground                 |

--- a/packages/playground/website/playwright/e2e/php-code-snippet.spec.ts
+++ b/packages/playground/website/playwright/e2e/php-code-snippet.spec.ts
@@ -158,7 +158,7 @@ test.describe('php-code-snippet embed', () => {
 					</script>
 					<php-snippet id="bootstrapped-fragment" name="site-title.php" bootstrap="#wordpress-bootstrap" php-fragment>
 						<script type="application/x-php">
-							echo ( function_exists( 'get_bloginfo' ) ? 'wordpress' : 'plain' ) . '|' . basename( __FILE__ ) . ':' . __LINE__;
+							echo '<?php|' . ( function_exists( 'get_bloginfo' ) ? 'wordpress' : 'plain' ) . '|' . basename( __FILE__ ) . ':' . __LINE__;
 						</script>
 					</php-snippet>
 					<php-snippet id="unbootstrapped-fragment" name="../secret.php" php-fragment>
@@ -186,11 +186,11 @@ test.describe('php-code-snippet embed', () => {
 			'#bootstrapped-fragment'
 		);
 		await expect(bootstrapped.locator('textarea.ta')).toHaveValue(
-			"echo ( function_exists( 'get_bloginfo' ) ? 'wordpress' : 'plain' ) . '|' . basename( __FILE__ ) . ':' . __LINE__;"
+			"echo '<?php|' . ( function_exists( 'get_bloginfo' ) ? 'wordpress' : 'plain' ) . '|' . basename( __FILE__ ) . ':' . __LINE__;"
 		);
 		await bootstrapped.locator('.run').click();
 		await expect(bootstrapped.locator('.output-body')).toHaveText(
-			'wordpress|site-title.php:1',
+			'<?php|wordpress|site-title.php:1',
 			{ timeout: 240_000 }
 		);
 

--- a/packages/playground/website/playwright/e2e/php-code-snippet.spec.ts
+++ b/packages/playground/website/playwright/e2e/php-code-snippet.spec.ts
@@ -144,6 +144,111 @@ test.describe('php-code-snippet embed', () => {
 		expect(rejected).toEqual({ code: true, output: true });
 	});
 
+	test('runs fragments with hidden bootstrap code and real filenames', async ({
+		page,
+	}) => {
+		await page.goto(DEMO_URL);
+		await waitForPhpSnippetDefinition(page);
+		await page.evaluate(() => {
+			document.body.insertAdjacentHTML(
+				'beforeend',
+				String.raw`
+					<script id="wordpress-bootstrap" type="application/x-php">
+						<?php require_once '/wordpress/wp-load.php';
+					</script>
+					<php-snippet id="bootstrapped-fragment" name="site-title.php" bootstrap="#wordpress-bootstrap" php-fragment>
+						<script type="application/x-php">
+							echo ( function_exists( 'get_bloginfo' ) ? 'wordpress' : 'plain' ) . '|' . basename( __FILE__ ) . ':' . __LINE__;
+						</script>
+					</php-snippet>
+					<php-snippet id="unbootstrapped-fragment" name="../secret.php" php-fragment>
+						<script type="application/x-php">
+							echo ( function_exists( 'get_bloginfo' ) ? 'wordpress' : 'plain' ) . '|' . basename( __FILE__ ) . ':' . __LINE__;
+						</script>
+					</php-snippet>
+				`
+			);
+		});
+		await ensurePlaygroundClientIsServed(page);
+		await page
+			.locator('#bootstrapped-fragment, #unbootstrapped-fragment')
+			.evaluateAll((snippets) => {
+				for (const snippet of snippets) {
+					snippet.setAttribute(
+						'playground-origin',
+						window.location.origin
+					);
+				}
+			});
+
+		const bootstrapped = await waitForRenderedPhpSnippet(
+			page,
+			'#bootstrapped-fragment'
+		);
+		await expect(bootstrapped.locator('textarea.ta')).toHaveValue(
+			"echo ( function_exists( 'get_bloginfo' ) ? 'wordpress' : 'plain' ) . '|' . basename( __FILE__ ) . ':' . __LINE__;"
+		);
+		await bootstrapped.locator('.run').click();
+		await expect(bootstrapped.locator('.output-body')).toHaveText(
+			'wordpress|site-title.php:1',
+			{ timeout: 240_000 }
+		);
+
+		const unbootstrapped = await waitForRenderedPhpSnippet(
+			page,
+			'#unbootstrapped-fragment'
+		);
+		await unbootstrapped.locator('.run').click();
+		await expect(unbootstrapped.locator('.output-body')).toHaveText(
+			'plain|snippet.php:1',
+			{ timeout: 30_000 }
+		);
+		await expect(
+			page.locator('iframe[title="PHP Snippet runtime"]')
+		).toHaveCount(1);
+	});
+
+	test('rejects missing bootstraps and opening tags in fragments before boot', async ({
+		page,
+	}) => {
+		await page.goto(DEMO_URL);
+		await waitForPhpSnippetDefinition(page);
+		await page.evaluate(() => {
+			document.body.insertAdjacentHTML(
+				'beforeend',
+				String.raw`
+					<php-snippet id="missing-bootstrap" bootstrap="#not-on-this-page">
+						<script type="application/x-php"><?php echo 'never';</script>
+					</php-snippet>
+					<php-snippet id="tagged-fragment" php-fragment>
+						<script type="application/x-php"><?php echo 'ambiguous';</script>
+					</php-snippet>
+				`
+			);
+		});
+
+		const missing = await waitForRenderedPhpSnippet(
+			page,
+			'#missing-bootstrap'
+		);
+		await missing.locator('.run').click();
+		await expect(missing.locator('.output-body')).toContainText(
+			'could not find a matching element'
+		);
+
+		const tagged = await waitForRenderedPhpSnippet(
+			page,
+			'#tagged-fragment'
+		);
+		await tagged.locator('.run').click();
+		await expect(tagged.locator('.output-body')).toContainText(
+			'must not contain <?php or <?= opening tags'
+		);
+		await expect(
+			page.locator('iframe[title="PHP Snippet runtime"]')
+		).toHaveCount(0);
+	});
+
 	test('runnable snippets are editable by default unless readonly', async ({
 		page,
 	}) => {

--- a/packages/playground/website/playwright/e2e/php-code-snippet.spec.ts
+++ b/packages/playground/website/playwright/e2e/php-code-snippet.spec.ts
@@ -153,10 +153,10 @@ test.describe('php-code-snippet embed', () => {
 			document.body.insertAdjacentHTML(
 				'beforeend',
 				String.raw`
-					<script id="load-wordpress" type="application/x-php">
+					<script id="load-wordpress" type="text/x-php">
 						<?php require_once '/wordpress/wp-load.php';
 					</script>
-					<php-snippet id="wordpress-implicit-tag" name="site-title.php" auto-prepend-script="#load-wordpress" implicit-php-open-tag>
+					<php-snippet id="wordpress-implicit-tag" name="auto-prepend-script.php" auto-prepend-script="#load-wordpress" implicit-php-open-tag>
 						<script type="application/x-php">
 							/* The complete form would start with <?php. */
 							echo ( function_exists( 'get_bloginfo' ) ? 'wordpress' : 'plain' ) . '|' . basename( __FILE__ ) . ':' . __LINE__;
@@ -191,7 +191,7 @@ test.describe('php-code-snippet embed', () => {
 		);
 		await wordpressSnippet.locator('.run').click();
 		await expect(wordpressSnippet.locator('.output-body')).toHaveText(
-			'wordpress|site-title.php:2',
+			'wordpress|auto-prepend-script.php:2',
 			{ timeout: 240_000 }
 		);
 
@@ -221,8 +221,12 @@ test.describe('php-code-snippet embed', () => {
 					<php-snippet id="missing-auto-prepend" auto-prepend-script="#not-on-this-page">
 						<script type="application/x-php"><?php echo 'never';</script>
 					</php-snippet>
+					<script id="setup-without-opening-tag" type="application/x-php">echo 'never';</script>
+					<php-snippet id="missing-auto-prepend-opening-tag" auto-prepend-script="#setup-without-opening-tag">
+						<script type="application/x-php"><?php echo 'never';</script>
+					</php-snippet>
 					<php-snippet id="explicit-opening-tag" implicit-php-open-tag>
-						<script type="application/x-php"><?php echo 'ambiguous';</script>
+						<script type="application/x-php"><? echo 'ambiguous';</script>
 					</php-snippet>
 				`
 			);
@@ -237,13 +241,22 @@ test.describe('php-code-snippet embed', () => {
 			'could not find a matching element'
 		);
 
+		const missingOpeningTag = await waitForRenderedPhpSnippet(
+			page,
+			'#missing-auto-prepend-opening-tag'
+		);
+		await missingOpeningTag.locator('.run').click();
+		await expect(missingOpeningTag.locator('.output-body')).toContainText(
+			'source must start with a <?php opening tag'
+		);
+
 		const tagged = await waitForRenderedPhpSnippet(
 			page,
 			'#explicit-opening-tag'
 		);
 		await tagged.locator('.run').click();
 		await expect(tagged.locator('.output-body')).toContainText(
-			'must not start with a <?php or <?= opening tag'
+			'must not start with a PHP opening tag'
 		);
 		await expect(
 			page.locator('iframe[title="PHP Snippet runtime"]')

--- a/packages/playground/website/playwright/e2e/php-code-snippet.spec.ts
+++ b/packages/playground/website/playwright/e2e/php-code-snippet.spec.ts
@@ -156,7 +156,7 @@ test.describe('php-code-snippet embed', () => {
 					<script id="load-wordpress" type="application/x-php">
 						<?php require_once '/wordpress/wp-load.php';
 					</script>
-					<php-snippet id="wordpress-fragment" name="site-title.php" run-before="#load-wordpress" php-fragment>
+					<php-snippet id="wordpress-fragment" name="site-title.php" auto-prepend-script="#load-wordpress" php-fragment>
 						<script type="application/x-php">
 							/* The complete form would start with <?php. */
 							echo ( function_exists( 'get_bloginfo' ) ? 'wordpress' : 'plain' ) . '|' . basename( __FILE__ ) . ':' . __LINE__;
@@ -209,7 +209,7 @@ test.describe('php-code-snippet embed', () => {
 		).toHaveCount(1);
 	});
 
-	test('rejects missing run-before scripts and opening tags in fragments before boot', async ({
+	test('rejects missing prepended scripts and opening tags in fragments before boot', async ({
 		page,
 	}) => {
 		await page.goto(DEMO_URL);
@@ -218,7 +218,7 @@ test.describe('php-code-snippet embed', () => {
 			document.body.insertAdjacentHTML(
 				'beforeend',
 				String.raw`
-					<php-snippet id="missing-run-before" run-before="#not-on-this-page">
+					<php-snippet id="missing-auto-prepend" auto-prepend-script="#not-on-this-page">
 						<script type="application/x-php"><?php echo 'never';</script>
 					</php-snippet>
 					<php-snippet id="tagged-fragment" php-fragment>
@@ -230,7 +230,7 @@ test.describe('php-code-snippet embed', () => {
 
 		const missing = await waitForRenderedPhpSnippet(
 			page,
-			'#missing-run-before'
+			'#missing-auto-prepend'
 		);
 		await missing.locator('.run').click();
 		await expect(missing.locator('.output-body')).toContainText(

--- a/packages/playground/website/playwright/e2e/php-code-snippet.spec.ts
+++ b/packages/playground/website/playwright/e2e/php-code-snippet.spec.ts
@@ -144,7 +144,7 @@ test.describe('php-code-snippet embed', () => {
 		expect(rejected).toEqual({ code: true, output: true });
 	});
 
-	test('runs fragments with hidden bootstrap code and real filenames', async ({
+	test('runs fragments with hidden code before them and real filenames', async ({
 		page,
 	}) => {
 		await page.goto(DEMO_URL);
@@ -153,15 +153,15 @@ test.describe('php-code-snippet embed', () => {
 			document.body.insertAdjacentHTML(
 				'beforeend',
 				String.raw`
-					<script id="wordpress-bootstrap" type="application/x-php">
+					<script id="load-wordpress" type="application/x-php">
 						<?php require_once '/wordpress/wp-load.php';
 					</script>
-					<php-snippet id="bootstrapped-fragment" name="site-title.php" bootstrap="#wordpress-bootstrap" php-fragment>
+					<php-snippet id="wordpress-fragment" name="site-title.php" run-before="#load-wordpress" php-fragment>
 						<script type="application/x-php">
 							echo '<?php|' . ( function_exists( 'get_bloginfo' ) ? 'wordpress' : 'plain' ) . '|' . basename( __FILE__ ) . ':' . __LINE__;
 						</script>
 					</php-snippet>
-					<php-snippet id="unbootstrapped-fragment" name="../secret.php" php-fragment>
+					<php-snippet id="plain-fragment" name="../secret.php" php-fragment>
 						<script type="application/x-php">
 							echo ( function_exists( 'get_bloginfo' ) ? 'wordpress' : 'plain' ) . '|' . basename( __FILE__ ) . ':' . __LINE__;
 						</script>
@@ -171,7 +171,7 @@ test.describe('php-code-snippet embed', () => {
 		});
 		await ensurePlaygroundClientIsServed(page);
 		await page
-			.locator('#bootstrapped-fragment, #unbootstrapped-fragment')
+			.locator('#wordpress-fragment, #plain-fragment')
 			.evaluateAll((snippets) => {
 				for (const snippet of snippets) {
 					snippet.setAttribute(
@@ -181,25 +181,25 @@ test.describe('php-code-snippet embed', () => {
 				}
 			});
 
-		const bootstrapped = await waitForRenderedPhpSnippet(
+		const wordpressFragment = await waitForRenderedPhpSnippet(
 			page,
-			'#bootstrapped-fragment'
+			'#wordpress-fragment'
 		);
-		await expect(bootstrapped.locator('textarea.ta')).toHaveValue(
+		await expect(wordpressFragment.locator('textarea.ta')).toHaveValue(
 			"echo '<?php|' . ( function_exists( 'get_bloginfo' ) ? 'wordpress' : 'plain' ) . '|' . basename( __FILE__ ) . ':' . __LINE__;"
 		);
-		await bootstrapped.locator('.run').click();
-		await expect(bootstrapped.locator('.output-body')).toHaveText(
+		await wordpressFragment.locator('.run').click();
+		await expect(wordpressFragment.locator('.output-body')).toHaveText(
 			'<?php|wordpress|site-title.php:1',
 			{ timeout: 240_000 }
 		);
 
-		const unbootstrapped = await waitForRenderedPhpSnippet(
+		const plainFragment = await waitForRenderedPhpSnippet(
 			page,
-			'#unbootstrapped-fragment'
+			'#plain-fragment'
 		);
-		await unbootstrapped.locator('.run').click();
-		await expect(unbootstrapped.locator('.output-body')).toHaveText(
+		await plainFragment.locator('.run').click();
+		await expect(plainFragment.locator('.output-body')).toHaveText(
 			'plain|snippet.php:1',
 			{ timeout: 30_000 }
 		);
@@ -208,7 +208,7 @@ test.describe('php-code-snippet embed', () => {
 		).toHaveCount(1);
 	});
 
-	test('rejects missing bootstraps and opening tags in fragments before boot', async ({
+	test('rejects missing run-before scripts and opening tags in fragments before boot', async ({
 		page,
 	}) => {
 		await page.goto(DEMO_URL);
@@ -217,7 +217,7 @@ test.describe('php-code-snippet embed', () => {
 			document.body.insertAdjacentHTML(
 				'beforeend',
 				String.raw`
-					<php-snippet id="missing-bootstrap" bootstrap="#not-on-this-page">
+					<php-snippet id="missing-run-before" run-before="#not-on-this-page">
 						<script type="application/x-php"><?php echo 'never';</script>
 					</php-snippet>
 					<php-snippet id="tagged-fragment" php-fragment>
@@ -229,7 +229,7 @@ test.describe('php-code-snippet embed', () => {
 
 		const missing = await waitForRenderedPhpSnippet(
 			page,
-			'#missing-bootstrap'
+			'#missing-run-before'
 		);
 		await missing.locator('.run').click();
 		await expect(missing.locator('.output-body')).toContainText(

--- a/packages/playground/website/playwright/e2e/php-code-snippet.spec.ts
+++ b/packages/playground/website/playwright/e2e/php-code-snippet.spec.ts
@@ -158,7 +158,8 @@ test.describe('php-code-snippet embed', () => {
 					</script>
 					<php-snippet id="wordpress-fragment" name="site-title.php" run-before="#load-wordpress" php-fragment>
 						<script type="application/x-php">
-							echo '<?php|' . ( function_exists( 'get_bloginfo' ) ? 'wordpress' : 'plain' ) . '|' . basename( __FILE__ ) . ':' . __LINE__;
+							/* The complete form would start with <?php. */
+							echo ( function_exists( 'get_bloginfo' ) ? 'wordpress' : 'plain' ) . '|' . basename( __FILE__ ) . ':' . __LINE__;
 						</script>
 					</php-snippet>
 					<php-snippet id="plain-fragment" name="../secret.php" php-fragment>
@@ -186,11 +187,11 @@ test.describe('php-code-snippet embed', () => {
 			'#wordpress-fragment'
 		);
 		await expect(wordpressFragment.locator('textarea.ta')).toHaveValue(
-			"echo '<?php|' . ( function_exists( 'get_bloginfo' ) ? 'wordpress' : 'plain' ) . '|' . basename( __FILE__ ) . ':' . __LINE__;"
+			"/* The complete form would start with <?php. */\necho ( function_exists( 'get_bloginfo' ) ? 'wordpress' : 'plain' ) . '|' . basename( __FILE__ ) . ':' . __LINE__;"
 		);
 		await wordpressFragment.locator('.run').click();
 		await expect(wordpressFragment.locator('.output-body')).toHaveText(
-			'<?php|wordpress|site-title.php:1',
+			'wordpress|site-title.php:2',
 			{ timeout: 240_000 }
 		);
 

--- a/packages/playground/website/playwright/e2e/php-code-snippet.spec.ts
+++ b/packages/playground/website/playwright/e2e/php-code-snippet.spec.ts
@@ -144,7 +144,7 @@ test.describe('php-code-snippet embed', () => {
 		expect(rejected).toEqual({ code: true, output: true });
 	});
 
-	test('runs fragments with hidden code before them and real filenames', async ({
+	test('runs snippets with implicit opening tags and real filenames', async ({
 		page,
 	}) => {
 		await page.goto(DEMO_URL);
@@ -156,13 +156,13 @@ test.describe('php-code-snippet embed', () => {
 					<script id="load-wordpress" type="application/x-php">
 						<?php require_once '/wordpress/wp-load.php';
 					</script>
-					<php-snippet id="wordpress-fragment" name="site-title.php" auto-prepend-script="#load-wordpress" php-fragment>
+					<php-snippet id="wordpress-implicit-tag" name="site-title.php" auto-prepend-script="#load-wordpress" implicit-php-open-tag>
 						<script type="application/x-php">
 							/* The complete form would start with <?php. */
 							echo ( function_exists( 'get_bloginfo' ) ? 'wordpress' : 'plain' ) . '|' . basename( __FILE__ ) . ':' . __LINE__;
 						</script>
 					</php-snippet>
-					<php-snippet id="plain-fragment" name="../secret.php" php-fragment>
+					<php-snippet id="plain-implicit-tag" name="../secret.php" implicit-php-open-tag>
 						<script type="application/x-php">
 							echo ( function_exists( 'get_bloginfo' ) ? 'wordpress' : 'plain' ) . '|' . basename( __FILE__ ) . ':' . __LINE__;
 						</script>
@@ -172,7 +172,7 @@ test.describe('php-code-snippet embed', () => {
 		});
 		await ensurePlaygroundClientIsServed(page);
 		await page
-			.locator('#wordpress-fragment, #plain-fragment')
+			.locator('#wordpress-implicit-tag, #plain-implicit-tag')
 			.evaluateAll((snippets) => {
 				for (const snippet of snippets) {
 					snippet.setAttribute(
@@ -182,25 +182,25 @@ test.describe('php-code-snippet embed', () => {
 				}
 			});
 
-		const wordpressFragment = await waitForRenderedPhpSnippet(
+		const wordpressSnippet = await waitForRenderedPhpSnippet(
 			page,
-			'#wordpress-fragment'
+			'#wordpress-implicit-tag'
 		);
-		await expect(wordpressFragment.locator('textarea.ta')).toHaveValue(
+		await expect(wordpressSnippet.locator('textarea.ta')).toHaveValue(
 			"/* The complete form would start with <?php. */\necho ( function_exists( 'get_bloginfo' ) ? 'wordpress' : 'plain' ) . '|' . basename( __FILE__ ) . ':' . __LINE__;"
 		);
-		await wordpressFragment.locator('.run').click();
-		await expect(wordpressFragment.locator('.output-body')).toHaveText(
+		await wordpressSnippet.locator('.run').click();
+		await expect(wordpressSnippet.locator('.output-body')).toHaveText(
 			'wordpress|site-title.php:2',
 			{ timeout: 240_000 }
 		);
 
-		const plainFragment = await waitForRenderedPhpSnippet(
+		const plainSnippet = await waitForRenderedPhpSnippet(
 			page,
-			'#plain-fragment'
+			'#plain-implicit-tag'
 		);
-		await plainFragment.locator('.run').click();
-		await expect(plainFragment.locator('.output-body')).toHaveText(
+		await plainSnippet.locator('.run').click();
+		await expect(plainSnippet.locator('.output-body')).toHaveText(
 			'plain|snippet.php:1',
 			{ timeout: 30_000 }
 		);
@@ -209,7 +209,7 @@ test.describe('php-code-snippet embed', () => {
 		).toHaveCount(1);
 	});
 
-	test('rejects missing prepended scripts and opening tags in fragments before boot', async ({
+	test('rejects missing prepended scripts and explicit opening tags before boot', async ({
 		page,
 	}) => {
 		await page.goto(DEMO_URL);
@@ -221,7 +221,7 @@ test.describe('php-code-snippet embed', () => {
 					<php-snippet id="missing-auto-prepend" auto-prepend-script="#not-on-this-page">
 						<script type="application/x-php"><?php echo 'never';</script>
 					</php-snippet>
-					<php-snippet id="tagged-fragment" php-fragment>
+					<php-snippet id="explicit-opening-tag" implicit-php-open-tag>
 						<script type="application/x-php"><?php echo 'ambiguous';</script>
 					</php-snippet>
 				`
@@ -239,11 +239,11 @@ test.describe('php-code-snippet embed', () => {
 
 		const tagged = await waitForRenderedPhpSnippet(
 			page,
-			'#tagged-fragment'
+			'#explicit-opening-tag'
 		);
 		await tagged.locator('.run').click();
 		await expect(tagged.locator('.output-body')).toContainText(
-			'must not contain <?php or <?= opening tags'
+			'must not start with a <?php or <?= opening tag'
 		);
 		await expect(
 			page.locator('iframe[title="PHP Snippet runtime"]')

--- a/packages/playground/website/public/php-code-snippet.js
+++ b/packages/playground/website/public/php-code-snippet.js
@@ -44,8 +44,10 @@
  *                         share the same blueprint share one runtime — the
  *                         blueprint is JSON-stringified and folded into the
  *                         cache key.
- *   run-before="wp-load" CSS-selector-or-id of a hidden PHP script to run
- *                         before this snippet on every execution.
+ *   auto-prepend-script="wp-load"
+ *                         CSS-selector-or-id of a hidden PHP script to run
+ *                         before this snippet on every execution, mirroring
+ *                         PHP's auto_prepend_file directive.
  *   php-fragment          treat the visible code as a PHP fragment without an
  *                         opening tag. Fragments starting with <?php or <?= are
  *                         rejected instead of being rewritten ambiguously.
@@ -59,18 +61,19 @@ const DEFAULT_WP = 'latest';
 const DOCS_URL =
 	'https://wordpress.github.io/wordpress-playground/guides/php-code-snippets/';
 const PLAYGROUND_URL = 'https://wordpress.org/playground/';
-const RUN_BEFORE_ENVIRONMENT_VARIABLE = 'PLAYGROUND_PHP_SNIPPET_RUN_BEFORE';
-const RUN_BEFORE_PRELOAD_PATH =
-	'/internal/shared/preload/php-code-snippet-run-before.php';
-const RUN_BEFORE_PRELOAD_CODE = `<?php
-$playground_php_snippet_run_before = getenv( '${RUN_BEFORE_ENVIRONMENT_VARIABLE}' );
+const AUTO_PREPEND_SCRIPT_ENVIRONMENT_VARIABLE =
+	'PLAYGROUND_PHP_SNIPPET_AUTO_PREPEND_SCRIPT';
+const AUTO_PREPEND_SCRIPT_PRELOAD_PATH =
+	'/internal/shared/preload/php-code-snippet-auto-prepend-script.php';
+const AUTO_PREPEND_SCRIPT_PRELOAD_CODE = `<?php
+$playground_php_snippet_auto_prepend_script = getenv( '${AUTO_PREPEND_SCRIPT_ENVIRONMENT_VARIABLE}' );
 if (
-	false !== $playground_php_snippet_run_before &&
-	'' !== $playground_php_snippet_run_before
+	false !== $playground_php_snippet_auto_prepend_script &&
+	'' !== $playground_php_snippet_auto_prepend_script
 ) {
-	require $playground_php_snippet_run_before;
+	require $playground_php_snippet_auto_prepend_script;
 }
-unset( $playground_php_snippet_run_before );`;
+unset( $playground_php_snippet_auto_prepend_script );`;
 let nextSnippetId = 0;
 
 /**
@@ -991,7 +994,7 @@ class PhpSnippet extends HTMLElement {
 		try {
 			const { blueprint, key: blueprintKey } =
 				resolveSetupBlueprint(this);
-			const runBefore = resolveRunBefore(this);
+			const autoPrependScript = resolveAutoPrependScript(this);
 			const phpFragment = this.hasAttribute('php-fragment');
 			if (phpFragment && /^\s*<\?(?:php|=)/i.test(code)) {
 				throw new Error(
@@ -1019,7 +1022,7 @@ class PhpSnippet extends HTMLElement {
 			this._setRunButtonProgress('Running', 100);
 			const response = await runPhpSnippet(client, {
 				code,
-				runBefore,
+				autoPrependScript,
 				phpFragment,
 				name: this.getAttribute('name'),
 				snippetId: this._snippetId,
@@ -1094,14 +1097,14 @@ class PhpSnippet extends HTMLElement {
 }
 
 /**
- * Resolve a snippet's `run-before` attribute to complete PHP source.
+ * Resolve a snippet's `auto-prepend-script` attribute to complete PHP source.
  *
  * The referenced element must be an inert PHP script. Empty scripts are
- * treated like an omitted run-before script so existing snippet execution
+ * treated like an omitted auto-prepend script so existing snippet execution
  * keeps its eval-mode filename and path behavior.
  */
-function resolveRunBefore(snippet) {
-	const ref = snippet.getAttribute('run-before');
+function resolveAutoPrependScript(snippet) {
+	const ref = snippet.getAttribute('auto-prepend-script');
 	if (!ref) return null;
 
 	let element = null;
@@ -1113,7 +1116,7 @@ function resolveRunBefore(snippet) {
 	if (!element) element = snippet.ownerDocument.getElementById(ref);
 	if (!element) {
 		throw new Error(
-			`<php-snippet run-before="${ref}"> could not find a matching element on the page.`
+			`<php-snippet auto-prepend-script="${ref}"> could not find a matching element on the page.`
 		);
 	}
 	if (
@@ -1121,7 +1124,7 @@ function resolveRunBefore(snippet) {
 		!['application/x-php', 'application/x-php+json'].includes(element.type)
 	) {
 		throw new Error(
-			`<php-snippet run-before="${ref}"> must reference a <script type="application/x-php"> or <script type="application/x-php+json"> element.`
+			`<php-snippet auto-prepend-script="${ref}"> must reference a <script type="application/x-php"> or <script type="application/x-php+json"> element.`
 		);
 	}
 
@@ -1130,9 +1133,9 @@ function resolveRunBefore(snippet) {
 
 async function runPhpSnippet(
 	client,
-	{ code, runBefore, phpFragment, name, snippetId }
+	{ code, autoPrependScript, phpFragment, name, snippetId }
 ) {
-	if (!runBefore && !phpFragment) {
+	if (!autoPrependScript && !phpFragment) {
 		return await client.run({ code });
 	}
 
@@ -1145,12 +1148,16 @@ async function runPhpSnippet(
 	await client.writeFile(snippetPath, phpFragment ? `<?php ${code}` : code);
 
 	const request = { scriptPath: snippetPath };
-	if (runBefore) {
-		const runBeforePath = `${snippetDirectory}/run-before.php`;
-		await client.writeFile(runBeforePath, runBefore);
-		await client.writeFile(RUN_BEFORE_PRELOAD_PATH, RUN_BEFORE_PRELOAD_CODE);
+	if (autoPrependScript) {
+		const autoPrependScriptPath =
+			`${snippetDirectory}/auto-prepend-script.php`;
+		await client.writeFile(autoPrependScriptPath, autoPrependScript);
+		await client.writeFile(
+			AUTO_PREPEND_SCRIPT_PRELOAD_PATH,
+			AUTO_PREPEND_SCRIPT_PRELOAD_CODE
+		);
 		request.env = {
-			[RUN_BEFORE_ENVIRONMENT_VARIABLE]: runBeforePath,
+			[AUTO_PREPEND_SCRIPT_ENVIRONMENT_VARIABLE]: autoPrependScriptPath,
 		};
 	}
 

--- a/packages/playground/website/public/php-code-snippet.js
+++ b/packages/playground/website/public/php-code-snippet.js
@@ -869,7 +869,7 @@ class PhpSnippet extends HTMLElement {
 	}
 
 	_render() {
-		const name = this.getAttribute('name') || 'snippet.php';
+		const name = sanitizePhpFilename(this.getAttribute('name') || 'snippet.php');
 		const runnable = this.getAttribute('runnable') !== 'false';
 		const editable =
 			runnable &&

--- a/packages/playground/website/public/php-code-snippet.js
+++ b/packages/playground/website/public/php-code-snippet.js
@@ -47,7 +47,7 @@
  *   bootstrap="wp-load"  CSS-selector-or-id of a hidden PHP script to run
  *                         before this snippet on every execution.
  *   php-fragment          treat the visible code as a PHP fragment without an
- *                         opening tag. Fragments containing <?php or <?= are
+ *                         opening tag. Fragments starting with <?php or <?= are
  *                         rejected instead of being rewritten ambiguously.
  *   playground-origin="https://playground.wordpress.net"
  *                         override the runtime origin (useful for local dev)
@@ -993,7 +993,7 @@ class PhpSnippet extends HTMLElement {
 				resolveSetupBlueprint(this);
 			const bootstrap = resolveBootstrap(this);
 			const phpFragment = this.hasAttribute('php-fragment');
-			if (phpFragment && /<\?(?:php|=)/i.test(code)) {
+			if (phpFragment && /^\s*<\?(?:php|=)/i.test(code)) {
 				throw new Error(
 					'<php-snippet php-fragment> code must not contain <?php or <?= opening tags.'
 				);

--- a/packages/playground/website/public/php-code-snippet.js
+++ b/packages/playground/website/public/php-code-snippet.js
@@ -44,6 +44,11 @@
  *                         share the same blueprint share one runtime — the
  *                         blueprint is JSON-stringified and folded into the
  *                         cache key.
+ *   bootstrap="wp-load"  CSS-selector-or-id of a hidden PHP script to run
+ *                         before this snippet on every execution.
+ *   php-fragment          treat the visible code as a PHP fragment without an
+ *                         opening tag. Fragments containing <?php or <?= are
+ *                         rejected instead of being rewritten ambiguously.
  *   playground-origin="https://playground.wordpress.net"
  *                         override the runtime origin (useful for local dev)
  */
@@ -54,6 +59,19 @@ const DEFAULT_WP = 'latest';
 const DOCS_URL =
 	'https://wordpress.github.io/wordpress-playground/guides/php-code-snippets/';
 const PLAYGROUND_URL = 'https://wordpress.org/playground/';
+const BOOTSTRAP_ENVIRONMENT_VARIABLE = 'PLAYGROUND_PHP_SNIPPET_BOOTSTRAP';
+const BOOTSTRAP_PRELOAD_PATH =
+	'/internal/shared/preload/php-code-snippet-bootstrap.php';
+const BOOTSTRAP_PRELOAD_CODE = `<?php
+$playground_php_snippet_bootstrap = getenv( '${BOOTSTRAP_ENVIRONMENT_VARIABLE}' );
+if (
+	false !== $playground_php_snippet_bootstrap &&
+	'' !== $playground_php_snippet_bootstrap
+) {
+	require $playground_php_snippet_bootstrap;
+}
+unset( $playground_php_snippet_bootstrap );`;
+let nextSnippetId = 0;
 
 /**
  * Minimal duck-typed port of @php-wasm/progress's ProgressTracker.
@@ -740,6 +758,7 @@ class PhpSnippet extends HTMLElement {
 	constructor() {
 		super();
 		this.attachShadow({ mode: 'open' });
+		this._snippetId = ++nextSnippetId;
 		this._code = '';
 		this._expectedOutput = null;
 		this._ready = Promise.resolve();
@@ -972,6 +991,13 @@ class PhpSnippet extends HTMLElement {
 		try {
 			const { blueprint, key: blueprintKey } =
 				resolveSetupBlueprint(this);
+			const bootstrap = resolveBootstrap(this);
+			const phpFragment = this.hasAttribute('php-fragment');
+			if (phpFragment && /<\?(?:php|=)/i.test(code)) {
+				throw new Error(
+					'<php-snippet php-fragment> code must not contain <?php or <?= opening tags.'
+				);
+			}
 			const client = await getSharedClient(
 				{
 					origin:
@@ -991,7 +1017,13 @@ class PhpSnippet extends HTMLElement {
 				}
 			);
 			this._setRunButtonProgress('Running', 100);
-			const response = await client.run({ code });
+			const response = await runPhpSnippet(client, {
+				code,
+				bootstrap,
+				phpFragment,
+				name: this.getAttribute('name'),
+				snippetId: this._snippetId,
+			});
 			outputBody.textContent = response.text || '(no output)';
 			if (response.errors) {
 				outputBody.textContent +=
@@ -1059,6 +1091,76 @@ class PhpSnippet extends HTMLElement {
 		};
 		outputBody.addEventListener('animationend', clear);
 	}
+}
+
+/**
+ * Resolve a snippet's `bootstrap` attribute to complete PHP source.
+ *
+ * The referenced element must be an inert PHP script. Empty scripts are
+ * treated like an omitted bootstrap so existing snippet execution keeps its
+ * eval-mode filename and path behavior.
+ */
+function resolveBootstrap(snippet) {
+	const ref = snippet.getAttribute('bootstrap');
+	if (!ref) return null;
+
+	let element = null;
+	try {
+		element = snippet.ownerDocument.querySelector(ref);
+	} catch {
+		// Invalid selector — fall through to getElementById.
+	}
+	if (!element) element = snippet.ownerDocument.getElementById(ref);
+	if (!element) {
+		throw new Error(
+			`<php-snippet bootstrap="${ref}"> could not find a matching element on the page.`
+		);
+	}
+	if (
+		!(element instanceof HTMLScriptElement) ||
+		!['application/x-php', 'application/x-php+json'].includes(element.type)
+	) {
+		throw new Error(
+			`<php-snippet bootstrap="${ref}"> must reference a <script type="application/x-php"> or <script type="application/x-php+json"> element.`
+		);
+	}
+
+	return readScriptPayload(element).trim() || null;
+}
+
+async function runPhpSnippet(
+	client,
+	{ code, bootstrap, phpFragment, name, snippetId }
+) {
+	if (!bootstrap && !phpFragment) {
+		return await client.run({ code });
+	}
+
+	const filename = sanitizePhpFilename(name);
+	const snippetDirectory = `/tmp/php-snippet-${snippetId}`;
+	if (!(await client.fileExists(snippetDirectory))) {
+		await client.mkdir(snippetDirectory);
+	}
+	const snippetPath = `${snippetDirectory}/${filename}`;
+	await client.writeFile(snippetPath, phpFragment ? `<?php ${code}` : code);
+
+	const request = { scriptPath: snippetPath };
+	if (bootstrap) {
+		const bootstrapPath = `${snippetDirectory}/bootstrap.php`;
+		await client.writeFile(bootstrapPath, bootstrap);
+		await client.writeFile(BOOTSTRAP_PRELOAD_PATH, BOOTSTRAP_PRELOAD_CODE);
+		request.env = {
+			[BOOTSTRAP_ENVIRONMENT_VARIABLE]: bootstrapPath,
+		};
+	}
+
+	return await client.run(request);
+}
+
+function sanitizePhpFilename(name) {
+	if (!name || name.startsWith('.')) return 'snippet.php';
+	const sanitized = name.replace(/[^A-Za-z0-9._-]/g, '-');
+	return sanitized && !sanitized.startsWith('.') ? sanitized : 'snippet.php';
 }
 
 /**

--- a/packages/playground/website/public/php-code-snippet.js
+++ b/packages/playground/website/public/php-code-snippet.js
@@ -44,7 +44,7 @@
  *                         share the same blueprint share one runtime — the
  *                         blueprint is JSON-stringified and folded into the
  *                         cache key.
- *   bootstrap="wp-load"  CSS-selector-or-id of a hidden PHP script to run
+ *   run-before="wp-load" CSS-selector-or-id of a hidden PHP script to run
  *                         before this snippet on every execution.
  *   php-fragment          treat the visible code as a PHP fragment without an
  *                         opening tag. Fragments starting with <?php or <?= are
@@ -59,18 +59,18 @@ const DEFAULT_WP = 'latest';
 const DOCS_URL =
 	'https://wordpress.github.io/wordpress-playground/guides/php-code-snippets/';
 const PLAYGROUND_URL = 'https://wordpress.org/playground/';
-const BOOTSTRAP_ENVIRONMENT_VARIABLE = 'PLAYGROUND_PHP_SNIPPET_BOOTSTRAP';
-const BOOTSTRAP_PRELOAD_PATH =
-	'/internal/shared/preload/php-code-snippet-bootstrap.php';
-const BOOTSTRAP_PRELOAD_CODE = `<?php
-$playground_php_snippet_bootstrap = getenv( '${BOOTSTRAP_ENVIRONMENT_VARIABLE}' );
+const RUN_BEFORE_ENVIRONMENT_VARIABLE = 'PLAYGROUND_PHP_SNIPPET_RUN_BEFORE';
+const RUN_BEFORE_PRELOAD_PATH =
+	'/internal/shared/preload/php-code-snippet-run-before.php';
+const RUN_BEFORE_PRELOAD_CODE = `<?php
+$playground_php_snippet_run_before = getenv( '${RUN_BEFORE_ENVIRONMENT_VARIABLE}' );
 if (
-	false !== $playground_php_snippet_bootstrap &&
-	'' !== $playground_php_snippet_bootstrap
+	false !== $playground_php_snippet_run_before &&
+	'' !== $playground_php_snippet_run_before
 ) {
-	require $playground_php_snippet_bootstrap;
+	require $playground_php_snippet_run_before;
 }
-unset( $playground_php_snippet_bootstrap );`;
+unset( $playground_php_snippet_run_before );`;
 let nextSnippetId = 0;
 
 /**
@@ -991,7 +991,7 @@ class PhpSnippet extends HTMLElement {
 		try {
 			const { blueprint, key: blueprintKey } =
 				resolveSetupBlueprint(this);
-			const bootstrap = resolveBootstrap(this);
+			const runBefore = resolveRunBefore(this);
 			const phpFragment = this.hasAttribute('php-fragment');
 			if (phpFragment && /^\s*<\?(?:php|=)/i.test(code)) {
 				throw new Error(
@@ -1019,7 +1019,7 @@ class PhpSnippet extends HTMLElement {
 			this._setRunButtonProgress('Running', 100);
 			const response = await runPhpSnippet(client, {
 				code,
-				bootstrap,
+				runBefore,
 				phpFragment,
 				name: this.getAttribute('name'),
 				snippetId: this._snippetId,
@@ -1094,14 +1094,14 @@ class PhpSnippet extends HTMLElement {
 }
 
 /**
- * Resolve a snippet's `bootstrap` attribute to complete PHP source.
+ * Resolve a snippet's `run-before` attribute to complete PHP source.
  *
  * The referenced element must be an inert PHP script. Empty scripts are
- * treated like an omitted bootstrap so existing snippet execution keeps its
- * eval-mode filename and path behavior.
+ * treated like an omitted run-before script so existing snippet execution
+ * keeps its eval-mode filename and path behavior.
  */
-function resolveBootstrap(snippet) {
-	const ref = snippet.getAttribute('bootstrap');
+function resolveRunBefore(snippet) {
+	const ref = snippet.getAttribute('run-before');
 	if (!ref) return null;
 
 	let element = null;
@@ -1113,7 +1113,7 @@ function resolveBootstrap(snippet) {
 	if (!element) element = snippet.ownerDocument.getElementById(ref);
 	if (!element) {
 		throw new Error(
-			`<php-snippet bootstrap="${ref}"> could not find a matching element on the page.`
+			`<php-snippet run-before="${ref}"> could not find a matching element on the page.`
 		);
 	}
 	if (
@@ -1121,7 +1121,7 @@ function resolveBootstrap(snippet) {
 		!['application/x-php', 'application/x-php+json'].includes(element.type)
 	) {
 		throw new Error(
-			`<php-snippet bootstrap="${ref}"> must reference a <script type="application/x-php"> or <script type="application/x-php+json"> element.`
+			`<php-snippet run-before="${ref}"> must reference a <script type="application/x-php"> or <script type="application/x-php+json"> element.`
 		);
 	}
 
@@ -1130,9 +1130,9 @@ function resolveBootstrap(snippet) {
 
 async function runPhpSnippet(
 	client,
-	{ code, bootstrap, phpFragment, name, snippetId }
+	{ code, runBefore, phpFragment, name, snippetId }
 ) {
-	if (!bootstrap && !phpFragment) {
+	if (!runBefore && !phpFragment) {
 		return await client.run({ code });
 	}
 
@@ -1145,12 +1145,12 @@ async function runPhpSnippet(
 	await client.writeFile(snippetPath, phpFragment ? `<?php ${code}` : code);
 
 	const request = { scriptPath: snippetPath };
-	if (bootstrap) {
-		const bootstrapPath = `${snippetDirectory}/bootstrap.php`;
-		await client.writeFile(bootstrapPath, bootstrap);
-		await client.writeFile(BOOTSTRAP_PRELOAD_PATH, BOOTSTRAP_PRELOAD_CODE);
+	if (runBefore) {
+		const runBeforePath = `${snippetDirectory}/run-before.php`;
+		await client.writeFile(runBeforePath, runBefore);
+		await client.writeFile(RUN_BEFORE_PRELOAD_PATH, RUN_BEFORE_PRELOAD_CODE);
 		request.env = {
-			[BOOTSTRAP_ENVIRONMENT_VARIABLE]: bootstrapPath,
+			[RUN_BEFORE_ENVIRONMENT_VARIABLE]: runBeforePath,
 		};
 	}
 

--- a/packages/playground/website/public/php-code-snippet.js
+++ b/packages/playground/website/public/php-code-snippet.js
@@ -48,9 +48,10 @@
  *                         CSS-selector-or-id of a hidden PHP script to run
  *                         before this snippet on every execution, mirroring
  *                         PHP's auto_prepend_file directive.
- *   php-fragment          treat the visible code as a PHP fragment without an
- *                         opening tag. Fragments starting with <?php or <?= are
- *                         rejected instead of being rewritten ambiguously.
+ *   implicit-php-open-tag
+ *                         add a PHP opening tag before the visible code. Code
+ *                         starting with <?php or <?= is rejected instead of
+ *                         being rewritten ambiguously.
  *   playground-origin="https://playground.wordpress.net"
  *                         override the runtime origin (useful for local dev)
  */
@@ -995,10 +996,10 @@ class PhpSnippet extends HTMLElement {
 			const { blueprint, key: blueprintKey } =
 				resolveSetupBlueprint(this);
 			const autoPrependScript = resolveAutoPrependScript(this);
-			const phpFragment = this.hasAttribute('php-fragment');
-			if (phpFragment && /^\s*<\?(?:php|=)/i.test(code)) {
+			const implicitPhpOpenTag = this.hasAttribute('implicit-php-open-tag');
+			if (implicitPhpOpenTag && /^\s*<\?(?:php|=)/i.test(code)) {
 				throw new Error(
-					'<php-snippet php-fragment> code must not contain <?php or <?= opening tags.'
+					'<php-snippet implicit-php-open-tag> code must not start with a <?php or <?= opening tag.'
 				);
 			}
 			const client = await getSharedClient(
@@ -1023,7 +1024,7 @@ class PhpSnippet extends HTMLElement {
 			const response = await runPhpSnippet(client, {
 				code,
 				autoPrependScript,
-				phpFragment,
+				implicitPhpOpenTag,
 				name: this.getAttribute('name'),
 				snippetId: this._snippetId,
 			});
@@ -1133,9 +1134,9 @@ function resolveAutoPrependScript(snippet) {
 
 async function runPhpSnippet(
 	client,
-	{ code, autoPrependScript, phpFragment, name, snippetId }
+	{ code, autoPrependScript, implicitPhpOpenTag, name, snippetId }
 ) {
-	if (!autoPrependScript && !phpFragment) {
+	if (!autoPrependScript && !implicitPhpOpenTag) {
 		return await client.run({ code });
 	}
 
@@ -1145,7 +1146,10 @@ async function runPhpSnippet(
 		await client.mkdir(snippetDirectory);
 	}
 	const snippetPath = `${snippetDirectory}/${filename}`;
-	await client.writeFile(snippetPath, phpFragment ? `<?php ${code}` : code);
+	await client.writeFile(
+		snippetPath,
+		implicitPhpOpenTag ? `<?php ${code}` : code
+	);
 
 	const request = { scriptPath: snippetPath };
 	if (autoPrependScript) {

--- a/packages/playground/website/public/php-code-snippet.js
+++ b/packages/playground/website/public/php-code-snippet.js
@@ -50,8 +50,8 @@
  *                         PHP's auto_prepend_file directive.
  *   implicit-php-open-tag
  *                         add a PHP opening tag before the visible code. Code
- *                         starting with <?php or <?= is rejected instead of
- *                         being rewritten ambiguously.
+ *                         starting with any PHP opening tag is rejected
+ *                         instead of being rewritten ambiguously.
  *   playground-origin="https://playground.wordpress.net"
  *                         override the runtime origin (useful for local dev)
  */
@@ -59,6 +59,15 @@
 const DEFAULT_ORIGIN = 'https://playground.wordpress.net';
 const DEFAULT_PHP = '8.4';
 const DEFAULT_WP = 'latest';
+const PHP_SCRIPT_TYPES = [
+	'application/x-php',
+	'application/x-php+json',
+	'text/x-php',
+	'text/php',
+];
+const PHP_SCRIPT_SELECTOR = PHP_SCRIPT_TYPES.map(
+	(type) => `script[type="${type}"]`
+).join(', ');
 const DOCS_URL =
 	'https://wordpress.github.io/wordpress-playground/guides/php-code-snippets/';
 const PLAYGROUND_URL = 'https://wordpress.org/playground/';
@@ -288,27 +297,16 @@ async function bootRuntime({ origin, php, wp, blueprint }, entry) {
 /**
  * Resolve a snippet's `blueprint` attribute to a Blueprint object.
  *
- * The lookup tries in order: a CSS selector, then `getElementById`, then
- * (if neither matched) returns null. The element is expected to be a
- * <template> whose textContent is a JSON Blueprint. The text is parsed
- * once per snippet but the resulting cache key collapses identical
- * blueprints into a single runtime boot.
+ * The lookup tries a CSS selector, then `getElementById`, and throws when
+ * neither matches. The element is expected to be a <template> whose
+ * textContent is a JSON Blueprint. The text is parsed once per snippet but
+ * the resulting cache key collapses identical blueprints into a single
+ * runtime boot.
  */
 function resolveSetupBlueprint(snippet) {
 	const ref = snippet.getAttribute('blueprint');
 	if (!ref) return { blueprint: null, key: '' };
-	let el = null;
-	try {
-		el = snippet.ownerDocument.querySelector(ref);
-	} catch {
-		// Invalid selector — fall through to getElementById.
-	}
-	if (!el) el = snippet.ownerDocument.getElementById(ref);
-	if (!el) {
-		throw new Error(
-			`<php-snippet blueprint="${ref}"> could not find a matching element on the page.`
-		);
-	}
+	const el = resolveElementReference(snippet, 'blueprint', ref);
 	const source =
 		el.tagName === 'TEMPLATE' ? el.content.textContent : el.textContent;
 	const text = (source || '').trim();
@@ -865,9 +863,7 @@ class PhpSnippet extends HTMLElement {
 			}
 			return await res.text();
 		}
-		const script = this.querySelector(
-			'script[type="application/x-php"], script[type="application/x-php+json"], script[type="text/x-php"], script[type="text/php"]'
-		);
+		const script = this.querySelector(PHP_SCRIPT_SELECTOR);
 		if (script) return readScriptPayload(script);
 		return dedentLeading(this.textContent || '');
 	}
@@ -997,9 +993,9 @@ class PhpSnippet extends HTMLElement {
 				resolveSetupBlueprint(this);
 			const autoPrependScript = resolveAutoPrependScript(this);
 			const implicitPhpOpenTag = this.hasAttribute('implicit-php-open-tag');
-			if (implicitPhpOpenTag && /^\s*<\?(?:php|=)/i.test(code)) {
+			if (implicitPhpOpenTag && /^\s*<\?/.test(code)) {
 				throw new Error(
-					'<php-snippet implicit-php-open-tag> code must not start with a <?php or <?= opening tag.'
+					'<php-snippet implicit-php-open-tag> code must not start with a PHP opening tag.'
 				);
 			}
 			const client = await getSharedClient(
@@ -1108,6 +1104,30 @@ function resolveAutoPrependScript(snippet) {
 	const ref = snippet.getAttribute('auto-prepend-script');
 	if (!ref) return null;
 
+	const element = resolveElementReference(
+		snippet,
+		'auto-prepend-script',
+		ref
+	);
+	if (
+		!(element instanceof HTMLScriptElement) ||
+		!PHP_SCRIPT_TYPES.includes(element.type)
+	) {
+		throw new Error(
+			`<php-snippet auto-prepend-script="${ref}"> must reference a PHP <script> with one of these types: ${PHP_SCRIPT_TYPES.join(', ')}.`
+		);
+	}
+
+	const code = readScriptPayload(element).trim();
+	if (code && !/^<\?php(?:\s|$)/i.test(code)) {
+		throw new Error(
+			`<php-snippet auto-prepend-script="${ref}"> source must start with a <?php opening tag.`
+		);
+	}
+	return code || null;
+}
+
+function resolveElementReference(snippet, attribute, ref) {
 	let element = null;
 	try {
 		element = snippet.ownerDocument.querySelector(ref);
@@ -1117,19 +1137,10 @@ function resolveAutoPrependScript(snippet) {
 	if (!element) element = snippet.ownerDocument.getElementById(ref);
 	if (!element) {
 		throw new Error(
-			`<php-snippet auto-prepend-script="${ref}"> could not find a matching element on the page.`
+			`<php-snippet ${attribute}="${ref}"> could not find a matching element on the page.`
 		);
 	}
-	if (
-		!(element instanceof HTMLScriptElement) ||
-		!['application/x-php', 'application/x-php+json'].includes(element.type)
-	) {
-		throw new Error(
-			`<php-snippet auto-prepend-script="${ref}"> must reference a <script type="application/x-php"> or <script type="application/x-php+json"> element.`
-		);
-	}
-
-	return readScriptPayload(element).trim() || null;
+	return element;
 }
 
 async function runPhpSnippet(
@@ -1142,36 +1153,37 @@ async function runPhpSnippet(
 
 	const filename = sanitizePhpFilename(name);
 	const snippetDirectory = `/tmp/php-snippet-${snippetId}`;
-	if (!(await client.fileExists(snippetDirectory))) {
-		await client.mkdir(snippetDirectory);
-	}
+	await client.mkdir(snippetDirectory);
 	const snippetPath = `${snippetDirectory}/${filename}`;
-	await client.writeFile(
-		snippetPath,
-		implicitPhpOpenTag ? `<?php ${code}` : code
-	);
-
 	const request = { scriptPath: snippetPath };
+	const writes = [
+		client.writeFile(
+			snippetPath,
+			implicitPhpOpenTag ? `<?php ${code}` : code
+		),
+	];
 	if (autoPrependScript) {
 		const autoPrependScriptPath =
-			`${snippetDirectory}/auto-prepend-script.php`;
-		await client.writeFile(autoPrependScriptPath, autoPrependScript);
-		await client.writeFile(
-			AUTO_PREPEND_SCRIPT_PRELOAD_PATH,
-			AUTO_PREPEND_SCRIPT_PRELOAD_CODE
+			`${snippetDirectory}/.auto-prepend-script.php`;
+		writes.push(
+			client.writeFile(autoPrependScriptPath, autoPrependScript),
+			client.writeFile(
+				AUTO_PREPEND_SCRIPT_PRELOAD_PATH,
+				AUTO_PREPEND_SCRIPT_PRELOAD_CODE
+			)
 		);
 		request.env = {
 			[AUTO_PREPEND_SCRIPT_ENVIRONMENT_VARIABLE]: autoPrependScriptPath,
 		};
 	}
+	await Promise.all(writes);
 
 	return await client.run(request);
 }
 
 function sanitizePhpFilename(name) {
 	if (!name || name.startsWith('.')) return 'snippet.php';
-	const sanitized = name.replace(/[^A-Za-z0-9._-]/g, '-');
-	return sanitized && !sanitized.startsWith('.') ? sanitized : 'snippet.php';
+	return name.replace(/[^A-Za-z0-9._-]/g, '-');
 }
 
 /**


### PR DESCRIPTION
Adds two independent `<php-snippet>` options:

- `auto-prepend-script` points to an inert, complete PHP script that runs before every execution, mirroring PHP's `auto_prepend_file` directive.
- `implicit-php-open-tag` adds a PHP opening tag before visible source that omits it.

```html
<script id="load-wordpress" type="application/x-php">
<?php require_once '/wordpress/wp-load.php';
</script>

<php-snippet
    name="site-title.php"
    auto-prepend-script="#load-wordpress"
    implicit-php-open-tag
>
    <script type="application/x-php">
echo get_bloginfo( 'name' );
    </script>
</php-snippet>
```

`implicit-php-open-tag` also works without hidden setup:

```html
<php-snippet name="sum.php" implicit-php-open-tag>
    <script type="application/x-php">
echo array_sum( [ 10, 20, 12 ] );
    </script>
</php-snippet>
```

An auto-prepended script also works when the visible snippet includes its own opening tag:

```html
<php-snippet name="site-title.php" auto-prepend-script="#load-wordpress">
    <script type="application/x-php">
<?php
echo get_bloginfo( 'name' );
    </script>
</php-snippet>
```

The auto-prepended script and snippet remain separate PHP files. Each complete file owns its opening tag; `implicit-php-open-tag` adds an opener only to visible source that omits it. The snippet keeps the filename from `name`, so PHP diagnostics map back to the displayed code. Per-request setup also lets snippets with different setup code share a runtime without leaking it into later runs.

Snippets using neither option keep the existing eval path.

Closes #4261.

## Testing

Open the PHP snippet E2E fixture. Run a snippet with `auto-prepend-script` and `implicit-php-open-tag`, then one with only `implicit-php-open-tag`. Confirm only the first can call WordPress, both report their displayed first line, and only one runtime iframe is created.
