### PR TITLE
Improve interrupted OPFS sync message

### DIFF
--- a/packages/playground/website/src/components/site-error-modal/get-site-error-view.spec.tsx
+++ b/packages/playground/website/src/components/site-error-modal/get-site-error-view.spec.tsx
@@ -26,21 +26,24 @@ describe('getSiteErrorView', () => {
 		expect(renderToStaticMarkup(view.body)).toContain(url);
 	});
 
-	it('explains interrupted initial saves without storage jargon', () => {
+	it('explains interrupted initial saves and recovery options', () => {
 		const view = getSiteErrorView({
 			error: 'initial-opfs-sync-interrupted',
 			site: createSite(),
 			helpers,
 		});
 
-		expect(view.title).toBe('Start a new Playground to continue');
-		expect(renderToStaticMarkup(view.body)).toContain(
-			'This saved Playground is incomplete and can’t be reopened'
+		const body = renderToStaticMarkup(view.body);
+
+		expect(view.title).toBe('This Playground isn’t ready to reopen');
+		expect(body).toContain(
+			'Its initial copy to browser storage has not finished'
 		);
-		expect(renderToStaticMarkup(view.body)).toContain(
-			'the previous save stopped before all WordPress files were copied'
+		expect(body).toContain(
+			'Another tab may still be saving this Playground'
 		);
-		expect(renderToStaticMarkup(view.actions[0])).toContain(
+		expect(renderToStaticMarkup(view.actions[0])).toContain('Reload');
+		expect(renderToStaticMarkup(view.actions[1])).toContain(
 			'Start a new Playground'
 		);
 	});

--- a/packages/playground/website/src/components/site-error-modal/get-site-error-view.tsx
+++ b/packages/playground/website/src/components/site-error-modal/get-site-error-view.tsx
@@ -122,28 +122,35 @@ function initialOpfsSyncInterruptedView({
 	helpers,
 }: SiteErrorViewContext): SiteErrorViewConfig {
 	return {
-		title: 'Start a new Playground to continue',
+		title: 'This Playground isn’t ready to reopen',
 		isDeveloperError: false,
 		body: (
 			<>
 				<p className={css.errorLead}>
-					This saved Playground is incomplete and can’t be reopened.
-					Start a new Playground to keep working.
+					Its initial copy to browser storage has not finished.
 				</p>
 				<ul className={css.errorList}>
 					<li>
-						What happened: the previous save stopped before all
-						WordPress files were copied.
+						Another tab may still be saving this Playground. If so,
+						wait for it to finish, then click{' '}
+						<strong>Reload</strong>.
 					</li>
 					<li>
-						This can happen if the tab was closed or reloaded, the
-						browser suspended the page, or the browser ran out of
-						space for saved sites.
+						If the creating tab was closed, reloaded, suspended, or
+						ran out of storage, the copy may not finish. Start a new
+						Playground to continue.
 					</li>
 				</ul>
 			</>
 		),
 		actions: [
+			<Button
+				variant="secondary"
+				key="reload-page"
+				onClick={helpers.reloadPage}
+			>
+				Reload
+			</Button>,
 			<Button
 				variant="primary"
 				key="reload-tab"


### PR DESCRIPTION
## Motivation for the change, related issues

Fixes #4253.

The existing message treats an interrupted initial OPFS sync as permanently incomplete, even though another tab may still be actively saving the Playground.

## Implementation details

- Updates the message to describe the Playground as not ready yet.
- Explains that another tab may still be completing the initial save.
- Adds a secondary Reload action using `helpers.reloadPage`.
- Keeps the existing Start a new Playground action as the fallback.

## Testing Instructions (or ideally a Blueprint)

- Run `npm run format:uncommitted`.
- Run `npm exec nx run playground-website:typecheck`.
- Run `npm exec nx run playground-website:lint`.
- Confirm that all checks pass.