### PR TITLE
[Website] Sync site-view resize with the full-width Dock's collapse transition

### DIFF
--- a/packages/playground/website/src/components/layout/style.module.css
+++ b/packages/playground/website/src/components/layout/style.module.css
@@ -21,6 +21,11 @@ body {
 	height: 100dvh;
 	min-width: var(--site-view-min-width);
 	position: relative;
+	/* Matches the Dock's own transform transition (dock/style.module.css) so a
+	   full-width Dock collapsing/expanding resizes the site view in step with
+	   the Dock sliding, instead of snapping straight to the end size and
+	   leaving the still-sliding Dock overlapping the freshly resized iframe. */
+	transition: height 0.36s cubic-bezier(0.22, 1, 0.36, 1);
 }
 
 .site-view-content {
@@ -84,6 +89,7 @@ body {
 }
 
 @media (prefers-reduced-motion: reduce) {
+	.site-view,
 	.site-view-content,
 	.site-view-content-blurred,
 	.preview-dismiss,


### PR DESCRIPTION
## Summary
- When the Dock is full-width and collapses, the site-view container already resizes instead of the Dock overlaying it — but the resize snapped to its final height instantly while the Dock itself took 360ms to slide down, so the still-sliding Dock briefly overlapped the already-shrunk iframe.
- Give the site-view height a transition matching the Dock's own transform transition so the two animate in lockstep, and respect `prefers-reduced-motion`.

## Test plan
- [ ] Toggle the Dock to full-width, then collapse/expand it and confirm the site preview resizes smoothly with no visible overlap during the animation
- [ ] Verify the same on mobile widths (dock is always full-width there)
- [ ] Confirm no visible transition change with `prefers-reduced-motion: reduce` enabled