### PR TITLE
[CI] Fix Gutenberg editor frame tests for the latest Gutenberg release

### DIFF
--- a/packages/playground/website/cypress/e2e/query-api.cy.ts
+++ b/packages/playground/website/cypress/e2e/query-api.cy.ts
@@ -197,21 +197,23 @@ describe('Query API', () => {
 		// });
 
 		function checkIfGutenbergIsPatched() {
-			// Check if the inserter button is styled.
-			// If Gutenberg wasn't correctly patched,
-			// the inserter will look like a default
-			// browser button.
+			// If Gutenberg wasn't correctly patched, the editor-canvas
+			// iframe renders no blocks and loads no stylesheets.
 			cy.wordPressDocument()
 				.find('iframe[name="editor-canvas"]', {
 					// Give GitHub CI plenty of time
 					timeout: 60000 * 10,
 				})
 				.its('0.contentDocument')
-				.find('.block-editor-inserter__toggle', {
+				.find('.block-editor-block-list__layout', {
 					// Give GitHub CI plenty of time
 					timeout: 60000 * 10,
 				})
-				.should('not.have.css', 'background-color', undefined);
+				.should('exist');
+			cy.wordPressDocument()
+				.find('iframe[name="editor-canvas"]')
+				.its('0.contentDocument.styleSheets')
+				.should('have.length.greaterThan', 0);
 		}
 	});
 });


### PR DESCRIPTION
## Motivation for the change, related issues

The `test-e2e` job fails on every branch, including [trunk](https://github.com/WordPress/wordpress-playground/actions/runs/32300067696) and [unrelated docs PRs](https://github.com/WordPress/wordpress-playground/actions/runs/32280902321/job/96191429494). Both "Patching Gutenberg editor frame" tests in `query-api.cy.ts` time out after 10 minutes waiting for `.block-editor-inserter__toggle` inside the `editor-canvas` iframe.

The tests install the newest Gutenberg release at runtime via `?plugin=gutenberg`, and the latest release no longer renders an inserter toggle inside the canvas. The bundled WordPress editor still renders one; with the plugin active the canvas contains no element matching `inserter`, `appender`, or `toggle`. The editor itself works — the canvas renders the block list and loads its stylesheets — so only the selector went stale, and the failure appeared on every branch at once when the release shipped.

The old chained assertion `not.have.css('background-color', undefined)` compared the computed style against `undefined`, which never happens, so it always passed. The only real guard was the element existence check.

## Implementation details

`checkIfGutenbergIsPatched()` now asserts that `.block-editor-block-list__layout` exists inside the `editor-canvas` iframe and that the iframe document loads at least one stylesheet. Both hold in the bundled WordPress editor and with the Gutenberg plugin installed. The stylesheet check fails when editor assets stop loading inside the iframe, which is what the patching guards.

## Testing Instructions (or ideally a Blueprint)

1. `npm run dev`
2. `npx cypress run --project packages/playground/website --spec packages/playground/website/cypress/e2e/query-api.cy.ts --config baseUrl=http://127.0.0.1:5400/website-server/` — the two "Patching Gutenberg editor frame" tests pass; before this change they time out after 10 minutes each.
