### PR TITLE
Fix CI e2e failures after WP 7.1 / Gutenberg 23.8

### DIFF
--- a/packages/docs/site/tests/api-reference.spec.ts
+++ b/packages/docs/site/tests/api-reference.spec.ts
@@ -8,7 +8,7 @@ const apiPath =
 	`${normalizedBasePath === '/' ? '' : normalizedBasePath}/api`;
 
 test.describe('Docs API reference', () => {
-	test('loads without runtime errors', async ({ page }) => {
+	test('loads without runtime errors', async ({ page, baseURL }) => {
 		const pageErrors: Error[] = [];
 		const consoleErrors: string[] = [];
 
@@ -25,6 +25,17 @@ test.describe('Docs API reference', () => {
 				}
 				consoleErrors.push(text);
 			}
+		});
+
+		// This test covers the docs build, not third-party widgets such as
+		// the kapa.ai assistant. Serve every cross-origin request an empty
+		// response so they never load and can't fail the test.
+		const docsOrigin = new URL(baseURL!).origin;
+		await page.route('**/*', (route) => {
+			if (new URL(route.request().url()).origin === docsOrigin) {
+				return route.continue();
+			}
+			return route.fulfill({ status: 200, body: '' });
 		});
 
 		await page.goto(apiPath, {

--- a/packages/docs/site/tests/api-reference.spec.ts
+++ b/packages/docs/site/tests/api-reference.spec.ts
@@ -7,6 +7,11 @@ const apiPath =
 	process.env.DOCS_E2E_API_PATH ??
 	`${normalizedBasePath === '/' ? '' : normalizedBasePath}/api`;
 
+const STUB_CONTENT_TYPES: Record<string, string> = {
+	script: 'application/javascript',
+	stylesheet: 'text/css',
+};
+
 test.describe('Docs API reference', () => {
 	test('loads without runtime errors', async ({ page, baseURL }) => {
 		const pageErrors: Error[] = [];
@@ -28,14 +33,19 @@ test.describe('Docs API reference', () => {
 		});
 
 		// This test covers the docs build, not third-party widgets such as
-		// the kapa.ai assistant. Serve every cross-origin request an empty
-		// response so they never load and can't fail the test.
+		// the kapa.ai assistant. Answer every cross-origin request with a
+		// typed empty stub so they never load and the browser has nothing
+		// to log about them.
 		const docsOrigin = new URL(baseURL!).origin;
 		await page.route('**/*', (route) => {
 			if (new URL(route.request().url()).origin === docsOrigin) {
 				return route.continue();
 			}
-			return route.fulfill({ status: 200, body: '' });
+			const contentType =
+				STUB_CONTENT_TYPES[route.request().resourceType()];
+			return contentType
+				? route.fulfill({ status: 200, contentType, body: '' })
+				: route.fulfill({ status: 204 });
 		});
 
 		await page.goto(apiPath, {

--- a/packages/playground/website/cypress/e2e/query-api.cy.ts
+++ b/packages/playground/website/cypress/e2e/query-api.cy.ts
@@ -197,21 +197,27 @@ describe('Query API', () => {
 		// });
 
 		function checkIfGutenbergIsPatched() {
-			// Check if the inserter button is styled.
-			// If Gutenberg wasn't correctly patched,
-			// the inserter will look like a default
-			// browser button.
+			// Check that the editor canvas loaded its stylesheets. If the
+			// canvas frame wasn't correctly patched, its CSS requests 404
+			// and blocks render with browser-default styles. The
+			// `overflow-wrap` rule comes from block-editor's content.css
+			// and the browser default is `normal`.
+			//
+			// The block list always contains at least the post title block,
+			// unlike the default block appender that Gutenberg 23.8 replaced
+			// with a real (ghost) paragraph block.
 			cy.wordPressDocument()
 				.find('iframe[name="editor-canvas"]', {
 					// Give GitHub CI plenty of time
 					timeout: 60000 * 10,
 				})
 				.its('0.contentDocument')
-				.find('.block-editor-inserter__toggle', {
+				.find('.block-editor-block-list__block', {
 					// Give GitHub CI plenty of time
 					timeout: 60000 * 10,
 				})
-				.should('not.have.css', 'background-color', undefined);
+				.first()
+				.should('have.css', 'overflow-wrap', 'break-word');
 		}
 	});
 });


### PR DESCRIPTION
## Motivation for the change, related issues

CI on trunk has been red since the WordPress 7.1 recompile (a9835e14e). Two jobs fail, neither caused by the WP build itself:

1. **`test-e2e`** — `query-api.cy.ts › Patching Gutenberg editor frame` (both tests). Gutenberg **23.8.0** shipped on 2026-08-19, the same day the job started failing. WordPress/gutenberg#81231 renders a real ghost paragraph instead of the default block appender, so a new post's canvas no longer contains `.block-editor-inserter__toggle`, and the test times out after 10 minutes waiting for it.
2. **`test-docs-api-reference`** — `api-reference.spec.ts › loads without runtime errors` fails intermittently on `Failed to load resource: 404` from `https://proxy.kapa.ai/`, the third-party assistant widget.

## Implementation details

- The Cypress test now asserts that the editor canvas loaded its stylesheets by checking `overflow-wrap: break-word` on the first `.block-editor-block-list__block`. That rule comes from block-editor's `content.css` in every supported WordPress version (verified against 6.8, 7.0, 7.1 and Gutenberg 23.8), the browser default is `normal`, and the block list always contains at least the post title block — so the assertion survives the appender change while still proving the canvas frame was patched correctly.
- The docs test registers a `page.route('**/*')` that answers every cross-origin request with an empty `200`, so the kapa.ai widget is never fetched and only assets served by the docs build itself are under test.

## Testing Instructions (or ideally a Blueprint)

- CI: `test-e2e` and `test-docs-api-reference` should pass on this PR.
- Locally: `npx nx e2e playground-website --spec packages/playground/website/cypress/e2e/query-api.cy.ts` and `npx nx e2e docs-site`.
