### PR TITLE
[personal-wp] Backup reminder follow-ups

### DIFF
--- a/packages/playground/personal-wp/src/components/playground-viewport/index.tsx
+++ b/packages/playground/personal-wp/src/components/playground-viewport/index.tsx
@@ -1674,7 +1674,7 @@ function AutoBackupPrompt({
 					Click here to download it
 				</button>
 				{sizeEstimate !== null && ` (~${formatBytes(sizeEstimate, 0)})`}
-				.
+				{'.'}
 			</p>
 			<button
 				type="button"

--- a/packages/playground/personal-wp/src/components/playground-viewport/index.tsx
+++ b/packages/playground/personal-wp/src/components/playground-viewport/index.tsx
@@ -1673,7 +1673,8 @@ function AutoBackupPrompt({
 				>
 					Click here to download it
 				</button>
-				{sizeEstimate !== null && ` (~${formatBytes(sizeEstimate)})`}.
+				{sizeEstimate !== null && ` (~${formatBytes(sizeEstimate, 0)})`}
+				.
 			</p>
 			<button
 				type="button"

--- a/packages/playground/personal-wp/src/components/site-manager/site-info-panel/index.tsx
+++ b/packages/playground/personal-wp/src/components/site-manager/site-info-panel/index.tsx
@@ -410,10 +410,10 @@ async function copyUrl(url: string): Promise<boolean> {
 type AutoBackupInterval = NonNullable<SiteMetadata['autoBackupInterval']>;
 
 const autoBackupOptions: { value: AutoBackupInterval; label: string }[] = [
-	{ value: 'none', label: 'No auto-download' },
-	{ value: 'daily', label: 'Auto-download daily' },
-	{ value: 'every-2-days', label: 'Auto-download every 2 days' },
-	{ value: 'weekly', label: 'Auto-download weekly' },
+	{ value: 'none', label: 'No reminder' },
+	{ value: 'daily', label: 'Remind daily' },
+	{ value: 'every-2-days', label: 'Remind every 2 days' },
+	{ value: 'weekly', label: 'Remind weekly' },
 ];
 
 function BackupSection() {
@@ -517,7 +517,7 @@ function BackupSection() {
 					<SelectControl
 						__nextHasNoMarginBottom
 						className={css.backupSelect}
-						label="Automatic backups"
+						label="Backup reminders"
 						hideLabelFromVision
 						value={autoBackupSelectValue}
 						options={autoBackupOptions}

--- a/packages/playground/personal-wp/src/lib/hooks/use-backup.ts
+++ b/packages/playground/personal-wp/src/lib/hooks/use-backup.ts
@@ -33,13 +33,20 @@ function formatBackupFilename(siteName: string): string {
 }
 
 /**
- * Sums the bytes zipWpContent() would archive: wp-content minus the legacy
- * runtime paths, plus wp-config.php. The result is uncompressed, so it's an
- * upper bound rather than the exact zip size.
+ * Estimates the size of the zip zipWpContent() would produce: wp-content
+ * minus the legacy runtime paths, plus wp-config.php.
+ *
+ * Files in formats that are already compressed (images, fonts, media,
+ * archives) barely shrink under deflate, while text and SQLite files
+ * typically end up at 10-30% of their size. The factors below were
+ * calibrated against a real backup and land within ~10% of the zip size,
+ * erring high.
  */
 export async function estimateBackupSize(
 	playground: NonNullable<ReturnType<typeof usePlaygroundClient>>
 ): Promise<number | null> {
+	const COMPRESSED_FORMAT_FACTOR = 0.97;
+	const OTHER_FORMAT_FACTOR = 0.25;
 	try {
 		const documentRoot = await playground.documentRoot;
 		const wpContentPath = joinPaths(documentRoot, 'wp-content');
@@ -53,11 +60,37 @@ export async function estimateBackupSize(
 			wpContentPath,
 			wpConfigPath: joinPaths(documentRoot, 'wp-config.php'),
 			excludedPaths,
+			compressedExtensions: [
+				'jpg',
+				'jpeg',
+				'png',
+				'gif',
+				'webp',
+				'avif',
+				'heic',
+				'woff',
+				'woff2',
+				'mp3',
+				'mp4',
+				'm4a',
+				'webm',
+				'ogg',
+				'zip',
+				'gz',
+				'bz2',
+				'xz',
+				'zst',
+				'7z',
+				'rar',
+				'pdf',
+			],
 		});
 		const response = await playground.run({
 			code: `<?php
 				$excluded = ${js.excludedPaths};
-				$total = @filesize(${js.wpConfigPath}) ?: 0;
+				$compressedExtensions = array_flip(${js.compressedExtensions});
+				$compressed = 0;
+				$other = @filesize(${js.wpConfigPath}) ?: 0;
 				$iterator = new RecursiveIteratorIterator(
 					new RecursiveCallbackFilterIterator(
 						new RecursiveDirectoryIterator(
@@ -70,15 +103,26 @@ export async function estimateBackupSize(
 					)
 				);
 				foreach ($iterator as $file) {
-					if ($file->isFile()) {
-						$total += $file->getSize();
+					if (!$file->isFile()) {
+						continue;
+					}
+					$extension = strtolower($file->getExtension());
+					if (isset($compressedExtensions[$extension])) {
+						$compressed += $file->getSize();
+					} else {
+						$other += $file->getSize();
 					}
 				}
-				echo $total;
+				echo json_encode(array('compressed' => $compressed, 'other' => $other));
 			`,
 		});
-		const total = Number(response.text.trim());
-		return Number.isFinite(total) ? total : null;
+		const { compressed, other } = JSON.parse(response.text.trim());
+		if (!Number.isFinite(compressed) || !Number.isFinite(other)) {
+			return null;
+		}
+		return Math.round(
+			compressed * COMPRESSED_FORMAT_FACTOR + other * OTHER_FORMAT_FACTOR
+		);
 	} catch (error) {
 		logger.debug('Could not estimate backup size:', error);
 		return null;

--- a/packages/playground/personal-wp/src/lib/utils/format-bytes.ts
+++ b/packages/playground/personal-wp/src/lib/utils/format-bytes.ts
@@ -1,10 +1,12 @@
 export function formatBytes(bytes: number, decimals = 2): string {
 	if (bytes === 0) return '0 B';
+	// toFixed() throws a RangeError outside 0..100 or for non-integers.
+	const precision = Math.min(Math.max(Math.trunc(decimals) || 0, 0), 100);
 	const k = 1024;
 	const sizes = ['B', 'KB', 'MB', 'GB'];
 	const i = Math.min(
 		Math.floor(Math.log(bytes) / Math.log(k)),
 		sizes.length - 1
 	);
-	return `${parseFloat((bytes / Math.pow(k, i)).toFixed(decimals))} ${sizes[i]}`;
+	return `${parseFloat((bytes / Math.pow(k, i)).toFixed(precision))} ${sizes[i]}`;
 }

--- a/packages/playground/personal-wp/src/lib/utils/format-bytes.ts
+++ b/packages/playground/personal-wp/src/lib/utils/format-bytes.ts
@@ -1,4 +1,4 @@
-export function formatBytes(bytes: number): string {
+export function formatBytes(bytes: number, decimals = 2): string {
 	if (bytes === 0) return '0 B';
 	const k = 1024;
 	const sizes = ['B', 'KB', 'MB', 'GB'];
@@ -6,5 +6,5 @@ export function formatBytes(bytes: number): string {
 		Math.floor(Math.log(bytes) / Math.log(k)),
 		sizes.length - 1
 	);
-	return `${parseFloat((bytes / Math.pow(k, i)).toFixed(2))} ${sizes[i]}`;
+	return `${parseFloat((bytes / Math.pow(k, i)).toFixed(decimals))} ${sizes[i]}`;
 }


### PR DESCRIPTION
These changes weren't shipped by accident in #4255:

<img width="638" height="266" alt="Screenshot 2026-08-22 at 08 11 06" src="https://github.com/user-attachments/assets/ebb78126-08f0-4568-ad66-b06bb4996aa1" />

<img width="798" height="310" alt="Screenshot 2026-08-22 at 08 14 39" src="https://github.com/user-attachments/assets/2b56c70d-7e5c-44e0-9151-786977fc4a70" />
