### PR TITLE
Run `wp db query` through `$wpdb` in the wp-cli step

### DIFF
--- a/packages/playground/blueprints/src/lib/steps/wp-cli.ts
+++ b/packages/playground/blueprints/src/lib/steps/wp-cli.ts
@@ -24,6 +24,67 @@ const stdinUnsupportedMessage =
 	'This WP-CLI command tried to read from STDIN, but the wp-cli Blueprint ' +
 	'step does not support interactive input. Provide all required arguments.';
 
+const wpCliOverridesPath = '/tmp/playground-wp-cli-overrides.php';
+
+/**
+ * Loaded via `--require` before WP-CLI dispatches the command.
+ *
+ * `wp db query` normally shells out to the `mysql` binary, which does not
+ * exist in Playground and whose spawn traps the WASM runtime. Re-register it
+ * on top of $wpdb so the query runs against the SQLite-backed database.
+ */
+const wpCliOverrides = `<?php
+if ( ! class_exists( 'WP_CLI' ) ) {
+	return;
+}
+
+WP_CLI::add_command(
+	'db query',
+	function ( $args, $assoc_args ) {
+		global $wpdb;
+
+		$sql = isset( $args[0] ) ? trim( $args[0] ) : '';
+		if ( '' === $sql ) {
+			WP_CLI::error(
+				'Pass the SQL query as an argument. Reading it from STDIN ' .
+				'is not supported in Playground.'
+			);
+		}
+
+		$wpdb->suppress_errors( true );
+		$rows = $wpdb->get_results( $sql, ARRAY_A );
+		if ( '' !== $wpdb->last_error ) {
+			// The SQLite driver reports errors as an HTML debug dump. Surface
+			// only the underlying database error message.
+			$error = $wpdb->last_error;
+			if ( preg_match( '/class="error_message"[^>]*>(.*?)<\\/div>/s', $error, $m ) ) {
+				$error = $m[1];
+			}
+			WP_CLI::error( trim( wp_strip_all_tags( $error ) ) );
+		}
+
+		if ( ! empty( $rows ) ) {
+			WP_CLI\\Utils\\format_items( 'table', $rows, array_keys( $rows[0] ) );
+		} elseif ( ! preg_match( '/^(SELECT|SHOW|DESCRIBE|DESC|EXPLAIN|PRAGMA)\\b/i', $sql ) ) {
+			WP_CLI::success(
+				sprintf( 'Query OK, %d rows affected.', $wpdb->rows_affected )
+			);
+		}
+	},
+	array(
+		'shortdesc' => 'Executes a query against the database.',
+		'synopsis'  => array(
+			array(
+				'type'     => 'positional',
+				'name'     => 'sql',
+				'optional' => true,
+			),
+		),
+		'when'      => 'after_wp_load',
+	)
+);
+`;
+
 export const assertWpCli = async (
 	playground: UniversalPHP,
 	wpCliPath: string = defaultWpCliPath
@@ -126,6 +187,7 @@ This will ensure your code works reliably regardless of the current working dire
 
 	await playground.writeFile('/tmp/stdout', '');
 	await playground.writeFile('/tmp/stderr', '');
+	await playground.writeFile(wpCliOverridesPath, wpCliOverrides);
 	await playground.writeFile(
 		joinPaths(documentRoot, 'run-cli.php'),
 		`<?php
@@ -140,7 +202,8 @@ This will ensure your code works reliably regardless of the current working dire
 		// Set the argv global.
 		$GLOBALS['argv'] = array_merge([
 		  "/tmp/wp-cli.phar",
-		  "--path=${documentRoot}"
+		  "--path=${documentRoot}",
+		  "--require=${wpCliOverridesPath}"
 		], ${phpVar(argsWithRewrittenPaths)});
 
 		// Fail before a command can treat missing interactive input as an empty

--- a/packages/playground/blueprints/src/lib/steps/wp-cli.ts
+++ b/packages/playground/blueprints/src/lib/steps/wp-cli.ts
@@ -51,8 +51,9 @@ WP_CLI::add_command(
 			);
 		}
 
-		$wpdb->suppress_errors( true );
-		$rows = $wpdb->get_results( $sql, ARRAY_A );
+		$suppressed = $wpdb->suppress_errors( true );
+		$rows       = $wpdb->get_results( $sql, ARRAY_A );
+		$wpdb->suppress_errors( $suppressed );
 		if ( '' !== $wpdb->last_error ) {
 			// The SQLite driver reports errors as an HTML debug dump. Surface
 			// only the underlying database error message.
@@ -77,7 +78,7 @@ WP_CLI::add_command(
 			array(
 				'type'     => 'positional',
 				'name'     => 'sql',
-				'optional' => true,
+				'optional' => false,
 			),
 		),
 		'when'      => 'after_wp_load',

--- a/packages/playground/blueprints/src/tests/steps/wp-cli.spec.ts
+++ b/packages/playground/blueprints/src/tests/steps/wp-cli.spec.ts
@@ -94,6 +94,20 @@ describe('Blueprint step wpCLI', () => {
 		});
 		expect(currentName.text).toBe(originalName.text);
 	});
+
+	it('should run wp db query through $wpdb instead of the mysql binary', async () => {
+		const result = await wpCLI(php, {
+			command:
+				'wp db query "SELECT COUNT(*) AS posts FROM wp_posts" --no-color',
+		});
+		expect(result.text).toContain('| posts |');
+
+		await expect(
+			wpCLI(php, {
+				command: 'wp db query "SELECT nope FROM wp_options" --no-color',
+			})
+		).rejects.toThrow('no such column: nope');
+	});
 });
 
 describe('splitShellCommand', () => {


### PR DESCRIPTION
## Motivation for the change, related issues

`wp db query` shells out to the `mysql` binary, which does not exist in Playground. Combined with the fake STDIN stream installed by `run-cli.php`, the `proc_open()` call traps the WASM runtime with `index out of bounds` instead of failing cleanly, so the command was unusable in both Blueprints and the Dock terminal.

## Implementation details

The wp-cli step now writes a small override file and passes it via `--require`. That file re-registers `db query` with `WP_CLI::add_command()` on top of `$wpdb` (`when: after_wp_load`), so queries run against the SQLite-backed database:

- result rows print as a WP-CLI table;
- non-SELECT statements report `Query OK, N rows affected.`;
- database errors are surfaced as a plain message (e.g. `no such column: nope`) rather than the SQLite driver's HTML debug dump, with wpdb's `error_log` output suppressed.

Not covered: other `mysql`-backed subcommands (`wp db export/import/cli/check…`) still hit the spawn path and trap the same way. They could get the same treatment or a "mysql is not available" guard in the spawn handler.

## Testing Instructions (or ideally a Blueprint)

- New test in `packages/playground/blueprints/src/tests/steps/wp-cli.spec.ts` covering SELECT output and an invalid-column error.
- Manually: open the Dock terminal in WP-CLI mode and run `wp db query "SELECT COUNT(*) FROM wp_posts"`.
