### PR TITLE
[CI] Reduce Actions artifact storage from Playwright and deploy uploads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -348,18 +348,23 @@ jobs:
                   else
                     sudo CI=true PLAYWRIGHT_TEST_GROUP=${{ matrix.test_group || 'regular' }} npx playwright test --config=packages/playground/website/playwright/playwright.ci.config.ts --project=${{ matrix.browser }} $SHARD_ARG
                   fi
+            # Only upload reports and snapshots for failed runs — they exist
+            # to debug failures and update snapshots, and uploading them on
+            # every run is the repository's largest source of artifact storage.
             - uses: actions/upload-artifact@v4
-              if: ${{ !cancelled() }}
+              if: ${{ failure() }}
               with:
                   name: playwright-report-${{ matrix.browser }}${{ matrix.test_group && format('-{0}', matrix.test_group) || '' }}${{ matrix.shard_name && format('-shard-{0}', matrix.shard_name) || '' }}
                   path: packages/playground/website/playwright-report/
                   if-no-files-found: ignore
+                  retention-days: 7
             - uses: actions/upload-artifact@v4
-              if: ${{ !cancelled() }}
+              if: ${{ failure() }}
               with:
                   name: playwright-snapshots-${{ matrix.browser }}${{ matrix.test_group && format('-{0}', matrix.test_group) || '' }}${{ matrix.shard_name && format('-shard-{0}', matrix.shard_name) || '' }}
                   path: packages/playground/website/playwright/e2e/deployment.spec.ts-snapshots/
                   if-no-files-found: ignore
+                  retention-days: 7
 
     test-e2e-personal-wp:
         runs-on: ubuntu-latest
@@ -376,11 +381,12 @@ jobs:
             - name: Run personal-wp Playwright e2e tests
               run: CI=true npx playwright test --config=packages/playground/personal-wp/playwright/playwright.config.ts --project=chromium
             - uses: actions/upload-artifact@v4
-              if: ${{ !cancelled() }}
+              if: ${{ failure() }}
               with:
                   name: playwright-personal-wp-report
                   path: packages/playground/personal-wp/playwright-report/
                   if-no-files-found: ignore
+                  retention-days: 7
 
     test-e2e-components:
         if: github.repository == 'WordPress/wordpress-playground' || github.event_name == 'pull_request'
@@ -398,11 +404,12 @@ jobs:
             - name: Run Playwright tests for components
               run: npx nx e2e playground-components
             - uses: actions/upload-artifact@v4
-              if: ${{ !cancelled() }}
+              if: ${{ failure() }}
               with:
                   name: playwright-components-report
                   path: packages/playground/components/playwright-report/
                   if-no-files-found: ignore
+                  retention-days: 7
 
     # Run MCP e2e tests independently from other tests because running a local version of the MCP server from TypeScript files requires Node 22+
     test-e2e-mcp:
@@ -422,11 +429,12 @@ jobs:
             - name: Run MCP e2e tests
               run: npx nx test:mcp playground-mcp
             - uses: actions/upload-artifact@v4
-              if: ${{ !cancelled() }}
+              if: ${{ failure() }}
               with:
                   name: playwright-mcp-report
                   path: packages/playground/mcp/playwright-report/
                   if-no-files-found: ignore
+                  retention-days: 7
 
     test-docs-api-reference:
         if: github.repository == 'WordPress/wordpress-playground' || github.event_name == 'pull_request'
@@ -444,11 +452,12 @@ jobs:
             - name: Verify docs API reference
               run: npx nx run docs-site:api-e2e
             - uses: actions/upload-artifact@v4
-              if: ${{ !cancelled() }}
+              if: ${{ failure() }}
               with:
                   name: docs-api-e2e-report
                   path: packages/docs/site/test-results/
                   if-no-files-found: ignore
+                  retention-days: 7
 
     test-built-npm-packages:
         if: github.repository == 'WordPress/wordpress-playground' || github.event_name == 'pull_request'

--- a/.github/workflows/deploy-my-wordpress-net.yml
+++ b/.github/workflows/deploy-my-wordpress-net.yml
@@ -84,6 +84,10 @@ jobs:
               with:
                   name: my-wordpress-net
                   path: my-wordpress-net.tar.gz
+                  # The build is deployed via SSH below; the artifact is only
+                  # a debugging aid and doesn't need long retention. At ~620 MB
+                  # per weekly build, the default retention adds up quickly.
+                  retention-days: 7
 
             - name: Deploy my.wordpress.net build
               shell: bash


### PR DESCRIPTION
## Motivation for the change, related issues

The WordPress Foundation enterprise account hit 100% of its included 50 GB of GitHub Actions storage this billing cycle. This repository is the single largest contributor (~270 GB-months accrued in August; it was holding ~420 GB of artifacts on Aug 1, now draining as older artifacts expire).

The two remaining active sources are:

1. **Playwright reports and snapshots uploaded on every run.** The e2e matrix (chromium/firefox/webkit × 3 shards + 3 storage lanes) uploads a report and a snapshots artifact per leg with `if: ${{ !cancelled() }}` — 24 artifacts per CI run even when everything passes, plus the personal-wp, components, MCP, and docs-api reports (~170 artifacts/day). Nothing downloads them on success — they exist to debug failures and update snapshots. (Cypress screenshots already upload only on failure.)
2. **The weekly `my-wordpress-net` deploy artifact** (~620 MB each). The build is deployed via SSH in the same job; the artifact is only a debugging aid.

## Implementation details

- Playwright report/snapshot uploads in `ci.yml` now use `if: ${{ failure() }}` and `retention-days: 7`.
- The `my-wordpress-net` upload in `deploy-my-wordpress-net.yml` gets `retention-days: 7`.
- The `playground-website` artifact in `deploy-website.yml` is deliberately untouched, since it's documented as a downloadable pre-built package for self-hosting.

## Testing Instructions (or ideally a Blueprint)

CI on this PR: on a green run, the Playwright jobs should no longer list report/snapshot artifacts on the run summary. To verify the failure path, the conditions mirror the existing Cypress screenshots step (`if: ${{ failure() }}`), which uploads as expected on failing runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Build and documentation test artifacts are now uploaded only when their corresponding checks fail.
  * Uploaded debugging artifacts are retained for seven days.
  * Added guidance clarifying artifact retention and storage usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->