### PR TITLE
CI: Slim down the Auto-label PR checkout to the minimum needed

### DIFF
--- a/.github/workflows/auto-label-prs.yml
+++ b/.github/workflows/auto-label-prs.yml
@@ -55,7 +55,24 @@ jobs:
             # head is safe.
             - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
               with:
-                  fetch-depth: 0 # Full base history so the merge-base is present.
+                  # Minimal fetch for `git diff base...head` (three-dot, see
+                  # git-numstat.mjs). It needs the merge-base of the base and
+                  # head, plus the blobs of the files that actually changed —
+                  # nothing else.
+                  #   fetch-depth: 0  — full COMMIT+TREE graph so the merge-base
+                  #     is present. A stale PR's merge-base can be far back, so a
+                  #     fixed shallow depth would break the diff.
+                  #   filter: blob:none — blobless partial clone: skip every
+                  #     historical blob (this repo commits huge PHP.wasm/
+                  #     WordPress binaries across all history) and let git lazily
+                  #     fetch only the changed blobs the diff reads.
+                  #   sparse-checkout — materialize only the label scripts this
+                  #     job runs, so checkout doesn't pull HEAD's big binaries
+                  #     into the working tree either. The diff reads the object
+                  #     DB, not the tree, so this doesn't affect it.
+                  fetch-depth: 0
+                  filter: blob:none
+                  sparse-checkout: packages/meta
             # Install the label modules' dependencies from their own
             # package.json + lockfile. Scoped to that dir, so it does not touch
             # the repo's workspaces. --ignore-scripts: this job has


### PR DESCRIPTION
## Why

The Auto-label workflow added in #4290 checks out with `fetch-depth: 0`. That's a full-history clone that downloads **every blob across all of history** — and this repo commits large PHP.wasm and WordPress binaries — plus `actions/checkout` then materializes the **entire HEAD working tree** (more big binaries) on disk. The job never reads any of that.

All the job actually does with git is:
1. `git fetch` the PR head, and
2. `git diff --numstat -z --no-renames base...head` (three-dot, in `packages/meta/src/pr-labels/git-numstat.mjs`).

That diff runs entirely off the object database (commit/tree/blob OIDs). Its only real needs are the **merge-base** of base and head, and the **blobs of the files that actually changed**. Full history and a full working tree are far more than that.

## What

Keep `fetch-depth: 0` but add two filters so the checkout fetches the minimum:

- `filter: blob:none` — blobless partial clone. Fetches the full commit + tree graph (still required so the merge-base is present) but **no historical blobs**; git lazily fetches only the changed blobs the diff reads.
- `sparse-checkout: packages/meta` — materialize only the directory whose scripts the job runs (`bin/label-pr.mjs`, `src/pr-labels/*`, and the `npm ci` lockfile), so checkout doesn't pull HEAD's big binaries onto disk either.

`fetch-depth: 0` stays: a stale PR's merge-base can be arbitrarily far back, so a fixed shallow depth would risk breaking the three-dot diff.

### Change detection is unaffected

`sparse-checkout` only limits what's written to the **working tree** — it has no effect on `git diff`, which compares named commits via the object DB. Whole-repo labeling still works exactly as before; the job just stops downloading binaries it never opens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the automated pull request labeling workflow to process repository changes more efficiently.
  * Preserved accurate change detection while reducing unnecessary repository data retrieval during workflow runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->