### PR TITLE
[Website] Exclude PHP next from pre-emptive offline loading

### DIFF
--- a/packages/playground/website/playwright/e2e/offline-mode-cache.spec.ts
+++ b/packages/playground/website/playwright/e2e/offline-mode-cache.spec.ts
@@ -1,0 +1,25 @@
+import { test, expect } from '@playwright/test';
+
+test('PHP 8.3 does not prefetch PHP next runtimes', async ({ page }) => {
+	const blueprint = {
+		preferredVersions: {
+			php: '8.3',
+			wp: 'latest',
+		},
+	};
+	await page.goto(`./?storage=none#${JSON.stringify(blueprint)}`);
+	test.skip(
+		new URL(page.url()).pathname.startsWith('/website-server/'),
+		'The offline asset manifest is generated only by production builds.'
+	);
+
+	const manifestResponse = await page.request.get(
+		new URL('assets-required-for-offline-mode.json', page.url()).href
+	);
+	expect(manifestResponse.ok()).toBeTruthy();
+
+	const requiredAssets = (await manifestResponse.json()) as string[];
+	expect(requiredAssets).not.toEqual(
+		expect.arrayContaining([expect.stringMatching(/^\/php-next\//)])
+	);
+});

--- a/packages/playground/website/public/php-next/offline-cache-test-fixture.txt
+++ b/packages/playground/website/public/php-next/offline-cache-test-fixture.txt
@@ -1,2 +1,8 @@
-This file stands in for generated PHP-next runtime files during end-to-end builds.
-The PHP-next sync replaces this directory for local development and deployment.
+This placeholder makes the offline-cache E2E test exercise the /php-next/ exclusion.
+
+CI does not download the large, generated PHP-next runtimes. Without a file in this
+directory, the test would still pass if /php-next/ were accidentally added back to the
+pre-emptive offline manifest. The file contents are never used.
+
+Local development and production deployments run sync-php-next-assets.mjs, which replaces
+this directory with the real PHP-next runtime files.

--- a/packages/playground/website/public/php-next/offline-cache-test-fixture.txt
+++ b/packages/playground/website/public/php-next/offline-cache-test-fixture.txt
@@ -1,0 +1,2 @@
+This file stands in for generated PHP-next runtime files during end-to-end builds.
+The PHP-next sync replaces this directory for local development and deployment.

--- a/packages/vite-extensions/vite-list-assets-required-for-offline-mode.ts
+++ b/packages/vite-extensions/vite-list-assets-required-for-offline-mode.ts
@@ -60,6 +60,7 @@ const patternsToNotCache = [
 	 */
 	/^\/assets\/php_.*\.wasm$/, // PHP WASM files
 	/^\/assets\/php_.*\.js$/, // PHP JS files
+	/^\/php-next\/.*/, // PHP next runtime files
 	// Minified WordPress builds: tar.zst core bundles (vite hashes to
 	// wp-<v>.tar-<hash>.zst, so the emitted extension is .zst) + zip static bundles.
 	/^\/assets\/wp-.*\.(zip|zst)$/,


### PR DESCRIPTION
PHP next is deployed under `/php-next/`, while the offline manifest filter only excluded PHP binaries under `/assets/`. The manifest therefore listed both PHP 8.6 runtimes and downloaded them after boot, even when a Blueprint selected PHP 8.3.

Excludes `/php-next/` from the pre-emptive offline list. A Playground that selects PHP next will still fetch and cache its selected runtime during boot, like every stable PHP version.

## Why the test fixture exists

PHP-next runtimes are generated files. They are not committed, and the E2E build does not download them. Without any file under `public/php-next/`, the test would pass even if the `/php-next/` exclusion were removed because the manifest generator would have no PHP-next path to classify.

`offline-cache-test-fixture.txt` gives the E2E build one small `/php-next/` path. The old behavior adds that path to the pre-emptive manifest. This change excludes it. The file contents are never used.

Local development and production deployments run `sync-php-next-assets.mjs`. That script replaces the entire directory with the real PHP-next runtime files, so the placeholder is absent from those builds.

## Testing

The E2E test loads a PHP 8.3 Blueprint and confirms that the built offline manifest has no `/php-next/` entries. The check does not name a PHP-next version, so it also covers PHP 8.7 and later versions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved offline mode by excluding PHP next-runtime assets from cached asset manifests.
  * Reduced unnecessary assets included when using PHP 8.3 offline.
* **Tests**
  * Added automated coverage verifying that PHP 8.3 offline manifests do not contain PHP next-runtime files.
  * Added validation for offline asset caching behavior across supported runtime configurations.
* **Documentation**
  * Clarified the role of the offline-cache test fixture and how it is maintained during development and deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->