### PR TITLE
[Website] Avoid second service worker fetch on first visit

### DIFF
--- a/packages/playground/remote/src/lib/boot-playground-remote.ts
+++ b/packages/playground/remote/src/lib/boot-playground-remote.ts
@@ -88,22 +88,25 @@ export async function bootPlaygroundRemote() {
 		}
 	}
 
+	const hadServiceWorkerRegistration = !!(await sw.getRegistration());
 	const registration = await sw.register(serviceWorkerUrl + '', {
 		type: 'module',
 		// Always bypass HTTP cache when fetching the new Service Worker script:
 		updateViaCache: 'none',
 	});
 
-	// Check if there's a new service worker available and, if so, enqueue
-	// the update:
-	try {
-		await registration.update();
-	} catch (e) {
-		// registration.update() throws if it can't reach the server.
-		// We're swallowing the error to keep the app working in offline mode
-		// or when playground.wordpress.net is down. We can be sure we have a
-		// functional service worker at this point because sw.register() succeeded.
-		logger.error('Failed to update service worker.', e);
+	// register() already fetches the Service Worker on the first visit. Existing
+	// registrations still need an explicit check for a newly deployed version.
+	if (hadServiceWorkerRegistration) {
+		try {
+			await registration.update();
+		} catch (e) {
+			// registration.update() throws if it can't reach the server.
+			// We're swallowing the error to keep the app working in offline mode
+			// or when playground.wordpress.net is down. We can be sure we have a
+			// functional service worker at this point because sw.register() succeeded.
+			logger.error('Failed to update service worker.', e);
+		}
 	}
 
 	/**


### PR DESCRIPTION
A first Playground visit now skips the immediate `registration.update()` call. When there is no prior registration, `register()` has just fetched `/sw.js`, so the update repeats that fetch and blocks the remote boot. Browsers with an existing registration still run `update()` so they can pick up a new deployment.

In 10 isolated first-registration runs using production `/sw.js`, the awaited update took:

- 209 ms median
- 245 ms mean
- 201–356 ms range

Every run fetched `/sw.js` twice. The production response was 80,567 bytes compressed and 231,809 bytes raw.

The release-change tests pass with HTTP caching enabled and disabled. The offline test also passes.

## Testing

1. Open Playground in a fresh browser profile and confirm WordPress loads.
2. Reload the page and confirm WordPress still loads.
3. Load the local deployment test site twice, stop its server, and confirm another reload works from the service worker cache.
