### PR TITLE
[Blueprints] Restore snapshots across mounted filesystems

### DIFF
--- a/packages/playground/blueprints/src/lib/steps/import-wordpress-files.ts
+++ b/packages/playground/blueprints/src/lib/steps/import-wordpress-files.ts
@@ -234,8 +234,8 @@ export const importWordPressFiles: StepHandler<
 		// copy of any staged paths that have not moved yet.
 		commitInProgress = importedFilenames.length > 0;
 		for (const fileName of importedFilenames) {
-			await removePath(playground, joinPaths(documentRoot, fileName));
-			await playground.mv(
+			await replacePathPreservingDirectoryRoot(
+				playground,
 				joinPaths(importPath, fileName),
 				joinPaths(documentRoot, fileName)
 			);
@@ -492,4 +492,38 @@ async function removePath(playground: UniversalPHP, path: string) {
 			await playground.unlink(path);
 		}
 	}
+}
+
+async function replacePathPreservingDirectoryRoot(
+	playground: UniversalPHP,
+	fromPath: string,
+	toPath: string
+) {
+	const fromIsDirectory = await playground.isDir(fromPath);
+	const toExists = await playground.fileExists(toPath);
+	const toIsDirectory = toExists && (await playground.isDir(toPath));
+
+	if (fromIsDirectory && toIsDirectory) {
+		const importedNames = await playground.listFiles(fromPath);
+		const importedNameSet = new Set(importedNames);
+		for (const currentName of await playground.listFiles(toPath)) {
+			if (!importedNameSet.has(currentName)) {
+				await removePath(playground, joinPaths(toPath, currentName));
+			}
+		}
+		for (const importedName of importedNames) {
+			await replacePathPreservingDirectoryRoot(
+				playground,
+				joinPaths(fromPath, importedName),
+				joinPaths(toPath, importedName)
+			);
+		}
+		await playground.rmdir(fromPath);
+		return;
+	}
+
+	if (toExists && (fromIsDirectory || toIsDirectory)) {
+		await removePath(playground, toPath);
+	}
+	await playground.mv(fromPath, toPath);
 }

--- a/packages/playground/blueprints/src/tests/steps/import-wordpress-files.spec.ts
+++ b/packages/playground/blueprints/src/tests/steps/import-wordpress-files.spec.ts
@@ -536,6 +536,93 @@ describe('Blueprint step importWordPressFiles', () => {
 		).toBe(true);
 	});
 
+	it('should restore a wrapped snapshot without replacing mounted directory roots', async () => {
+		await sourcePHP.run({
+			code: `<?php
+			require ${phpVar(await sourcePHP.documentRoot)} . '/wp-load.php';
+			update_option('blogname', 'Snapshot round trip');
+			`,
+		});
+		const exportPath = joinPaths('/tmp', `${randomFilename()}.zip`);
+		const wrappedPath = joinPaths('/tmp', `${randomFilename()}.zip`);
+		await targetPHP.writeFile(exportPath, await zipWpContent(sourcePHP));
+		await targetPHP.run({
+			code: `<?php
+			$source = new ZipArchive();
+			$source->open(${phpVar(exportPath)});
+			$wrapped = new ZipArchive();
+			$wrapped->open(${phpVar(wrappedPath)}, ZipArchive::CREATE | ZipArchive::OVERWRITE);
+			for ($index = 0; $index < $source->numFiles; $index++) {
+				$name = $source->getNameIndex($index);
+				$wrapped->addFromString('wordpress/' . $name, $source->getFromIndex($index));
+			}
+			$wpAdmin = new RecursiveIteratorIterator(
+				new RecursiveDirectoryIterator('/wordpress/wp-admin', FilesystemIterator::SKIP_DOTS)
+			);
+			foreach ($wpAdmin as $file) {
+				$relativePath = substr($file->getPathname(), strlen('/wordpress/wp-admin/'));
+				$wrapped->addFile($file->getPathname(), 'wordpress/wp-admin/' . $relativePath);
+			}
+			$wrapped->addFromString('wordpress/wp-admin/admin-post.php', '<?php // Restored core file');
+			$source->close();
+			$wrapped->close();
+			`,
+		});
+
+		const documentRoot = await targetPHP.documentRoot;
+		const preservedRoots = new Set([
+			joinPaths(documentRoot, 'wp-content'),
+			joinPaths(documentRoot, 'wp-content/database'),
+		]);
+		const mv = targetPHP.mv.bind(targetPHP);
+		const mvSpy = vi
+			.spyOn(targetPHP, 'mv')
+			.mockImplementation((fromPath, toPath) => {
+				if (preservedRoots.has(toPath)) {
+					throw new Error(
+						`Cannot replace mounted directory root: ${toPath}`
+					);
+				}
+				return mv(fromPath, toPath);
+			});
+		const preservedFile = joinPaths(
+			documentRoot,
+			'wp-admin/admin-post.php'
+		);
+		const unlink = targetPHP.unlink.bind(targetPHP);
+		const unlinkSpy = vi
+			.spyOn(targetPHP, 'unlink')
+			.mockImplementation((path) => {
+				if (path === preservedFile) {
+					throw new Error(`Cannot unlink mounted file: ${path}`);
+				}
+				return unlink(path);
+			});
+
+		try {
+			await importWordPressFiles(targetPHP, {
+				wordPressFilesZip: new File(
+					[await targetPHP.readFileAsBuffer(wrappedPath)],
+					'wordpress-snapshot.zip'
+				),
+			});
+		} finally {
+			mvSpy.mockRestore();
+			unlinkSpy.mockRestore();
+		}
+
+		const result = await targetPHP.run({
+			code: `<?php
+			require ${phpVar(documentRoot)} . '/wp-load.php';
+			echo get_option('blogname');
+			`,
+		});
+		expect(result.text).toBe('Snapshot round trip');
+		expect(await targetPHP.readFileAsText(preservedFile)).toBe(
+			'<?php // Restored core file'
+		);
+	});
+
 	it('should import WordPress files from a single wrapping directory', async () => {
 		const zipPath = joinPaths('/tmp', `${randomFilename()}.zip`);
 		const pluginPath =


### PR DESCRIPTION
## Motivation for the change, related issues

`build-snapshot` archives could not be restored by `importWordPressFiles` in the CLI because the import commit removed mounted directory roots before moving staged files into place. Cross-filesystem moves also could not recreate mounted files after they had been unlinked.

Fixes #4297.

## Implementation details

Reconcile existing directories recursively instead of replacing their roots. This preserves mount points such as `wp-content/database`, removes destination entries absent from the snapshot, and overwrites existing regular files in place.

Adds a wrapped-snapshot round-trip regression that restores database state while asserting that mounted directory roots and an existing mounted core file are not removed.

## Testing Instructions (or ideally a Blueprint)

- `npx vitest --config packages/playground/blueprints/vite.config.ts run packages/playground/blueprints/src/tests/steps/import-wordpress-files.spec.ts`
- `npx nx run playground-blueprints:typecheck`
- `npx nx run playground-blueprints:lint`
- Built a snapshot with the unbuilt CLI, restored it with `run-blueprint`, and asserted the exported database option survived.
- Restored the original 79 MB snapshot from #4297 through the patched CLI; all import, URL rewrite, and login Blueprint steps completed.

## AI assistance

OpenAI GPT-5.6 Sol was used through OpenCode to trace the mounted-filesystem failure, implement the fix and regression, and execute the verification workflow. The changes and test evidence were reviewed by the author.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved WordPress snapshot imports to merge directory contents correctly and remove files no longer present in the archive.
  - Preserved staged runtime files and mounted WordPress content and database directories during restoration.
  - Resolved file and directory conflicts when replacing existing WordPress files.

- **Tests**
  - Added coverage for restoring wrapped WordPress snapshots and replacing existing core files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->