### PR TITLE
[CLI] Keep snapshot return tests below the Windows timeout

### DIFF
--- a/packages/playground/cli/tests/run-cli.spec.ts
+++ b/packages/playground/cli/tests/run-cli.spec.ts
@@ -2206,6 +2206,20 @@ describe('other run-cli behaviors', () => {
 	});
 
 	describe('return types', () => {
+		// These tests need a real ZIP, but not a full WordPress install. A tiny
+		// local site keeps the Windows run well below the default test timeout.
+		const snapshotBlueprint: RunCLIArgs['blueprint'] = {
+			steps: [
+				{
+					step: 'runPHP',
+					code: `<?php
+						mkdir('/wordpress', 0777, true);
+						file_put_contents('/wordpress/index.php', '');
+					`,
+				},
+			],
+		};
+
 		test('runCLI returns void for run-blueprint command', async () => {
 			const result = await runCLI({
 				command: 'run-blueprint',
@@ -2224,15 +2238,18 @@ describe('other run-cli behaviors', () => {
 			try {
 				const result = await runCLI({
 					command: 'build-snapshot',
-					blueprint: undefined,
+					wordpressInstallMode: 'do-not-attempt-installing',
+					skipSqliteSetup: true,
+					blueprint: snapshotBlueprint,
 					outfile,
+					workers: 1,
 				});
 				expect(result).toBeUndefined();
 				expect(existsSync(outfile)).toBe(true);
 			} finally {
 				rmSync(tmpDir, { recursive: true });
 			}
-		}, 60_000 /* allow extra time to avoid testing timeouts on Windows */);
+		});
 
 		test('runCLI returns RunCLIServer for server command', async () => {
 			await using result = await runCLI({
@@ -2293,10 +2310,18 @@ describe('other run-cli behaviors', () => {
 				path.join(tmpdir(), 'playground-snapshot-test-')
 			);
 			const outfile = path.join(tmpDir, 'snapshot.zip');
+			const blueprintPath = path.join(tmpDir, 'blueprint.json');
 			try {
+				await writeFile(
+					blueprintPath,
+					JSON.stringify(snapshotBlueprint)
+				);
 				const result = await parseOptionsAndRunCLI([
 					'build-snapshot',
 					`--outfile=${outfile}`,
+					`--blueprint=${blueprintPath}`,
+					'--wordpress-install-mode=do-not-attempt-installing',
+					'--skip-sqlite-setup',
 					'--verbosity=quiet',
 				]);
 				expect('exitCode' in result).toBe(true);
@@ -2304,7 +2329,7 @@ describe('other run-cli behaviors', () => {
 			} finally {
 				rmSync(tmpDir, { recursive: true });
 			}
-		}, 60_000 /* allow extra time to avoid testing timeouts on Windows */);
+		});
 
 		test('parseOptionsAndRunCLI returns CLIExitResult for php command', async () => {
 			const stdoutSpy = vi


### PR DESCRIPTION
Two `build-snapshot` return-type tests installed complete WordPress sites. On Windows they took 42–49 seconds when passing and both crossed their 60-second timeout in [this trunk run](https://github.com/WordPress/wordpress-playground/actions/runs/33416075828/job/99567213397).

This PR gives those tests a tiny local Blueprint, skips WordPress and SQLite installation, and uses one worker for the direct `runCLI()` call. The tests still create real snapshot ZIPs and check the same return values. They now complete in about 0.6 and 1.4 seconds locally under the default 30-second timeout.

## Testing

The full `run-cli.spec.ts` file passed with 96 tests. CLI typecheck, lint, formatting, and `git diff --check` also passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated snapshot return-type tests to use a minimal local Blueprint.
  * Improved CLI snapshot testing with temporary Blueprint configuration.
  * Limited direct snapshot test execution to a single worker for more consistent results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->