### PR TITLE
Personal Playground: let a WordPress page request a site backup

### DIFF
--- a/packages/playground/personal-wp/README.md
+++ b/packages/playground/personal-wp/README.md
@@ -93,6 +93,46 @@ Response:
 Blueprint URLs must be `https:`, `data:`, or local `http:` URLs. Dependent tabs
 cannot install blueprints and will return an error result.
 
+#### Backup Site
+
+Use `backup-site` to ask Personal Playground to zip the current site and hand the
+file to the browser's downloader — the same backup the Site Tools panel produces.
+Dependent tabs forward the request to the active tab, which is where the download
+then appears.
+
+```js
+window.parent.postMessage(
+	{
+		type: 'relay',
+		relayType: 'backup-site',
+		requestId,
+	},
+	'*'
+);
+```
+
+Response:
+
+```ts
+{
+	type: 'relay';
+	relayType: 'backup-site-result';
+	requestId?: string;
+	status: 'started' | 'success' | 'error';
+	error?: string;
+}
+```
+
+`started` is sent as soon as the request is accepted, before the site is zipped.
+Waiting for it lets a page tell a slow backup apart from an older Personal
+Playground that ignores the message, so it can fall back to pointing at Site
+Tools. `success` or `error` follows once the zip is done.
+
+No confirmation dialog is shown: the file only reaches the user's own disk, the
+requesting page never gets to read it, and a browser download is visible anyway.
+Only one backup runs at a time; a request that arrives while one is in flight
+comes back as an error.
+
 ### Offline Support
 
 Works as a Progressive Web App (PWA) for offline use. Install it on your device for a native app-like experience.

--- a/packages/playground/personal-wp/README.md
+++ b/packages/playground/personal-wp/README.md
@@ -128,6 +128,10 @@ Waiting for it lets a page tell a slow backup apart from an older Personal
 Playground that ignores the message, so it can fall back to pointing at Site
 Tools. `success` or `error` follows once the zip is done.
 
+A request that arrives before the site has finished coming up waits for it, up
+to 15 seconds, rather than being refused — the page doing the asking was served
+by that site, so it is generally the shell's state that is behind.
+
 No confirmation dialog is shown: the file only reaches the user's own disk, the
 requesting page never gets to read it, and a browser download is visible anyway.
 Only one backup runs at a time; a request that arrives while one is in flight

--- a/packages/playground/personal-wp/playwright/e2e/relay-backup.spec.ts
+++ b/packages/playground/personal-wp/playwright/e2e/relay-backup.spec.ts
@@ -8,6 +8,13 @@ test('should download a site backup requested by a relay message', async ({
 	wordpress,
 }) => {
 	await website.goto('./');
+	// WordPress renders behind the loading screen, so a non-empty frame body
+	// is not yet a booted site: while the loading screen is up, a backup is
+	// refused the same way the Site Tools button is unavailable. Wait for it
+	// to go away.
+	await expect(
+		website.page.getByRole('progressbar', { name: 'Loading WordPress' })
+	).toHaveCount(0);
 
 	const downloadPromise = website.page.waitForEvent('download');
 	const result = await wordpress.locator('body').evaluate(

--- a/packages/playground/personal-wp/playwright/e2e/relay-backup.spec.ts
+++ b/packages/playground/personal-wp/playwright/e2e/relay-backup.spec.ts
@@ -1,0 +1,45 @@
+import { test, expect } from '../playground-fixtures';
+
+// The `backup-site` relay message lets a WordPress page (e.g. the My Apps
+// "move to hosting" guide) start the same site backup the Site Tools panel
+// offers, without the user hunting for it.
+test('should download a site backup requested by a relay message', async ({
+	website,
+	wordpress,
+}) => {
+	await website.goto('./');
+
+	const downloadPromise = website.page.waitForEvent('download');
+	const result = await wordpress.locator('body').evaluate(
+		() =>
+			new Promise<{ statuses: string[]; error?: string }>((resolve) => {
+				const requestId = 'e2e-backup-request';
+				const statuses: string[] = [];
+				window.addEventListener('message', (event) => {
+					const data = event.data;
+					if (
+						!data ||
+						data.type !== 'relay' ||
+						data.relayType !== 'backup-site-result' ||
+						data.requestId !== requestId
+					) {
+						return;
+					}
+					statuses.push(data.status);
+					if (data.status !== 'started') {
+						resolve({ statuses, error: data.error });
+					}
+				});
+				window.parent.postMessage(
+					{ type: 'relay', relayType: 'backup-site', requestId },
+					'*'
+				);
+			})
+	);
+
+	// 'started' is what tells a caller the message was understood at all.
+	expect(result).toEqual({ statuses: ['started', 'success'] });
+
+	const download = await downloadPromise;
+	expect(download.suggestedFilename()).toMatch(/-backup-.*\.zip$/);
+});

--- a/packages/playground/personal-wp/playwright/e2e/relay-backup.spec.ts
+++ b/packages/playground/personal-wp/playwright/e2e/relay-backup.spec.ts
@@ -1,3 +1,4 @@
+import type { FrameLocator } from '@playwright/test';
 import { test, expect } from '../playground-fixtures';
 
 // The `backup-site` relay message lets a WordPress page (e.g. the My Apps
@@ -17,32 +18,7 @@ test('should download a site backup requested by a relay message', async ({
 	).toHaveCount(0);
 
 	const downloadPromise = website.page.waitForEvent('download');
-	const result = await wordpress.locator('body').evaluate(
-		() =>
-			new Promise<{ statuses: string[]; error?: string }>((resolve) => {
-				const requestId = 'e2e-backup-request';
-				const statuses: string[] = [];
-				window.addEventListener('message', (event) => {
-					const data = event.data;
-					if (
-						!data ||
-						data.type !== 'relay' ||
-						data.relayType !== 'backup-site-result' ||
-						data.requestId !== requestId
-					) {
-						return;
-					}
-					statuses.push(data.status);
-					if (data.status !== 'started') {
-						resolve({ statuses, error: data.error });
-					}
-				});
-				window.parent.postMessage(
-					{ type: 'relay', relayType: 'backup-site', requestId },
-					'*'
-				);
-			})
-	);
+	const [result] = await requestBackups(wordpress, 1);
 
 	// 'started' is what tells a caller the message was understood at all.
 	expect(result).toEqual({ statuses: ['started', 'success'] });
@@ -50,3 +26,78 @@ test('should download a site backup requested by a relay message', async ({
 	const download = await downloadPromise;
 	expect(download.suggestedFilename()).toMatch(/-backup-.*\.zip$/);
 });
+
+// Two requests in the same turn read the same React state, so only a lock the
+// hook holds itself can keep them from zipping the site twice.
+test('should run one backup for two requests made in the same turn', async ({
+	website,
+	wordpress,
+}) => {
+	await website.goto('./');
+	await expect(
+		website.page.getByRole('progressbar', { name: 'Loading WordPress' })
+	).toHaveCount(0);
+
+	const downloads: string[] = [];
+	website.page.on('download', (download) =>
+		downloads.push(download.suggestedFilename())
+	);
+
+	const results = await requestBackups(wordpress, 2);
+
+	expect(results.map((result) => result.statuses.at(-1)).sort()).toEqual([
+		'error',
+		'success',
+	]);
+	expect(downloads).toHaveLength(1);
+});
+
+/**
+ * Post `count` backup requests from the WordPress frame in one turn and
+ * resolve once each has reported a final status.
+ */
+function requestBackups(wordpress: FrameLocator, count: number) {
+	return wordpress.locator('body').evaluate(
+		(_body, requestCount: number) =>
+			Promise.all(
+				Array.from(
+					{ length: requestCount },
+					(_, index) =>
+						new Promise<{ statuses: string[]; error?: string }>(
+							(resolve) => {
+								const requestId = `e2e-backup-request-${index}`;
+								const statuses: string[] = [];
+								window.addEventListener('message', (event) => {
+									const data = event.data;
+									if (
+										!data ||
+										data.type !== 'relay' ||
+										data.relayType !==
+											'backup-site-result' ||
+										data.requestId !== requestId
+									) {
+										return;
+									}
+									statuses.push(data.status);
+									if (data.status !== 'started') {
+										resolve({
+											statuses,
+											error: data.error,
+										});
+									}
+								});
+								window.parent.postMessage(
+									{
+										type: 'relay',
+										relayType: 'backup-site',
+										requestId,
+									},
+									'*'
+								);
+							}
+						)
+				)
+			),
+		count
+	);
+}

--- a/packages/playground/personal-wp/src/components/playground-viewport/index.tsx
+++ b/packages/playground/personal-wp/src/components/playground-viewport/index.tsx
@@ -1484,6 +1484,14 @@ function SeamlessViewport({ siteSlug }: { siteSlug: string }) {
 			);
 			if (installBlueprintMessage) {
 				void installBlueprintFromRelay(event, installBlueprintMessage);
+				return;
+			}
+
+			const backupSiteMessage = getBackupSiteMessageData(
+				relayValidation.data
+			);
+			if (backupSiteMessage) {
+				void backupSiteFromRelay(event, backupSiteMessage);
 			}
 		}
 		window.addEventListener('message', handleMessage);
@@ -1493,8 +1501,11 @@ function SeamlessViewport({ siteSlug }: { siteSlug: string }) {
 	}, [
 		applyBlueprint,
 		applyBlueprintInMainTab,
+		canBackupNow,
 		hasLocalRuntimeClient,
 		isDependentMode,
+		mainTabStatus,
+		performBackup,
 		requestBlueprintInstallConfirmation,
 		siteSlug,
 		url,
@@ -1564,6 +1575,47 @@ function SeamlessViewport({ siteSlug }: { siteSlug: string }) {
 						usageStatsRequestSource,
 					})),
 		});
+	}
+
+	async function backupSiteFromRelay(
+		event: MessageEvent,
+		message: BackupSiteMessageData
+	) {
+		const { requestId } = message;
+		if (!canBackupNow) {
+			postBackupSiteResult(event, {
+				requestId,
+				status: 'error',
+				error: isDependentMode
+					? getMainTabUnavailableMessage(mainTabStatus)
+					: 'Playground is not ready.',
+			});
+			return;
+		}
+
+		// Zipping a site takes a while. Acknowledge the request right away so
+		// the requesting page can tell a slow backup apart from a Personal
+		// Playground that does not support this message at all.
+		postBackupSiteResult(event, { requestId, status: 'started' });
+
+		try {
+			const succeeded = await performBackup();
+			postBackupSiteResult(event, {
+				requestId,
+				status: succeeded ? 'success' : 'error',
+				...(succeeded
+					? {}
+					: {
+							error: 'The backup could not be created. Another backup may still be running.',
+						}),
+			});
+		} catch (e) {
+			postBackupSiteResult(event, {
+				requestId,
+				status: 'error',
+				error: getErrorMessage(e),
+			});
+		}
 	}
 
 	// Reflect the WordPress URL in the browser's address bar.
@@ -2156,6 +2208,12 @@ type InstallBlueprintMessageData = {
 	requestId?: string;
 };
 
+type BackupSiteMessageData = {
+	type: 'relay';
+	relayType: 'backup-site';
+	requestId?: string;
+};
+
 type BlueprintInstallDialogRequest = {
 	blueprintUrl: string;
 };
@@ -2194,6 +2252,14 @@ type InstallBlueprintResultMessage = {
 	blueprintUrl: string;
 	requestId?: string;
 	status: InstallBlueprintResult['status'] | 'cancelled';
+	error?: string;
+};
+
+type BackupSiteResultMessage = {
+	type: 'relay';
+	relayType: 'backup-site-result';
+	requestId?: string;
+	status: 'started' | 'success' | 'error';
 	error?: string;
 };
 
@@ -2240,6 +2306,19 @@ function getInstallBlueprintMessageData(
 		type: 'relay',
 		relayType: 'install-blueprint',
 		blueprintUrl: data.blueprintUrl,
+		requestId: getRequestId(data),
+	};
+}
+
+function getBackupSiteMessageData(
+	data: RelayMessageData
+): BackupSiteMessageData | undefined {
+	if (data.relayType !== 'backup-site') {
+		return;
+	}
+	return {
+		type: 'relay',
+		relayType: 'backup-site',
 		requestId: getRequestId(data),
 	};
 }
@@ -2305,6 +2384,23 @@ function postInstallBlueprintResult(
 			relayType: 'install-blueprint-result',
 			...result,
 		} satisfies InstallBlueprintResultMessage,
+		event.origin
+	);
+}
+
+function postBackupSiteResult(
+	event: MessageEvent,
+	result: Omit<BackupSiteResultMessage, 'type' | 'relayType'>
+) {
+	if (!event.source) {
+		return;
+	}
+	(event.source as Window).postMessage(
+		{
+			type: 'relay',
+			relayType: 'backup-site-result',
+			...result,
+		} satisfies BackupSiteResultMessage,
 		event.origin
 	);
 }

--- a/packages/playground/personal-wp/src/components/playground-viewport/index.tsx
+++ b/packages/playground/personal-wp/src/components/playground-viewport/index.tsx
@@ -1081,6 +1081,11 @@ function SeamlessViewport({ siteSlug }: { siteSlug: string }) {
 		!isBooting &&
 		(isDependentMode ? mainTabStatus === 'connected' : !!playground);
 	const hasActiveSiteError = activeSiteError && activeSiteSlug === siteSlug;
+	// A relay request can arrive while the site is still coming up, and it has
+	// to read the state as of that moment rather than as of the render that
+	// registered the listener.
+	const backupStateRef = useRef({ canBackupNow, performBackup });
+	backupStateRef.current = { canBackupNow, performBackup };
 
 	const loadingScreenHtml = useMemo(
 		() =>
@@ -1577,12 +1582,21 @@ function SeamlessViewport({ siteSlug }: { siteSlug: string }) {
 		});
 	}
 
+	/**
+	 * Zip the current site for a `backup-site` relay message and report back.
+	 *
+	 * Runs the same backup as the Site Tools button, so a dependent tab
+	 * forwards to the active tab and the download appears there.
+	 */
 	async function backupSiteFromRelay(
 		event: MessageEvent,
 		message: BackupSiteMessageData
 	) {
 		const { requestId } = message;
-		if (!canBackupNow) {
+		// The page that asked was served by this very site, so a site that
+		// looks unready here is almost always one whose state has not caught
+		// up yet — worth a short wait before refusing.
+		if (!(await waitForBackupReadiness(backupStateRef))) {
 			postBackupSiteResult(event, {
 				requestId,
 				status: 'error',
@@ -1599,7 +1613,7 @@ function SeamlessViewport({ siteSlug }: { siteSlug: string }) {
 		postBackupSiteResult(event, { requestId, status: 'started' });
 
 		try {
-			const succeeded = await performBackup();
+			const succeeded = await backupStateRef.current.performBackup();
 			postBackupSiteResult(event, {
 				requestId,
 				status: succeeded ? 'success' : 'error',
@@ -2310,6 +2324,25 @@ function getInstallBlueprintMessageData(
 	};
 }
 
+/**
+ * Wait until the site can serve a backup, up to `timeoutMs`.
+ *
+ * Resolves to whether it got there.
+ */
+async function waitForBackupReadiness(
+	stateRef: { current: { canBackupNow: boolean } },
+	timeoutMs = 15000
+): Promise<boolean> {
+	const deadline = Date.now() + timeoutMs;
+	while (!stateRef.current.canBackupNow && Date.now() < deadline) {
+		await new Promise((resolve) => setTimeout(resolve, 100));
+	}
+	return stateRef.current.canBackupNow;
+}
+
+/**
+ * Read a validated relay message as a backup request, if that is what it is.
+ */
 function getBackupSiteMessageData(
 	data: RelayMessageData
 ): BackupSiteMessageData | undefined {
@@ -2388,6 +2421,9 @@ function postInstallBlueprintResult(
 	);
 }
 
+/**
+ * Send a `backup-site-result` back to the frame that asked for the backup.
+ */
 function postBackupSiteResult(
 	event: MessageEvent,
 	result: Omit<BackupSiteResultMessage, 'type' | 'relayType'>

--- a/packages/playground/personal-wp/src/lib/hooks/use-backup.ts
+++ b/packages/playground/personal-wp/src/lib/hooks/use-backup.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
 import {
 	usePlaygroundClient,
 	usePlaygroundClientInfo,
@@ -155,6 +155,12 @@ export function useBackup() {
 	const dispatch = useAppDispatch();
 	const [isBackingUp, setIsBackingUp] = useState(false);
 	const [isRequestingRemote, setIsRequestingRemote] = useState(false);
+	// The state above renders the buttons; these guard the work itself. Two
+	// calls in the same turn — a double click, or two relay requests from a
+	// WordPress page — would both read the state as false and start a backup
+	// each, racing over the backup history.
+	const isBackingUpRef = useRef(false);
+	const isRequestingRemoteRef = useRef(false);
 
 	const isMainMode = clientInfo && !clientInfo.isDependentMode;
 	const isDependentMode = clientInfo?.isDependentMode ?? false;
@@ -162,7 +168,8 @@ export function useBackup() {
 	const performBackup = useCallback(async (): Promise<boolean> => {
 		// In dependent mode, request backup from the main tab
 		if (isDependentMode && activeSite) {
-			if (isRequestingRemote) return false;
+			if (isRequestingRemoteRef.current) return false;
+			isRequestingRemoteRef.current = true;
 			setIsRequestingRemote(true);
 			try {
 				const succeeded = await requestRemoteBackup(activeSite.slug);
@@ -171,14 +178,16 @@ export function useBackup() {
 				}
 				return succeeded;
 			} finally {
+				isRequestingRemoteRef.current = false;
 				setIsRequestingRemote(false);
 			}
 		}
 
-		if (!playground || !activeSite || isBackingUp) {
+		if (!playground || !activeSite || isBackingUpRef.current) {
 			return false;
 		}
 
+		isBackingUpRef.current = true;
 		setIsBackingUp(true);
 		try {
 			// Get site name from WordPress, fall back to metadata
@@ -214,16 +223,10 @@ export function useBackup() {
 
 			return true;
 		} finally {
+			isBackingUpRef.current = false;
 			setIsBackingUp(false);
 		}
-	}, [
-		playground,
-		activeSite,
-		isBackingUp,
-		isRequestingRemote,
-		isDependentMode,
-		dispatch,
-	]);
+	}, [playground, activeSite, isDependentMode, dispatch]);
 
 	// Register this tab as the backup handler when in main mode
 	useEffect(() => {


### PR DESCRIPTION
## Motivation for the change, related issues

A page running inside Personal Playground can already ask it to install a blueprint (`install-blueprint`). It cannot ask for the thing people need far more often: a backup.

Today the only route is the Site Tools panel, so any guide that starts with "take this site somewhere else" has to open by describing where to click — which is exactly where readers fall off. The My Apps *Make this a hosted WordPress* guide begins that way (akirk/my-apps#147, WordPress/blueprints#236); with this message its first step becomes a button.

## Implementation details

Adds a `backup-site` relay message beside `install-blueprint`, handled in the same `SeamlessViewport` listener and behind the same validation (relay shape, iframe tree, same origin).

It runs the existing `useBackup()` → `performBackup()` path — the one the Site Tools button uses — so dependent tabs keep forwarding to the active tab through the tab coordinator, and only one backup runs at a time.

The reply is `backup-site-result`:

```ts
{
	type: 'relay';
	relayType: 'backup-site-result';
	requestId?: string;
	status: 'started' | 'success' | 'error';
	error?: string;
}
```

`started` is sent as soon as the request is accepted, before the zip is built. Without it a caller cannot tell a slow backup apart from a Personal Playground that ignores the message, and so has no moment at which to fall back to pointing at Site Tools.

**No confirmation dialog**, unlike blueprint installs. The file only reaches the user's own disk, the requesting page never gets to read it, and a browser download is visible anyway; a dialog would just reintroduce the click this message exists to remove. Noted in the README so it reads as a decision rather than an oversight.

## Testing Instructions (or ideally a Blueprint)

New Playwright test, `packages/playground/personal-wp/playwright/e2e/relay-backup.spec.ts`:

```
npx playwright test --config=packages/playground/personal-wp/playwright/playwright.config.ts relay-backup
```

It posts the message from inside the WordPress iframe and asserts the statuses arrive as `['started', 'success']` and that a real download named `<site>-backup-<date>-<time>.zip` starts. Passing locally, along with lint, typecheck and the 131 unit tests.

By hand: open Personal Playground and run this in the WordPress frame's console —

```js
window.parent.postMessage({ type: 'relay', relayType: 'backup-site', requestId: '1' }, '*');
```

A backup zip should download, and the two result messages arrive on `window`.

https://claude.ai/code/session_015Wt1kT6weBQHE9oGvD4M8C

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for WordPress integrations to request site backups through relay messages.
  - Backup requests provide progress updates and report successful completion or errors.
  - Successful backups generate downloadable ZIP archives with the expected filename.
  - Requests wait for backup readiness and prevent duplicate concurrent operations.

- **Documentation**
  - Added documentation covering request formats, response statuses, progress reporting, forwarding behavior, and error handling.

- **Tests**
  - Added end-to-end coverage for backup requests, status updates, ZIP downloads, and duplicate-request handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->