### PR TITLE
Add daily/weekly/monthly activity streaks to Personal WP usage stats

### DIFF
--- a/packages/playground/personal-wp/src/lib/personalwp/usage-stats.spec.ts
+++ b/packages/playground/personal-wp/src/lib/personalwp/usage-stats.spec.ts
@@ -318,6 +318,29 @@ describe('Personal WP usage stats', () => {
 		expect(JSON.stringify(properties)).not.toContain('token=secret');
 	});
 
+	it('ignores a backward clock jump instead of resetting and re-emitting the streak', () => {
+		const day1 = Date.UTC(2026, 5, 10);
+		let metadata = {} as SiteMetadata;
+
+		const first = getStreakUsageStatsUpdate(metadata, day1);
+		metadata = { ...metadata, ...first.metadata };
+
+		const day2 = getStreakUsageStatsUpdate(metadata, day1 + DAY);
+		expect(day2.events).toContainEqual({
+			event: 'daily_streak',
+			properties: { bucket: '2' },
+		});
+		metadata = { ...metadata, ...day2.metadata };
+
+		// The client's clock jumps back to before the last-recorded day.
+		const clockSkewedBackward = getStreakUsageStatsUpdate(
+			metadata,
+			day1 - 3 * DAY
+		);
+		expect(clockSkewedBackward.events).toEqual([]);
+		expect(clockSkewedBackward.metadata).toEqual({});
+	});
+
 	it('advances the daily streak once per day and resets after a gap', () => {
 		const day1 = Date.UTC(2026, 5, 1);
 		let metadata = {} as SiteMetadata;

--- a/packages/playground/personal-wp/src/lib/personalwp/usage-stats.spec.ts
+++ b/packages/playground/personal-wp/src/lib/personalwp/usage-stats.spec.ts
@@ -5,11 +5,14 @@ import {
 	classifyBlueprintUrl,
 	getBlueprintUsageStatsProperties,
 	getSiteUsageStatsProperties,
+	getStreakUsageStatsUpdate,
 	getUsageStatsDate,
 	isUsageStatsAllowedOnCurrentHost,
 	logPersonalWpEvent,
 	shouldLogReturningVisitUsageStats,
 } from './usage-stats';
+
+const DAY = 24 * 60 * 60 * 1000;
 
 describe('Personal WP usage stats', () => {
 	afterEach(() => {
@@ -313,5 +316,131 @@ describe('Personal WP usage stats', () => {
 			blueprint_source: 'same-origin',
 		});
 		expect(JSON.stringify(properties)).not.toContain('token=secret');
+	});
+
+	it('advances the daily streak once per day and resets after a gap', () => {
+		const day1 = Date.UTC(2026, 5, 1);
+		let metadata = {} as SiteMetadata;
+
+		const first = getStreakUsageStatsUpdate(metadata, day1);
+		expect(first.events).toContainEqual({
+			event: 'daily_streak',
+			properties: { bucket: '1' },
+		});
+		metadata = { ...metadata, ...first.metadata };
+
+		const laterSameDay = getStreakUsageStatsUpdate(
+			metadata,
+			day1 + 12 * 60 * 60 * 1000
+		);
+		expect(laterSameDay.events).toEqual([]);
+
+		const day2 = getStreakUsageStatsUpdate(metadata, day1 + DAY);
+		expect(day2.events).toContainEqual({
+			event: 'daily_streak',
+			properties: { bucket: '2' },
+		});
+		metadata = { ...metadata, ...day2.metadata };
+
+		const afterGap = getStreakUsageStatsUpdate(metadata, day1 + 4 * DAY);
+		expect(afterGap.events).toContainEqual({
+			event: 'daily_streak',
+			properties: { bucket: '1' },
+		});
+	});
+
+	it('walks the daily streak bucket boundaries across consecutive days', () => {
+		const start = Date.UTC(2026, 5, 1);
+		let metadata = {} as SiteMetadata;
+		const buckets: string[] = [];
+
+		for (let day = 0; day < 31; day++) {
+			const update = getStreakUsageStatsUpdate(
+				metadata,
+				start + day * DAY
+			);
+			metadata = { ...metadata, ...update.metadata };
+			const dailyEvent = update.events.find(
+				(event) => event.event === 'daily_streak'
+			);
+			buckets.push(dailyEvent!.properties.bucket as string);
+		}
+
+		expect(buckets[0]).toBe('1');
+		expect(buckets[1]).toBe('2');
+		expect(buckets[2]).toBe('3-6');
+		expect(buckets[5]).toBe('3-6');
+		expect(buckets[6]).toBe('7-13');
+		expect(buckets[13]).toBe('14-29');
+		expect(buckets[29]).toBe('30+');
+	});
+
+	it('advances the weekly streak across calendar weeks and resets on a skipped week', () => {
+		const monday1 = Date.UTC(2026, 5, 1);
+		let metadata = {} as SiteMetadata;
+
+		const first = getStreakUsageStatsUpdate(metadata, monday1);
+		expect(first.events).toContainEqual({
+			event: 'weekly_streak',
+			properties: { bucket: '1' },
+		});
+		metadata = { ...metadata, ...first.metadata };
+
+		const fridaySameWeek = getStreakUsageStatsUpdate(
+			metadata,
+			monday1 + 4 * DAY
+		);
+		expect(
+			fridaySameWeek.events.some(
+				(event) => event.event === 'weekly_streak'
+			)
+		).toBe(false);
+
+		const monday2 = getStreakUsageStatsUpdate(metadata, monday1 + 7 * DAY);
+		expect(monday2.events).toContainEqual({
+			event: 'weekly_streak',
+			properties: { bucket: '2' },
+		});
+		metadata = { ...metadata, ...monday2.metadata };
+
+		const mondaySkippedWeek = getStreakUsageStatsUpdate(
+			metadata,
+			monday1 + 21 * DAY
+		);
+		expect(mondaySkippedWeek.events).toContainEqual({
+			event: 'weekly_streak',
+			properties: { bucket: '1' },
+		});
+	});
+
+	it('advances the monthly streak across a year boundary and resets on a skipped month', () => {
+		const december = Date.UTC(2025, 11, 15);
+		let metadata = {} as SiteMetadata;
+
+		const first = getStreakUsageStatsUpdate(metadata, december);
+		expect(first.events).toContainEqual({
+			event: 'monthly_streak',
+			properties: { bucket: '1' },
+		});
+		metadata = { ...metadata, ...first.metadata };
+
+		const january = getStreakUsageStatsUpdate(
+			metadata,
+			Date.UTC(2026, 0, 10)
+		);
+		expect(january.events).toContainEqual({
+			event: 'monthly_streak',
+			properties: { bucket: '2' },
+		});
+		metadata = { ...metadata, ...january.metadata };
+
+		const marchSkippedFebruary = getStreakUsageStatsUpdate(
+			metadata,
+			Date.UTC(2026, 2, 5)
+		);
+		expect(marchSkippedFebruary.events).toContainEqual({
+			event: 'monthly_streak',
+			properties: { bucket: '1' },
+		});
 	});
 });

--- a/packages/playground/personal-wp/src/lib/personalwp/usage-stats.ts
+++ b/packages/playground/personal-wp/src/lib/personalwp/usage-stats.ts
@@ -248,6 +248,12 @@ function getStreakState(
  * Returns the new streak state when `currentPeriodKey` starts a period that
  * hasn't been reported yet, or `undefined` when it was already reported
  * (the per-period dedupe that keeps event counts privacy-preserving).
+ *
+ * Period keys (YYYY-MM-DD or YYYY-MM) sort the same lexicographically as
+ * chronologically, so a `currentPeriodKey` that isn't strictly after the
+ * last recorded one — including one from a backward-skewed client clock —
+ * is treated as already reported rather than as a gap that resets the
+ * streak and re-emits an event for a period that was already counted.
  */
 function advanceStreak(
 	previous: StreakState | undefined,
@@ -257,7 +263,7 @@ function advanceStreak(
 		currentPeriodKey: string
 	) => boolean
 ): StreakState | undefined {
-	if (previous?.periodKey === currentPeriodKey) {
+	if (previous && previous.periodKey >= currentPeriodKey) {
 		return undefined;
 	}
 

--- a/packages/playground/personal-wp/src/lib/personalwp/usage-stats.ts
+++ b/packages/playground/personal-wp/src/lib/personalwp/usage-stats.ts
@@ -21,7 +21,10 @@ export type PersonalWpUsageStatsEvent =
 	| 'remote_access_started'
 	| 'health_check_installed'
 	| 'sidebar_opened'
-	| 'backup_restored';
+	| 'backup_restored'
+	| 'daily_streak'
+	| 'weekly_streak'
+	| 'monthly_streak';
 
 export type PersonalWpUsageStatsProperties = Record<string, JsonValue>;
 export type BlueprintInstallUsageStatsTrigger =
@@ -60,6 +63,28 @@ type BlueprintUsageStatsProperties = {
 type BlueprintUsageStatsOptions = {
 	requestSource?: BlueprintInstallUsageStatsRequestSource;
 };
+
+export type StreakUsageStatsMetadata = Pick<
+	SiteMetadata,
+	| 'lastDailyStreakDate'
+	| 'dailyStreak'
+	| 'lastWeeklyStreakWeekStart'
+	| 'weeklyStreak'
+	| 'lastMonthlyStreakMonth'
+	| 'monthlyStreak'
+>;
+
+export type StreakUsageStatsEvent = {
+	event: 'daily_streak' | 'weekly_streak' | 'monthly_streak';
+	properties: PersonalWpUsageStatsProperties;
+};
+
+export type StreakUsageStatsUpdate = {
+	metadata: StreakUsageStatsMetadata;
+	events: StreakUsageStatsEvent[];
+};
+
+type StreakState = { streak: number; periodKey: string };
 
 const EVENT_SCHEMA = 'personal-wp-event/v1';
 const SAFE_PLUGIN_SLUG = /^[a-z0-9][a-z0-9-]{0,100}$/;
@@ -133,6 +158,191 @@ export function shouldLogReturningVisitUsageStats(
 
 export function getUsageStatsDate(timestamp: number): string {
 	return new Date(timestamp).toISOString().slice(0, 10);
+}
+
+export function getUsageStatsWeekStart(timestamp: number): string {
+	const date = new Date(timestamp);
+	const utcDate = new Date(
+		Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate())
+	);
+	const daysSinceMonday = (utcDate.getUTCDay() + 6) % 7;
+	utcDate.setUTCDate(utcDate.getUTCDate() - daysSinceMonday);
+	return utcDate.toISOString().slice(0, 10);
+}
+
+export function getUsageStatsMonth(timestamp: number): string {
+	return new Date(timestamp).toISOString().slice(0, 7);
+}
+
+/**
+ * Computes streak updates for a site at all three granularities. A streak
+ * only advances when the new period immediately follows the last recorded
+ * one; any gap (or a first-ever visit) resets it to 1. Each granularity
+ * reports at most once per period, so summing the resulting event counts
+ * server-side gives a privacy-preserving proxy for distinct active sites
+ * per day/week/month without any per-site identifier ever being sent.
+ */
+export function getStreakUsageStatsUpdate(
+	metadata: SiteMetadata,
+	now: number
+): StreakUsageStatsUpdate {
+	const metadataUpdate: StreakUsageStatsMetadata = {};
+	const events: StreakUsageStatsEvent[] = [];
+
+	const daily = advanceStreak(
+		getStreakState(metadata.lastDailyStreakDate, metadata.dailyStreak),
+		getUsageStatsDate(now),
+		isNextDay
+	);
+	if (daily) {
+		metadataUpdate.lastDailyStreakDate = daily.periodKey;
+		metadataUpdate.dailyStreak = daily.streak;
+		events.push({
+			event: 'daily_streak',
+			properties: { bucket: getDailyStreakBucket(daily.streak) },
+		});
+	}
+
+	const weekly = advanceStreak(
+		getStreakState(
+			metadata.lastWeeklyStreakWeekStart,
+			metadata.weeklyStreak
+		),
+		getUsageStatsWeekStart(now),
+		isNextWeek
+	);
+	if (weekly) {
+		metadataUpdate.lastWeeklyStreakWeekStart = weekly.periodKey;
+		metadataUpdate.weeklyStreak = weekly.streak;
+		events.push({
+			event: 'weekly_streak',
+			properties: { bucket: getWeeklyStreakBucket(weekly.streak) },
+		});
+	}
+
+	const monthly = advanceStreak(
+		getStreakState(metadata.lastMonthlyStreakMonth, metadata.monthlyStreak),
+		getUsageStatsMonth(now),
+		isNextMonth
+	);
+	if (monthly) {
+		metadataUpdate.lastMonthlyStreakMonth = monthly.periodKey;
+		metadataUpdate.monthlyStreak = monthly.streak;
+		events.push({
+			event: 'monthly_streak',
+			properties: { bucket: getMonthlyStreakBucket(monthly.streak) },
+		});
+	}
+
+	return { metadata: metadataUpdate, events };
+}
+
+function getStreakState(
+	periodKey: string | undefined,
+	streak: number | undefined
+): StreakState | undefined {
+	return periodKey && streak ? { periodKey, streak } : undefined;
+}
+
+/**
+ * Returns the new streak state when `currentPeriodKey` starts a period that
+ * hasn't been reported yet, or `undefined` when it was already reported
+ * (the per-period dedupe that keeps event counts privacy-preserving).
+ */
+function advanceStreak(
+	previous: StreakState | undefined,
+	currentPeriodKey: string,
+	isImmediatelyFollowing: (
+		previousPeriodKey: string,
+		currentPeriodKey: string
+	) => boolean
+): StreakState | undefined {
+	if (previous?.periodKey === currentPeriodKey) {
+		return undefined;
+	}
+
+	const streak =
+		previous && isImmediatelyFollowing(previous.periodKey, currentPeriodKey)
+			? previous.streak + 1
+			: 1;
+	return { streak, periodKey: currentPeriodKey };
+}
+
+function isNextDay(previousDate: string, currentDate: string): boolean {
+	return addUtcDays(previousDate, 1) === currentDate;
+}
+
+function isNextWeek(
+	previousWeekStart: string,
+	currentWeekStart: string
+): boolean {
+	return addUtcDays(previousWeekStart, 7) === currentWeekStart;
+}
+
+function isNextMonth(previousMonth: string, currentMonth: string): boolean {
+	const [year, month] = previousMonth.split('-').map(Number);
+	const next = new Date(Date.UTC(year, month, 1));
+	return next.toISOString().slice(0, 7) === currentMonth;
+}
+
+function addUtcDays(date: string, days: number): string {
+	const next = new Date(`${date}T00:00:00.000Z`);
+	next.setUTCDate(next.getUTCDate() + days);
+	return next.toISOString().slice(0, 10);
+}
+
+function getDailyStreakBucket(streak: number): string {
+	if (streak <= 1) {
+		return '1';
+	}
+	if (streak === 2) {
+		return '2';
+	}
+	if (streak <= 6) {
+		return '3-6';
+	}
+	if (streak <= 13) {
+		return '7-13';
+	}
+	if (streak <= 29) {
+		return '14-29';
+	}
+	return '30+';
+}
+
+function getWeeklyStreakBucket(streak: number): string {
+	if (streak <= 1) {
+		return '1';
+	}
+	if (streak === 2) {
+		return '2';
+	}
+	if (streak <= 4) {
+		return '3-4';
+	}
+	if (streak <= 8) {
+		return '5-8';
+	}
+	return '9+';
+}
+
+function getMonthlyStreakBucket(streak: number): string {
+	if (streak <= 1) {
+		return '1';
+	}
+	if (streak === 2) {
+		return '2';
+	}
+	if (streak === 3) {
+		return '3';
+	}
+	if (streak <= 6) {
+		return '4-6';
+	}
+	if (streak <= 12) {
+		return '7-12';
+	}
+	return '13+';
 }
 
 export function getBlueprintUsageStatsProperties(

--- a/packages/playground/personal-wp/src/lib/state/redux/boot-site-client.ts
+++ b/packages/playground/personal-wp/src/lib/state/redux/boot-site-client.ts
@@ -48,6 +48,7 @@ import {
 	getUsageStatsDate,
 	getBlueprintUsageStatsProperties,
 	getSiteUsageStatsProperties,
+	getStreakUsageStatsUpdate,
 	isUsageStatsAllowedOnCurrentHost,
 	logPersonalWpEvent,
 	shouldLogReturningVisitUsageStats,
@@ -504,12 +505,27 @@ function logBootUsageStats({
 		});
 	}
 
+	const streakUpdate = getStreakUsageStatsUpdate(
+		site.metadata,
+		bootCompletedAt
+	);
+	Object.assign(metadata, streakUpdate.metadata);
+	for (const streakEvent of streakUpdate.events) {
+		logPersonalWpEvent(streakEvent.event, streakEvent.properties);
+	}
+
 	return metadata;
 }
 
 type BootUsageStatsMetadata = Pick<
 	SiteMetadata,
-	'lastUsageStatsReturningVisitDate'
+	| 'lastUsageStatsReturningVisitDate'
+	| 'lastDailyStreakDate'
+	| 'dailyStreak'
+	| 'lastWeeklyStreakWeekStart'
+	| 'weeklyStreak'
+	| 'lastMonthlyStreakMonth'
+	| 'monthlyStreak'
 >;
 
 function getWordPressInstallModeCaption(

--- a/packages/playground/personal-wp/src/lib/state/redux/slice-sites.ts
+++ b/packages/playground/personal-wp/src/lib/state/redux/slice-sites.ts
@@ -597,6 +597,30 @@ export interface SiteMetadata {
 	lastUsageStatsReturningVisitDate?: string;
 
 	/**
+	 * UTC date of the last day this site reported a daily-streak usage
+	 * stats event, and the number of consecutive days (including that one)
+	 * it was reported for.
+	 */
+	lastDailyStreakDate?: string;
+	dailyStreak?: number;
+
+	/**
+	 * UTC date of the Monday starting the last week this site reported a
+	 * weekly-streak usage stats event, and the number of consecutive weeks
+	 * (including that one) it was reported for.
+	 */
+	lastWeeklyStreakWeekStart?: string;
+	weeklyStreak?: number;
+
+	/**
+	 * UTC year-month (YYYY-MM) of the last month this site reported a
+	 * monthly-streak usage stats event, and the number of consecutive
+	 * months (including that one) it was reported for.
+	 */
+	lastMonthlyStreakMonth?: string;
+	monthlyStreak?: number;
+
+	/**
 	 * Timestamps for one-off migrations applied to this site.
 	 */
 	appliedMigrations?: Record<string, number>;

--- a/packages/playground/website-deployment/my-wordpress-net/mywp-event-dashboard.php
+++ b/packages/playground/website-deployment/my-wordpress-net/mywp-event-dashboard.php
@@ -11,6 +11,7 @@ const MYWP_EVENT_DASHBOARD_ALLOWED_GRANULARITIES = array( 'day', 'hour' );
 const MYWP_EVENT_DASHBOARD_CURL_CONNECT_TIMEOUT = 5;
 const MYWP_EVENT_DASHBOARD_CURL_TIMEOUT = 10;
 const MYWP_EVENT_DASHBOARD_SAFE_PLUGIN_SLUG_PATTERN = '/^[a-z0-9][a-z0-9-]{0,100}$/';
+const MYWP_EVENT_DASHBOARD_STREAK_TRACKING_START_DATE = '2026-09-03';
 
 if ( 'cli' !== php_sapi_name() ) {
 	mywp_event_dashboard_handle_request();
@@ -1312,6 +1313,16 @@ function mywp_event_dashboard_render_engagement_area(
 				selected range &mdash; not a lifetime unique-user count, and not
 				directly comparable to each other across different-length ranges.
 			</p>
+			<p class="muted">
+				Streak tracking started on
+				<?php echo mywp_event_dashboard_h(
+					mywp_event_dashboard_format_date(
+						MYWP_EVENT_DASHBOARD_STREAK_TRACKING_START_DATE
+					)
+				); ?>. Every site's streak began at 1 from that date, so
+				expect low streak numbers for a while &mdash; they don't yet
+				reflect how long sites had actually been used before then.
+			</p>
 		</div>
 		<div class="grid">
 			<div class="panel">
@@ -1866,6 +1877,11 @@ function mywp_event_dashboard_filter_url( $range, $granularity, $area = null ) {
 
 function mywp_event_dashboard_number( $value ) {
 	return number_format( (int) $value );
+}
+
+function mywp_event_dashboard_format_date( $date ) {
+	$timestamp = strtotime( $date );
+	return false === $timestamp ? $date : gmdate( 'F j, Y', $timestamp );
 }
 
 function mywp_event_dashboard_h( $value ) {

--- a/packages/playground/website-deployment/my-wordpress-net/mywp-event-dashboard.php
+++ b/packages/playground/website-deployment/my-wordpress-net/mywp-event-dashboard.php
@@ -996,6 +996,7 @@ function mywp_event_dashboard_get_current_area( $groups ) {
 				'new-installs',
 				'returning-visitors',
 				'blueprint-installs',
+				'engagement',
 				'remote-access',
 				'health-check',
 				'sidebar',
@@ -1016,6 +1017,7 @@ function mywp_event_dashboard_area( $type, $plugin_slug = null ) {
 		'new-installs' => 'New installs',
 		'returning-visitors' => 'Returning visitors',
 		'blueprint-installs' => 'Blueprint installs',
+		'engagement' => 'Engagement',
 		'remote-access' => 'Remote Access',
 		'health-check' => 'Health Check',
 		'sidebar' => 'Site Tools',
@@ -1048,6 +1050,7 @@ function mywp_event_dashboard_render_area_controls(
 		mywp_event_dashboard_area( 'new-installs' ),
 		mywp_event_dashboard_area( 'returning-visitors' ),
 		mywp_event_dashboard_area( 'blueprint-installs' ),
+		mywp_event_dashboard_area( 'engagement' ),
 		mywp_event_dashboard_area( 'remote-access' ),
 		mywp_event_dashboard_area( 'health-check' ),
 		mywp_event_dashboard_area( 'sidebar' ),
@@ -1178,7 +1181,17 @@ function mywp_event_dashboard_render_area(
 					'blueprint_installed:trigger',
 					'blueprint_installed:request_source',
 					'blueprint_installed:blueprint_source',
+					'blueprint_installed:previous_visit_age_bucket',
+					'blueprint_installed:site_age_bucket',
 				),
+				$stats,
+				$groups,
+				$metric_definitions
+			);
+			return;
+
+		case 'engagement':
+			mywp_event_dashboard_render_engagement_area(
 				$stats,
 				$groups,
 				$metric_definitions
@@ -1264,9 +1277,81 @@ function mywp_event_dashboard_render_overview_area( $stats, $groups ) {
 			<p class="muted">New installs, returning visits, and blueprint installs over time.</p>
 		</div>
 		<div class="panel">
-			<?php mywp_event_dashboard_render_timeline( $stats['timeline'] ); ?>
+			<?php
+			mywp_event_dashboard_render_timeline(
+				mywp_event_dashboard_filter_timeline_values(
+					$stats['timeline'],
+					mywp_event_dashboard_primary_event_values()
+				)
+			);
+			?>
 		</div>
 	</section>
+	<?php
+}
+
+function mywp_event_dashboard_render_engagement_area(
+	$stats,
+	$groups,
+	$metric_definitions
+) {
+	$daily_active = mywp_event_dashboard_event_count( $groups, 'daily_streak' );
+	$weekly_active = mywp_event_dashboard_event_count( $groups, 'weekly_streak' );
+	$monthly_active = mywp_event_dashboard_event_count( $groups, 'monthly_streak' );
+	$timeline = mywp_event_dashboard_filter_timeline_values(
+		$stats['timeline'],
+		array( 'daily_streak', 'weekly_streak', 'monthly_streak' )
+	);
+	?>
+	<section class="dashboard-section">
+		<div class="section-heading">
+			<h2>Engagement</h2>
+			<p class="muted">
+				Each site reports at most one ping per day/week/month, so these
+				counts are a privacy-preserving proxy for active sites in the
+				selected range &mdash; not a lifetime unique-user count, and not
+				directly comparable to each other across different-length ranges.
+			</p>
+		</div>
+		<div class="grid">
+			<div class="panel">
+				<div class="muted">Daily active sites</div>
+				<div class="stat-number"><?php echo mywp_event_dashboard_number( $daily_active ); ?></div>
+				<div class="kpi-detail">Sum of one-ping-per-day site activity in range</div>
+			</div>
+			<div class="panel">
+				<div class="muted">Weekly active sites</div>
+				<div class="stat-number"><?php echo mywp_event_dashboard_number( $weekly_active ); ?></div>
+				<div class="kpi-detail">Sum of one-ping-per-week site activity in range</div>
+			</div>
+			<div class="panel">
+				<div class="muted">Monthly active sites</div>
+				<div class="stat-number"><?php echo mywp_event_dashboard_number( $monthly_active ); ?></div>
+				<div class="kpi-detail">Sum of one-ping-per-month site activity in range</div>
+			</div>
+		</div>
+	</section>
+
+	<section class="dashboard-section">
+		<div class="section-heading">
+			<h2>Engagement trend</h2>
+		</div>
+		<div class="panel">
+			<?php mywp_event_dashboard_render_timeline( $timeline ); ?>
+		</div>
+	</section>
+
+	<?php mywp_event_dashboard_render_metric_section(
+		'Streak distribution',
+		'Consecutive periods in a row each reporting site has been active for.',
+		array(
+			'daily_streak:bucket',
+			'weekly_streak:bucket',
+			'monthly_streak:bucket',
+		),
+		$groups,
+		$metric_definitions
+	); ?>
 	<?php
 }
 
@@ -1535,8 +1620,8 @@ function mywp_event_dashboard_render_timeline_legend( $event_values ) {
 	echo '</div>';
 }
 
-function mywp_event_dashboard_order_event_values( $event_values ) {
-	$preferred_order = array(
+function mywp_event_dashboard_primary_event_values() {
+	return array(
 		'wordpress_installed',
 		'returning_visit',
 		'blueprint_installed',
@@ -1545,6 +1630,10 @@ function mywp_event_dashboard_order_event_values( $event_values ) {
 		'sidebar_opened',
 		'backup_restored',
 	);
+}
+
+function mywp_event_dashboard_order_event_values( $event_values ) {
+	$preferred_order = mywp_event_dashboard_primary_event_values();
 	$ordered_values = array();
 	foreach ( $preferred_order as $event_value ) {
 		if ( in_array( $event_value, $event_values, true ) ) {
@@ -1649,6 +1738,8 @@ function mywp_event_dashboard_metric_sections() {
 				'blueprint_installed:trigger',
 				'blueprint_installed:request_source',
 				'blueprint_installed:blueprint_source',
+				'blueprint_installed:previous_visit_age_bucket',
+				'blueprint_installed:site_age_bucket',
 			),
 		),
 	);
@@ -1695,6 +1786,9 @@ function mywp_event_dashboard_event_color( $event ) {
 		'health_check_installed' => '#5b5fc7',
 		'sidebar_opened' => '#007cba',
 		'backup_restored' => '#008a20',
+		'daily_streak' => '#0a7a69',
+		'weekly_streak' => '#3858e9',
+		'monthly_streak' => '#b26200',
 	);
 
 	if ( isset( $colors[ $event ] ) ) {
@@ -1723,6 +1817,9 @@ function mywp_event_dashboard_event_label( $event ) {
 		'health_check_installed' => 'Health Check installs',
 		'sidebar_opened' => 'Site Tools opens',
 		'backup_restored' => 'Backup restores',
+		'daily_streak' => 'Daily active',
+		'weekly_streak' => 'Weekly active',
+		'monthly_streak' => 'Monthly active',
 	);
 
 	return $labels[ $event ] ?? $event;
@@ -1740,6 +1837,11 @@ function mywp_event_dashboard_metric_definitions() {
 		'blueprint_installed:request_source' => 'Blueprint Installs: Request Source',
 		'blueprint_installed:blueprint_source' => 'Blueprint Installs: Source Class',
 		'blueprint_installed:plugin_slug' => 'Blueprint Installs: Plugin Slug',
+		'blueprint_installed:previous_visit_age_bucket' => 'Blueprint Installs: Previous Visit Age',
+		'blueprint_installed:site_age_bucket' => 'Blueprint Installs: Site Age',
+		'daily_streak:bucket' => 'Daily Streak (consecutive days)',
+		'weekly_streak:bucket' => 'Weekly Streak (consecutive weeks)',
+		'monthly_streak:bucket' => 'Monthly Streak (consecutive months)',
 	);
 }
 

--- a/packages/playground/website-deployment/my-wordpress-net/mywp-event-dashboard.php
+++ b/packages/playground/website-deployment/my-wordpress-net/mywp-event-dashboard.php
@@ -1880,8 +1880,14 @@ function mywp_event_dashboard_number( $value ) {
 }
 
 function mywp_event_dashboard_format_date( $date ) {
-	$timestamp = strtotime( $date );
-	return false === $timestamp ? $date : gmdate( 'F j, Y', $timestamp );
+	$parsed = DateTime::createFromFormat(
+		'!Y-m-d',
+		$date,
+		new DateTimeZone( 'UTC' )
+	);
+	return false === $parsed
+		? $date
+		: gmdate( 'F j, Y', $parsed->getTimestamp() );
 }
 
 function mywp_event_dashboard_h( $value ) {

--- a/packages/playground/website-deployment/my-wordpress-net/mywp-event.php
+++ b/packages/playground/website-deployment/my-wordpress-net/mywp-event.php
@@ -14,6 +14,9 @@ const MYWP_EVENT_ALLOWED_EVENTS = array(
 	'health_check_installed',
 	'sidebar_opened',
 	'backup_restored',
+	'daily_streak',
+	'weekly_streak',
+	'monthly_streak',
 );
 
 if ( 'cli' !== php_sapi_name() ) {
@@ -248,6 +251,23 @@ function mywp_event_collect_stat_bumps( $payload ) {
 		return $bumps;
 	}
 
+	if (
+		in_array(
+			$event,
+			array( 'daily_streak', 'weekly_streak', 'monthly_streak' ),
+			true
+		)
+	) {
+		mywp_event_add_allowed_property(
+			$bumps,
+			$event,
+			'bucket',
+			$properties,
+			mywp_event_streak_buckets( $event )
+		);
+		return $bumps;
+	}
+
 	mywp_event_add_allowed_property(
 		$bumps,
 		$event,
@@ -394,6 +414,23 @@ function mywp_event_age_buckets() {
 		'31-90-days',
 		'over-90-days',
 	);
+}
+
+/**
+ * Must match the bucket boundaries in usage-stats.ts (getDailyStreakBucket,
+ * getWeeklyStreakBucket, getMonthlyStreakBucket) — these are the values the
+ * client is allowed to send for each streak event's `bucket` property.
+ */
+function mywp_event_streak_buckets( $event ) {
+	if ( 'daily_streak' === $event ) {
+		return array( '1', '2', '3-6', '7-13', '14-29', '30+' );
+	}
+
+	if ( 'weekly_streak' === $event ) {
+		return array( '1', '2', '3-4', '5-8', '9+' );
+	}
+
+	return array( '1', '2', '3', '4-6', '7-12', '13+' );
 }
 
 function mywp_event_sync_bump_extra( $dbh, $name, $value, $num, $today, $hour ) {


### PR DESCRIPTION
## Summary
- Adds three new client-logged events (`daily_streak`, `weekly_streak`, `monthly_streak`) that track per-site consecutive-period engagement, bucketed before transmission so no raw/unbounded counter is ever sent (an unbounded per-site counter would be a de-facto linkable identifier across requests).
- Each streak event fires at most once per its period (day/week/month), so the existing generic `event` rollup on the server gives, as a byproduct, a privacy-preserving proxy for daily/weekly/monthly active sites — no per-site identifier is ever transmitted.
- Adds a new "Engagement" area to the internal usage dashboard (`mywp-event-dashboard.php`) showing these active-site proxy counts, a trend chart, and the streak-distribution breakdown; the existing Overview "Event trend" chart is now explicitly scoped to the original 7 events so it isn't swamped by the new high-volume pings.
- Also surfaces two previously-collected-but-unshown dimensions (`previous_visit_age_bucket`, `site_age_bucket`) on the existing Blueprint Installs dashboard panel.

## Test plan
- [x] `php tests.php` in `packages/playground/website-deployment` (dashboard + event-ingestion unit tests)
- [x] `php -l` on both modified PHP files
- [x] `npx nx test playground-personal-wp --testFile=usage-stats.spec.ts` (14 tests, including day/week/month rollover, year-boundary, gap-reset, and bucket-boundary cases)
- [x] `npx nx typecheck playground-personal-wp`
- [x] `npx nx lint playground-personal-wp`
- [x] Manual smoke-render of the new Engagement dashboard area with synthetic data, confirming streak events no longer leak into the Overview trend chart

https://claude.ai/code/session_01WmrzrATRxMuU5Jijs9KeNQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added daily, weekly, and monthly activity streak tracking.
  * Added engagement dashboard metrics for streak activity, streak distributions, and usage trends.
  * Added timeline filtering and clearer date formatting for engagement insights.
  * Added previous-visit and site-age dimensions to blueprint installation views.
  * Added validation for streak event categories and supported streak ranges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->