### PR TITLE
Fold renamed plugin slugs together in the Personal WP stats dashboard

### DIFF
--- a/packages/playground/website-deployment/my-wordpress-net/mywp-event-dashboard.php
+++ b/packages/playground/website-deployment/my-wordpress-net/mywp-event-dashboard.php
@@ -13,6 +13,17 @@ const MYWP_EVENT_DASHBOARD_CURL_TIMEOUT = 10;
 const MYWP_EVENT_DASHBOARD_SAFE_PLUGIN_SLUG_PATTERN = '/^[a-z0-9][a-z0-9-]{0,100}$/';
 const MYWP_EVENT_DASHBOARD_STREAK_TRACKING_START_DATE = '2026-09-03';
 
+/**
+ * Plugin slugs that changed when an app was renamed. The stats tables keep the
+ * raw values that were reported at install time, so the dashboard folds the
+ * previous slug into the current one while reading them and each app shows up
+ * as a single entry.
+ */
+const MYWP_EVENT_DASHBOARD_RENAMED_PLUGIN_SLUGS = array(
+	'travel-app' => 'traveler',
+	'wordcamp-companion' => 'session-planner-for-wordcamps',
+);
+
 if ( 'cli' !== php_sapi_name() ) {
 	mywp_event_dashboard_handle_request();
 }
@@ -618,7 +629,7 @@ function mywp_event_dashboard_query_rollup(
 	}
 	mysqli_stmt_close( $statement );
 
-	return $rows;
+	return mywp_event_dashboard_fold_renamed_plugin_slug_rows( $rows );
 }
 
 function mywp_event_dashboard_query_event_timeline(
@@ -674,7 +685,93 @@ function mywp_event_dashboard_query_metric_timeline(
 	}
 	mysqli_stmt_close( $statement );
 
+	if ( 'blueprint_installed:plugin_slug' === $metric_name ) {
+		return mywp_event_dashboard_fold_renamed_plugin_slug_timeline( $rows );
+	}
+
 	return $rows;
+}
+
+/**
+ * Merges rollup rows whose plugin slug changed into the row for the current
+ * slug, keeping the `name` ASC, `views` DESC, `value` ASC order the query uses.
+ */
+function mywp_event_dashboard_fold_renamed_plugin_slug_rows( $rows ) {
+	$folded = array();
+	foreach ( $rows as $row ) {
+		if ( 'blueprint_installed:plugin_slug' === $row['name'] ) {
+			$row['value'] = mywp_event_dashboard_canonical_plugin_slug(
+				$row['value']
+			);
+		}
+
+		$key = $row['name'] . "\n" . $row['value'];
+		if ( isset( $folded[ $key ] ) ) {
+			$folded[ $key ]['views'] += $row['views'];
+			continue;
+		}
+
+		$folded[ $key ] = $row;
+	}
+
+	$folded = array_values( $folded );
+	usort(
+		$folded,
+		function ( $a, $b ) {
+			if ( $a['name'] !== $b['name'] ) {
+				return strcmp( $a['name'], $b['name'] );
+			}
+			if ( $a['views'] !== $b['views'] ) {
+				return $b['views'] - $a['views'];
+			}
+			return strcmp( $a['value'], $b['value'] );
+		}
+	);
+
+	return $folded;
+}
+
+/**
+ * Merges timeline rows whose plugin slug changed into the row for the current
+ * slug, keeping the `period` ASC, `value` ASC order the query uses.
+ */
+function mywp_event_dashboard_fold_renamed_plugin_slug_timeline( $rows ) {
+	$folded = array();
+	foreach ( $rows as $row ) {
+		$row['value'] = mywp_event_dashboard_canonical_plugin_slug(
+			$row['value']
+		);
+
+		$key = $row['period'] . "\n" . $row['value'];
+		if ( isset( $folded[ $key ] ) ) {
+			$folded[ $key ]['views'] += $row['views'];
+			continue;
+		}
+
+		$folded[ $key ] = $row;
+	}
+
+	$folded = array_values( $folded );
+	usort(
+		$folded,
+		function ( $a, $b ) {
+			if ( $a['period'] !== $b['period'] ) {
+				return strcmp( $a['period'], $b['period'] );
+			}
+			return strcmp( $a['value'], $b['value'] );
+		}
+	);
+
+	return $folded;
+}
+
+function mywp_event_dashboard_canonical_plugin_slug( $plugin_slug ) {
+	if ( ! is_string( $plugin_slug ) ) {
+		return $plugin_slug;
+	}
+
+	return MYWP_EVENT_DASHBOARD_RENAMED_PLUGIN_SLUGS[ $plugin_slug ]
+		?? $plugin_slug;
 }
 
 function mywp_event_dashboard_group_rows( $rows ) {
@@ -982,7 +1079,9 @@ function mywp_event_dashboard_get_current_area( $groups ) {
 	}
 
 	if ( 'plugin' === $area ) {
-		$plugin_slug = $_GET['plugin_slug'] ?? '';
+		$plugin_slug = mywp_event_dashboard_canonical_plugin_slug(
+			$_GET['plugin_slug'] ?? ''
+		);
 		if ( mywp_event_dashboard_is_safe_plugin_slug( $plugin_slug ) ) {
 			return mywp_event_dashboard_area( 'plugin', $plugin_slug );
 		}

--- a/packages/playground/website-deployment/tests.php
+++ b/packages/playground/website-deployment/tests.php
@@ -393,7 +393,92 @@ assert_equal(
     'Dashboard should reject unsafe plugin slugs'
 );
 
+$_GET = array(
+    'area' => 'plugin',
+    'plugin_slug' => 'travel-app',
+);
+assert_equal(
+    'traveler',
+    mywp_event_dashboard_get_current_area( array() )['plugin_slug'],
+    'Dashboard should open the current slug for a renamed plugin link'
+);
+
 $_GET = $mywp_event_get_snapshot;
+
+$folded_plugin_slug_rows = mywp_event_dashboard_fold_renamed_plugin_slug_rows(
+    array(
+        array(
+            'name' => 'blueprint_installed:plugin_slug',
+            'value' => 'friends',
+            'views' => 7,
+        ),
+        array(
+            'name' => 'blueprint_installed:plugin_slug',
+            'value' => 'travel-app',
+            'views' => 5,
+        ),
+        array(
+            'name' => 'blueprint_installed:plugin_slug',
+            'value' => 'traveler',
+            'views' => 4,
+        ),
+        array(
+            'name' => 'blueprint_installed:blueprint_source',
+            'value' => 'travel-app',
+            'views' => 2,
+        ),
+    )
+);
+assert_equal(
+    'blueprint_installed:blueprint_source=travel-app:2,'
+        . 'blueprint_installed:plugin_slug=traveler:9,'
+        . 'blueprint_installed:plugin_slug=friends:7',
+    implode(
+        ',',
+        array_map(
+            function ( $row ) {
+                return "{$row['name']}={$row['value']}:{$row['views']}";
+            },
+            $folded_plugin_slug_rows
+        )
+    ),
+    'Dashboard should merge renamed plugin slugs and keep the query ordering'
+);
+
+$folded_plugin_slug_timeline =
+    mywp_event_dashboard_fold_renamed_plugin_slug_timeline(
+        array(
+            array(
+                'period' => '2026-09-01',
+                'value' => 'travel-app',
+                'views' => 3,
+            ),
+            array(
+                'period' => '2026-09-01',
+                'value' => 'traveler',
+                'views' => 2,
+            ),
+            array(
+                'period' => '2026-09-02',
+                'value' => 'wordcamp-companion',
+                'views' => 1,
+            ),
+        )
+    );
+assert_equal(
+    '2026-09-01=traveler:5,'
+        . '2026-09-02=session-planner-for-wordcamps:1',
+    implode(
+        ',',
+        array_map(
+            function ( $row ) {
+                return "{$row['period']}={$row['value']}:{$row['views']}";
+            },
+            $folded_plugin_slug_timeline
+        )
+    ),
+    'Dashboard should merge renamed plugin slugs within a timeline period'
+);
 
 assert_equal(
     '/mywp-event-dashboard.php?range=90&granularity=hour&area=plugin&plugin_slug=friends',


### PR DESCRIPTION
Two apps were renamed (`travel-app` → `traveler`, `wordcamp-companion` → `session-planner-for-wordcamps`). Blueprint installs keep reporting the old slug for installs that predate the rename, and from clients still carrying a stale app catalog, so `/mywp-event-dashboard.php` listed each app twice with its installs split between the two entries.

## What this does

Maps previous slugs to current ones at read time:

- `mywp_event_dashboard_query_rollup()` folds `blueprint_installed:plugin_slug` rows onto the canonical value, sums the duplicates and re-sorts to the ordering the query itself uses. That covers the Plugin nav, the metric tables and the drilldown count in one place.
- The plugin-slug timeline query folds the same way; the event timeline is untouched.
- `mywp_event_dashboard_get_current_area()` canonicalizes the requested slug, so an old `?area=plugin&plugin_slug=travel-app` link lands on the merged page instead of an empty one.

`MYWP_EVENT_DASHBOARD_RENAMED_PLUGIN_SLUGS` is the single place to add the next rename.

The stats tables keep the raw reported values — no ingest change, no schema change, no data migration. Nothing is lost, and the change is reversible.

Folding the timeline also heads off an undercount that would have surfaced there: `render_timeline()` assigns rather than adds each value's views within a period, so two rows for the same period would have silently dropped one of them.

## Testing

`php packages/playground/website-deployment/tests.php` passes, with four new assertions: the rollup fold merges and re-sorts, a matching value under a different metric name is left alone, the timeline fold merges within a period, and the drilldown resolves an old slug. `php -l` is clean on both files.

Not verified against the production database — the change only affects how existing rows are read.

https://claude.ai/code/session_01YBXe2c6oBYmANtFRv4Pdfj

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the event dashboard to recognize renamed plugin slugs and associate them with the current plugin.
  * Combined historical and current plugin data, including view counts and timeline values, while preserving dashboard ordering.
  * Ensured selected plugin views resolve correctly after a plugin rename.

* **Tests**
  * Added coverage for renamed plugin resolution, aggregated results, timeline merging, and ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->