### PR TITLE
Do not forward PHP's User-Agent header to fetch()

### DIFF
--- a/packages/php-wasm/web/src/lib/tcp-over-fetch-websocket.ts
+++ b/packages/php-wasm/web/src/lib/tcp-over-fetch-websocket.ts
@@ -813,6 +813,19 @@ export class RawBytesFetch {
 		 * is handled above when choosing the target URL because fetch does not
 		 * support Host spoofing.
 		 */
+		/*
+		 * User-Agent is not a CORS-safelisted request header, and PHP sends one
+		 * with every request (WordPress sets its own). Forwarding it turns every
+		 * cross-origin request into a preflighted one, and few servers answer an
+		 * OPTIONS preflight with the CORS headers the browser then requires. The
+		 * CORS proxy fallback does not help either: its Access-Control-Allow-Headers
+		 * does not list User-Agent, so the preflight to the proxy fails as well and
+		 * the request is never sent.
+		 *
+		 * Chrome already ignores a User-Agent set through fetch() and sends its own,
+		 * so this only changes what Firefox does, and it changes it to match Chrome.
+		 * The browser fills in its own User-Agent for the outgoing request.
+		 */
 		for (const header of [
 			'Connection',
 			'Content-Length',
@@ -825,6 +838,7 @@ export class RawBytesFetch {
 			'Trailer',
 			'Transfer-Encoding',
 			'Upgrade',
+			'User-Agent',
 		]) {
 			normalizedHeaders.delete(header);
 		}

--- a/packages/php-wasm/web/src/test/tcp-over-fetch-websocket.spec.ts
+++ b/packages/php-wasm/web/src/test/tcp-over-fetch-websocket.spec.ts
@@ -150,6 +150,10 @@ function createTestApp(): Express {
 		});
 	});
 
+	app.get('/request-headers', (req, res) => {
+		res.json(req.headers);
+	});
+
 	app.get('/error', (req, res) => {
 		res.status(500).send('Internal Server Error');
 	});
@@ -328,6 +332,22 @@ describe('TCPOverFetchWebsocket over HTTP', () => {
 		expect(response).toContain('HTTP/1.1 200 OK');
 		expect(response).toContain('Part 1');
 		expect(response).toContain('Part 2');
+	});
+
+	it('should not forward the User-Agent header set by PHP', async () => {
+		// A forwarded User-Agent is not CORS-safelisted and would make every
+		// cross-origin request preflighted. The browser sends its own instead.
+		const socket = await makeRequest({
+			host,
+			port,
+			path: '/request-headers',
+			additionalHeaders:
+				'User-Agent: WordPress/6.8; https://example.com\r\n',
+			outputType: 'stream',
+		});
+		const response = await bufferResponse(socket);
+		expect(response).toContain('HTTP/1.1 200 OK');
+		expect(response).not.toContain('WordPress/6.8');
 	});
 
 	it('should handle an error response', async () => {


### PR DESCRIPTION
## What

`normalizeRequestHeadersForFetch()` now drops `User-Agent` along with the other headers that describe only the PHP-to-socket hop.

## Why

PHP sends a `User-Agent` with every request, and WordPress sets its own (`WordPress/<version>; <site url>`), so this affects every `wp_remote_get()` call made from Playground.

`User-Agent` is not a CORS-safelisted request header. Forwarding it to `fetch()` turns every cross-origin request into a **preflighted** one, and that breaks both paths in `fetchWithCorsProxy()`:

1. **Direct fetch** — the browser sends `OPTIONS` first. Most sites do not answer a preflight with `Access-Control-Allow-Origin` / `Access-Control-Allow-Headers`, so it fails.
2. **CORS proxy fallback** — the retry carries the same header, so it is preflighted too, and the proxy replies with

   ```
   Access-Control-Allow-Headers: Accept, Authorization, Content-Type, git-protocol,
                                 wp_blog, wp_install,
                                 x-cors-proxy-allowed-request-headers,
                                 x-cors-proxy-content-type
   ```

   `user-agent` is not on that list, so this preflight fails as well and the real request is never sent. In a HAR the entry shows up as `status: 0`, no response headers, `time: 0`.

The result is that in **Firefox**, a plugin that fetches an external page gets nothing at all, while the same blueprint works in Chrome. That difference is the whole bug: Chrome ignores a `User-Agent` set through `fetch()` and sends its own, so nothing is ever preflighted there. Verified with a cross-origin `fetch(url, { headers: { 'User-Agent': 'CORSTEST/1.0' } })` from Chromium — the server received `Mozilla/5.0 … Chrome/…`, identical to a fetch with no custom header, and no `OPTIONS` was logged.

Dropping the header makes Firefox behave the way Chrome already does. The browser fills in its own `User-Agent`, which is what the target server receives today from every Chrome user anyway.

## Alternative considered

Adding `User-Agent` to `Access-Control-Allow-Headers` in `packages/playground/php-cors-proxy/cors-proxy.php`. That fixes only the proxy path, leaves the direct fetch preflighted, and would let any caller set an arbitrary `User-Agent` for requests to third-party sites through the shared proxy — while `cors-proxy.php` itself carries a `@TODO` about treating non-browser user agents differently.

## Testing

Added a regression test that sends `User-Agent: WordPress/6.8; https://example.com` through `TCPOverFetchWebsocket` and asserts the header does not reach the server. It fails on `trunk` (`expected 'HTTP/1.1 200 OK…' not to contain 'WordPress/6.8'`) and passes with this change; the whole `tcp-over-fetch-websocket` suite is green (31 tests).

https://claude.ai/code/session_01TqH2TVgzAyPTu5WFHANfBA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved browser-based PHP socket requests by allowing the browser to provide its own user-agent information.
  * Resolved a Firefox-specific issue that could trigger unnecessary CORS preflight requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->