### PR TITLE
Record which channel new and returning Personal WP visits came through

### DIFF
--- a/packages/playground/personal-wp/src/lib/personalwp/usage-stats.spec.ts
+++ b/packages/playground/personal-wp/src/lib/personalwp/usage-stats.spec.ts
@@ -3,6 +3,7 @@ import type { BlueprintV1Declaration } from '@wp-playground/blueprints';
 import type { SiteMetadata } from '../state/redux/slice-sites';
 import {
 	classifyBlueprintUrl,
+	classifyReferrer,
 	getBlueprintUsageStatsProperties,
 	getSiteUsageStatsProperties,
 	getStreakUsageStatsUpdate,
@@ -296,6 +297,56 @@ describe('Personal WP usage stats', () => {
 			'data-url'
 		);
 		expect(classifyBlueprintUrl('http://[invalid')).toBe('invalid-url');
+	});
+
+	it('classifies referrers instead of reporting them', () => {
+		vi.stubGlobal('location', {
+			origin: 'https://my.wordpress.net',
+		});
+
+		expect(classifyReferrer('')).toBe('direct');
+		expect(classifyReferrer('https://my.wordpress.net/builder')).toBe(
+			'internal'
+		);
+		expect(classifyReferrer('https://news.ycombinator.com/item?id=1')).toBe(
+			'hacker-news'
+		);
+		expect(classifyReferrer('https://www.google.co.uk/search?q=x')).toBe(
+			'search'
+		);
+		expect(classifyReferrer('https://example.com/a-blog-post')).toBe(
+			'other-external'
+		);
+		expect(classifyReferrer('not a url')).toBe('other-external');
+	});
+
+	it('reports make.wordpress.org separately from wordpress.org', () => {
+		vi.stubGlobal('location', {
+			origin: 'https://my.wordpress.net',
+		});
+
+		expect(classifyReferrer('https://make.wordpress.org/core/')).toBe(
+			'make-wordpress-org'
+		);
+		expect(classifyReferrer('https://wordpress.org/plugins/')).toBe(
+			'wordpress-org'
+		);
+		expect(classifyReferrer('https://developer.wordpress.org/')).toBe(
+			'wordpress-org'
+		);
+	});
+
+	it('does not treat a look-alike host as a known referrer', () => {
+		vi.stubGlobal('location', {
+			origin: 'https://my.wordpress.net',
+		});
+
+		expect(classifyReferrer('https://notwordpress.org/')).toBe(
+			'other-external'
+		);
+		expect(classifyReferrer('https://wordpress.org.example.com/')).toBe(
+			'other-external'
+		);
 	});
 
 	it('does not report blueprint identifiers', () => {

--- a/packages/playground/personal-wp/src/lib/personalwp/usage-stats.spec.ts
+++ b/packages/playground/personal-wp/src/lib/personalwp/usage-stats.spec.ts
@@ -344,6 +344,12 @@ describe('Personal WP usage stats', () => {
 		expect(normalizeReferrer('http://192.168.1.5/dashboard')).toBe(
 			'private-address'
 		);
+		expect(normalizeReferrer('http://[::1]/dashboard')).toBe(
+			'private-address'
+		);
+		expect(normalizeReferrer('http://[2001:db8::1]/dashboard')).toBe(
+			'private-address'
+		);
 	});
 
 	it('keeps an unreadable referrer apart from a private address', () => {

--- a/packages/playground/personal-wp/src/lib/personalwp/usage-stats.spec.ts
+++ b/packages/playground/personal-wp/src/lib/personalwp/usage-stats.spec.ts
@@ -332,16 +332,25 @@ describe('Personal WP usage stats', () => {
 		);
 	});
 
-	it('does not report hosts that identify a network rather than a site', () => {
+	it('reports a host that names a network as private-address', () => {
 		vi.stubGlobal('location', {
 			origin: 'https://my.wordpress.net',
 		});
 
-		expect(normalizeReferrer('http://wiki/page')).toBe('unknown');
-		expect(normalizeReferrer('http://localhost:3000/')).toBe('unknown');
-		expect(normalizeReferrer('http://192.168.1.5/dashboard')).toBe(
-			'unknown'
+		expect(normalizeReferrer('http://wiki/page')).toBe('private-address');
+		expect(normalizeReferrer('http://localhost:3000/')).toBe(
+			'private-address'
 		);
+		expect(normalizeReferrer('http://192.168.1.5/dashboard')).toBe(
+			'private-address'
+		);
+	});
+
+	it('keeps an unreadable referrer apart from a private address', () => {
+		vi.stubGlobal('location', {
+			origin: 'https://my.wordpress.net',
+		});
+
 		expect(normalizeReferrer('android-app://com.example.reader')).toBe(
 			'unknown'
 		);

--- a/packages/playground/personal-wp/src/lib/personalwp/usage-stats.spec.ts
+++ b/packages/playground/personal-wp/src/lib/personalwp/usage-stats.spec.ts
@@ -3,7 +3,7 @@ import type { BlueprintV1Declaration } from '@wp-playground/blueprints';
 import type { SiteMetadata } from '../state/redux/slice-sites';
 import {
 	classifyBlueprintUrl,
-	classifyReferrer,
+	normalizeReferrer,
 	getBlueprintUsageStatsProperties,
 	getSiteUsageStatsProperties,
 	getStreakUsageStatsUpdate,
@@ -299,54 +299,56 @@ describe('Personal WP usage stats', () => {
 		expect(classifyBlueprintUrl('http://[invalid')).toBe('invalid-url');
 	});
 
-	it('classifies referrers instead of reporting them', () => {
+	it('reports only the referring host, never the path', () => {
 		vi.stubGlobal('location', {
 			origin: 'https://my.wordpress.net',
 		});
 
-		expect(classifyReferrer('')).toBe('direct');
-		expect(classifyReferrer('https://my.wordpress.net/builder')).toBe(
+		expect(normalizeReferrer('')).toBe('direct');
+		expect(normalizeReferrer('https://my.wordpress.net/builder')).toBe(
 			'internal'
 		);
-		expect(classifyReferrer('https://news.ycombinator.com/item?id=1')).toBe(
-			'hacker-news'
+		expect(
+			normalizeReferrer('https://news.ycombinator.com/item?id=1')
+		).toBe('news.ycombinator.com');
+		expect(normalizeReferrer('https://www.example.com/a-post#top')).toBe(
+			'example.com'
 		);
-		expect(classifyReferrer('https://www.google.co.uk/search?q=x')).toBe(
-			'search'
+		expect(normalizeReferrer('https://Blog.Example.CO.UK:8443/x')).toBe(
+			'blog.example.co.uk'
 		);
-		expect(classifyReferrer('https://example.com/a-blog-post')).toBe(
-			'other-external'
-		);
-		expect(classifyReferrer('not a url')).toBe('other-external');
 	});
 
-	it('reports make.wordpress.org separately from wordpress.org', () => {
+	it('keeps make.wordpress.org distinct from wordpress.org', () => {
 		vi.stubGlobal('location', {
 			origin: 'https://my.wordpress.net',
 		});
 
-		expect(classifyReferrer('https://make.wordpress.org/core/')).toBe(
-			'make-wordpress-org'
+		expect(normalizeReferrer('https://make.wordpress.org/core/')).toBe(
+			'make.wordpress.org'
 		);
-		expect(classifyReferrer('https://wordpress.org/plugins/')).toBe(
-			'wordpress-org'
-		);
-		expect(classifyReferrer('https://developer.wordpress.org/')).toBe(
-			'wordpress-org'
+		expect(normalizeReferrer('https://wordpress.org/plugins/')).toBe(
+			'wordpress.org'
 		);
 	});
 
-	it('does not treat a look-alike host as a known referrer', () => {
+	it('does not report hosts that identify a network rather than a site', () => {
 		vi.stubGlobal('location', {
 			origin: 'https://my.wordpress.net',
 		});
 
-		expect(classifyReferrer('https://notwordpress.org/')).toBe(
-			'other-external'
+		expect(normalizeReferrer('http://wiki/page')).toBe('unknown');
+		expect(normalizeReferrer('http://localhost:3000/')).toBe('unknown');
+		expect(normalizeReferrer('http://192.168.1.5/dashboard')).toBe(
+			'unknown'
 		);
-		expect(classifyReferrer('https://wordpress.org.example.com/')).toBe(
-			'other-external'
+		expect(normalizeReferrer('android-app://com.example.reader')).toBe(
+			'unknown'
 		);
+		expect(normalizeReferrer('not a url')).toBe('unknown');
+		expect(
+			normalizeReferrer(`https://${'a'.repeat(130)}.example.com/`)
+		).toBe('unknown');
 	});
 
 	it('does not report blueprint identifiers', () => {

--- a/packages/playground/personal-wp/src/lib/personalwp/usage-stats.ts
+++ b/packages/playground/personal-wp/src/lib/personalwp/usage-stats.ts
@@ -46,6 +46,18 @@ export type PersonalWpUsageStatsOptions = {
 	fetchImpl?: typeof fetch;
 };
 
+export type ReferrerSourceClass =
+	| 'direct'
+	| 'github'
+	| 'hacker-news'
+	| 'internal'
+	| 'make-wordpress-org'
+	| 'other-external'
+	| 'reddit'
+	| 'search'
+	| 'wordpress-org'
+	| 'x';
+
 type BlueprintSourceClass =
 	| 'same-origin'
 	| 'wordpress-org'
@@ -91,6 +103,20 @@ const SAFE_PLUGIN_SLUG = /^[a-z0-9][a-z0-9-]{0,100}$/;
 const MAX_PLUGIN_SLUGS = 10;
 const UNKNOWN_PLUGIN_SLUG = 'unknown';
 const USAGE_STATS_HOST = personalWpUsageStatsHost || 'my.wordpress.net';
+const SEARCH_ENGINE_DOMAINS = [
+	'baidu.com',
+	'bing.com',
+	'duckduckgo.com',
+	'ecosia.org',
+	'qwant.com',
+	'search.brave.com',
+	'startpage.com',
+	'yahoo.com',
+	'yandex.com',
+	'yandex.ru',
+];
+/** Matches google.com and its country domains (google.de, google.co.uk). */
+const GOOGLE_SEARCH_HOST = /^google\.[a-z]{2,3}(\.[a-z]{2})?$/;
 
 export function logPersonalWpEvent(
 	event: PersonalWpUsageStatsEvent,
@@ -407,6 +433,87 @@ export function classifyBlueprintUrl(url: string): BlueprintSourceClass {
 		return 'github';
 	}
 	return 'external-url';
+}
+
+/**
+ * Classifies the referring site into a small closed vocabulary so that a
+ * traffic spike can be attributed to a source without the referrer URL ever
+ * leaving the browser. Anything unrecognized becomes `other-external`, which
+ * keeps the reported cardinality fixed: a referrer that sent a single visit
+ * is never recorded, so it cannot narrow down who that visitor was.
+ *
+ * Modern browsers default to `strict-origin-when-cross-origin`, so the origin
+ * usually survives even though the path does not. Referrals from native apps,
+ * from sites sending `no-referrer`, and from HTTPS to HTTP send nothing at all
+ * and are reported as `direct`.
+ */
+export function classifyReferrer(
+	referrer = globalThis.document?.referrer ?? ''
+): ReferrerSourceClass {
+	if (!referrer) {
+		return 'direct';
+	}
+
+	let parsedUrl: URL;
+	try {
+		parsedUrl = new URL(referrer);
+	} catch {
+		return 'other-external';
+	}
+
+	if (parsedUrl.origin === globalThis.location?.origin) {
+		return 'internal';
+	}
+
+	const host = parsedUrl.hostname.toLowerCase();
+	// make.wordpress.org is a subdomain of wordpress.org, so it has to be
+	// matched before the wordpress.org check that would otherwise absorb it.
+	if (isHostOrSubdomain(host, 'make.wordpress.org')) {
+		return 'make-wordpress-org';
+	}
+	if (isHostOrSubdomain(host, 'wordpress.org')) {
+		return 'wordpress-org';
+	}
+	if (isHostOrSubdomain(host, 'news.ycombinator.com')) {
+		return 'hacker-news';
+	}
+	if (
+		isHostOrSubdomain(host, 'reddit.com') ||
+		isHostOrSubdomain(host, 'redd.it')
+	) {
+		return 'reddit';
+	}
+	if (
+		isHostOrSubdomain(host, 'x.com') ||
+		isHostOrSubdomain(host, 'twitter.com') ||
+		isHostOrSubdomain(host, 't.co')
+	) {
+		return 'x';
+	}
+	if (
+		isHostOrSubdomain(host, 'github.com') ||
+		host === 'raw.githubusercontent.com'
+	) {
+		return 'github';
+	}
+	if (isSearchEngineHost(host)) {
+		return 'search';
+	}
+	return 'other-external';
+}
+
+function isSearchEngineHost(host: string): boolean {
+	const bareHost = host.startsWith('www.') ? host.slice(4) : host;
+	if (GOOGLE_SEARCH_HOST.test(bareHost)) {
+		return true;
+	}
+	return SEARCH_ENGINE_DOMAINS.some((domain) =>
+		isHostOrSubdomain(host, domain)
+	);
+}
+
+function isHostOrSubdomain(host: string, domain: string): boolean {
+	return host === domain || host.endsWith(`.${domain}`);
 }
 
 function getAgeBucket(timestamp: number | undefined, now: number): string {

--- a/packages/playground/personal-wp/src/lib/personalwp/usage-stats.ts
+++ b/packages/playground/personal-wp/src/lib/personalwp/usage-stats.ts
@@ -423,12 +423,13 @@ export function classifyBlueprintUrl(url: string): BlueprintSourceClass {
  * which are where a referrer says what someone was reading, never leave the
  * browser.
  *
- * Hosts that identify a place rather than a site are reported as `unknown`
- * instead: single-label intranet names (`wiki`, `localhost`) and IP literals
- * are no use for spotting a traffic source and are the kind most likely to
- * point at one person's network. Every reported host therefore contains a
- * dot, which is also what keeps a host from colliding with the `direct`,
- * `internal` and `unknown` markers.
+ * Hosts that name a network rather than a site are reported as
+ * `private-address`: single-label intranet names (`wiki`, `localhost`) and IP
+ * literals are no use for spotting a traffic source and are the kind most
+ * likely to point at one person's network. They are kept apart from
+ * `unknown`, which means the referrer could not be read at all, so a rise in
+ * either can be told from the other. Every reported host therefore contains a
+ * dot, which is also what keeps a host from colliding with a marker.
  *
  * Modern browsers default to `strict-origin-when-cross-origin`, so the origin
  * usually survives even though the path does not. Referrals from native apps,
@@ -460,13 +461,13 @@ export function normalizeReferrer(
 		.toLowerCase()
 		.replace(/^www\./, '')
 		.replace(/\.$/, '');
-	const labels = host.split('.');
-	if (
-		labels.length < 2 ||
-		!SAFE_REFERRER_HOST.test(host) ||
-		IPV4_LAST_LABEL.test(labels[labels.length - 1])
-	) {
+	if (!SAFE_REFERRER_HOST.test(host)) {
 		return 'unknown';
+	}
+
+	const labels = host.split('.');
+	if (labels.length < 2 || IPV4_LAST_LABEL.test(labels[labels.length - 1])) {
+		return 'private-address';
 	}
 	return host;
 }

--- a/packages/playground/personal-wp/src/lib/personalwp/usage-stats.ts
+++ b/packages/playground/personal-wp/src/lib/personalwp/usage-stats.ts
@@ -97,8 +97,10 @@ const USAGE_STATS_HOST = personalWpUsageStatsHost || 'my.wordpress.net';
  * characters the endpoint accepts so a host is never silently dropped there.
  */
 const SAFE_REFERRER_HOST = /^[a-z0-9][a-z0-9._-]{0,127}$/;
-/** Trailing label of an IPv4 literal, which is reported as `unknown`. */
+/** Trailing label of an IPv4 literal, which is reported as `private-address`. */
 const IPV4_LAST_LABEL = /^\d+$/;
+/** IPv6 literals retain square brackets in URL.hostname. */
+const IPV6_LITERAL = /^\[[0-9a-f:]+\]$/i;
 
 export function logPersonalWpEvent(
 	event: PersonalWpUsageStatsEvent,
@@ -461,6 +463,9 @@ export function normalizeReferrer(
 		.toLowerCase()
 		.replace(/^www\./, '')
 		.replace(/\.$/, '');
+	if (IPV6_LITERAL.test(host)) {
+		return 'private-address';
+	}
 	if (!SAFE_REFERRER_HOST.test(host)) {
 		return 'unknown';
 	}

--- a/packages/playground/personal-wp/src/lib/personalwp/usage-stats.ts
+++ b/packages/playground/personal-wp/src/lib/personalwp/usage-stats.ts
@@ -46,18 +46,6 @@ export type PersonalWpUsageStatsOptions = {
 	fetchImpl?: typeof fetch;
 };
 
-export type ReferrerSourceClass =
-	| 'direct'
-	| 'github'
-	| 'hacker-news'
-	| 'internal'
-	| 'make-wordpress-org'
-	| 'other-external'
-	| 'reddit'
-	| 'search'
-	| 'wordpress-org'
-	| 'x';
-
 type BlueprintSourceClass =
 	| 'same-origin'
 	| 'wordpress-org'
@@ -103,20 +91,14 @@ const SAFE_PLUGIN_SLUG = /^[a-z0-9][a-z0-9-]{0,100}$/;
 const MAX_PLUGIN_SLUGS = 10;
 const UNKNOWN_PLUGIN_SLUG = 'unknown';
 const USAGE_STATS_HOST = personalWpUsageStatsHost || 'my.wordpress.net';
-const SEARCH_ENGINE_DOMAINS = [
-	'baidu.com',
-	'bing.com',
-	'duckduckgo.com',
-	'ecosia.org',
-	'qwant.com',
-	'search.brave.com',
-	'startpage.com',
-	'yahoo.com',
-	'yandex.com',
-	'yandex.ru',
-];
-/** Matches google.com and its country domains (google.de, google.co.uk). */
-const GOOGLE_SEARCH_HOST = /^google\.[a-z]{2,3}(\.[a-z]{2})?$/;
+/**
+ * Host shape accepted for reporting. Bounded at 128 characters to match the
+ * `value` column the stats rollup stores it in, and restricted to the
+ * characters the endpoint accepts so a host is never silently dropped there.
+ */
+const SAFE_REFERRER_HOST = /^[a-z0-9][a-z0-9._-]{0,127}$/;
+/** Trailing label of an IPv4 literal, which is reported as `unknown`. */
+const IPV4_LAST_LABEL = /^\d+$/;
 
 export function logPersonalWpEvent(
 	event: PersonalWpUsageStatsEvent,
@@ -436,20 +418,26 @@ export function classifyBlueprintUrl(url: string): BlueprintSourceClass {
 }
 
 /**
- * Classifies the referring site into a small closed vocabulary so that a
- * traffic spike can be attributed to a source without the referrer URL ever
- * leaving the browser. Anything unrecognized becomes `other-external`, which
- * keeps the reported cardinality fixed: a referrer that sent a single visit
- * is never recorded, so it cannot narrow down who that visitor was.
+ * Reduces the referring site to a bare hostname so a traffic spike can be
+ * attributed to its source. Only the host is reported: the path and query,
+ * which are where a referrer says what someone was reading, never leave the
+ * browser.
+ *
+ * Hosts that identify a place rather than a site are reported as `unknown`
+ * instead: single-label intranet names (`wiki`, `localhost`) and IP literals
+ * are no use for spotting a traffic source and are the kind most likely to
+ * point at one person's network. Every reported host therefore contains a
+ * dot, which is also what keeps a host from colliding with the `direct`,
+ * `internal` and `unknown` markers.
  *
  * Modern browsers default to `strict-origin-when-cross-origin`, so the origin
  * usually survives even though the path does not. Referrals from native apps,
  * from sites sending `no-referrer`, and from HTTPS to HTTP send nothing at all
  * and are reported as `direct`.
  */
-export function classifyReferrer(
+export function normalizeReferrer(
 	referrer = globalThis.document?.referrer ?? ''
-): ReferrerSourceClass {
+): string {
 	if (!referrer) {
 		return 'direct';
 	}
@@ -458,62 +446,29 @@ export function classifyReferrer(
 	try {
 		parsedUrl = new URL(referrer);
 	} catch {
-		return 'other-external';
+		return 'unknown';
 	}
 
+	if (!['http:', 'https:'].includes(parsedUrl.protocol)) {
+		return 'unknown';
+	}
 	if (parsedUrl.origin === globalThis.location?.origin) {
 		return 'internal';
 	}
 
-	const host = parsedUrl.hostname.toLowerCase();
-	// make.wordpress.org is a subdomain of wordpress.org, so it has to be
-	// matched before the wordpress.org check that would otherwise absorb it.
-	if (isHostOrSubdomain(host, 'make.wordpress.org')) {
-		return 'make-wordpress-org';
-	}
-	if (isHostOrSubdomain(host, 'wordpress.org')) {
-		return 'wordpress-org';
-	}
-	if (isHostOrSubdomain(host, 'news.ycombinator.com')) {
-		return 'hacker-news';
-	}
+	const host = parsedUrl.hostname
+		.toLowerCase()
+		.replace(/^www\./, '')
+		.replace(/\.$/, '');
+	const labels = host.split('.');
 	if (
-		isHostOrSubdomain(host, 'reddit.com') ||
-		isHostOrSubdomain(host, 'redd.it')
+		labels.length < 2 ||
+		!SAFE_REFERRER_HOST.test(host) ||
+		IPV4_LAST_LABEL.test(labels[labels.length - 1])
 	) {
-		return 'reddit';
+		return 'unknown';
 	}
-	if (
-		isHostOrSubdomain(host, 'x.com') ||
-		isHostOrSubdomain(host, 'twitter.com') ||
-		isHostOrSubdomain(host, 't.co')
-	) {
-		return 'x';
-	}
-	if (
-		isHostOrSubdomain(host, 'github.com') ||
-		host === 'raw.githubusercontent.com'
-	) {
-		return 'github';
-	}
-	if (isSearchEngineHost(host)) {
-		return 'search';
-	}
-	return 'other-external';
-}
-
-function isSearchEngineHost(host: string): boolean {
-	const bareHost = host.startsWith('www.') ? host.slice(4) : host;
-	if (GOOGLE_SEARCH_HOST.test(bareHost)) {
-		return true;
-	}
-	return SEARCH_ENGINE_DOMAINS.some((domain) =>
-		isHostOrSubdomain(host, domain)
-	);
-}
-
-function isHostOrSubdomain(host: string, domain: string): boolean {
-	return host === domain || host.endsWith(`.${domain}`);
+	return host;
 }
 
 function getAgeBucket(timestamp: number | undefined, now: number): string {

--- a/packages/playground/personal-wp/src/lib/state/redux/boot-site-client.ts
+++ b/packages/playground/personal-wp/src/lib/state/redux/boot-site-client.ts
@@ -45,6 +45,7 @@ import { isAppBasePath } from '../url/app-base-url';
 import { PLAYGROUND_QUERY_KEYS } from '../url/router';
 import { getBrowserPathAsLandingPage } from '../url/landing-page';
 import {
+	classifyReferrer,
 	getUsageStatsDate,
 	getBlueprintUsageStatsProperties,
 	getSiteUsageStatsProperties,
@@ -487,6 +488,7 @@ function logBootUsageStats({
 			...siteProperties,
 			original_blueprint_source:
 				site.metadata.originalBlueprintSource.type,
+			referrer_source: classifyReferrer(),
 		});
 	} else if (
 		isWordPressInstalled &&

--- a/packages/playground/personal-wp/src/lib/state/redux/boot-site-client.ts
+++ b/packages/playground/personal-wp/src/lib/state/redux/boot-site-client.ts
@@ -483,18 +483,24 @@ function logBootUsageStats({
 		bootCompletedAt
 	);
 	const metadata: BootUsageStatsMetadata = {};
+	// Reported for both ways of arriving, so a channel can be read for new
+	// and returning sites alike.
+	const referrerSource = normalizeReferrer();
 	if (wordpressInstallMode === 'download-and-install') {
 		logPersonalWpEvent('wordpress_installed', {
 			...siteProperties,
 			original_blueprint_source:
 				site.metadata.originalBlueprintSource.type,
-			referrer_source: normalizeReferrer(),
+			referrer_source: referrerSource,
 		});
 	} else if (
 		isWordPressInstalled &&
 		shouldLogReturningVisitUsageStats(site.metadata, bootCompletedAt)
 	) {
-		logPersonalWpEvent('returning_visit', siteProperties);
+		logPersonalWpEvent('returning_visit', {
+			...siteProperties,
+			referrer_source: referrerSource,
+		});
 		metadata.lastUsageStatsReturningVisitDate =
 			getUsageStatsDate(bootCompletedAt);
 	}

--- a/packages/playground/personal-wp/src/lib/state/redux/boot-site-client.ts
+++ b/packages/playground/personal-wp/src/lib/state/redux/boot-site-client.ts
@@ -45,7 +45,7 @@ import { isAppBasePath } from '../url/app-base-url';
 import { PLAYGROUND_QUERY_KEYS } from '../url/router';
 import { getBrowserPathAsLandingPage } from '../url/landing-page';
 import {
-	classifyReferrer,
+	normalizeReferrer,
 	getUsageStatsDate,
 	getBlueprintUsageStatsProperties,
 	getSiteUsageStatsProperties,
@@ -488,7 +488,7 @@ function logBootUsageStats({
 			...siteProperties,
 			original_blueprint_source:
 				site.metadata.originalBlueprintSource.type,
-			referrer_source: classifyReferrer(),
+			referrer_source: normalizeReferrer(),
 		});
 	} else if (
 		isWordPressInstalled &&

--- a/packages/playground/website-deployment/my-wordpress-net/mywp-event-dashboard.php
+++ b/packages/playground/website-deployment/my-wordpress-net/mywp-event-dashboard.php
@@ -8,6 +8,7 @@ const MYWP_EVENT_DASHBOARD_STATE_TTL = 600;
 const MYWP_EVENT_DASHBOARD_PATH = '/mywp-event-dashboard.php';
 const MYWP_EVENT_DASHBOARD_ALLOWED_RANGES = array( 7, 30, 90 );
 const MYWP_EVENT_DASHBOARD_ALLOWED_GRANULARITIES = array( 'day', 'hour' );
+const MYWP_EVENT_DASHBOARD_ALLOWED_FORMATS = array( 'html', 'json' );
 const MYWP_EVENT_DASHBOARD_CURL_CONNECT_TIMEOUT = 5;
 const MYWP_EVENT_DASHBOARD_CURL_TIMEOUT = 10;
 const MYWP_EVENT_DASHBOARD_SAFE_PLUGIN_SLUG_PATTERN = '/^[a-z0-9][a-z0-9-]{0,100}$/';
@@ -63,6 +64,12 @@ function mywp_event_dashboard_handle_request() {
 
 	$range = mywp_event_dashboard_get_range();
 	$granularity = mywp_event_dashboard_get_granularity();
+	$format = mywp_event_dashboard_get_format();
+	// Sent before the HEAD check so a HEAD request advertises the same type
+	// the matching GET would return.
+	if ( 'json' === $format ) {
+		header( 'Content-Type: application/json; charset=utf-8' );
+	}
 
 	try {
 		$stats = mywp_event_dashboard_load_stats(
@@ -75,6 +82,11 @@ function mywp_event_dashboard_handle_request() {
 	}
 
 	if ( 'HEAD' === $_SERVER['REQUEST_METHOD'] ) {
+		return;
+	}
+
+	if ( 'json' === $format ) {
+		mywp_event_dashboard_render_json( $stats );
 		return;
 	}
 
@@ -560,6 +572,13 @@ function mywp_event_dashboard_get_granularity() {
 		: 'day';
 }
 
+function mywp_event_dashboard_get_format() {
+	$format = $_GET['format'] ?? 'html';
+	return in_array( $format, MYWP_EVENT_DASHBOARD_ALLOWED_FORMATS, true )
+		? $format
+		: 'html';
+}
+
 function mywp_event_dashboard_load_stats( $dbh, $range, $granularity ) {
 	$table = 'hour' === $granularity
 		? 'mywp_event_stats_hourly'
@@ -784,6 +803,73 @@ function mywp_event_dashboard_group_rows( $rows ) {
 		$groups[ $name ][] = $row;
 	}
 	return $groups;
+}
+
+/**
+ * Emits the same numbers the HTML dashboard renders, without the navigation
+ * chrome, so a spike can be analysed by a script instead of by reading bars.
+ * Every area's breakdown is included at once because the JSON consumer has no
+ * area to switch between.
+ */
+function mywp_event_dashboard_render_json( $stats ) {
+	$groups = mywp_event_dashboard_group_rows( $stats['rows'] );
+	$events = $groups['event'] ?? array();
+
+	$metrics = array();
+	foreach ( $groups as $name => $rows ) {
+		if ( 'event' !== $name ) {
+			$metrics[ $name ] = mywp_event_dashboard_json_views_by_value( $rows );
+		}
+	}
+
+	echo json_encode(
+		array(
+			'schema' => 'mywp-event-dashboard/v1',
+			'generated_at' => gmdate( 'c' ),
+			'range' => $stats['range'],
+			'granularity' => $stats['granularity'],
+			'since' => $stats['since'],
+			'total_events' => mywp_event_dashboard_sum_views( $events ),
+			'events' => mywp_event_dashboard_json_views_by_value( $events ),
+			'metrics' => (object) $metrics,
+			'timeline' => mywp_event_dashboard_json_timeline( $stats['timeline'] ),
+			'blueprint_plugin_slug_timeline' => mywp_event_dashboard_json_timeline(
+				$stats['blueprint_plugin_slug_timeline']
+			),
+		),
+		JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES
+	);
+}
+
+function mywp_event_dashboard_json_views_by_value( $rows ) {
+	$views = array();
+	foreach ( $rows as $row ) {
+		$views[ $row['value'] ] = $row['views'];
+	}
+	return (object) $views;
+}
+
+function mywp_event_dashboard_json_timeline( $rows ) {
+	$periods = array();
+	foreach ( $rows as $row ) {
+		$period = $row['period'];
+		if ( ! isset( $periods[ $period ] ) ) {
+			$periods[ $period ] = array(
+				'period' => $period,
+				'total' => 0,
+				'values' => array(),
+			);
+		}
+		$periods[ $period ]['values'][ $row['value'] ] = $row['views'];
+		$periods[ $period ]['total'] += $row['views'];
+	}
+
+	$timeline = array();
+	foreach ( $periods as $period ) {
+		$period['values'] = (object) $period['values'];
+		$timeline[] = $period;
+	}
+	return $timeline;
 }
 
 function mywp_event_dashboard_render( $stats, $current_user ) {
@@ -1246,6 +1332,7 @@ function mywp_event_dashboard_render_area(
 				'First-use events for new Personal WP sites.',
 				'wordpress_installed',
 				array(
+					'wordpress_installed:referrer_source',
 					'wordpress_installed:original_blueprint_source',
 					'wordpress_installed:site_age_bucket',
 					'wordpress_installed:previous_visit_age_bucket',
@@ -1834,6 +1921,7 @@ function mywp_event_dashboard_metric_sections() {
 		'Growth and Retention' => array(
 			'description' => 'Signals that explain new-site and returning-site usage.',
 			'metrics' => array(
+				'wordpress_installed:referrer_source',
 				'wordpress_installed:original_blueprint_source',
 				'wordpress_installed:site_age_bucket',
 				'wordpress_installed:previous_visit_age_bucket',
@@ -1941,6 +2029,7 @@ function mywp_event_dashboard_metric_definitions() {
 		'wordpress_installed:site_age_bucket' => 'New Installs: Site Age',
 		'wordpress_installed:previous_visit_age_bucket' => 'New Installs: Previous Visit Age',
 		'wordpress_installed:original_blueprint_source' => 'New Installs: Original Blueprint Source',
+		'wordpress_installed:referrer_source' => 'New Installs: Referrer Source',
 		'returning_visit:site_age_bucket' => 'Returning Visits: Site Age',
 		'returning_visit:previous_visit_age_bucket' => 'Returning Visits: Previous Visit Age',
 		'blueprint_installed:trigger' => 'Blueprint Installs: Trigger',

--- a/packages/playground/website-deployment/my-wordpress-net/mywp-event-dashboard.php
+++ b/packages/playground/website-deployment/my-wordpress-net/mywp-event-dashboard.php
@@ -28,6 +28,7 @@ const MYWP_EVENT_DASHBOARD_REFERRER_SOURCE_MIN_VIEWS = 5;
 const MYWP_EVENT_DASHBOARD_REFERRER_SOURCE_MARKERS = array(
 	'direct',
 	'internal',
+	'private-address',
 	'unknown',
 );
 const MYWP_EVENT_DASHBOARD_STREAK_TRACKING_START_DATE = '2026-09-03';

--- a/packages/playground/website-deployment/my-wordpress-net/mywp-event-dashboard.php
+++ b/packages/playground/website-deployment/my-wordpress-net/mywp-event-dashboard.php
@@ -12,7 +12,10 @@ const MYWP_EVENT_DASHBOARD_ALLOWED_FORMATS = array( 'html', 'json' );
 const MYWP_EVENT_DASHBOARD_CURL_CONNECT_TIMEOUT = 5;
 const MYWP_EVENT_DASHBOARD_CURL_TIMEOUT = 10;
 const MYWP_EVENT_DASHBOARD_SAFE_PLUGIN_SLUG_PATTERN = '/^[a-z0-9][a-z0-9-]{0,100}$/';
-const MYWP_EVENT_DASHBOARD_REFERRER_SOURCE_METRIC = 'wordpress_installed:referrer_source';
+const MYWP_EVENT_DASHBOARD_REFERRER_SOURCE_METRICS = array(
+	'wordpress_installed:referrer_source',
+	'returning_visit:referrer_source',
+);
 const MYWP_EVENT_DASHBOARD_REFERRER_SOURCE_OTHER = 'other-external';
 /**
  * Referring hosts are stored as they arrive, but a host seen fewer times than
@@ -737,7 +740,11 @@ function mywp_event_dashboard_fold_rare_referrer_source_rows( $rows ) {
 	$folded = array();
 	foreach ( $rows as $row ) {
 		if (
-			MYWP_EVENT_DASHBOARD_REFERRER_SOURCE_METRIC === $row['name'] &&
+			in_array(
+				$row['name'],
+				MYWP_EVENT_DASHBOARD_REFERRER_SOURCE_METRICS,
+				true
+			) &&
 			$row['views'] < MYWP_EVENT_DASHBOARD_REFERRER_SOURCE_MIN_VIEWS &&
 			! in_array(
 				$row['value'],
@@ -1405,6 +1412,7 @@ function mywp_event_dashboard_render_area(
 				'Visits to existing Personal WP sites.',
 				'returning_visit',
 				array(
+					'returning_visit:referrer_source',
 					'returning_visit:previous_visit_age_bucket',
 					'returning_visit:site_age_bucket',
 				),
@@ -1978,6 +1986,7 @@ function mywp_event_dashboard_metric_sections() {
 			'description' => 'Signals that explain new-site and returning-site usage.',
 			'metrics' => array(
 				'wordpress_installed:referrer_source',
+				'returning_visit:referrer_source',
 				'wordpress_installed:original_blueprint_source',
 				'wordpress_installed:site_age_bucket',
 				'wordpress_installed:previous_visit_age_bucket',
@@ -2086,6 +2095,7 @@ function mywp_event_dashboard_metric_definitions() {
 		'wordpress_installed:previous_visit_age_bucket' => 'New Installs: Previous Visit Age',
 		'wordpress_installed:original_blueprint_source' => 'New Installs: Original Blueprint Source',
 		'wordpress_installed:referrer_source' => 'New Installs: Referrer Source',
+		'returning_visit:referrer_source' => 'Returning Visits: Referrer Source',
 		'returning_visit:site_age_bucket' => 'Returning Visits: Site Age',
 		'returning_visit:previous_visit_age_bucket' => 'Returning Visits: Previous Visit Age',
 		'blueprint_installed:trigger' => 'Blueprint Installs: Trigger',

--- a/packages/playground/website-deployment/my-wordpress-net/mywp-event-dashboard.php
+++ b/packages/playground/website-deployment/my-wordpress-net/mywp-event-dashboard.php
@@ -12,6 +12,21 @@ const MYWP_EVENT_DASHBOARD_ALLOWED_FORMATS = array( 'html', 'json' );
 const MYWP_EVENT_DASHBOARD_CURL_CONNECT_TIMEOUT = 5;
 const MYWP_EVENT_DASHBOARD_CURL_TIMEOUT = 10;
 const MYWP_EVENT_DASHBOARD_SAFE_PLUGIN_SLUG_PATTERN = '/^[a-z0-9][a-z0-9-]{0,100}$/';
+const MYWP_EVENT_DASHBOARD_REFERRER_SOURCE_METRIC = 'wordpress_installed:referrer_source';
+const MYWP_EVENT_DASHBOARD_REFERRER_SOURCE_OTHER = 'other-external';
+/**
+ * Referring hosts are stored as they arrive, but a host seen fewer times than
+ * this in the selected range is shown folded into `other-external`. A host
+ * that sent one visit cannot indicate a traffic source, and reporting it on
+ * its own alongside the timeline would come close to reporting the visit.
+ */
+const MYWP_EVENT_DASHBOARD_REFERRER_SOURCE_MIN_VIEWS = 5;
+/* Reported in place of a host, so never folded away. */
+const MYWP_EVENT_DASHBOARD_REFERRER_SOURCE_MARKERS = array(
+	'direct',
+	'internal',
+	'unknown',
+);
 const MYWP_EVENT_DASHBOARD_STREAK_TRACKING_START_DATE = '2026-09-03';
 
 /**
@@ -648,7 +663,9 @@ function mywp_event_dashboard_query_rollup(
 	}
 	mysqli_stmt_close( $statement );
 
-	return mywp_event_dashboard_fold_renamed_plugin_slug_rows( $rows );
+	return mywp_event_dashboard_fold_rare_referrer_source_rows(
+		mywp_event_dashboard_fold_renamed_plugin_slug_rows( $rows )
+	);
 }
 
 function mywp_event_dashboard_query_event_timeline(
@@ -712,6 +729,38 @@ function mywp_event_dashboard_query_metric_timeline(
 }
 
 /**
+ * Merges referring hosts below the reporting threshold into a single
+ * `other-external` row, keeping the order the query uses. The stored rows are
+ * left alone; this only bounds what the dashboard and the JSON output show.
+ */
+function mywp_event_dashboard_fold_rare_referrer_source_rows( $rows ) {
+	$folded = array();
+	foreach ( $rows as $row ) {
+		if (
+			MYWP_EVENT_DASHBOARD_REFERRER_SOURCE_METRIC === $row['name'] &&
+			$row['views'] < MYWP_EVENT_DASHBOARD_REFERRER_SOURCE_MIN_VIEWS &&
+			! in_array(
+				$row['value'],
+				MYWP_EVENT_DASHBOARD_REFERRER_SOURCE_MARKERS,
+				true
+			)
+		) {
+			$row['value'] = MYWP_EVENT_DASHBOARD_REFERRER_SOURCE_OTHER;
+		}
+
+		$key = $row['name'] . "\n" . $row['value'];
+		if ( isset( $folded[ $key ] ) ) {
+			$folded[ $key ]['views'] += $row['views'];
+			continue;
+		}
+
+		$folded[ $key ] = $row;
+	}
+
+	return mywp_event_dashboard_sort_rollup_rows( array_values( $folded ) );
+}
+
+/**
  * Merges rollup rows whose plugin slug changed into the row for the current
  * slug, keeping the `name` ASC, `views` DESC, `value` ASC order the query uses.
  */
@@ -733,9 +782,16 @@ function mywp_event_dashboard_fold_renamed_plugin_slug_rows( $rows ) {
 		$folded[ $key ] = $row;
 	}
 
-	$folded = array_values( $folded );
+	return mywp_event_dashboard_sort_rollup_rows( array_values( $folded ) );
+}
+
+/**
+ * Restores the `name` ASC, `views` DESC, `value` ASC order the rollup query
+ * returns, which folding rows together disturbs.
+ */
+function mywp_event_dashboard_sort_rollup_rows( $rows ) {
 	usort(
-		$folded,
+		$rows,
 		function ( $a, $b ) {
 			if ( $a['name'] !== $b['name'] ) {
 				return strcmp( $a['name'], $b['name'] );
@@ -747,7 +803,7 @@ function mywp_event_dashboard_fold_renamed_plugin_slug_rows( $rows ) {
 		}
 	);
 
-	return $folded;
+	return $rows;
 }
 
 /**

--- a/packages/playground/website-deployment/my-wordpress-net/mywp-event.php
+++ b/packages/playground/website-deployment/my-wordpress-net/mywp-event.php
@@ -298,6 +298,31 @@ function mywp_event_collect_stat_bumps( $payload ) {
 				'remote-url',
 			)
 		);
+		/*
+		 * The client classifies document.referrer into this closed vocabulary
+		 * before sending it, so the referrer URL itself never reaches the
+		 * server. Re-checking it here keeps the reported cardinality fixed
+		 * even if a client sends something else. Must match
+		 * ReferrerSourceClass in usage-stats.ts.
+		 */
+		mywp_event_add_allowed_property(
+			$bumps,
+			$event,
+			'referrer_source',
+			$properties,
+			array(
+				'direct',
+				'github',
+				'hacker-news',
+				'internal',
+				'make-wordpress-org',
+				'other-external',
+				'reddit',
+				'search',
+				'wordpress-org',
+				'x',
+			)
+		);
 	}
 
 	if ( 'blueprint_installed' === $event ) {

--- a/packages/playground/website-deployment/my-wordpress-net/mywp-event.php
+++ b/packages/playground/website-deployment/my-wordpress-net/mywp-event.php
@@ -5,6 +5,10 @@ const MYWP_EVENT_RATE_LIMIT_CAPACITY = 300;
 const MYWP_EVENT_RATE_LIMIT_FILL_RATE_PER_MINUTE = 120;
 const MYWP_EVENT_MAX_PLUGIN_SLUGS = 10;
 const MYWP_EVENT_SAFE_PLUGIN_SLUG_PATTERN = '/^[a-z0-9][a-z0-9-]{0,100}$/';
+const MYWP_EVENT_REFERRER_SOURCE_EVENTS = array(
+	'wordpress_installed',
+	'returning_visit',
+);
 /* Must match SAFE_REFERRER_HOST in usage-stats.ts. */
 const MYWP_EVENT_SAFE_REFERRER_SOURCE_PATTERN = '/^[a-z0-9][a-z0-9._-]{0,127}$/';
 
@@ -300,13 +304,17 @@ function mywp_event_collect_stat_bumps( $payload ) {
 				'remote-url',
 			)
 		);
-		/*
-		 * The client reduces document.referrer to a bare host before sending
-		 * it, so the path and query never reach the server. Re-checking the
-		 * shape here keeps a client from storing something that isn't a host
-		 * in the rollup. Hosts seen too rarely to be a traffic source are
-		 * folded together when the dashboard reads them back.
-		 */
+	}
+
+	/*
+	 * Recorded for both ways of arriving, so a channel can be read for new
+	 * and returning sites alike. The client reduces document.referrer to a
+	 * bare host before sending it, so the path and query never reach the
+	 * server. Re-checking the shape here keeps a client from storing
+	 * something that isn't a host in the rollup. Hosts seen too rarely to be
+	 * a traffic source are folded together when the dashboard reads them back.
+	 */
+	if ( in_array( $event, MYWP_EVENT_REFERRER_SOURCE_EVENTS, true ) ) {
 		mywp_event_add_safe_property(
 			$bumps,
 			$event,

--- a/packages/playground/website-deployment/my-wordpress-net/mywp-event.php
+++ b/packages/playground/website-deployment/my-wordpress-net/mywp-event.php
@@ -5,6 +5,8 @@ const MYWP_EVENT_RATE_LIMIT_CAPACITY = 300;
 const MYWP_EVENT_RATE_LIMIT_FILL_RATE_PER_MINUTE = 120;
 const MYWP_EVENT_MAX_PLUGIN_SLUGS = 10;
 const MYWP_EVENT_SAFE_PLUGIN_SLUG_PATTERN = '/^[a-z0-9][a-z0-9-]{0,100}$/';
+/* Must match SAFE_REFERRER_HOST in usage-stats.ts. */
+const MYWP_EVENT_SAFE_REFERRER_SOURCE_PATTERN = '/^[a-z0-9][a-z0-9._-]{0,127}$/';
 
 const MYWP_EVENT_ALLOWED_EVENTS = array(
 	'wordpress_installed',
@@ -299,29 +301,18 @@ function mywp_event_collect_stat_bumps( $payload ) {
 			)
 		);
 		/*
-		 * The client classifies document.referrer into this closed vocabulary
-		 * before sending it, so the referrer URL itself never reaches the
-		 * server. Re-checking it here keeps the reported cardinality fixed
-		 * even if a client sends something else. Must match
-		 * ReferrerSourceClass in usage-stats.ts.
+		 * The client reduces document.referrer to a bare host before sending
+		 * it, so the path and query never reach the server. Re-checking the
+		 * shape here keeps a client from storing something that isn't a host
+		 * in the rollup. Hosts seen too rarely to be a traffic source are
+		 * folded together when the dashboard reads them back.
 		 */
-		mywp_event_add_allowed_property(
+		mywp_event_add_safe_property(
 			$bumps,
 			$event,
 			'referrer_source',
 			$properties,
-			array(
-				'direct',
-				'github',
-				'hacker-news',
-				'internal',
-				'make-wordpress-org',
-				'other-external',
-				'reddit',
-				'search',
-				'wordpress-org',
-				'x',
-			)
+			MYWP_EVENT_SAFE_REFERRER_SOURCE_PATTERN
 		);
 	}
 
@@ -380,6 +371,19 @@ function mywp_event_add_allowed_property(
 ) {
 	$value = $properties[ $property ] ?? null;
 	if ( in_array( $value, $allowed_values, true ) ) {
+		mywp_event_add_bump( $bumps, "$event:$property", $value );
+	}
+}
+
+function mywp_event_add_safe_property(
+	&$bumps,
+	$event,
+	$property,
+	$properties,
+	$pattern
+) {
+	$value = $properties[ $property ] ?? null;
+	if ( is_string( $value ) && preg_match( $pattern, $value ) ) {
 		mywp_event_add_bump( $bumps, "$event:$property", $value );
 	}
 }

--- a/packages/playground/website-deployment/my-wordpress-net/mywp-event.php
+++ b/packages/playground/website-deployment/my-wordpress-net/mywp-event.php
@@ -13,6 +13,7 @@ const MYWP_EVENT_REFERRER_SOURCE_EVENTS = array(
 const MYWP_EVENT_REFERRER_SOURCE_MARKERS = array(
 	'direct',
 	'internal',
+	'private-address',
 	'unknown',
 );
 /* Must match SAFE_REFERRER_HOST in usage-stats.ts. */
@@ -404,8 +405,9 @@ function mywp_event_add_referrer_source_bump( &$bumps, $event, $properties ) {
 /**
  * Applies the same rule the client does, so a client that skips it cannot
  * store a host the client would have refused to send. Single-label names and
- * IP literals identify a network rather than a site, and rejecting them is
- * also what keeps a host from colliding with the markers above.
+ * IP literals name a network rather than a site; the client reports those as
+ * `private-address`, and rejecting them here is also what keeps a host from
+ * colliding with the markers above.
  */
 function mywp_event_is_reportable_referrer_host( $host ) {
 	if ( ! preg_match( MYWP_EVENT_SAFE_REFERRER_SOURCE_PATTERN, $host ) ) {

--- a/packages/playground/website-deployment/my-wordpress-net/mywp-event.php
+++ b/packages/playground/website-deployment/my-wordpress-net/mywp-event.php
@@ -9,8 +9,16 @@ const MYWP_EVENT_REFERRER_SOURCE_EVENTS = array(
 	'wordpress_installed',
 	'returning_visit',
 );
+/* Reported in place of a host. Must match usage-stats.ts. */
+const MYWP_EVENT_REFERRER_SOURCE_MARKERS = array(
+	'direct',
+	'internal',
+	'unknown',
+);
 /* Must match SAFE_REFERRER_HOST in usage-stats.ts. */
 const MYWP_EVENT_SAFE_REFERRER_SOURCE_PATTERN = '/^[a-z0-9][a-z0-9._-]{0,127}$/';
+/* Trailing label of an IPv4 literal. IPv6 has no match for the pattern above. */
+const MYWP_EVENT_IPV4_LAST_LABEL_PATTERN = '/^\d+$/';
 
 const MYWP_EVENT_ALLOWED_EVENTS = array(
 	'wordpress_installed',
@@ -315,13 +323,7 @@ function mywp_event_collect_stat_bumps( $payload ) {
 	 * a traffic source are folded together when the dashboard reads them back.
 	 */
 	if ( in_array( $event, MYWP_EVENT_REFERRER_SOURCE_EVENTS, true ) ) {
-		mywp_event_add_safe_property(
-			$bumps,
-			$event,
-			'referrer_source',
-			$properties,
-			MYWP_EVENT_SAFE_REFERRER_SOURCE_PATTERN
-		);
+		mywp_event_add_referrer_source_bump( $bumps, $event, $properties );
 	}
 
 	if ( 'blueprint_installed' === $event ) {
@@ -383,17 +385,42 @@ function mywp_event_add_allowed_property(
 	}
 }
 
-function mywp_event_add_safe_property(
-	&$bumps,
-	$event,
-	$property,
-	$properties,
-	$pattern
-) {
-	$value = $properties[ $property ] ?? null;
-	if ( is_string( $value ) && preg_match( $pattern, $value ) ) {
-		mywp_event_add_bump( $bumps, "$event:$property", $value );
+function mywp_event_add_referrer_source_bump( &$bumps, $event, $properties ) {
+	$value = $properties['referrer_source'] ?? null;
+	if ( ! is_string( $value ) ) {
+		return;
 	}
+
+	if (
+		! in_array( $value, MYWP_EVENT_REFERRER_SOURCE_MARKERS, true ) &&
+		! mywp_event_is_reportable_referrer_host( $value )
+	) {
+		return;
+	}
+
+	mywp_event_add_bump( $bumps, "$event:referrer_source", $value );
+}
+
+/**
+ * Applies the same rule the client does, so a client that skips it cannot
+ * store a host the client would have refused to send. Single-label names and
+ * IP literals identify a network rather than a site, and rejecting them is
+ * also what keeps a host from colliding with the markers above.
+ */
+function mywp_event_is_reportable_referrer_host( $host ) {
+	if ( ! preg_match( MYWP_EVENT_SAFE_REFERRER_SOURCE_PATTERN, $host ) ) {
+		return false;
+	}
+
+	$labels = explode( '.', $host );
+	if ( count( $labels ) < 2 ) {
+		return false;
+	}
+
+	return ! preg_match(
+		MYWP_EVENT_IPV4_LAST_LABEL_PATTERN,
+		$labels[ count( $labels ) - 1 ]
+	);
 }
 
 function mywp_event_add_safe_list_bumps(

--- a/packages/playground/website-deployment/my-wordpress-net/mywp-event.php
+++ b/packages/playground/website-deployment/my-wordpress-net/mywp-event.php
@@ -413,6 +413,9 @@ function mywp_event_is_reportable_referrer_host( $host ) {
 	if ( ! preg_match( MYWP_EVENT_SAFE_REFERRER_SOURCE_PATTERN, $host ) ) {
 		return false;
 	}
+	if ( 0 === strpos( $host, 'www.' ) || '.' === substr( $host, -1 ) ) {
+		return false;
+	}
 
 	$labels = explode( '.', $host );
 	if ( count( $labels ) < 2 ) {

--- a/packages/playground/website-deployment/tests.php
+++ b/packages/playground/website-deployment/tests.php
@@ -129,6 +129,8 @@ foreach (
         'wiki',
         '192.168.1.5',
         '10.0.0.1',
+        'www.example.com',
+        'example.com.',
         'Example.com',
         'exam ple.com',
         'exa/mple.com',

--- a/packages/playground/website-deployment/tests.php
+++ b/packages/playground/website-deployment/tests.php
@@ -101,7 +101,10 @@ assert_equal(
 
 // The client reduces document.referrer to a bare host, but a client that
 // skips that must not be able to store something else in the rollup.
-foreach ( array( 'direct', 'internal', 'unknown' ) as $mywp_event_marker ) {
+foreach (
+    array( 'direct', 'internal', 'private-address', 'unknown' )
+    as $mywp_event_marker
+) {
     assert_equal(
         false,
         mywp_event_is_reportable_referrer_host( $mywp_event_marker ),
@@ -139,6 +142,12 @@ foreach (
         "Referring host $mywp_event_rejected_host should be rejected"
     );
 }
+
+assert_equal(
+    false,
+    mywp_event_is_reportable_referrer_host( 'private-address' ),
+    'private-address stands in for a host rather than being one'
+);
 
 $mywp_event_referrer_bumps = array();
 mywp_event_add_referrer_source_bump(

--- a/packages/playground/website-deployment/tests.php
+++ b/packages/playground/website-deployment/tests.php
@@ -99,6 +99,69 @@ assert_equal(
     'Playground API entry point should not be edge cached'
 );
 
+// The client reduces document.referrer to a bare host, but a client that
+// skips that must not be able to store something else in the rollup.
+foreach ( array( 'direct', 'internal', 'unknown' ) as $mywp_event_marker ) {
+    assert_equal(
+        false,
+        mywp_event_is_reportable_referrer_host( $mywp_event_marker ),
+        'Markers stand in for a host rather than being one'
+    );
+}
+
+foreach (
+    array( 'news.ycombinator.com', 'make.wordpress.org', 'a.b.example.co.uk' )
+    as $mywp_event_host
+) {
+    assert_equal(
+        true,
+        mywp_event_is_reportable_referrer_host( $mywp_event_host ),
+        "Referring host $mywp_event_host should be reportable"
+    );
+}
+
+foreach (
+    array(
+        'localhost',
+        'wiki',
+        '192.168.1.5',
+        '10.0.0.1',
+        'Example.com',
+        'exam ple.com',
+        'exa/mple.com',
+        str_repeat( 'a', 130 ) . '.example.com',
+    )
+    as $mywp_event_rejected_host
+) {
+    assert_equal(
+        false,
+        mywp_event_is_reportable_referrer_host( $mywp_event_rejected_host ),
+        "Referring host $mywp_event_rejected_host should be rejected"
+    );
+}
+
+$mywp_event_referrer_bumps = array();
+mywp_event_add_referrer_source_bump(
+    $mywp_event_referrer_bumps,
+    'returning_visit',
+    array( 'referrer_source' => 'localhost' )
+);
+mywp_event_add_referrer_source_bump(
+    $mywp_event_referrer_bumps,
+    'returning_visit',
+    array( 'referrer_source' => 'direct' )
+);
+mywp_event_add_referrer_source_bump(
+    $mywp_event_referrer_bumps,
+    'returning_visit',
+    array( 'referrer_source' => 'make.wordpress.org' )
+);
+assert_equal(
+    'direct,make.wordpress.org',
+    implode( ',', array_column( $mywp_event_referrer_bumps, 'value' ) ),
+    'Only markers and reportable hosts are recorded'
+);
+
 $mywp_event_server_snapshot = $_SERVER;
 
 $_SERVER['HTTP_HOST'] = 'my.wordpress.net';


### PR DESCRIPTION
## Why

A traffic spike currently can't be explained from the stats dashboard. Every dimension recorded for `wordpress_installed` is near-constant — `original_blueprint_source` is ~94% a single value over 30 days, `site_age_bucket` is ~98% `same-day` — so a day with twice the usual installs looks identical to a normal day apart from the count.

This adds a dimension that varies: for a given range, how many arrivals came through which channel — for new sites **and** returning ones.

## What is stored

The referring host, as it arrives, reduced to a bare hostname — lowercased, `www.` stripped, port and trailing dot removed. `https://news.ycombinator.com/item?id=1` is stored as `news.ycombinator.com`.

**Only the host.** The path and query — where a referrer says what someone was *reading* — never leave the browser; the client reduces the referrer before sending, and the endpoint applies the same rule, so a path can't be stored even by a client that skips the client-side step.

Four markers stand in for a host where there isn't one:

- `direct` — no referrer. Modern browsers default to `strict-origin-when-cross-origin`, so the origin usually survives, but native apps, sites sending `no-referrer`, and HTTPS→HTTP send nothing.
- `internal` — same origin.
- `private-address` — a host that names a network rather than a site: single-label intranet names (`wiki`, `localhost`) and IP literals. No use for spotting a traffic source, and the kind most likely to point at one network.
- `unknown` — the referrer had no usable host at all: unparseable, a non-HTTP scheme, or a host too long or oddly shaped to store.

Every stored host contains a dot, which is what stops a host from colliding with a marker. `private-address` and `unknown` are kept apart so a rise in either can be told from the other — they have different causes and call for different responses. A referrer naming a *public* IP literal also lands in `private-address`; distinguishing it would mean range-checking every address for a vanishingly rare case, and both want the same treatment anyway.

## Where it shows up

Both are panels in the existing detail grids — no new dashboard section:

| Surface | Shows |
|---|---|
| `?area=new-installs` → New installs details | New Installs: Referrer Source |
| `?area=returning-visitors` → Returning visitors details | Returning Visits: Referrer Source |
| `?format=json` | `metrics["wordpress_installed:referrer_source"]` and `metrics["returning_visit:referrer_source"]` |

`returning_visit` is already deduplicated to at most one event per site per day, so the returning breakdown counts sites that came back through a channel that day, not individual visits.

## Where the privacy bound sits

At **read** time, not write time. A host seen fewer than five times in the selected range is folded into `other-external` when the dashboard reads it back, so the long tail is never broken out next to the hourly timeline — a host with one view, shown against a specific hour, comes close to reporting the visit itself. Stored rows are untouched, and the three markers are never folded since they can't identify anyone.

This costs nothing for the intended use. A traffic event by definition produces one host with many views, so no host that could indicate a spike is ever folded away — only the tail that never could.

An earlier revision used a fixed allowlist of known sources instead. That was dropped: it could only report a source someone had predicted, so every unpredicted spike landed in `other-external` and the case the dimension exists to explain was the one case it couldn't.

## Also: `?format=json`

Returns every area's numbers at once — `events`, all `metrics` breakdowns, `timeline` with per-period totals, and the plugin-slug timeline — so a spike can be analysed by a script rather than by reading bar widths. Works with the existing `range` and `granularity` params, and reflects the same read-time threshold the HTML does, so the two agree. `Content-Type` is sent before the HEAD check so a HEAD advertises what the matching GET would return.

## No schema change, no breaking changes

The rollup tables are keyed by `(date, name, value)` and the write path inserts on demand, so a new dimension is new rows, not new columns. The host pattern is bounded at 128 characters to match the `value` column, so a host is never silently truncated.

Everything is additive. The only edits to existing code are extracting the rollup sort comparator, which would otherwise have been copied a third time, and adding the referrer property to the returning-visit event.

## Testing

- `nx test playground-personal-wp` — 139/139, including host normalisation (case, `www.`, port, path), `make.wordpress.org` staying distinct from `wordpress.org`, and the rejections: single-label hosts, `localhost`, IPv4 literals, non-HTTP schemes, unparseable input, over-length hosts
- `website-deployment/tests.php` — new server-side coverage that markers are not hosts, real hosts pass, and `localhost` / `wiki` / IPv4 / uppercase / over-length are rejected before being recorded
- Read-time threshold exercised under PHP CLI: hosts at 340 and 12 views kept, three hosts at 4/1/1 summed into `other-external`, `direct` at 2 and `unknown` at 3 kept as markers, other metrics untouched, query ordering restored
- Both dashboard areas rendered under PHP CLI to confirm the panels appear with the threshold applied
- `nx typecheck` and `nx lint` clean; `php -l` clean on all three PHP files

Referrer numbers are not retroactive — they start accruing once the client ships, and until the first event arrives each panel is absent rather than showing zeros, since `render_metric_section()` filters out empty groups.

https://claude.ai/code/session_0136k1RVcpjbCPgPgQTwB9oe


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added JSON output for the event dashboard, including metrics, totals, timelines, and HEAD request support.
  * Added referrer-source reporting for new installations and returning visits.
  * Normalized external referrers by hostname while recognizing direct, internal, private-address, and unknown sources.
  * Grouped low-volume external referrers into an “other-external” category.

* **Bug Fixes**
  * Improved validation for malformed, local, non-HTTP, IP-based, unsafe, noncanonical, and oversized referrer values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
