### PR TITLE
[Website] Show Playground updates in the dock

### DIFF
--- a/packages/playground/website/playwright/e2e/playground-updates.spec.ts
+++ b/packages/playground/website/playwright/e2e/playground-updates.spec.ts
@@ -1,0 +1,75 @@
+import { test, expect } from '../playground-fixtures';
+
+test('reads updates without leaving a custom Blueprint site', async ({
+	website,
+	wordpress,
+}) => {
+	const page = website.page;
+	const articleUrl =
+		'https://make.wordpress.org/playground/2026/09/05/new-feature/';
+	await page.route(
+		'https://make.wordpress.org/playground/wp-json/wp/v2/posts?*',
+		(route) =>
+			route.fulfill({
+				json: [
+					{
+						id: 740,
+						date_gmt: '2026-09-05T10:59:22',
+						link: articleUrl,
+						title: { rendered: 'A new Playground feature' },
+					},
+				],
+			})
+	);
+	await website.goto(
+		'./?storage=temp#' +
+			encodeURIComponent(
+				JSON.stringify({
+					landingPage: '/wp-admin/plugins.php',
+					login: true,
+				})
+			)
+	);
+	await expect(
+		wordpress.getByRole('heading', { name: 'Plugins', exact: true })
+	).toBeVisible();
+	const pane = page.getByRole('dialog', {
+		name: 'What’s new in Playground pane',
+	});
+	await expect(pane).not.toBeVisible();
+	await page
+		.getByRole('button', { name: 'What’s new — unread updates' })
+		.click();
+	await expect(pane).toBeVisible();
+	await expect(
+		page.getByRole('button', { name: 'What’s new', exact: true })
+	).toHaveAttribute('aria-expanded', 'true');
+
+	// Route the article too: this checks the new-tab behavior without depending
+	// on the blog being available or moving the running WordPress site.
+	await page
+		.context()
+		.route(articleUrl, (route) =>
+			route.fulfill({ body: '<h1>A new Playground feature</h1>' })
+		);
+	const popupPromise = page.waitForEvent('popup');
+	await pane.getByRole('link', { name: /A new Playground feature/ }).click();
+	const popup = await popupPromise;
+	await expect(popup).toHaveURL(articleUrl);
+	await popup.close();
+	await page.keyboard.press('Escape');
+	await expect(pane).not.toBeVisible();
+	await expect(
+		wordpress.getByRole('heading', { name: 'Plugins', exact: true })
+	).toBeVisible();
+	await expect(
+		page.getByRole('button', { name: 'What’s new', exact: true })
+	).toBeFocused();
+
+	await page.reload();
+	await website.waitForNestedIframes();
+	await expect(
+		page.getByRole('button', { name: 'What’s new', exact: true })
+	).toBeVisible();
+	await expect(pane).not.toBeVisible();
+});

--- a/packages/playground/website/src/components/dock/dock-corner-launcher.tsx
+++ b/packages/playground/website/src/components/dock/dock-corner-launcher.tsx
@@ -9,6 +9,7 @@ export type DockCornerLauncherProps = {
 	children: ReactNode;
 	isDragging?: boolean;
 	isFolding?: boolean;
+	hasNotification?: boolean;
 	ariaLabel?: string;
 	title?: string;
 	onClick?: MouseEventHandler<HTMLButtonElement>;
@@ -27,6 +28,7 @@ export function DockCornerLauncher({
 	children,
 	isDragging = false,
 	isFolding = false,
+	hasNotification = false,
 	ariaLabel = 'Show Playground tools',
 	title = 'Drag out or click to show Playground tools',
 	onClick,
@@ -43,7 +45,9 @@ export function DockCornerLauncher({
 				[css.dockCornerRight]: side === 'right',
 				[css.dockCornerDragging]: isDragging,
 			})}
-			aria-label={ariaLabel}
+			aria-label={
+				hasNotification ? `${ariaLabel} — unread updates` : ariaLabel
+			}
 			title={title}
 			disabled={isFolding}
 			onPointerDown={onPointerDown}
@@ -55,6 +59,9 @@ export function DockCornerLauncher({
 			<span className={css.dockCornerLogo} aria-hidden="true">
 				{children}
 			</span>
+			{hasNotification && (
+				<span className={css.dockItemDot} aria-hidden="true" />
+			)}
 		</button>
 	);
 }

--- a/packages/playground/website/src/components/dock/dock.tsx
+++ b/packages/playground/website/src/components/dock/dock.tsx
@@ -46,6 +46,7 @@ import {
 } from '../../lib/state/redux/store';
 import { isSiteSavingDisabled } from '../../lib/state/url/router';
 import { useInlineRename } from '../../lib/hooks/use-inline-rename';
+import { usePlaygroundUpdates } from '../../lib/hooks/use-playground-updates';
 import playgroundLogoUrl from '../../playground-logo.svg';
 import AddressBar from '../address-bar';
 import { SaveStatusIndicator } from '../browser-chrome/save-status-indicator';
@@ -202,6 +203,10 @@ const PANE_COPY: Record<
 		title: 'Store permanently',
 		description: '',
 	},
+	updates: {
+		title: 'What’s new in Playground',
+		description: 'From make.wordpress.org/playground',
+	},
 };
 
 /**
@@ -217,6 +222,9 @@ export function Dock({
 	const activeModal = useAppSelector((state) => state.ui.activeModal);
 	const activeSiteError = useAppSelector(selectActiveSiteError);
 	const section = useAppSelector((state) => state.ui.dockPaneSection);
+	const updates = usePlaygroundUpdates(
+		dockPaneIsOpen && section === 'updates' && !activeSiteError
+	);
 	const shareExportOpen = useAppSelector((state) => state.ui.shareExportOpen);
 	const [newPlaygroundHeaderOverride, setNewPlaygroundHeaderOverride] =
 		useState<DockPaneHeaderOverride>();
@@ -1096,6 +1104,7 @@ export function Dock({
 			{(cornered || isFolding || isMaximizing) && (
 				<DockCornerLauncher
 					side={cornerSide ?? cornerLauncherSideRef.current}
+					hasNotification={updates.hasUnread}
 					isDragging={isMaximizing}
 					isFolding={isFolding}
 					onPointerDown={handleCornerPointerDown}
@@ -1223,6 +1232,7 @@ export function Dock({
 					}}
 				>
 					<SiteManager
+						updates={updates}
 						isVisible={paneContentVisible}
 						mobileUi={isMobile}
 						onPaneCloseBlockedChange={onPaneCloseBlockedChange}
@@ -1338,6 +1348,32 @@ export function Dock({
 								/>
 							)}
 						</div>
+						<button
+							type="button"
+							className={css.dockUpdates}
+							aria-label={
+								updates.hasUnread
+									? 'What’s new — unread updates'
+									: 'What’s new'
+							}
+							aria-expanded={
+								dockPaneIsOpen && section === 'updates'
+							}
+							disabled={paneCloseBlocked}
+							onClick={(event) => {
+								// Safari needs explicit focus for the pane's return-focus path.
+								event.currentTarget.focus();
+								openSection('updates');
+							}}
+						>
+							What’s new
+							{updates.hasUnread && (
+								<span
+									className={css.dockUpdatesDot}
+									aria-hidden="true"
+								/>
+							)}
+						</button>
 						<DockTogglePill
 							isCollapsed={isCollapsed}
 							isFullWidth={isFullWidth}

--- a/packages/playground/website/src/components/dock/dock.tsx
+++ b/packages/playground/website/src/components/dock/dock.tsx
@@ -13,7 +13,7 @@ import type {
 	PointerEvent as ReactPointerEvent,
 } from 'react';
 import { CSSTransition } from 'react-transition-group';
-import { Icon } from '@wordpress/components';
+import { Button, Icon } from '@wordpress/components';
 import {
 	close,
 	code,
@@ -1201,6 +1201,17 @@ export function Dock({
 								<Icon icon={plus} size={20} />
 								New Playground
 							</button>
+						) : section === 'updates' ? (
+							<Button
+								className={css.updatesClose}
+								icon={close}
+								iconSize={20}
+								size="compact"
+								variant="tertiary"
+								label="Close updates"
+								disabled={paneCloseBlocked}
+								onClick={() => dispatch(setDockPaneOpen(false))}
+							/>
 						) : undefined
 					}
 					headerOverride={paneHeaderOverride}
@@ -1209,6 +1220,7 @@ export function Dock({
 							Boolean(activeSiteError) ||
 							(!dockPaneIsOpen && paneExitComplete),
 						[css.paneWide]: isWideSection,
+						[css.paneUpdates]: section === 'updates',
 					})}
 					style={paneStyle}
 					isEditor={isEditorSection}

--- a/packages/playground/website/src/components/dock/playground-updates.module.css
+++ b/packages/playground/website/src/components/dock/playground-updates.module.css
@@ -1,0 +1,56 @@
+.updates {
+	padding: 0 var(--pane-inline-padding) var(--space-6);
+}
+
+.posts {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+}
+
+.posts li {
+	border-bottom: 1px solid var(--border-subtle);
+}
+
+.posts a {
+	color: var(--ink);
+	display: block;
+	padding: var(--space-4) 0;
+	text-decoration: none;
+}
+
+.posts time,
+.notice {
+	color: var(--ink-muted);
+	font-size: 13px;
+}
+
+.posts h3 {
+	align-items: baseline;
+	display: flex;
+	font-size: 15px;
+	font-weight: 600;
+	gap: var(--space-3);
+	justify-content: space-between;
+	line-height: 1.4;
+	margin: var(--space-1) 0;
+}
+
+.posts svg,
+.blog-link svg {
+	fill: currentColor;
+	flex-shrink: 0;
+}
+
+.posts a:hover h3,
+.blog-link {
+	color: var(--accent-link);
+}
+
+.blog-link {
+	align-items: center;
+	display: inline-flex;
+	font-size: 13px;
+	gap: var(--space-2);
+	margin-top: var(--space-4);
+}

--- a/packages/playground/website/src/components/dock/playground-updates.module.css
+++ b/packages/playground/website/src/components/dock/playground-updates.module.css
@@ -1,5 +1,11 @@
 .updates {
-	padding: 0 var(--pane-inline-padding) var(--space-6);
+	flex: 1;
+	font-size: 14px;
+	font-weight: 400;
+	line-height: 1.45;
+	min-height: 0;
+	overflow-y: auto;
+	padding: 0 var(--pane-inline-padding) var(--pane-inline-padding);
 }
 
 .posts {
@@ -15,31 +21,40 @@
 .posts a {
 	color: var(--ink);
 	display: block;
-	padding: var(--space-4) 0;
+	padding: 19px 0;
 	text-decoration: none;
 }
 
-.posts time,
-.notice {
+.posts time {
 	color: var(--ink-muted);
-	font-size: 13px;
+	display: block;
+	font-size: 12px;
+	margin-bottom: 5px;
 }
 
 .posts h3 {
-	align-items: baseline;
+	align-items: flex-start;
 	display: flex;
-	font-size: 15px;
-	font-weight: 600;
-	gap: var(--space-3);
+	font-size: 14px;
+	font-weight: 500;
+	gap: 14px;
 	justify-content: space-between;
-	line-height: 1.4;
-	margin: var(--space-1) 0;
+	line-height: inherit;
+	margin: 0;
 }
 
-.posts svg,
-.blog-link svg {
+.posts h3 span {
+	min-width: 0;
+}
+
+.link-arrow {
 	fill: currentColor;
 	flex-shrink: 0;
+	transform: rotate(45deg);
+}
+
+.posts .link-arrow {
+	margin-top: 3px;
 }
 
 .posts a:hover h3,
@@ -50,7 +65,23 @@
 .blog-link {
 	align-items: center;
 	display: inline-flex;
-	font-size: 13px;
 	gap: var(--space-2);
 	margin-top: var(--space-4);
+	text-decoration: none;
+}
+
+.posts a:hover h3 span,
+.blog-link:hover {
+	text-decoration: underline;
+}
+
+.notice {
+	color: var(--ink-muted);
+	font-size: 13px;
+}
+
+@media (pointer: coarse) {
+	.blog-link {
+		min-height: 44px;
+	}
 }

--- a/packages/playground/website/src/components/dock/playground-updates.tsx
+++ b/packages/playground/website/src/components/dock/playground-updates.tsx
@@ -1,4 +1,4 @@
-import { Icon, external } from '@wordpress/icons';
+import { Icon, arrowUp } from '@wordpress/icons';
 import type { usePlaygroundUpdates } from '../../lib/hooks/use-playground-updates';
 import { PaneLoading } from '../pane-loading';
 import css from './playground-updates.module.css';
@@ -49,8 +49,12 @@ export function PlaygroundUpdates({
 										)}
 									</time>
 									<h3>
-										{post.title}
-										<Icon icon={external} size={16} />
+										<span>{post.title}</span>
+										<Icon
+											className={css.linkArrow}
+											icon={arrowUp}
+											size={14}
+										/>
 									</h3>
 								</a>
 							</li>
@@ -64,7 +68,8 @@ export function PlaygroundUpdates({
 				target="_blank"
 				rel="noopener noreferrer"
 			>
-				All Playground updates <Icon icon={external} size={16} />
+				All Playground updates
+				<Icon className={css.linkArrow} icon={arrowUp} size={14} />
 			</a>
 		</div>
 	);

--- a/packages/playground/website/src/components/dock/playground-updates.tsx
+++ b/packages/playground/website/src/components/dock/playground-updates.tsx
@@ -1,0 +1,71 @@
+import { Icon, external } from '@wordpress/icons';
+import type { usePlaygroundUpdates } from '../../lib/hooks/use-playground-updates';
+import { PaneLoading } from '../pane-loading';
+import css from './playground-updates.module.css';
+
+/** Shows Make announcements without navigating or modifying the running site. */
+export function PlaygroundUpdates({
+	posts,
+	status,
+}: Pick<ReturnType<typeof usePlaygroundUpdates>, 'posts' | 'status'>) {
+	return (
+		<div className={css.updates}>
+			{status === 'loading' && !posts.length ? (
+				<PaneLoading message="Loading Playground updates…" />
+			) : (
+				<>
+					{status === 'error' && (
+						<p className={css.notice} role="status">
+							{posts.length
+								? 'Showing saved updates. The latest posts could not be checked.'
+								: 'Updates could not be loaded. You can read them on the Playground blog.'}
+						</p>
+					)}
+					{status === 'ready' && !posts.length && (
+						<p className={css.notice}>
+							No updates have been published yet.
+						</p>
+					)}
+					<ul className={css.posts}>
+						{posts.map((post) => (
+							<li key={post.id}>
+								<a
+									href={post.url}
+									target="_blank"
+									rel="noopener noreferrer"
+								>
+									<time
+										dateTime={new Date(
+											post.date
+										).toISOString()}
+									>
+										{new Date(post.date).toLocaleDateString(
+											undefined,
+											{
+												year: 'numeric',
+												month: 'long',
+												day: 'numeric',
+											}
+										)}
+									</time>
+									<h3>
+										{post.title}
+										<Icon icon={external} size={16} />
+									</h3>
+								</a>
+							</li>
+						))}
+					</ul>
+				</>
+			)}
+			<a
+				className={css.blogLink}
+				href="https://make.wordpress.org/playground/category/updates/"
+				target="_blank"
+				rel="noopener noreferrer"
+			>
+				All Playground updates <Icon icon={external} size={16} />
+			</a>
+		</div>
+	);
+}

--- a/packages/playground/website/src/components/dock/style.module.css
+++ b/packages/playground/website/src/components/dock/style.module.css
@@ -73,6 +73,46 @@
 	min-width: 0;
 }
 
+.dock-updates {
+	align-items: center;
+	background: transparent;
+	border: 0;
+	border-radius: 9px;
+	color: var(--ink-bright-on-dark);
+	cursor: pointer;
+	display: inline-flex;
+	flex-shrink: 0;
+	font: inherit;
+	font-size: 13px;
+	gap: 6px;
+	min-height: 34px;
+	padding: 0 8px;
+	white-space: nowrap;
+}
+
+.dock-updates:hover,
+.dock-updates[aria-expanded='true'] {
+	background: var(--chrome-control-hover-background);
+}
+
+.dock-updates:focus-visible {
+	outline: 2px solid var(--accent-soft);
+	outline-offset: -2px;
+}
+
+.dock-updates:disabled {
+	cursor: default;
+	opacity: 0.45;
+}
+
+.dock-updates-dot {
+	background: var(--accent-soft);
+	border-radius: 50%;
+	flex-shrink: 0;
+	height: 6px;
+	width: 6px;
+}
+
 /* The active Playground's name is kept in the DOM for screen readers and as the
    stable "Playground title" hook, but not shown — the save-status pill carries
    the only visible status, and the name would just repeat it for unsaved sites. */

--- a/packages/playground/website/src/components/dock/style.module.css
+++ b/packages/playground/website/src/components/dock/style.module.css
@@ -77,16 +77,17 @@
 	align-items: center;
 	background: transparent;
 	border: 0;
-	border-radius: 9px;
+	border-radius: 6px;
 	color: var(--ink-bright-on-dark);
 	cursor: pointer;
 	display: inline-flex;
 	flex-shrink: 0;
 	font: inherit;
-	font-size: 13px;
-	gap: 6px;
+	font-size: 12px;
+	font-weight: 400;
+	gap: 7px;
 	min-height: 34px;
-	padding: 0 8px;
+	padding: 0 9px;
 	white-space: nowrap;
 }
 
@@ -498,6 +499,59 @@
 	font-size: 13px;
 	line-height: 1.45;
 	margin: var(--space-2) 0 0;
+}
+
+/* Announcements use a quieter reading layout than the site-tool forms. The
+   same inset aligns the shared header, post details, dividers, and footer. */
+.pane.pane-updates {
+	--pane-inline-padding: 22px;
+	background: var(--surface-raised);
+	font-weight: 400;
+}
+
+.pane-updates .pane-header:has(.pane-description) {
+	align-items: flex-start;
+	gap: var(--space-3);
+	padding: var(--pane-inline-padding) var(--pane-inline-padding) 0;
+}
+
+.pane-updates .pane-header h2 {
+	font-size: 18px;
+	font-weight: 500;
+	letter-spacing: normal;
+	line-height: 1.35;
+}
+
+.pane-updates .pane-description {
+	font-size: 12px;
+	margin-top: 3px;
+}
+
+@media (min-width: 1025px) {
+	.pane.pane-updates {
+		--radius-pane: 12px;
+		width: min(540px, calc(100vw - 40px));
+	}
+}
+
+@media (max-width: 400px) {
+	.pane.pane-updates {
+		--pane-inline-padding: 16px;
+	}
+
+	/* Keep the address readable when save status and updates no longer fit
+	   beside it. Controls wrap together without changing their tab order. */
+	.dock-top-row:has(.dock-updates) {
+		flex-wrap: wrap;
+	}
+
+	.dock-top-row:has(.dock-updates) .dock-address {
+		flex-basis: 100%;
+	}
+
+	.dock-top-row:has(.dock-updates) .dock-status {
+		margin-left: auto;
+	}
 }
 
 /* The active Playground's name sits right under the "This Playground" title as
@@ -965,6 +1019,11 @@
 	   "New Playground" header action is redundant on mobile — hide it so the
 	   close X can own the header's top-right corner without crowding. */
 	.pane-header-action {
+		display: none;
+	}
+
+	/* The shared mobile close control replaces the updates header action. */
+	.pane-updates .updates-close {
 		display: none;
 	}
 

--- a/packages/playground/website/src/components/site-manager/index.tsx
+++ b/packages/playground/website/src/components/site-manager/index.tsx
@@ -7,6 +7,8 @@ import {
 	useAppSelector,
 } from '../../lib/state/redux/store';
 import type { DockPaneHeaderOverride } from '../dock/dock-pane';
+import { PlaygroundUpdates } from '../dock/playground-updates';
+import type { usePlaygroundUpdates } from '../../lib/hooks/use-playground-updates';
 import { SavedPlaygroundsPanel } from '../saved-playgrounds-panel';
 import { SaveSiteModal } from '../save-site-modal';
 import { SiteInfoPanel, type SiteInfoTabName } from './site-info-panel';
@@ -17,6 +19,7 @@ export type SiteManagerProps = {
 	className?: string;
 	isVisible: boolean;
 	mobileUi: boolean;
+	updates: Pick<ReturnType<typeof usePlaygroundUpdates>, 'posts' | 'status'>;
 	onPaneCloseBlockedChange: (isBlocked: boolean) => void;
 	onNewPlaygroundHeaderChange: (
 		header: DockPaneHeaderOverride | undefined
@@ -30,6 +33,7 @@ export const SiteManager = forwardRef<HTMLDivElement, SiteManagerProps>(
 			className,
 			isVisible,
 			mobileUi,
+			updates,
 			onPaneCloseBlockedChange,
 			onNewPlaygroundHeaderChange,
 		},
@@ -83,7 +87,9 @@ export const SiteManager = forwardRef<HTMLDivElement, SiteManagerProps>(
 		}, [activeSection]);
 
 		let activePanel: JSX.Element | null = null;
-		if (activeSection === 'save') {
+		if (activeSection === 'updates') {
+			activePanel = <PlaygroundUpdates {...updates} />;
+		} else if (activeSection === 'save') {
 			activePanel =
 				isVisible && activeSite ? (
 					<SaveSiteModal

--- a/packages/playground/website/src/lib/hooks/use-playground-updates.spec.tsx
+++ b/packages/playground/website/src/lib/hooks/use-playground-updates.spec.tsx
@@ -1,0 +1,220 @@
+// @vitest-environment jsdom
+
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import type { Root } from 'react-dom/client';
+import {
+	parsePlaygroundUpdates,
+	usePlaygroundUpdates,
+} from './use-playground-updates';
+
+const post = {
+	id: 740,
+	date_gmt: '2026-09-05T10:59:22',
+	link: 'https://make.wordpress.org/playground/2026/09/05/new-feature/',
+	title: { rendered: 'A new feature &amp; a demo' },
+};
+const publishedAt = Date.parse(`${post.date_gmt}Z`);
+
+describe('Playground updates', () => {
+	let root: Root;
+	let container: HTMLDivElement;
+	let updates: ReturnType<typeof usePlaygroundUpdates>;
+
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date('2026-09-06T12:00:00Z'));
+		vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockResolvedValue(new Response(JSON.stringify([post])))
+		);
+		localStorage.clear();
+		container = document.createElement('div');
+		document.body.append(container);
+		root = createRoot(container);
+	});
+
+	afterEach(() => {
+		act(() => root.unmount());
+		container.remove();
+		vi.restoreAllMocks();
+		vi.unstubAllGlobals();
+		vi.useRealTimers();
+	});
+
+	it('marks the displayed publication date and retains it after closing', async () => {
+		await render(false);
+		expect(updates.hasUnread).toBe(true);
+		expect(localStorage.getItem('playground-updates-last-seen')).toBeNull();
+		await render(true);
+		expect(updates.hasUnread).toBe(false);
+		expect(
+			Number(localStorage.getItem('playground-updates-last-seen'))
+		).toBe(publishedAt);
+		await render(false);
+		expect(updates.hasUnread).toBe(false);
+		expect(fetch).toHaveBeenCalledTimes(1);
+	});
+
+	it('clears unread posts in another tab through the shared storage marker', async () => {
+		await render(false);
+		await act(async () => {
+			localStorage.setItem(
+				'playground-updates-last-seen',
+				String(publishedAt)
+			);
+			window.dispatchEvent(
+				new StorageEvent('storage', {
+					key: 'playground-updates-last-seen',
+				})
+			);
+		});
+		expect(updates.hasUnread).toBe(false);
+	});
+
+	it('does not move a newer tab’s read marker backwards', async () => {
+		await render(false);
+		const newerDate = publishedAt + 60000;
+		localStorage.setItem('playground-updates-last-seen', String(newerDate));
+		await render(true);
+		expect(
+			Number(localStorage.getItem('playground-updates-last-seen'))
+		).toBe(newerDate);
+	});
+
+	it('uses a fresh cache without requesting the same posts again', async () => {
+		cachePosts(Date.now());
+		await render(false);
+		expect(updates.posts[0].id).toBe(post.id);
+		expect(fetch).not.toHaveBeenCalled();
+	});
+
+	it('retains cached posts when the next refresh fails', async () => {
+		cachePosts(Date.now() - 2 * 60 * 60 * 1000);
+		vi.mocked(fetch).mockRejectedValue(new TypeError('Offline'));
+		await render(false);
+		expect(updates.status).toBe('error');
+		expect(updates.posts[0].id).toBe(post.id);
+		expect(
+			JSON.parse(localStorage.getItem('playground-updates')!).posts
+		).toEqual([post]);
+	});
+
+	it('replaces a corrupt cache with the next successful response', async () => {
+		localStorage.setItem('playground-updates', '{broken');
+		await render(false);
+		expect(updates.status).toBe('ready');
+		expect(updates.posts[0].id).toBe(post.id);
+	});
+
+	it('still loads and clears unread posts when local storage is blocked', async () => {
+		vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+			throw new Error('Blocked');
+		});
+		vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+			throw new Error('Blocked');
+		});
+		await render(false);
+		expect(updates.hasUnread).toBe(true);
+		await render(true);
+		expect(updates.hasUnread).toBe(false);
+		expect(updates.status).toBe('ready');
+	});
+
+	it('shows a dot for a newly published post but not an edited old post', async () => {
+		await render(true);
+		await render(false);
+		vi.mocked(fetch).mockResolvedValueOnce(
+			new Response(
+				JSON.stringify([
+					{ ...post, title: { rendered: 'An edited title' } },
+				])
+			)
+		);
+		await act(() => vi.advanceTimersByTimeAsync(60 * 60 * 1000));
+		expect(updates.posts[0].title).toBe('An edited title');
+		expect(updates.hasUnread).toBe(false);
+		vi.mocked(fetch).mockResolvedValueOnce(
+			new Response(
+				JSON.stringify([
+					{ ...post, id: 741, date_gmt: '2026-09-06T10:00:00' },
+					post,
+				])
+			)
+		);
+		await act(() => vi.advanceTimersByTimeAsync(60 * 60 * 1000));
+		expect(updates.hasUnread).toBe(true);
+	});
+
+	it('marks posts that finish loading while the pane is open', async () => {
+		let finish: (response: Response) => void;
+		vi.mocked(fetch).mockReturnValue(
+			new Promise((resolve) => {
+				finish = resolve;
+			})
+		);
+		await render(true);
+		expect(localStorage.getItem('playground-updates-last-seen')).toBeNull();
+		await act(async () => finish(new Response(JSON.stringify([post]))));
+		expect(updates.hasUnread).toBe(false);
+		expect(
+			Number(localStorage.getItem('playground-updates-last-seen'))
+		).toBe(publishedAt);
+	});
+
+	it('turns remote HTML into text without mounting its elements', () => {
+		const parsed = parsePlaygroundUpdates([
+			{
+				...post,
+				title: {
+					rendered:
+						'<img src="https://example.com/tracker" onerror="alert(1)">A &amp; B<script>bad()</script>',
+				},
+			},
+		]);
+		expect(parsed[0].title).toBe('A & B');
+		expect(document.querySelector('img,script')).toBeNull();
+	});
+
+	it.each([
+		// eslint-disable-next-line no-script-url -- Rejected input, never used as an href.
+		'javascript:alert(1)',
+		'https://example.com/playground/post',
+		'https://make.wordpress.org.evil.test/playground/post',
+		'https://make.wordpress.org/core/post',
+		'https://user:secret@make.wordpress.org/playground/post',
+	])(
+		'rejects an article link outside the public Playground blog: %s',
+		(link) => {
+			expect(() => parsePlaygroundUpdates([{ ...post, link }])).toThrow();
+		}
+	);
+
+	it('rejects malformed responses instead of displaying an empty success', () => {
+		expect(() => parsePlaygroundUpdates({ code: 'rest_error' })).toThrow();
+		expect(() =>
+			parsePlaygroundUpdates([{ ...post, date_gmt: 'invalid' }])
+		).toThrow();
+		expect(() => parsePlaygroundUpdates([null])).toThrow();
+	});
+
+	/** Mounts the hook with the same open state the Dock supplies. */
+	async function render(isOpen: boolean) {
+		await act(async () => root.render(<UpdatesProbe isOpen={isOpen} />));
+	}
+
+	/** Exposes hook state while retaining React's normal effects and lifecycle. */
+	function UpdatesProbe({ isOpen }: { isOpen: boolean }) {
+		updates = usePlaygroundUpdates(isOpen);
+		return null;
+	}
+
+	/** Seeds the same raw response retained by the production cache. */
+	function cachePosts(fetchedAt: number) {
+		localStorage.setItem(
+			'playground-updates',
+			JSON.stringify({ fetchedAt, posts: [post] })
+		);
+	}
+});

--- a/packages/playground/website/src/lib/hooks/use-playground-updates.ts
+++ b/packages/playground/website/src/lib/hooks/use-playground-updates.ts
@@ -1,0 +1,212 @@
+import { useEffect, useRef, useState } from 'react';
+
+// Category 7 is Make Playground's existing Updates category. Meetings and
+// status reports have separate categories and do not belong in this pane.
+const UPDATES_URL =
+	'https://make.wordpress.org/playground/wp-json/wp/v2/posts?categories=7&per_page=5&_fields=id,date_gmt,link,title';
+const CACHE_KEY = 'playground-updates';
+const LAST_SEEN_KEY = 'playground-updates-last-seen';
+const REFRESH_INTERVAL = 60 * 60 * 1000;
+
+export type PlaygroundUpdate = {
+	id: number;
+	date: number;
+	url: string;
+	title: string;
+};
+
+/**
+ * Loads Make updates outside the WordPress runtime. Cached posts survive a
+ * failed request, and the read marker is shared by every site in this browser.
+ */
+export function usePlaygroundUpdates(isOpen: boolean) {
+	const [cached] = useState(readCachedUpdates);
+	const [posts, setPosts] = useState(cached.posts);
+	const [status, setStatus] = useState<'loading' | 'ready' | 'error'>(
+		cached.fetchedAt ? 'ready' : 'loading'
+	);
+	const [lastSeen, setLastSeen] = useState(readLastSeen);
+	const newestDate = Math.max(0, ...posts.map((post) => post.date));
+	const fetchedAt = useRef(cached.fetchedAt);
+
+	useEffect(() => {
+		let disposed = false;
+		let pending: AbortController | undefined;
+
+		/** Refreshes stale posts without competing with an in-flight request. */
+		async function refresh() {
+			if (pending || Date.now() - fetchedAt.current < REFRESH_INTERVAL) {
+				return;
+			}
+			const controller = new AbortController();
+			pending = controller;
+			const timeout = window.setTimeout(() => controller.abort(), 10000);
+			setStatus('loading');
+			try {
+				const response = await fetch(UPDATES_URL, {
+					credentials: 'omit',
+					signal: controller.signal,
+				});
+				if (!response.ok) {
+					throw new Error('Could not load Playground updates.');
+				}
+				const data = await response.json();
+				const updates = parsePlaygroundUpdates(data);
+				if (disposed) {
+					return;
+				}
+				fetchedAt.current = Date.now();
+				setPosts(updates);
+				setStatus('ready');
+				try {
+					localStorage.setItem(
+						CACHE_KEY,
+						JSON.stringify({
+							fetchedAt: fetchedAt.current,
+							posts: data,
+						})
+					);
+				} catch {
+					// Updates still work when browser storage is unavailable or full.
+				}
+			} catch {
+				if (!disposed) {
+					setStatus('error');
+				}
+			} finally {
+				window.clearTimeout(timeout);
+				pending = undefined;
+			}
+		}
+
+		/** Checks for updates when a long-running Playground becomes visible. */
+		function refreshWhenVisible() {
+			if (document.visibilityState === 'visible') {
+				void refresh();
+			}
+		}
+
+		void refresh();
+		const interval = window.setInterval(
+			refreshWhenVisible,
+			REFRESH_INTERVAL
+		);
+		window.addEventListener('online', refreshWhenVisible);
+		document.addEventListener('visibilitychange', refreshWhenVisible);
+		return () => {
+			disposed = true;
+			pending?.abort();
+			window.clearInterval(interval);
+			window.removeEventListener('online', refreshWhenVisible);
+			document.removeEventListener(
+				'visibilitychange',
+				refreshWhenVisible
+			);
+		};
+	}, []);
+
+	useEffect(() => {
+		/** Clears the dot here when another tab has already shown the posts. */
+		function syncLastSeen(event: StorageEvent) {
+			if (event.key === LAST_SEEN_KEY || event.key === null) {
+				setLastSeen(readLastSeen());
+			}
+		}
+		window.addEventListener('storage', syncLastSeen);
+		return () => window.removeEventListener('storage', syncLastSeen);
+	}, []);
+
+	useEffect(() => {
+		if (!isOpen || newestDate <= lastSeen) {
+			return;
+		}
+		// Compare publication dates, not the visitor's clock or modified dates:
+		// editing an old announcement must not make it unread again. Re-read
+		// storage so an older tab cannot move another tab's marker backwards.
+		const seen = Math.max(newestDate, readLastSeen());
+		setLastSeen(seen);
+		try {
+			localStorage.setItem(LAST_SEEN_KEY, String(seen));
+		} catch {
+			// Keep the in-memory marker when persistent storage is blocked.
+		}
+	}, [isOpen, newestDate, lastSeen]);
+
+	return { posts, status, hasUnread: newestDate > lastSeen };
+}
+
+/** Validates both network and cached posts before they reach the Dock. */
+export function parsePlaygroundUpdates(data: unknown): PlaygroundUpdate[] {
+	if (!Array.isArray(data)) {
+		throw new Error('Invalid Playground updates response.');
+	}
+	return data.map((post) => {
+		if (
+			!post ||
+			!Number.isSafeInteger(post.id) ||
+			typeof post.date_gmt !== 'string' ||
+			typeof post.link !== 'string' ||
+			typeof post.title?.rendered !== 'string'
+		) {
+			throw new Error('Invalid Playground update.');
+		}
+		const url = new URL(post.link);
+		const date = Date.parse(`${post.date_gmt}Z`);
+		if (
+			url.origin !== 'https://make.wordpress.org' ||
+			!url.pathname.startsWith('/playground/') ||
+			url.username ||
+			url.password ||
+			!Number.isFinite(date)
+		) {
+			throw new Error('Invalid Playground update URL or date.');
+		}
+		return {
+			id: post.id,
+			date,
+			url: url.href,
+			title: htmlToText(post.title.rendered),
+		};
+	});
+}
+
+/** Extracts plain text in an inert template; feed HTML never enters the page. */
+function htmlToText(html: string): string {
+	const template = document.createElement('template');
+	template.innerHTML = html;
+	template.content
+		.querySelectorAll('script, style')
+		.forEach((node) => node.remove());
+	return (template.content.textContent ?? '').replace(/\s+/g, ' ').trim();
+}
+
+/** Revalidates the saved API response so a broken cache cannot break the Dock. */
+function readCachedUpdates(): { posts: PlaygroundUpdate[]; fetchedAt: number } {
+	try {
+		const cached = JSON.parse(localStorage.getItem(CACHE_KEY) ?? 'null');
+		if (
+			cached &&
+			Number.isFinite(cached.fetchedAt) &&
+			cached.fetchedAt > 0 &&
+			cached.fetchedAt <= Date.now()
+		) {
+			return {
+				posts: parsePlaygroundUpdates(cached.posts),
+				fetchedAt: cached.fetchedAt,
+			};
+		}
+	} catch {
+		// A missing, unreadable, or outdated cache is replaced by the next fetch.
+	}
+	return { posts: [], fetchedAt: 0 };
+}
+
+/** Reads the latest publication date shown in this browser, or zero if unread. */
+function readLastSeen(): number {
+	try {
+		const seen = Number(localStorage.getItem(LAST_SEEN_KEY));
+		return Number.isFinite(seen) && seen > 0 ? seen : 0;
+	} catch {
+		return 0;
+	}
+}

--- a/packages/playground/website/src/lib/state/redux/slice-ui.ts
+++ b/packages/playground/website/src/lib/state/redux/slice-ui.ts
@@ -32,7 +32,8 @@ export type DockPaneSection =
 	| 'logs'
 	| 'mail'
 	| 'share'
-	| 'save';
+	| 'save'
+	| 'updates';
 
 export const modalSlugs = {
 	LOG: 'log',


### PR DESCRIPTION
Adds a **What’s new** entry beside the Dock’s save status. It opens the latest five posts from [Make Playground’s Updates category](https://make.wordpress.org/playground/category/updates/), including for sites that skip the welcome page.

Posts refresh hourly while Playground is visible. Cached posts remain available if the blog cannot be reached. A small dot marks new posts until the pane is opened; the read marker is shared across sites and tabs in the same browser. The pane never opens on its own, and article links open in a new tab.

Uses titles and dates. Make’s generated excerpts sometimes contain glossary definitions mixed into the text.

The pane follows the mockup’s narrower white surface, lighter type, and shared content margins. On narrow phones, the address gets its own row and the post list scrolls below the header.

## Proposed follow-up: authored excerpts

Use each Make post’s Excerpt field for an optional, one-sentence summary. Make would expose the saved, author-written text through its public API without WordPress’s automatic excerpt fallback.

Playground would display that summary as plain text when present. Missing or blank excerpts would leave the title-and-date row unchanged: the post still appears, with no placeholder or empty summary space. Publishing would not require an excerpt, and existing posts would not need to be backfilled. No first-sentence extraction or AI generation.

This is a proposal; this PR currently displays titles and dates only.

## Demo

https://github.com/user-attachments/assets/adcdca09-a560-4b87-a8f6-e3d55459aa76

## Before and after

| Screen | Before | After |
| --- | --- | --- |
| Desktop | ![Desktop before](https://github.com/user-attachments/assets/02d6502d-84f9-42a0-ab9c-253e96d6bd44) | ![Desktop with updates open](https://github.com/user-attachments/assets/06cf737c-989e-413c-9ff2-386b69177923) |
| Mobile | ![Mobile before](https://github.com/user-attachments/assets/ff02883a-c2d4-41d8-a765-b8e5f02df080) | ![Mobile with updates open](https://github.com/user-attachments/assets/fcc80ad6-090d-47a7-ab62-b8768cc34179) |

## Testing

1. Open a custom Blueprint that lands on `/wp-admin/plugins.php`.
2. Open **What’s new**. Check that the dot clears and the latest posts appear.
3. Open a post, then return to Playground. The WordPress page should be unchanged.
4. Close the pane with Escape or its close button. Collapse the tools and open **What’s new** again.
5. Reload and repeat at a phone width. Read posts should stay read, and the blog link should stay reachable by scrolling on short screens.

The website’s 416 unit tests, type check, lint, and the new Chrome browser test pass locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a “What’s new” panel to browse Playground updates without leaving the site.
  - Added unread-update indicators, accessible labels, and cross-tab read-state synchronization.
  - Updates refresh automatically and remain available through loading, error, and empty states.
  - Added links to individual updates and the complete updates archive.

- **Tests**
  - Added coverage for update loading, caching, unread states, refresh behavior, validation, and end-to-end panel interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

