### PR TITLE
[i18n] Update Tagalog intro.md to match English docs

### DIFF
--- a/packages/docs/site/i18n/tl/docusaurus-plugin-content-docs/current/main/intro.md
+++ b/packages/docs/site/i18n/tl/docusaurus-plugin-content-docs/current/main/intro.md
@@ -2,6 +2,7 @@
 title: Panimula
 slug: /
 id: introduction
+description: Maligayang pagdating sa dokumentasyon ng WordPress Playground! Ipinakikilala ng pahinang ito ang istruktura ng dokumentasyon at tumutulong sa iyo na maghanap ng daan.
 ---
 
 # Dokumentasyon ng WordPress Playground
@@ -69,10 +70,20 @@ Kung ikaw ay developer o tech user, maaari mong direktang tingnan ang mga API:
 Ang WordPress Playground ay open-source at malugod na tinatanggap ang lahat ng kontribyutor mula sa code, disenyo, dokumentasyon, hanggang triage. Huwag mag-alala, _hindi mo kailangang malaman ang WebAssembly_ para makapag-ambag!
 
 - Tingnan ang [Contributors Handbook](/contributing) para sa detalye kung paano ka makakatulong.
-- Sumali sa `#meta-playground` channel sa Slack (tingnan ang [WordPress Slack page](https://make.wordpress.org/chat/) para sa impormasyon sa pag-signup)
+- Sumali sa `#playground` channel sa Slack (tingnan ang [WordPress Slack page](https://make.wordpress.org/chat/) para sa impormasyon sa pag-signup)
 
-<div class="callout callout-tip">
+Tulad ng sa lahat ng proyekto ng WordPress, nais naming matiyak ang magiliw na kapaligiran para sa lahat. Dahil dito, inaasahan sa lahat ng kontribyutor na sundin ang aming [Code of Conduct](https://make.wordpress.org/handbook/community-code-of-conduct/).
 
-Tingnan ang aming [Code of Conduct](https://make.wordpress.org/handbook/community-code-of-conduct/) upang matiyak ang magiliw na kapaligiran para sa lahat.
+## Paggamit ng Playground kasama ang mga AI assistant
 
-</div>
+Ang WordPress Playground ay dinisenyo para gumana kasama ang mga AI coding agent at AI-powered na tool. Tumutakbo ito nang buo sa client-side sa WebAssembly — walang authentication, walang kailangang backend, at naka-isolate sa browser nang walang persistent na side effect sa labas ng sandbox — kaya ito ay isang ligtas at maaasahang environment para sa AI-generated na demo at prototype.
+
+- **[Paggamit ng Playground kasama ang mga AI agent](/guides/agent-skill-wp-playground)** — I-install ang `wp-playground` skill para sa Claude Code, Cursor, Gemini CLI, GitHub Copilot, at iba pang coding agent. Ilarawan kung ano ang kailangan mo; ang agent ang magpapatakbo ng mga command.
+- **[AI-readable site index](https://playground.wordpress.net/llms.txt)** — Machine-readable na buod ng mga kakayahan, API, at docs ng Playground sa format na `llms.txt`.
+- **[AGENTS.md](https://github.com/WordPress/wordpress-playground/blob/trunk/AGENTS.md)** — Gabay para sa mga AI coding agent na nag-aambag sa codebase na ito.
+
+## Lisensya
+
+Ang WordPress Playground ay malayang software na inilabas sa ilalim ng mga tuntunin ng GNU General Public License version 2 o (sa iyong pagpipilian) anumang mas bagong bersyon. Para sa kumpletong lisensya, tingnan ang [LICENSE.md](https://github.com/WordPress/wordpress-playground/blob/trunk/LICENSE).
+
+<br/><br/><p align="center"><img src="https://s.w.org/style/images/codeispoetry.png?1" alt="Code is Poetry." /></p>


### PR DESCRIPTION
Add the missing AI assistants and license sections, and point Slack to #playground.

## Motivation for the change, related issues
English docs/main/intro.md already documents AI usage ([#3534](https://github.com/WordPress/wordpress-playground/pull/3534)), the GPLv2 license, and the #playground Slack channel ([#2345](https://github.com/WordPress/wordpress-playground/pull/2345)). The Tagalog page still omitted those sections and linked #meta-playground.

That left /tl/ readers without the AI skill / llms.txt / AGENTS.md links, without the license notice, and with a stale Slack channel name.

## Implementation details

- Updated packages/docs/site/i18n/tl/docusaurus-plugin-content-docs/current/main/intro.md.
- Added a Tagalog description in the frontmatter.
- Changed Slack from #meta-playground to #playground.
- Moved the Code of Conduct from a tip callout into the Get Involved paragraph, matching English.
- Added Paggamit ng Playground kasama ang mga AI assistant, with links to the agent skill guide, llms.txt, and AGENTS.md.
- Added Lisensya (GPLv2 or later) and the “Code is Poetry” image.

## Testing Instructions (or ideally a Blueprint)
Docs-only change; no Blueprint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a Filipino-language page description.
  - Updated contribution guidance with a direct Code of Conduct link and instructions for the designated Slack channel.
  - Added documentation covering AI assistant integration and licensing.
  - Added a closing “Code is Poetry” image to the introductory page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->