### PR TITLE
[docs] Updating WASM compiling doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ PHP=7.4 npx @php-wasm/cli -v
 npx @php-wasm/cli phpcbf
 ```
 
+For debug build examples and an explanation of the Emscripten flags, see [Debug builds](https://developer.wordpress.org/playground/developers/architecture/wasm-php-compiling/#debug-builds).
+
 ### Test offline support
 
 To test the offline support you need to build the website and run a local server:

--- a/packages/docs/site/docs/developers/23-architecture/03-wasm-php-compiling.md
+++ b/packages/docs/site/docs/developers/23-architecture/03-wasm-php-compiling.md
@@ -4,7 +4,7 @@ slug: /developers/architecture/wasm-php-compiling
 
 # Compiling PHP
 
-The build pipeline lives in a [`Dockerfile`](https://github.com/WordPress/wordpress-playground/blob/trunk/src/packages/php-wasm/compile/Dockerfile). It was originally forked from [seanmorris/php-wasm](https://github.com/seanmorris/php-wasm)
+The build pipeline lives in a [`Dockerfile`](https://github.com/WordPress/wordpress-playground/blob/trunk/packages/php-wasm/compile/php/Dockerfile). It was originally forked from [seanmorris/php-wasm](https://github.com/seanmorris/php-wasm)
 
 In broad strokes, that `Dockerfile`:
 
@@ -16,11 +16,64 @@ In broad strokes, that `Dockerfile`:
 - Outputs a `php.wasm` file and one or more JavaScript loaders, depending on the configuration.
 - Transforms the Emscripten's default `php.js` output into an ESM module with additional features.
 
-To find out more about each step, refer directly to the [Dockerfile](https://github.com/WordPress/wordpress-playground/blob/trunk/src/packages/php-wasm/compile/Dockerfile).
+To find out more about each step, refer directly to the [Dockerfile](https://github.com/WordPress/wordpress-playground/blob/trunk/packages/php-wasm/compile/php/Dockerfile).
 
 ### Building
 
-To build all PHP versions, run `nx recompile-php:all php-wasm-web` (or `php-wasm-node`) in the repository root. You'll find the output files in `packages/php-wasm/php-web/public`. To build a specific version, run `nx recompile-php:all php-wasm-node --PHP_VERSION=8.0 --WITH_JSPI=yes` (and repeat with `--WITH_JSPI=no`).
+With Docker running and the repository dependencies installed, run these commands from the repository root:
+
+```sh
+# Build all supported PHP versions for the web, in both JSPI and Asyncify modes.
+npx nx recompile-php:all php-wasm-web
+
+# Build only PHP 8.4 for the web, in JSPI mode.
+npx nx recompile-php:jspi php-wasm-web -- --PHP_VERSION=8.4
+```
+
+Replace `php-wasm-web` with `php-wasm-node` to build for Node.js, or `recompile-php:jspi` with `recompile-php:asyncify` to build the Asyncify variant. The output goes to `packages/php-wasm/web-builds/<major>-<minor>/<mode>/` or `packages/php-wasm/node-builds/<major>-<minor>/<mode>/`.
+
+### Debug builds
+
+Use `--WITH_DEBUG=yes` to build PHP.wasm with readable JavaScript output and DWARF debug information for stepping through C code in a WebAssembly debugger:
+
+```sh
+# Build PHP 8.4 for debugging in the browser.
+npx nx recompile-php:jspi php-wasm-web -- --PHP_VERSION=8.4 --WITH_DEBUG=yes
+
+# Build PHP 8.4 for debugging in Node.js.
+npx nx recompile-php:jspi php-wasm-node -- --PHP_VERSION=8.4 --WITH_DEBUG=yes
+```
+
+The same option works with `recompile-php:asyncify`. Debug builds produce larger files and run more slowly than optimized builds. They replace the selected version's artifacts in the output directory described above. Rebuild with `--WITH_DEBUG=no --WITH_SOURCEMAPS=no` to restore an optimized build.
+
+For WebAssembly source maps, use `--WITH_SOURCEMAPS=yes`:
+
+```sh
+npx nx recompile-php:jspi php-wasm-web -- --PHP_VERSION=8.4 --WITH_SOURCEMAPS=yes
+```
+
+This generates a `php.wasm.map` file and copies the source files needed for debugging into the build output. For web builds, the source map URL points to the local development server at `http://127.0.0.1:5400`; run `npm run dev` to serve it.
+
+#### Emscripten options
+
+The build script translates these options into compiler flags in the [PHP Dockerfile](https://github.com/WordPress/wordpress-playground/blob/trunk/packages/php-wasm/compile/php/Dockerfile):
+
+| Flag           | Purpose                                                                                                | When Playground uses it                                                 |
+| -------------- | ------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------- |
+| `-O0`          | Disables optimization of the final WebAssembly and JavaScript output.                                  | `WITH_DEBUG=yes` or `WITH_SOURCEMAPS=yes`, replacing the default `-O3`. |
+| `-g2`          | Keeps function names and readable JavaScript, without retaining DWARF information in the final module. | Node.js builds when neither debug option is enabled.                    |
+| `-g3`          | Retains DWARF information for source-level debugging.                                                  | `WITH_DEBUG=yes` or `WITH_SOURCEMAPS=yes`.                              |
+| `-gsource-map` | Generates a WebAssembly source map from compiler debug information.                                    | `WITH_SOURCEMAPS=yes`.                                                  |
+
+See the [Emscripten compiler reference](https://emscripten.org/docs/tools_reference/emcc.html) for details on these flags.
+
+#### Runtime assertions
+
+Debug information and runtime assertions are separate settings. Playground explicitly passes `-s ASSERTIONS=0`, including in debug builds, so `--WITH_DEBUG=yes` does not enable extra runtime checks.
+
+To investigate a runtime failure with assertions, change that setting in the PHP Dockerfile's final `emcc` command and rebuild. Emscripten documents `-s ASSERTIONS=1` for runtime checks and `-s ASSERTIONS=2` for additional, slower checks. There is no `WITH_ASSERTIONS` build option. See the [Emscripten assertions reference](https://emscripten.org/docs/tools_reference/settings_reference.html#assertions).
+
+Assertions can also report an environment mismatch between `web` and `worker`. Check the build's `ENVIRONMENT` setting and the JavaScript loader's execution context when investigating those errors; see the [discussion in issue #176](https://github.com/WordPress/wordpress-playground/issues/176#issuecomment-1483754022).
 
 ### PHP next builds
 
@@ -44,7 +97,7 @@ npm run recompile:php:web:next
 
 ### PHP extensions
 
-PHP is built with several extensions listed in the [`Dockerfile`](https://github.com/WordPress/wordpress-playground/blob/trunk/src/packages/php-wasm/compile/Dockerfile).
+PHP is built with several extensions listed in the [`Dockerfile`](https://github.com/WordPress/wordpress-playground/blob/trunk/packages/php-wasm/compile/php/Dockerfile).
 
 Some extensions, like `zip`, can be turned on or off during the build. Others, like `sqlite3`, are hardcoded.
 
@@ -72,11 +125,13 @@ Refer to the inline documentation in [`php_wasm.c`](https://github.com/WordPress
 The build is configurable via the [Docker `--build-arg` feature](https://docs.docker.com/engine/reference/commandline/build/#set-build-time-variables---build-arg). You can set them up through the `build.js` script, just run this command to get the usage message:
 
 ```sh
-nx recompile-php php-wasm-web
+npx nx recompile-php:jspi php-wasm-web -- --help
 ```
 
 **Supported build options:**
 
+- `WITH_DEBUG` – `yes` or `no`. Build with DWARF debug information and disable final optimization. See [Debug builds](#debug-builds).
+- `WITH_SOURCEMAPS` – `yes` or `no`. Generate WebAssembly source maps and disable final optimization. See [Debug builds](#debug-builds).
 - `PHP_VERSION` – The PHP version to build, default: `8.0.24`. This value must point to an existing branch of the https://github.com/php/php-src.git repository when prefixed with `PHP-`. For example, `7.4.0` is valid because the branch `PHP-7.4.0` exists, but just `7` is invalid because there's no branch `PHP-7`. The PHP versions that are known to work are `7.4.*` and `8.0.*`. Others likely work as well but they haven't been tried.
 - `EMSCRIPTEN_ENVIRONMENT` – `web` or `node`, default: `web`. The platform to build for. When building for `web`, two JavaScript loaders will be created: `php-web.js` and `php-webworker.js`. When building for Node.js, only one loader called `php-node.js` will be created.
 - `WITH_LIBXML` – `yes` or `no`, default: `no`. Whether to build with `libxml2` and the `dom`, `xml`, and `simplexml` PHP extensions (`DOMDocument`, `SimpleXML`, ..).

--- a/packages/docs/site/docs/developers/23-architecture/03-wasm-php-compiling.md
+++ b/packages/docs/site/docs/developers/23-architecture/03-wasm-php-compiling.md
@@ -18,7 +18,7 @@ In broad strokes, that `Dockerfile`:
 
 To find out more about each step, refer directly to the [Dockerfile](https://github.com/WordPress/wordpress-playground/blob/trunk/packages/php-wasm/compile/php/Dockerfile).
 
-### Building
+## Building
 
 With Docker running and the repository dependencies installed, run these commands from the repository root:
 
@@ -32,7 +32,7 @@ npx nx recompile-php:jspi php-wasm-web -- --PHP_VERSION=8.4
 
 Replace `php-wasm-web` with `php-wasm-node` to build for Node.js, or `recompile-php:jspi` with `recompile-php:asyncify` to build the Asyncify variant. The output goes to `packages/php-wasm/web-builds/<major>-<minor>/<mode>/` or `packages/php-wasm/node-builds/<major>-<minor>/<mode>/`.
 
-### Debug builds
+## Debug builds
 
 Use `--WITH_DEBUG=yes` to build PHP.wasm with readable JavaScript output and DWARF debug information for stepping through C code in a WebAssembly debugger:
 
@@ -54,7 +54,7 @@ npx nx recompile-php:jspi php-wasm-web -- --PHP_VERSION=8.4 --WITH_SOURCEMAPS=ye
 
 This generates a `php.wasm.map` file and copies the source files needed for debugging into the build output. For web builds, the source map URL points to the local development server at `http://127.0.0.1:5400`; run `npm run dev` to serve it.
 
-#### Emscripten options
+### Emscripten options
 
 The build script translates these options into compiler flags in the [PHP Dockerfile](https://github.com/WordPress/wordpress-playground/blob/trunk/packages/php-wasm/compile/php/Dockerfile):
 
@@ -67,15 +67,13 @@ The build script translates these options into compiler flags in the [PHP Docker
 
 See the [Emscripten compiler reference](https://emscripten.org/docs/tools_reference/emcc.html) for details on these flags.
 
-#### Runtime assertions
+### Runtime assertions
 
 Debug information and runtime assertions are separate settings. Playground explicitly passes `-s ASSERTIONS=0`, including in debug builds, so `--WITH_DEBUG=yes` does not enable extra runtime checks.
 
 To investigate a runtime failure with assertions, change that setting in the PHP Dockerfile's final `emcc` command and rebuild. Emscripten documents `-s ASSERTIONS=1` for runtime checks and `-s ASSERTIONS=2` for additional, slower checks. There is no `WITH_ASSERTIONS` build option. See the [Emscripten assertions reference](https://emscripten.org/docs/tools_reference/settings_reference.html#assertions).
 
-Assertions can also report an environment mismatch between `web` and `worker`. Check the build's `ENVIRONMENT` setting and the JavaScript loader's execution context when investigating those errors; see the [discussion in issue #176](https://github.com/WordPress/wordpress-playground/issues/176#issuecomment-1483754022).
-
-### PHP next builds
+## PHP next builds
 
 Playground can also run the next PHP version from the php-src development branch in the web runtime. These builds are published separately from the main repository because the generated WebAssembly files are large and change often.
 
@@ -95,7 +93,7 @@ npm run recompile:php:web:next
 
 `php=next` currently ships web main modules only. Matching extension side modules and Playground CLI support are separate follow-up work.
 
-### PHP extensions
+## PHP extensions
 
 PHP is built with several extensions listed in the [`Dockerfile`](https://github.com/WordPress/wordpress-playground/blob/trunk/packages/php-wasm/compile/php/Dockerfile).
 
@@ -110,7 +108,7 @@ a manifest that selects the artifact matching the active PHP version and async
 mode. See [Loading PHP extensions](/developers/apis/javascript-api/php-extensions)
 for the runtime API.
 
-### C API exposed to JavaScript
+## C API exposed to JavaScript
 
 The C API exposed to JavaScript lives in the [`php_wasm.c`](https://github.com/WordPress/wordpress-playground/blob/trunk/src/packages/php-wasm/compile/build-assets/php_wasm.c) file. The most important functions are:
 
@@ -120,7 +118,7 @@ The C API exposed to JavaScript lives in the [`php_wasm.c`](https://github.com/W
 
 Refer to the inline documentation in [`php_wasm.c`](https://github.com/WordPress/wordpress-playground/blob/trunk/src/packages/php-wasm/compile/build-assets/php_wasm.c) to learn more.
 
-### Build configuration
+## Build configuration
 
 The build is configurable via the [Docker `--build-arg` feature](https://docs.docker.com/engine/reference/commandline/build/#set-build-time-variables---build-arg). You can set them up through the `build.js` script, just run this command to get the usage message:
 
@@ -128,11 +126,13 @@ The build is configurable via the [Docker `--build-arg` feature](https://docs.do
 npx nx recompile-php:jspi php-wasm-web -- --help
 ```
 
-**Supported build options:**
+**Selected build options:**
+
+This list highlights debug and basic build settings. For the full set of options, run the help command above; see [the build script](https://github.com/WordPress/wordpress-playground/blob/trunk/packages/php-wasm/compile/build.js) for platform-specific defaults.
 
 - `WITH_DEBUG` – `yes` or `no`. Build with DWARF debug information and disable final optimization. See [Debug builds](#debug-builds).
 - `WITH_SOURCEMAPS` – `yes` or `no`. Generate WebAssembly source maps and disable final optimization. See [Debug builds](#debug-builds).
-- `PHP_VERSION` – The PHP version to build, default: `8.0.24`. This value must point to an existing branch of the https://github.com/php/php-src.git repository when prefixed with `PHP-`. For example, `7.4.0` is valid because the branch `PHP-7.4.0` exists, but just `7` is invalid because there's no branch `PHP-7`. The PHP versions that are known to work are `7.4.*` and `8.0.*`. Others likely work as well but they haven't been tried.
+- `PHP_VERSION` – The PHP version to build. Use a major/minor version such as `8.4` to select its latest release from [the supported PHP versions](https://github.com/WordPress/wordpress-playground/blob/trunk/packages/php-wasm/supported-php-versions.mjs), or an exact release such as `8.4.25`. The build clones the corresponding `php-<version>` tag from php-src.
 - `EMSCRIPTEN_ENVIRONMENT` – `web` or `node`, default: `web`. The platform to build for. When building for `web`, two JavaScript loaders will be created: `php-web.js` and `php-webworker.js`. When building for Node.js, only one loader called `php-node.js` will be created.
 - `WITH_LIBXML` – `yes` or `no`, default: `no`. Whether to build with `libxml2` and the `dom`, `xml`, and `simplexml` PHP extensions (`DOMDocument`, `SimpleXML`, ..).
 - `WITH_LIBZIP` – `yes` or `no`, default: `yes`. Whether to build with `zlib`, `libzip`, and the `zip` PHP extension (`ZipArchive`).

--- a/packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current/developers/23-architecture/03-wasm-php-compiling.md
+++ b/packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current/developers/23-architecture/03-wasm-php-compiling.md
@@ -46,10 +46,10 @@ To find out more about each step, refer directly to the [Dockerfile](https://git
 Para obtener más información sobre cada paso, consulta directamente el [Dockerfile](https://github.com/WordPress/wordpress-playground/blob/trunk/packages/php-wasm/compile/php/Dockerfile).
 
 <!--
-### Building
+## Building
 -->
 
-### Compilación
+## Compilación
 
 <!--
 With Docker running and the repository dependencies installed, run these commands from the repository root:
@@ -82,10 +82,10 @@ Replace `php-wasm-web` with `php-wasm-node` to build for Node.js, or `recompile-
 Sustituye `php-wasm-web` por `php-wasm-node` para compilar para Node.js, o `recompile-php:jspi` por `recompile-php:asyncify` para compilar la variante Asyncify. Los archivos se generan en `packages/php-wasm/web-builds/<major>-<minor>/<mode>/` o `packages/php-wasm/node-builds/<major>-<minor>/<mode>/`.
 
 <!--
-### Debug builds
+## Debug builds
 -->
 
-### Compilaciones para depuración {#debug-builds}
+## Compilaciones para depuración {#debug-builds}
 
 <!--
 Use `--WITH_DEBUG=yes` to build PHP.wasm with readable JavaScript output and DWARF debug information for stepping through C code in a WebAssembly debugger:
@@ -140,10 +140,10 @@ This generates a `php.wasm.map` file and copies the source files needed for debu
 Esto genera un archivo `php.wasm.map` y copia los archivos de código fuente necesarios para la depuración en el directorio de salida de la compilación. En las compilaciones para la web, la URL del mapa de código fuente apunta al servidor de desarrollo local en `http://127.0.0.1:5400`; ejecuta `npm run dev` para servirlo.
 
 <!--
-#### Emscripten options
+### Emscripten options
 -->
 
-#### Opciones de Emscripten
+### Opciones de Emscripten
 
 <!--
 The build script translates these options into compiler flags in the [PHP Dockerfile](https://github.com/WordPress/wordpress-playground/blob/trunk/packages/php-wasm/compile/php/Dockerfile):
@@ -174,10 +174,10 @@ See the [Emscripten compiler reference](https://emscripten.org/docs/tools_refere
 Consulta la [referencia del compilador Emscripten](https://emscripten.org/docs/tools_reference/emcc.html) para obtener más información sobre estos indicadores.
 
 <!--
-#### Runtime assertions
+### Runtime assertions
 -->
 
-#### Aserciones en tiempo de ejecución
+### Aserciones en tiempo de ejecución
 
 <!--
 Debug information and runtime assertions are separate settings. Playground explicitly passes `-s ASSERTIONS=0`, including in debug builds, so `--WITH_DEBUG=yes` does not enable extra runtime checks.
@@ -192,16 +192,10 @@ To investigate a runtime failure with assertions, change that setting in the PHP
 Para investigar un fallo en tiempo de ejecución con aserciones, cambia ese ajuste en el comando `emcc` final del Dockerfile de PHP y vuelve a compilar. Emscripten documenta `-s ASSERTIONS=1` para comprobaciones en tiempo de ejecución y `-s ASSERTIONS=2` para comprobaciones adicionales, más lentas. No existe una opción de compilación `WITH_ASSERTIONS`. Consulta la [referencia de aserciones de Emscripten](https://emscripten.org/docs/tools_reference/settings_reference.html#assertions).
 
 <!--
-Assertions can also report an environment mismatch between `web` and `worker`. Check the build's `ENVIRONMENT` setting and the JavaScript loader's execution context when investigating those errors; see the [discussion in issue #176](https://github.com/WordPress/wordpress-playground/issues/176#issuecomment-1483754022).
+## PHP next builds
 -->
 
-Las aserciones también pueden indicar una incompatibilidad de entorno entre `web` y `worker`. Comprueba el ajuste `ENVIRONMENT` de la compilación y el contexto de ejecución del cargador JavaScript al investigar estos errores; consulta la [discusión en la incidencia #176](https://github.com/WordPress/wordpress-playground/issues/176#issuecomment-1483754022).
-
-<!--
-### PHP next builds
--->
-
-### Compilaciones de PHP next
+## Compilaciones de PHP next
 
 <!--
 Playground can also run the next PHP version from the php-src development branch in the web runtime. These builds are published separately from the main repository because the generated WebAssembly files are large and change often.
@@ -254,10 +248,10 @@ npm run recompile:php:web:next
 Actualmente, `php=next` solo distribuye módulos principales para la web. Los módulos auxiliares de extensiones correspondientes y la compatibilidad con la CLI de Playground se abordarán en trabajos posteriores independientes.
 
 <!--
-### PHP extensions
+## PHP extensions
 -->
 
-### Extensiones de PHP
+## Extensiones de PHP
 
 <!--
 PHP is built with several extensions listed in the [`Dockerfile`](https://github.com/WordPress/wordpress-playground/blob/trunk/packages/php-wasm/compile/php/Dockerfile).
@@ -289,10 +283,10 @@ for the runtime API.
 PHP.wasm también puede cargar extensiones dinámicas `.so` antes de iniciar PHP. Las extensiones dinámicas integradas, como `intl`, `xdebug`, `redis` y `memcached`, se distribuyen con el paquete de Node, y las extensiones externas pueden proporcionarse con un manifiesto que seleccione el artefacto correspondiente a la versión de PHP y al modo asíncrono activos. Consulta [Cargar extensiones de PHP](/developers/apis/javascript-api/php-extensions) para conocer la API de ejecución.
 
 <!--
-### C API exposed to JavaScript
+## C API exposed to JavaScript
 -->
 
-### API de C expuesta a JavaScript
+## API de C expuesta a JavaScript
 
 <!--
 The C API exposed to JavaScript lives in the [`php_wasm.c`](https://github.com/WordPress/wordpress-playground/blob/trunk/src/packages/php-wasm/compile/build-assets/php_wasm.c) file. The most important functions are:
@@ -317,10 +311,10 @@ Refer to the inline documentation in [`php_wasm.c`](https://github.com/WordPress
 Consulta la documentación incluida en [`php_wasm.c`](https://github.com/WordPress/wordpress-playground/blob/trunk/src/packages/php-wasm/compile/build-assets/php_wasm.c) para obtener más información.
 
 <!--
-### Build configuration
+## Build configuration
 -->
 
-### Configuración de la compilación
+## Configuración de la compilación
 
 <!--
 The build is configurable via the [Docker `--build-arg` feature](https://docs.docker.com/engine/reference/commandline/build/#set-build-time-variables---build-arg). You can set them up through the `build.js` script, just run this command to get the usage message:
@@ -339,15 +333,19 @@ npx nx recompile-php:jspi php-wasm-web -- --help
 ```
 
 <!--
-**Supported build options:**
+**Selected build options:**
+
+This list highlights debug and basic build settings. For the full set of options, run the help command above; see [the build script](https://github.com/WordPress/wordpress-playground/blob/trunk/packages/php-wasm/compile/build.js) for platform-specific defaults.
 -->
 
-**Opciones de compilación disponibles:**
+**Opciones de compilación seleccionadas:**
+
+Esta lista destaca los ajustes de depuración y compilación básicos. Para consultar todas las opciones, ejecuta el comando de ayuda anterior; consulta [el script de compilación](https://github.com/WordPress/wordpress-playground/blob/trunk/packages/php-wasm/compile/build.js) para conocer los valores predeterminados de cada plataforma.
 
 <!--
 - `WITH_DEBUG` – `yes` or `no`. Build with DWARF debug information and disable final optimization. See [Debug builds](#debug-builds).
 - `WITH_SOURCEMAPS` – `yes` or `no`. Generate WebAssembly source maps and disable final optimization. See [Debug builds](#debug-builds).
-- `PHP_VERSION` – The PHP version to build, default: `8.0.24`. This value must point to an existing branch of the https://github.com/php/php-src.git repository when prefixed with `PHP-`. For example, `7.4.0` is valid because the branch `PHP-7.4.0` exists, but just `7` is invalid because there's no branch `PHP-7`. The PHP versions that are known to work are `7.4.*` and `8.0.*`. Others likely work as well but they haven't been tried.
+- `PHP_VERSION` – The PHP version to build. Use a major/minor version such as `8.4` to select its latest release from [the supported PHP versions](https://github.com/WordPress/wordpress-playground/blob/trunk/packages/php-wasm/supported-php-versions.mjs), or an exact release such as `8.4.25`. The build clones the corresponding `php-<version>` tag from php-src.
 - `EMSCRIPTEN_ENVIRONMENT` – `web` or `node`, default: `web`. The platform to build for. When building for `web`, two JavaScript loaders will be created: `php-web.js` and `php-webworker.js`. When building for Node.js, only one loader called `php-node.js` will be created.
 - `WITH_LIBXML` – `yes` or `no`, default: `no`. Whether to build with `libxml2` and the `dom`, `xml`, and `simplexml` PHP extensions (`DOMDocument`, `SimpleXML`, ..).
 - `WITH_LIBZIP` – `yes` or `no`, default: `yes`. Whether to build with `zlib`, `libzip`, and the `zip` PHP extension (`ZipArchive`).
@@ -356,7 +354,7 @@ npx nx recompile-php:jspi php-wasm-web -- --help
 
 - `WITH_DEBUG` – `yes` o `no`. Compila con información de depuración DWARF y desactiva la optimización final. Consulta [Compilaciones para depuración](#debug-builds).
 - `WITH_SOURCEMAPS` – `yes` o `no`. Genera mapas de código fuente de WebAssembly y desactiva la optimización final. Consulta [Compilaciones para depuración](#debug-builds).
-- `PHP_VERSION` – La versión de PHP que se compilará, predeterminada: `8.0.24`. Este valor debe corresponder a una rama existente del repositorio https://github.com/php/php-src.git al añadirle el prefijo `PHP-`. Por ejemplo, `7.4.0` es válido porque existe la rama `PHP-7.4.0`, pero solo `7` no es válido porque no existe la rama `PHP-7`. Las versiones de PHP que se sabe que funcionan son `7.4.*` y `8.0.*`. Es probable que otras también funcionen, pero no se han probado.
+- `PHP_VERSION` – La versión de PHP que se compilará. Usa una versión mayor/menor como `8.4` para seleccionar su última versión de [las versiones de PHP compatibles](https://github.com/WordPress/wordpress-playground/blob/trunk/packages/php-wasm/supported-php-versions.mjs), o una versión exacta como `8.4.25`. La compilación clona la etiqueta `php-<version>` correspondiente de php-src.
 - `EMSCRIPTEN_ENVIRONMENT` – `web` o `node`, predeterminado: `web`. La plataforma de destino de la compilación. Al compilar para `web`, se crean dos cargadores JavaScript: `php-web.js` y `php-webworker.js`. Al compilar para Node.js, solo se crea un cargador llamado `php-node.js`.
 - `WITH_LIBXML` – `yes` o `no`, predeterminado: `no`. Indica si se incluye `libxml2` y las extensiones de PHP `dom`, `xml` y `simplexml` (`DOMDocument`, `SimpleXML`, ...).
 - `WITH_LIBZIP` – `yes` o `no`, predeterminado: `yes`. Indica si se incluye `zlib`, `libzip` y la extensión de PHP `zip` (`ZipArchive`).

--- a/packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current/developers/23-architecture/03-wasm-php-compiling.md
+++ b/packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current/developers/23-architecture/03-wasm-php-compiling.md
@@ -1,5 +1,5 @@
 ---
-title: Compilando PHP
+title: Compilar PHP
 slug: /developers/architecture/wasm-php-compiling
 ---
 
@@ -7,19 +7,19 @@ slug: /developers/architecture/wasm-php-compiling
 # Compiling PHP
 -->
 
-# Compilando PHP
+# Compilar PHP
 
 <!--
 The build pipeline lives in a [`Dockerfile`](https://github.com/WordPress/wordpress-playground/blob/trunk/packages/php-wasm/compile/php/Dockerfile). It was originally forked from [seanmorris/php-wasm](https://github.com/seanmorris/php-wasm)
 -->
 
-O processo de compilação está em um [`Dockerfile`](https://github.com/WordPress/wordpress-playground/blob/trunk/packages/php-wasm/compile/php/Dockerfile). Ele foi originalmente derivado de [seanmorris/php-wasm](https://github.com/seanmorris/php-wasm).
+El proceso de compilación se encuentra en un [`Dockerfile`](https://github.com/WordPress/wordpress-playground/blob/trunk/packages/php-wasm/compile/php/Dockerfile). Originalmente se derivó de [seanmorris/php-wasm](https://github.com/seanmorris/php-wasm).
 
 <!--
 In broad strokes, that `Dockerfile`:
 -->
 
-Em linhas gerais, esse `Dockerfile`:
+A grandes rasgos, ese `Dockerfile`:
 
 <!--
 - Installs all the necessary linux packages (like `build-essential`)
@@ -31,31 +31,31 @@ Em linhas gerais, esse `Dockerfile`:
 - Transforms the Emscripten's default `php.js` output into an ESM module with additional features.
 -->
 
-- Instala todos os pacotes Linux necessários (como `build-essential`).
-- Baixa o PHP e as bibliotecas necessárias, como `sqlite3`.
-- Aplica algumas correções.
-- Compila tudo usando [Emscripten](https://emscripten.org/), um substituto direto para o compilador C.
-- Compila `php_wasm.c` – uma API conveniente para JavaScript.
-- Gera um arquivo `php.wasm` e um ou mais carregadores JavaScript, dependendo da configuração.
-- Transforma a saída padrão `php.js` do Emscripten em um módulo ESM com recursos adicionais.
+- Instala todos los paquetes de Linux necesarios (como `build-essential`).
+- Descarga PHP y las bibliotecas necesarias, como `sqlite3`.
+- Aplica algunos parches.
+- Compila todo con [Emscripten](https://emscripten.org/), un sustituto directo del compilador de C.
+- Compila `php_wasm.c`, una API práctica para JavaScript.
+- Genera un archivo `php.wasm` y uno o varios cargadores JavaScript, según la configuración.
+- Transforma la salida predeterminada `php.js` de Emscripten en un módulo ESM con funciones adicionales.
 
 <!--
 To find out more about each step, refer directly to the [Dockerfile](https://github.com/WordPress/wordpress-playground/blob/trunk/packages/php-wasm/compile/php/Dockerfile).
 -->
 
-Para saber mais sobre cada etapa, consulte diretamente o [Dockerfile](https://github.com/WordPress/wordpress-playground/blob/trunk/packages/php-wasm/compile/php/Dockerfile).
+Para obtener más información sobre cada paso, consulta directamente el [Dockerfile](https://github.com/WordPress/wordpress-playground/blob/trunk/packages/php-wasm/compile/php/Dockerfile).
 
 <!--
 ### Building
 -->
 
-### Compilação
+### Compilación
 
 <!--
 With Docker running and the repository dependencies installed, run these commands from the repository root:
 -->
 
-Com o Docker em execução e as dependências do repositório instaladas, execute estes comandos na raiz do repositório:
+Con Docker en ejecución y las dependencias del repositorio instaladas, ejecuta estos comandos desde la raíz del repositorio:
 
 <!--
 ```sh
@@ -68,10 +68,10 @@ npx nx recompile-php:jspi php-wasm-web -- --PHP_VERSION=8.4
 -->
 
 ```sh
-# Compila todas as versões suportadas do PHP para a web, nos modos JSPI e Asyncify.
+# Compila todas las versiones compatibles de PHP para la web, en los modos JSPI y Asyncify.
 npx nx recompile-php:all php-wasm-web
 
-# Compila apenas o PHP 8.4 para a web, no modo JSPI.
+# Compila solo PHP 8.4 para la web, en modo JSPI.
 npx nx recompile-php:jspi php-wasm-web -- --PHP_VERSION=8.4
 ```
 
@@ -79,19 +79,19 @@ npx nx recompile-php:jspi php-wasm-web -- --PHP_VERSION=8.4
 Replace `php-wasm-web` with `php-wasm-node` to build for Node.js, or `recompile-php:jspi` with `recompile-php:asyncify` to build the Asyncify variant. The output goes to `packages/php-wasm/web-builds/<major>-<minor>/<mode>/` or `packages/php-wasm/node-builds/<major>-<minor>/<mode>/`.
 -->
 
-Substitua `php-wasm-web` por `php-wasm-node` para compilar para Node.js, ou `recompile-php:jspi` por `recompile-php:asyncify` para compilar a variante Asyncify. A saída é gravada em `packages/php-wasm/web-builds/<major>-<minor>/<mode>/` ou `packages/php-wasm/node-builds/<major>-<minor>/<mode>/`.
+Sustituye `php-wasm-web` por `php-wasm-node` para compilar para Node.js, o `recompile-php:jspi` por `recompile-php:asyncify` para compilar la variante Asyncify. Los archivos se generan en `packages/php-wasm/web-builds/<major>-<minor>/<mode>/` o `packages/php-wasm/node-builds/<major>-<minor>/<mode>/`.
 
 <!--
 ### Debug builds
 -->
 
-### Compilações para depuração {#debug-builds}
+### Compilaciones para depuración {#debug-builds}
 
 <!--
 Use `--WITH_DEBUG=yes` to build PHP.wasm with readable JavaScript output and DWARF debug information for stepping through C code in a WebAssembly debugger:
 -->
 
-Use `--WITH_DEBUG=yes` para compilar PHP.wasm com saída JavaScript legível e informações de depuração DWARF para executar o código C passo a passo em um depurador WebAssembly:
+Usa `--WITH_DEBUG=yes` para compilar PHP.wasm con una salida JavaScript legible e información de depuración DWARF que permita recorrer el código C paso a paso en un depurador WebAssembly:
 
 <!--
 ```sh
@@ -104,10 +104,10 @@ npx nx recompile-php:jspi php-wasm-node -- --PHP_VERSION=8.4 --WITH_DEBUG=yes
 -->
 
 ```sh
-# Compila o PHP 8.4 para depuração no navegador.
+# Compila PHP 8.4 para depurarlo en el navegador.
 npx nx recompile-php:jspi php-wasm-web -- --PHP_VERSION=8.4 --WITH_DEBUG=yes
 
-# Compila o PHP 8.4 para depuração no Node.js.
+# Compila PHP 8.4 para depurarlo en Node.js.
 npx nx recompile-php:jspi php-wasm-node -- --PHP_VERSION=8.4 --WITH_DEBUG=yes
 ```
 
@@ -115,13 +115,13 @@ npx nx recompile-php:jspi php-wasm-node -- --PHP_VERSION=8.4 --WITH_DEBUG=yes
 The same option works with `recompile-php:asyncify`. Debug builds produce larger files and run more slowly than optimized builds. They replace the selected version's artifacts in the output directory described above. Rebuild with `--WITH_DEBUG=no --WITH_SOURCEMAPS=no` to restore an optimized build.
 -->
 
-A mesma opção funciona com `recompile-php:asyncify`. As compilações para depuração geram arquivos maiores e são mais lentas que as compilações otimizadas. Elas substituem os artefatos da versão selecionada no diretório de saída descrito acima. Compile novamente com `--WITH_DEBUG=no --WITH_SOURCEMAPS=no` para restaurar uma compilação otimizada.
+La misma opción funciona con `recompile-php:asyncify`. Las compilaciones para depuración generan archivos más grandes y se ejecutan más lentamente que las compilaciones optimizadas. Sustituyen los artefactos de la versión seleccionada en el directorio de salida descrito anteriormente. Vuelve a compilar con `--WITH_DEBUG=no --WITH_SOURCEMAPS=no` para restaurar una compilación optimizada.
 
 <!--
 For WebAssembly source maps, use `--WITH_SOURCEMAPS=yes`:
 -->
 
-Para gerar mapas de código-fonte WebAssembly, use `--WITH_SOURCEMAPS=yes`:
+Para generar mapas de código fuente de WebAssembly, usa `--WITH_SOURCEMAPS=yes`:
 
 <!--
 ```sh
@@ -137,19 +137,19 @@ npx nx recompile-php:jspi php-wasm-web -- --PHP_VERSION=8.4 --WITH_SOURCEMAPS=ye
 This generates a `php.wasm.map` file and copies the source files needed for debugging into the build output. For web builds, the source map URL points to the local development server at `http://127.0.0.1:5400`; run `npm run dev` to serve it.
 -->
 
-Isso gera um arquivo `php.wasm.map` e copia os arquivos de código-fonte necessários para depuração para o diretório de saída da compilação. Nas compilações para a web, o URL do mapa de código-fonte aponta para o servidor de desenvolvimento local em `http://127.0.0.1:5400`; execute `npm run dev` para disponibilizá-lo.
+Esto genera un archivo `php.wasm.map` y copia los archivos de código fuente necesarios para la depuración en el directorio de salida de la compilación. En las compilaciones para la web, la URL del mapa de código fuente apunta al servidor de desarrollo local en `http://127.0.0.1:5400`; ejecuta `npm run dev` para servirlo.
 
 <!--
 #### Emscripten options
 -->
 
-#### Opções do Emscripten
+#### Opciones de Emscripten
 
 <!--
 The build script translates these options into compiler flags in the [PHP Dockerfile](https://github.com/WordPress/wordpress-playground/blob/trunk/packages/php-wasm/compile/php/Dockerfile):
 -->
 
-O script de compilação converte essas opções em sinalizadores do compilador no [Dockerfile do PHP](https://github.com/WordPress/wordpress-playground/blob/trunk/packages/php-wasm/compile/php/Dockerfile):
+El script de compilación convierte estas opciones en indicadores del compilador en el [Dockerfile de PHP](https://github.com/WordPress/wordpress-playground/blob/trunk/packages/php-wasm/compile/php/Dockerfile):
 
 <!--
 | Flag           | Purpose                                                                                                | When Playground uses it                                                 |
@@ -160,66 +160,66 @@ O script de compilação converte essas opções em sinalizadores do compilador 
 | `-gsource-map` | Generates a WebAssembly source map from compiler debug information.                                    | `WITH_SOURCEMAPS=yes`.                                                  |
 -->
 
-| Sinalizador    | Finalidade                                                                                       | Quando o Playground o usa                                                     |
-| -------------- | ------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------- |
-| `-O0`          | Desativa a otimização da saída final de WebAssembly e JavaScript.                                | `WITH_DEBUG=yes` ou `WITH_SOURCEMAPS=yes`, substituindo o padrão `-O3`.       |
-| `-g2`          | Mantém os nomes das funções e o JavaScript legível, sem reter informações DWARF no módulo final. | Compilações para Node.js quando nenhuma das opções de depuração está ativada. |
-| `-g3`          | Mantém informações DWARF para depuração no nível do código-fonte.                                | `WITH_DEBUG=yes` ou `WITH_SOURCEMAPS=yes`.                                    |
-| `-gsource-map` | Gera um mapa de código-fonte WebAssembly a partir das informações de depuração do compilador.    | `WITH_SOURCEMAPS=yes`.                                                        |
+| Indicador      | Finalidad                                                                                                        | Cuándo lo usa Playground                                                               |
+| -------------- | ---------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| `-O0`          | Desactiva la optimización de la salida final de WebAssembly y JavaScript.                                        | `WITH_DEBUG=yes` o `WITH_SOURCEMAPS=yes`, en lugar del valor predeterminado `-O3`.     |
+| `-g2`          | Conserva los nombres de las funciones y el JavaScript legible, sin retener información DWARF en el módulo final. | Compilaciones para Node.js cuando ninguna de las opciones de depuración está activada. |
+| `-g3`          | Conserva la información DWARF para depurar a nivel de código fuente.                                             | `WITH_DEBUG=yes` o `WITH_SOURCEMAPS=yes`.                                              |
+| `-gsource-map` | Genera un mapa de código fuente de WebAssembly a partir de la información de depuración del compilador.          | `WITH_SOURCEMAPS=yes`.                                                                 |
 
 <!--
 See the [Emscripten compiler reference](https://emscripten.org/docs/tools_reference/emcc.html) for details on these flags.
 -->
 
-Consulte a [referência do compilador Emscripten](https://emscripten.org/docs/tools_reference/emcc.html) para saber mais sobre esses sinalizadores.
+Consulta la [referencia del compilador Emscripten](https://emscripten.org/docs/tools_reference/emcc.html) para obtener más información sobre estos indicadores.
 
 <!--
 #### Runtime assertions
 -->
 
-#### Asserções em tempo de execução
+#### Aserciones en tiempo de ejecución
 
 <!--
 Debug information and runtime assertions are separate settings. Playground explicitly passes `-s ASSERTIONS=0`, including in debug builds, so `--WITH_DEBUG=yes` does not enable extra runtime checks.
 -->
 
-As informações de depuração e as asserções em tempo de execução são configurações separadas. O Playground passa explicitamente `-s ASSERTIONS=0`, inclusive nas compilações para depuração, portanto `--WITH_DEBUG=yes` não ativa verificações adicionais em tempo de execução.
+La información de depuración y las aserciones en tiempo de ejecución son ajustes independientes. Playground pasa explícitamente `-s ASSERTIONS=0`, incluso en las compilaciones para depuración, por lo que `--WITH_DEBUG=yes` no activa comprobaciones adicionales en tiempo de ejecución.
 
 <!--
 To investigate a runtime failure with assertions, change that setting in the PHP Dockerfile's final `emcc` command and rebuild. Emscripten documents `-s ASSERTIONS=1` for runtime checks and `-s ASSERTIONS=2` for additional, slower checks. There is no `WITH_ASSERTIONS` build option. See the [Emscripten assertions reference](https://emscripten.org/docs/tools_reference/settings_reference.html#assertions).
 -->
 
-Para investigar uma falha em tempo de execução com asserções, altere essa configuração no comando `emcc` final do Dockerfile do PHP e compile novamente. O Emscripten documenta `-s ASSERTIONS=1` para verificações em tempo de execução e `-s ASSERTIONS=2` para verificações adicionais, mais lentas. Não existe uma opção de compilação `WITH_ASSERTIONS`. Consulte a [referência de asserções do Emscripten](https://emscripten.org/docs/tools_reference/settings_reference.html#assertions).
+Para investigar un fallo en tiempo de ejecución con aserciones, cambia ese ajuste en el comando `emcc` final del Dockerfile de PHP y vuelve a compilar. Emscripten documenta `-s ASSERTIONS=1` para comprobaciones en tiempo de ejecución y `-s ASSERTIONS=2` para comprobaciones adicionales, más lentas. No existe una opción de compilación `WITH_ASSERTIONS`. Consulta la [referencia de aserciones de Emscripten](https://emscripten.org/docs/tools_reference/settings_reference.html#assertions).
 
 <!--
 Assertions can also report an environment mismatch between `web` and `worker`. Check the build's `ENVIRONMENT` setting and the JavaScript loader's execution context when investigating those errors; see the [discussion in issue #176](https://github.com/WordPress/wordpress-playground/issues/176#issuecomment-1483754022).
 -->
 
-As asserções também podem indicar uma incompatibilidade de ambiente entre `web` e `worker`. Verifique a configuração `ENVIRONMENT` da compilação e o contexto de execução do carregador JavaScript ao investigar esses erros; consulte a [discussão na issue #176](https://github.com/WordPress/wordpress-playground/issues/176#issuecomment-1483754022).
+Las aserciones también pueden indicar una incompatibilidad de entorno entre `web` y `worker`. Comprueba el ajuste `ENVIRONMENT` de la compilación y el contexto de ejecución del cargador JavaScript al investigar estos errores; consulta la [discusión en la incidencia #176](https://github.com/WordPress/wordpress-playground/issues/176#issuecomment-1483754022).
 
 <!--
 ### PHP next builds
 -->
 
-### Compilações do PHP next
+### Compilaciones de PHP next
 
 <!--
 Playground can also run the next PHP version from the php-src development branch in the web runtime. These builds are published separately from the main repository because the generated WebAssembly files are large and change often.
 -->
 
-O Playground também pode executar a próxima versão do PHP a partir do branch de desenvolvimento do php-src no ambiente web. Essas compilações são publicadas separadamente do repositório principal porque os arquivos WebAssembly gerados são grandes e mudam com frequência.
+Playground también puede ejecutar la próxima versión de PHP desde la rama de desarrollo de php-src en el entorno web. Estas compilaciones se publican por separado del repositorio principal porque los archivos WebAssembly generados son grandes y cambian con frecuencia.
 
 <!--
 The nightly refresh workflow builds the php-src development branch, writes the web artifacts to the gitignored `packages/playground/website/public/php-next/` directory, and publishes the result to the `php-next-builds` branch. Website deploys and the local dev server sync that branch before serving `?php=next`.
 -->
 
-O fluxo de atualização noturno compila o branch de desenvolvimento do php-src, grava os artefatos para a web no diretório `packages/playground/website/public/php-next/`, ignorado pelo Git, e publica o resultado no branch `php-next-builds`. As implantações do site e o servidor de desenvolvimento local sincronizam esse branch antes de servir `?php=next`.
+El flujo de actualización nocturno compila la rama de desarrollo de php-src, escribe los artefactos para la web en el directorio `packages/playground/website/public/php-next/`, ignorado por Git, y publica el resultado en la rama `php-next-builds`. Los despliegues del sitio web y el servidor de desarrollo local sincronizan esa rama antes de servir `?php=next`.
 
 <!--
 To refresh the local copy manually, run:
 -->
 
-Para atualizar a cópia local manualmente, execute:
+Para actualizar la copia local manualmente, ejecuta:
 
 <!--
 ```sh
@@ -235,7 +235,7 @@ npm run sync:php-next
 To rebuild the web artifacts locally from the php-src development branch, run:
 -->
 
-Para recompilar localmente os artefatos para a web a partir do branch de desenvolvimento do php-src, execute:
+Para recompilar localmente los artefactos para la web desde la rama de desarrollo de php-src, ejecuta:
 
 <!--
 ```sh
@@ -251,31 +251,31 @@ npm run recompile:php:web:next
 `php=next` currently ships web main modules only. Matching extension side modules and Playground CLI support are separate follow-up work.
 -->
 
-Atualmente, `php=next` distribui apenas módulos principais para a web. Os módulos auxiliares de extensões correspondentes e o suporte à CLI do Playground serão tratados em trabalhos separados.
+Actualmente, `php=next` solo distribuye módulos principales para la web. Los módulos auxiliares de extensiones correspondientes y la compatibilidad con la CLI de Playground se abordarán en trabajos posteriores independientes.
 
 <!--
 ### PHP extensions
 -->
 
-### Extensões PHP
+### Extensiones de PHP
 
 <!--
 PHP is built with several extensions listed in the [`Dockerfile`](https://github.com/WordPress/wordpress-playground/blob/trunk/packages/php-wasm/compile/php/Dockerfile).
 -->
 
-O PHP é compilado com várias extensões listadas no [`Dockerfile`](https://github.com/WordPress/wordpress-playground/blob/trunk/packages/php-wasm/compile/php/Dockerfile).
+PHP se compila con varias extensiones que se enumeran en el [`Dockerfile`](https://github.com/WordPress/wordpress-playground/blob/trunk/packages/php-wasm/compile/php/Dockerfile).
 
 <!--
 Some extensions, like `zip`, can be turned on or off during the build. Others, like `sqlite3`, are hardcoded.
 -->
 
-Algumas extensões, como `zip`, podem ser ativadas ou desativadas durante a compilação. Outras, como `sqlite3`, são definidas diretamente no código.
+Algunas extensiones, como `zip`, pueden activarse o desactivarse durante la compilación. Otras, como `sqlite3`, están definidas directamente en el código.
 
 <!--
 If you need to turn off one of the hardcoded extensions, feel free to open an issue in this repo. Better yet, this project needs contributors. You are more than welcome to open a PR and author the change you need.
 -->
 
-Se você precisa desativar uma das extensões definidas diretamente no código, fique à vontade para abrir uma issue neste repositório. Melhor ainda: este projeto precisa de colaboradores. Você pode abrir um PR e implementar a alteração de que precisa.
+Si necesitas desactivar una de las extensiones definidas directamente en el código, puedes abrir una incidencia en este repositorio. Mejor aún: este proyecto necesita colaboradores. Puedes abrir una PR e implementar el cambio que necesitas.
 
 <!--
 PHP.wasm can also load dynamic `.so` extensions before PHP starts. Built-in
@@ -286,19 +286,19 @@ mode. See [Loading PHP extensions](/developers/apis/javascript-api/php-extension
 for the runtime API.
 -->
 
-PHP.wasm também pode carregar extensões dinâmicas `.so` antes de iniciar o PHP. Extensões dinâmicas integradas, como `intl`, `xdebug`, `redis` e `memcached`, são distribuídas com o pacote Node, e extensões externas podem ser fornecidas com um manifesto que seleciona o artefato correspondente à versão do PHP e ao modo assíncrono ativos. Consulte [Carregando extensões PHP](/developers/apis/javascript-api/php-extensions) para conhecer a API de execução.
+PHP.wasm también puede cargar extensiones dinámicas `.so` antes de iniciar PHP. Las extensiones dinámicas integradas, como `intl`, `xdebug`, `redis` y `memcached`, se distribuyen con el paquete de Node, y las extensiones externas pueden proporcionarse con un manifiesto que seleccione el artefacto correspondiente a la versión de PHP y al modo asíncrono activos. Consulta [Cargar extensiones de PHP](/developers/apis/javascript-api/php-extensions) para conocer la API de ejecución.
 
 <!--
 ### C API exposed to JavaScript
 -->
 
-### API C exposta ao JavaScript
+### API de C expuesta a JavaScript
 
 <!--
 The C API exposed to JavaScript lives in the [`php_wasm.c`](https://github.com/WordPress/wordpress-playground/blob/trunk/src/packages/php-wasm/compile/build-assets/php_wasm.c) file. The most important functions are:
 -->
 
-A API C exposta ao JavaScript está no arquivo [`php_wasm.c`](https://github.com/WordPress/wordpress-playground/blob/trunk/src/packages/php-wasm/compile/build-assets/php_wasm.c). As funções mais importantes são:
+La API de C expuesta a JavaScript se encuentra en el archivo [`php_wasm.c`](https://github.com/WordPress/wordpress-playground/blob/trunk/src/packages/php-wasm/compile/build-assets/php_wasm.c). Las funciones más importantes son:
 
 <!--
 - `void phpwasm_init()` – It creates a new PHP context and must be called before running any PHP code.
@@ -306,27 +306,27 @@ A API C exposta ao JavaScript está no arquivo [`php_wasm.c`](https://github.com
 - `void phpwasm_refresh()` – Destroy the current PHP context and starts a new one. Call it after running one PHP script and before running another.
 -->
 
-- `void phpwasm_init()` – Cria um novo contexto PHP e deve ser chamada antes de executar qualquer código PHP.
-- `int phpwasm_run(char *code)` – Executa um script PHP e grava a saída em /tmp/stdout e /tmp/stderr. Retorna o código de saída.
-- `void phpwasm_refresh()` – Destrói o contexto PHP atual e inicia um novo. Chame-a após executar um script PHP e antes de executar outro.
+- `void phpwasm_init()` – Crea un nuevo contexto de PHP y debe llamarse antes de ejecutar cualquier código PHP.
+- `int phpwasm_run(char *code)` – Ejecuta un script PHP y escribe la salida en /tmp/stdout y /tmp/stderr. Devuelve el código de salida.
+- `void phpwasm_refresh()` – Destruye el contexto de PHP actual e inicia uno nuevo. Llámala después de ejecutar un script PHP y antes de ejecutar otro.
 
 <!--
 Refer to the inline documentation in [`php_wasm.c`](https://github.com/WordPress/wordpress-playground/blob/trunk/src/packages/php-wasm/compile/build-assets/php_wasm.c) to learn more.
 -->
 
-Consulte a documentação no código de [`php_wasm.c`](https://github.com/WordPress/wordpress-playground/blob/trunk/src/packages/php-wasm/compile/build-assets/php_wasm.c) para saber mais.
+Consulta la documentación incluida en [`php_wasm.c`](https://github.com/WordPress/wordpress-playground/blob/trunk/src/packages/php-wasm/compile/build-assets/php_wasm.c) para obtener más información.
 
 <!--
 ### Build configuration
 -->
 
-### Configuração da compilação
+### Configuración de la compilación
 
 <!--
 The build is configurable via the [Docker `--build-arg` feature](https://docs.docker.com/engine/reference/commandline/build/#set-build-time-variables---build-arg). You can set them up through the `build.js` script, just run this command to get the usage message:
 -->
 
-A compilação é configurável pelo [recurso `--build-arg` do Docker](https://docs.docker.com/engine/reference/commandline/build/#set-build-time-variables---build-arg). Você pode definir as opções pelo script `build.js`; execute este comando para ver as instruções de uso:
+La compilación se puede configurar mediante la [opción `--build-arg` de Docker](https://docs.docker.com/engine/reference/commandline/build/#set-build-time-variables---build-arg). Puedes definir los ajustes mediante el script `build.js`; ejecuta este comando para ver las instrucciones de uso:
 
 <!--
 ```sh
@@ -342,7 +342,7 @@ npx nx recompile-php:jspi php-wasm-web -- --help
 **Supported build options:**
 -->
 
-**Opções de compilação suportadas:**
+**Opciones de compilación disponibles:**
 
 <!--
 - `WITH_DEBUG` – `yes` or `no`. Build with DWARF debug information and disable final optimization. See [Debug builds](#debug-builds).
@@ -354,10 +354,10 @@ npx nx recompile-php:jspi php-wasm-web -- --help
 - `WITH_NODEFS` – `yes` or `no`, default: `no`. Whether to include [the Emscripten's NODEFS JavaScript library](https://emscripten.org/docs/api_reference/Filesystem-API.html#filesystem-api-nodefs). It's useful for loading files and mounting directories from the local filesystem when running php.wasm from Node.js.
 -->
 
-- `WITH_DEBUG` – `yes` ou `no`. Compila com informações de depuração DWARF e desativa a otimização final. Consulte [Compilações para depuração](#debug-builds).
-- `WITH_SOURCEMAPS` – `yes` ou `no`. Gera mapas de código-fonte WebAssembly e desativa a otimização final. Consulte [Compilações para depuração](#debug-builds).
-- `PHP_VERSION` – A versão do PHP a compilar, padrão: `8.0.24`. Esse valor deve corresponder a um branch existente do repositório https://github.com/php/php-src.git quando precedido por `PHP-`. Por exemplo, `7.4.0` é válido porque o branch `PHP-7.4.0` existe, mas apenas `7` é inválido porque não existe um branch `PHP-7`. As versões do PHP que sabemos que funcionam são `7.4.*` e `8.0.*`. Outras provavelmente também funcionam, mas não foram testadas.
-- `EMSCRIPTEN_ENVIRONMENT` – `web` ou `node`, padrão: `web`. A plataforma para a qual compilar. Ao compilar para `web`, dois carregadores JavaScript são criados: `php-web.js` e `php-webworker.js`. Ao compilar para Node.js, apenas um carregador chamado `php-node.js` é criado.
-- `WITH_LIBXML` – `yes` ou `no`, padrão: `no`. Define se a compilação inclui `libxml2` e as extensões PHP `dom`, `xml` e `simplexml` (`DOMDocument`, `SimpleXML`, ...).
-- `WITH_LIBZIP` – `yes` ou `no`, padrão: `yes`. Define se a compilação inclui `zlib`, `libzip` e a extensão PHP `zip` (`ZipArchive`).
-- `WITH_NODEFS` – `yes` ou `no`, padrão: `no`. Define se a compilação inclui [a biblioteca JavaScript NODEFS do Emscripten](https://emscripten.org/docs/api_reference/Filesystem-API.html#filesystem-api-nodefs). Ela permite carregar arquivos e montar diretórios do sistema de arquivos local ao executar php.wasm no Node.js.
+- `WITH_DEBUG` – `yes` o `no`. Compila con información de depuración DWARF y desactiva la optimización final. Consulta [Compilaciones para depuración](#debug-builds).
+- `WITH_SOURCEMAPS` – `yes` o `no`. Genera mapas de código fuente de WebAssembly y desactiva la optimización final. Consulta [Compilaciones para depuración](#debug-builds).
+- `PHP_VERSION` – La versión de PHP que se compilará, predeterminada: `8.0.24`. Este valor debe corresponder a una rama existente del repositorio https://github.com/php/php-src.git al añadirle el prefijo `PHP-`. Por ejemplo, `7.4.0` es válido porque existe la rama `PHP-7.4.0`, pero solo `7` no es válido porque no existe la rama `PHP-7`. Las versiones de PHP que se sabe que funcionan son `7.4.*` y `8.0.*`. Es probable que otras también funcionen, pero no se han probado.
+- `EMSCRIPTEN_ENVIRONMENT` – `web` o `node`, predeterminado: `web`. La plataforma de destino de la compilación. Al compilar para `web`, se crean dos cargadores JavaScript: `php-web.js` y `php-webworker.js`. Al compilar para Node.js, solo se crea un cargador llamado `php-node.js`.
+- `WITH_LIBXML` – `yes` o `no`, predeterminado: `no`. Indica si se incluye `libxml2` y las extensiones de PHP `dom`, `xml` y `simplexml` (`DOMDocument`, `SimpleXML`, ...).
+- `WITH_LIBZIP` – `yes` o `no`, predeterminado: `yes`. Indica si se incluye `zlib`, `libzip` y la extensión de PHP `zip` (`ZipArchive`).
+- `WITH_NODEFS` – `yes` o `no`, predeterminado: `no`. Indica si se incluye [la biblioteca JavaScript NODEFS de Emscripten](https://emscripten.org/docs/api_reference/Filesystem-API.html#filesystem-api-nodefs). Permite cargar archivos y montar directorios del sistema de archivos local al ejecutar php.wasm desde Node.js.

--- a/packages/docs/site/i18n/fr/docusaurus-plugin-content-docs/current/developers/23-architecture/03-wasm-php-compiling.md
+++ b/packages/docs/site/i18n/fr/docusaurus-plugin-content-docs/current/developers/23-architecture/03-wasm-php-compiling.md
@@ -46,10 +46,10 @@ To find out more about each step, refer directly to the [Dockerfile](https://git
 Pour en savoir plus sur chaque étape, consultez directement le [Dockerfile](https://github.com/WordPress/wordpress-playground/blob/trunk/packages/php-wasm/compile/php/Dockerfile).
 
 <!--
-### Building
+## Building
 -->
 
-### Compilation
+## Compilation
 
 <!--
 With Docker running and the repository dependencies installed, run these commands from the repository root:
@@ -68,10 +68,10 @@ npx nx recompile-php:jspi php-wasm-web -- --PHP_VERSION=8.4
 -->
 
 ```sh
-# Compile toutes les versions PHP prises en charge pour le web, en modes JSPI et Asyncify.
+# Compile toutes les versions PHP prises en charge pour le web, aux modes JSPI et Asyncify.
 npx nx recompile-php:all php-wasm-web
 
-# Compile uniquement PHP 8.4 pour le web, en mode JSPI.
+# Compile uniquement PHP 8.4 pour le web, au mode JSPI.
 npx nx recompile-php:jspi php-wasm-web -- --PHP_VERSION=8.4
 ```
 
@@ -82,10 +82,10 @@ Replace `php-wasm-web` with `php-wasm-node` to build for Node.js, or `recompile-
 Remplacez `php-wasm-web` par `php-wasm-node` pour compiler pour Node.js, ou `recompile-php:jspi` par `recompile-php:asyncify` pour compiler la variante Asyncify. Les fichiers sont générés dans `packages/php-wasm/web-builds/<major>-<minor>/<mode>/` ou `packages/php-wasm/node-builds/<major>-<minor>/<mode>/`.
 
 <!--
-### Debug builds
+## Debug builds
 -->
 
-### Compilations de débogage {#debug-builds}
+## Compilations de débogage {#debug-builds}
 
 <!--
 Use `--WITH_DEBUG=yes` to build PHP.wasm with readable JavaScript output and DWARF debug information for stepping through C code in a WebAssembly debugger:
@@ -140,10 +140,10 @@ This generates a `php.wasm.map` file and copies the source files needed for debu
 Cette option génère un fichier `php.wasm.map` et copie les fichiers sources nécessaires au débogage dans le répertoire de sortie de la compilation. Pour les compilations web, l’URL de la carte de sources pointe vers le serveur de développement local à l’adresse `http://127.0.0.1:5400` ; exécutez `npm run dev` pour la rendre accessible.
 
 <!--
-#### Emscripten options
+### Emscripten options
 -->
 
-#### Options d’Emscripten
+### Options d’Emscripten
 
 <!--
 The build script translates these options into compiler flags in the [PHP Dockerfile](https://github.com/WordPress/wordpress-playground/blob/trunk/packages/php-wasm/compile/php/Dockerfile):
@@ -174,10 +174,10 @@ See the [Emscripten compiler reference](https://emscripten.org/docs/tools_refere
 Consultez la [référence du compilateur Emscripten](https://emscripten.org/docs/tools_reference/emcc.html) pour en savoir plus sur ces paramètres.
 
 <!--
-#### Runtime assertions
+### Runtime assertions
 -->
 
-#### Assertions à l’exécution
+### Assertions à l’exécution
 
 <!--
 Debug information and runtime assertions are separate settings. Playground explicitly passes `-s ASSERTIONS=0`, including in debug builds, so `--WITH_DEBUG=yes` does not enable extra runtime checks.
@@ -192,16 +192,10 @@ To investigate a runtime failure with assertions, change that setting in the PHP
 Pour analyser une erreur à l’exécution avec des assertions, modifiez ce réglage dans la commande `emcc` finale du Dockerfile de PHP et recompilez. Emscripten documente `-s ASSERTIONS=1` pour les vérifications à l’exécution et `-s ASSERTIONS=2` pour des vérifications supplémentaires, plus lentes. Il n’existe pas d’option de compilation `WITH_ASSERTIONS`. Consultez la [référence des assertions d’Emscripten](https://emscripten.org/docs/tools_reference/settings_reference.html#assertions).
 
 <!--
-Assertions can also report an environment mismatch between `web` and `worker`. Check the build's `ENVIRONMENT` setting and the JavaScript loader's execution context when investigating those errors; see the [discussion in issue #176](https://github.com/WordPress/wordpress-playground/issues/176#issuecomment-1483754022).
+## PHP next builds
 -->
 
-Les assertions peuvent aussi signaler une incompatibilité d’environnement entre `web` et `worker`. Vérifiez le réglage `ENVIRONMENT` de la compilation et le contexte d’exécution du chargeur JavaScript lorsque vous analysez ces erreurs ; consultez la [discussion dans le ticket #176](https://github.com/WordPress/wordpress-playground/issues/176#issuecomment-1483754022).
-
-<!--
-### PHP next builds
--->
-
-### Compilations de PHP next
+## Compilations de PHP next
 
 <!--
 Playground can also run the next PHP version from the php-src development branch in the web runtime. These builds are published separately from the main repository because the generated WebAssembly files are large and change often.
@@ -254,10 +248,10 @@ npm run recompile:php:web:next
 Actuellement, `php=next` ne distribue que des modules principaux pour le web. Les modules secondaires des extensions correspondantes et la prise en charge de la CLI de Playground feront l’objet de travaux ultérieurs distincts.
 
 <!--
-### PHP extensions
+## PHP extensions
 -->
 
-### Extensions PHP
+## Extensions PHP
 
 <!--
 PHP is built with several extensions listed in the [`Dockerfile`](https://github.com/WordPress/wordpress-playground/blob/trunk/packages/php-wasm/compile/php/Dockerfile).
@@ -289,10 +283,10 @@ for the runtime API.
 PHP.wasm peut aussi charger des extensions dynamiques `.so` avant le démarrage de PHP. Les extensions dynamiques intégrées, comme `intl`, `xdebug`, `redis` et `memcached`, sont distribuées avec le paquet Node. Les extensions externes peuvent être fournies avec un manifeste qui sélectionne l’artefact correspondant à la version de PHP et au mode asynchrone actifs. Consultez [Charger des extensions PHP](/developers/apis/javascript-api/php-extensions) pour découvrir l’API d’exécution.
 
 <!--
-### C API exposed to JavaScript
+## C API exposed to JavaScript
 -->
 
-### API C exposée à JavaScript
+## API C exposée à JavaScript
 
 <!--
 The C API exposed to JavaScript lives in the [`php_wasm.c`](https://github.com/WordPress/wordpress-playground/blob/trunk/src/packages/php-wasm/compile/build-assets/php_wasm.c) file. The most important functions are:
@@ -317,10 +311,10 @@ Refer to the inline documentation in [`php_wasm.c`](https://github.com/WordPress
 Consultez la documentation dans le code de [`php_wasm.c`](https://github.com/WordPress/wordpress-playground/blob/trunk/src/packages/php-wasm/compile/build-assets/php_wasm.c) pour en savoir plus.
 
 <!--
-### Build configuration
+## Build configuration
 -->
 
-### Configuration de la compilation
+## Configuration de la compilation
 
 <!--
 The build is configurable via the [Docker `--build-arg` feature](https://docs.docker.com/engine/reference/commandline/build/#set-build-time-variables---build-arg). You can set them up through the `build.js` script, just run this command to get the usage message:
@@ -339,15 +333,19 @@ npx nx recompile-php:jspi php-wasm-web -- --help
 ```
 
 <!--
-**Supported build options:**
+**Selected build options:**
+
+This list highlights debug and basic build settings. For the full set of options, run the help command above; see [the build script](https://github.com/WordPress/wordpress-playground/blob/trunk/packages/php-wasm/compile/build.js) for platform-specific defaults.
 -->
 
-**Options de compilation prises en charge :**
+**Sélection d’options de compilation :**
+
+Cette liste présente les réglages de débogage et de compilation de base. Pour consulter toutes les options, exécutez la commande d’aide ci-dessus ; consultez [le script de compilation](https://github.com/WordPress/wordpress-playground/blob/trunk/packages/php-wasm/compile/build.js) pour les valeurs par défaut propres à chaque plateforme.
 
 <!--
 - `WITH_DEBUG` – `yes` or `no`. Build with DWARF debug information and disable final optimization. See [Debug builds](#debug-builds).
 - `WITH_SOURCEMAPS` – `yes` or `no`. Generate WebAssembly source maps and disable final optimization. See [Debug builds](#debug-builds).
-- `PHP_VERSION` – The PHP version to build, default: `8.0.24`. This value must point to an existing branch of the https://github.com/php/php-src.git repository when prefixed with `PHP-`. For example, `7.4.0` is valid because the branch `PHP-7.4.0` exists, but just `7` is invalid because there's no branch `PHP-7`. The PHP versions that are known to work are `7.4.*` and `8.0.*`. Others likely work as well but they haven't been tried.
+- `PHP_VERSION` – The PHP version to build. Use a major/minor version such as `8.4` to select its latest release from [the supported PHP versions](https://github.com/WordPress/wordpress-playground/blob/trunk/packages/php-wasm/supported-php-versions.mjs), or an exact release such as `8.4.25`. The build clones the corresponding `php-<version>` tag from php-src.
 - `EMSCRIPTEN_ENVIRONMENT` – `web` or `node`, default: `web`. The platform to build for. When building for `web`, two JavaScript loaders will be created: `php-web.js` and `php-webworker.js`. When building for Node.js, only one loader called `php-node.js` will be created.
 - `WITH_LIBXML` – `yes` or `no`, default: `no`. Whether to build with `libxml2` and the `dom`, `xml`, and `simplexml` PHP extensions (`DOMDocument`, `SimpleXML`, ..).
 - `WITH_LIBZIP` – `yes` or `no`, default: `yes`. Whether to build with `zlib`, `libzip`, and the `zip` PHP extension (`ZipArchive`).
@@ -356,7 +354,7 @@ npx nx recompile-php:jspi php-wasm-web -- --help
 
 - `WITH_DEBUG` – `yes` ou `no`. Compile avec les informations de débogage DWARF et désactive l’optimisation finale. Consultez [Compilations de débogage](#debug-builds).
 - `WITH_SOURCEMAPS` – `yes` ou `no`. Génère des cartes de sources WebAssembly et désactive l’optimisation finale. Consultez [Compilations de débogage](#debug-builds).
-- `PHP_VERSION` – La version de PHP à compiler, par défaut : `8.0.24`. Cette valeur doit correspondre à une branche existante du dépôt https://github.com/php/php-src.git lorsqu’elle est précédée de `PHP-`. Par exemple, `7.4.0` est valide, car la branche `PHP-7.4.0` existe, mais `7` seul n’est pas valide, car il n’existe pas de branche `PHP-7`. Les versions de PHP dont le fonctionnement est confirmé sont `7.4.*` et `8.0.*`. Les autres fonctionnent probablement aussi, mais n’ont pas été testées.
+- `PHP_VERSION` – La version de PHP à compiler. Utilisez une version majeure/mineure comme `8.4` pour sélectionner sa dernière version dans [les versions de PHP prises en charge](https://github.com/WordPress/wordpress-playground/blob/trunk/packages/php-wasm/supported-php-versions.mjs), ou une version exacte comme `8.4.25`. La compilation clone le tag `php-<version>` correspondant de php-src.
 - `EMSCRIPTEN_ENVIRONMENT` – `web` ou `node`, par défaut : `web`. La plateforme cible de la compilation. Pour `web`, deux chargeurs JavaScript sont créés : `php-web.js` et `php-webworker.js`. Pour Node.js, un seul chargeur, nommé `php-node.js`, est créé.
 - `WITH_LIBXML` – `yes` ou `no`, par défaut : `no`. Indique s’il faut compiler avec `libxml2` et les extensions PHP `dom`, `xml` et `simplexml` (`DOMDocument`, `SimpleXML`, ...).
 - `WITH_LIBZIP` – `yes` ou `no`, par défaut : `yes`. Indique s’il faut compiler avec `zlib`, `libzip` et l’extension PHP `zip` (`ZipArchive`).

--- a/packages/docs/site/i18n/fr/docusaurus-plugin-content-docs/current/developers/23-architecture/03-wasm-php-compiling.md
+++ b/packages/docs/site/i18n/fr/docusaurus-plugin-content-docs/current/developers/23-architecture/03-wasm-php-compiling.md
@@ -1,0 +1,363 @@
+---
+title: Compiler PHP
+slug: /developers/architecture/wasm-php-compiling
+---
+
+<!--
+# Compiling PHP
+-->
+
+# Compiler PHP
+
+<!--
+The build pipeline lives in a [`Dockerfile`](https://github.com/WordPress/wordpress-playground/blob/trunk/packages/php-wasm/compile/php/Dockerfile). It was originally forked from [seanmorris/php-wasm](https://github.com/seanmorris/php-wasm)
+-->
+
+Le processus de compilation se trouve dans un [`Dockerfile`](https://github.com/WordPress/wordpress-playground/blob/trunk/packages/php-wasm/compile/php/Dockerfile). Il est issu à l’origine d’un fork de [seanmorris/php-wasm](https://github.com/seanmorris/php-wasm).
+
+<!--
+In broad strokes, that `Dockerfile`:
+-->
+
+Dans les grandes lignes, ce `Dockerfile` :
+
+<!--
+- Installs all the necessary linux packages (like `build-essential`)
+- Downloads PHP and the required libraries, e.g. `sqlite3`.
+- Applies a few patches.
+- Compiles everything using [Emscripten](https://emscripten.org/), a drop-in replacement for the C compiler.
+- Compiles `php_wasm.c` – a convenient API for JavaScript.
+- Outputs a `php.wasm` file and one or more JavaScript loaders, depending on the configuration.
+- Transforms the Emscripten's default `php.js` output into an ESM module with additional features.
+-->
+
+- Installe tous les paquets Linux nécessaires (comme `build-essential`).
+- Télécharge PHP et les bibliothèques nécessaires, par exemple `sqlite3`.
+- Applique quelques correctifs.
+- Compile le tout avec [Emscripten](https://emscripten.org/), un remplacement direct du compilateur C.
+- Compile `php_wasm.c`, une API pratique pour JavaScript.
+- Génère un fichier `php.wasm` et un ou plusieurs chargeurs JavaScript, selon la configuration.
+- Transforme la sortie par défaut `php.js` d’Emscripten en un module ESM doté de fonctionnalités supplémentaires.
+
+<!--
+To find out more about each step, refer directly to the [Dockerfile](https://github.com/WordPress/wordpress-playground/blob/trunk/packages/php-wasm/compile/php/Dockerfile).
+-->
+
+Pour en savoir plus sur chaque étape, consultez directement le [Dockerfile](https://github.com/WordPress/wordpress-playground/blob/trunk/packages/php-wasm/compile/php/Dockerfile).
+
+<!--
+### Building
+-->
+
+### Compilation
+
+<!--
+With Docker running and the repository dependencies installed, run these commands from the repository root:
+-->
+
+Une fois Docker lancé et les dépendances du dépôt installées, exécutez ces commandes à la racine du dépôt :
+
+<!--
+```sh
+# Build all supported PHP versions for the web, in both JSPI and Asyncify modes.
+npx nx recompile-php:all php-wasm-web
+
+# Build only PHP 8.4 for the web, in JSPI mode.
+npx nx recompile-php:jspi php-wasm-web -- --PHP_VERSION=8.4
+```
+-->
+
+```sh
+# Compile toutes les versions PHP prises en charge pour le web, en modes JSPI et Asyncify.
+npx nx recompile-php:all php-wasm-web
+
+# Compile uniquement PHP 8.4 pour le web, en mode JSPI.
+npx nx recompile-php:jspi php-wasm-web -- --PHP_VERSION=8.4
+```
+
+<!--
+Replace `php-wasm-web` with `php-wasm-node` to build for Node.js, or `recompile-php:jspi` with `recompile-php:asyncify` to build the Asyncify variant. The output goes to `packages/php-wasm/web-builds/<major>-<minor>/<mode>/` or `packages/php-wasm/node-builds/<major>-<minor>/<mode>/`.
+-->
+
+Remplacez `php-wasm-web` par `php-wasm-node` pour compiler pour Node.js, ou `recompile-php:jspi` par `recompile-php:asyncify` pour compiler la variante Asyncify. Les fichiers sont générés dans `packages/php-wasm/web-builds/<major>-<minor>/<mode>/` ou `packages/php-wasm/node-builds/<major>-<minor>/<mode>/`.
+
+<!--
+### Debug builds
+-->
+
+### Compilations de débogage {#debug-builds}
+
+<!--
+Use `--WITH_DEBUG=yes` to build PHP.wasm with readable JavaScript output and DWARF debug information for stepping through C code in a WebAssembly debugger:
+-->
+
+Utilisez `--WITH_DEBUG=yes` pour compiler PHP.wasm avec une sortie JavaScript lisible et des informations de débogage DWARF permettant de parcourir le code C pas à pas dans un débogueur WebAssembly :
+
+<!--
+```sh
+# Build PHP 8.4 for debugging in the browser.
+npx nx recompile-php:jspi php-wasm-web -- --PHP_VERSION=8.4 --WITH_DEBUG=yes
+
+# Build PHP 8.4 for debugging in Node.js.
+npx nx recompile-php:jspi php-wasm-node -- --PHP_VERSION=8.4 --WITH_DEBUG=yes
+```
+-->
+
+```sh
+# Compile PHP 8.4 pour le débogage dans le navigateur.
+npx nx recompile-php:jspi php-wasm-web -- --PHP_VERSION=8.4 --WITH_DEBUG=yes
+
+# Compile PHP 8.4 pour le débogage dans Node.js.
+npx nx recompile-php:jspi php-wasm-node -- --PHP_VERSION=8.4 --WITH_DEBUG=yes
+```
+
+<!--
+The same option works with `recompile-php:asyncify`. Debug builds produce larger files and run more slowly than optimized builds. They replace the selected version's artifacts in the output directory described above. Rebuild with `--WITH_DEBUG=no --WITH_SOURCEMAPS=no` to restore an optimized build.
+-->
+
+La même option fonctionne avec `recompile-php:asyncify`. Les compilations de débogage génèrent des fichiers plus volumineux et s’exécutent plus lentement que les compilations optimisées. Elles remplacent les artefacts de la version sélectionnée dans le répertoire de sortie décrit ci-dessus. Recompilez avec `--WITH_DEBUG=no --WITH_SOURCEMAPS=no` pour rétablir une compilation optimisée.
+
+<!--
+For WebAssembly source maps, use `--WITH_SOURCEMAPS=yes`:
+-->
+
+Pour générer des cartes de sources WebAssembly, utilisez `--WITH_SOURCEMAPS=yes` :
+
+<!--
+```sh
+npx nx recompile-php:jspi php-wasm-web -- --PHP_VERSION=8.4 --WITH_SOURCEMAPS=yes
+```
+-->
+
+```sh
+npx nx recompile-php:jspi php-wasm-web -- --PHP_VERSION=8.4 --WITH_SOURCEMAPS=yes
+```
+
+<!--
+This generates a `php.wasm.map` file and copies the source files needed for debugging into the build output. For web builds, the source map URL points to the local development server at `http://127.0.0.1:5400`; run `npm run dev` to serve it.
+-->
+
+Cette option génère un fichier `php.wasm.map` et copie les fichiers sources nécessaires au débogage dans le répertoire de sortie de la compilation. Pour les compilations web, l’URL de la carte de sources pointe vers le serveur de développement local à l’adresse `http://127.0.0.1:5400` ; exécutez `npm run dev` pour la rendre accessible.
+
+<!--
+#### Emscripten options
+-->
+
+#### Options d’Emscripten
+
+<!--
+The build script translates these options into compiler flags in the [PHP Dockerfile](https://github.com/WordPress/wordpress-playground/blob/trunk/packages/php-wasm/compile/php/Dockerfile):
+-->
+
+Le script de compilation traduit ces options en paramètres du compilateur dans le [Dockerfile de PHP](https://github.com/WordPress/wordpress-playground/blob/trunk/packages/php-wasm/compile/php/Dockerfile) :
+
+<!--
+| Flag           | Purpose                                                                                                | When Playground uses it                                                 |
+| -------------- | ------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------- |
+| `-O0`          | Disables optimization of the final WebAssembly and JavaScript output.                                  | `WITH_DEBUG=yes` or `WITH_SOURCEMAPS=yes`, replacing the default `-O3`. |
+| `-g2`          | Keeps function names and readable JavaScript, without retaining DWARF information in the final module. | Node.js builds when neither debug option is enabled.                    |
+| `-g3`          | Retains DWARF information for source-level debugging.                                                  | `WITH_DEBUG=yes` or `WITH_SOURCEMAPS=yes`.                              |
+| `-gsource-map` | Generates a WebAssembly source map from compiler debug information.                                    | `WITH_SOURCEMAPS=yes`.                                                  |
+-->
+
+| Paramètre      | Rôle                                                                                                                  | Quand Playground l’utilise                                                                   |
+| -------------- | --------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| `-O0`          | Désactive l’optimisation de la sortie finale WebAssembly et JavaScript.                                               | `WITH_DEBUG=yes` ou `WITH_SOURCEMAPS=yes`, à la place de la valeur par défaut `-O3`.         |
+| `-g2`          | Conserve les noms des fonctions et un JavaScript lisible, sans conserver les informations DWARF dans le module final. | Compilations pour Node.js lorsque ni l’une ni l’autre des options de débogage n’est activée. |
+| `-g3`          | Conserve les informations DWARF pour le débogage au niveau du code source.                                            | `WITH_DEBUG=yes` ou `WITH_SOURCEMAPS=yes`.                                                   |
+| `-gsource-map` | Génère une carte de sources WebAssembly à partir des informations de débogage du compilateur.                         | `WITH_SOURCEMAPS=yes`.                                                                       |
+
+<!--
+See the [Emscripten compiler reference](https://emscripten.org/docs/tools_reference/emcc.html) for details on these flags.
+-->
+
+Consultez la [référence du compilateur Emscripten](https://emscripten.org/docs/tools_reference/emcc.html) pour en savoir plus sur ces paramètres.
+
+<!--
+#### Runtime assertions
+-->
+
+#### Assertions à l’exécution
+
+<!--
+Debug information and runtime assertions are separate settings. Playground explicitly passes `-s ASSERTIONS=0`, including in debug builds, so `--WITH_DEBUG=yes` does not enable extra runtime checks.
+-->
+
+Les informations de débogage et les assertions à l’exécution sont des réglages distincts. Playground passe explicitement `-s ASSERTIONS=0`, y compris dans les compilations de débogage. L’option `--WITH_DEBUG=yes` n’active donc pas de vérifications supplémentaires à l’exécution.
+
+<!--
+To investigate a runtime failure with assertions, change that setting in the PHP Dockerfile's final `emcc` command and rebuild. Emscripten documents `-s ASSERTIONS=1` for runtime checks and `-s ASSERTIONS=2` for additional, slower checks. There is no `WITH_ASSERTIONS` build option. See the [Emscripten assertions reference](https://emscripten.org/docs/tools_reference/settings_reference.html#assertions).
+-->
+
+Pour analyser une erreur à l’exécution avec des assertions, modifiez ce réglage dans la commande `emcc` finale du Dockerfile de PHP et recompilez. Emscripten documente `-s ASSERTIONS=1` pour les vérifications à l’exécution et `-s ASSERTIONS=2` pour des vérifications supplémentaires, plus lentes. Il n’existe pas d’option de compilation `WITH_ASSERTIONS`. Consultez la [référence des assertions d’Emscripten](https://emscripten.org/docs/tools_reference/settings_reference.html#assertions).
+
+<!--
+Assertions can also report an environment mismatch between `web` and `worker`. Check the build's `ENVIRONMENT` setting and the JavaScript loader's execution context when investigating those errors; see the [discussion in issue #176](https://github.com/WordPress/wordpress-playground/issues/176#issuecomment-1483754022).
+-->
+
+Les assertions peuvent aussi signaler une incompatibilité d’environnement entre `web` et `worker`. Vérifiez le réglage `ENVIRONMENT` de la compilation et le contexte d’exécution du chargeur JavaScript lorsque vous analysez ces erreurs ; consultez la [discussion dans le ticket #176](https://github.com/WordPress/wordpress-playground/issues/176#issuecomment-1483754022).
+
+<!--
+### PHP next builds
+-->
+
+### Compilations de PHP next
+
+<!--
+Playground can also run the next PHP version from the php-src development branch in the web runtime. These builds are published separately from the main repository because the generated WebAssembly files are large and change often.
+-->
+
+Playground peut aussi exécuter la prochaine version de PHP depuis la branche de développement de php-src dans l’environnement web. Ces compilations sont publiées séparément du dépôt principal, car les fichiers WebAssembly générés sont volumineux et changent souvent.
+
+<!--
+The nightly refresh workflow builds the php-src development branch, writes the web artifacts to the gitignored `packages/playground/website/public/php-next/` directory, and publishes the result to the `php-next-builds` branch. Website deploys and the local dev server sync that branch before serving `?php=next`.
+-->
+
+Le workflow de mise à jour nocturne compile la branche de développement de php-src, écrit les artefacts web dans le répertoire `packages/playground/website/public/php-next/`, ignoré par Git, et publie le résultat dans la branche `php-next-builds`. Les déploiements du site et le serveur de développement local synchronisent cette branche avant de servir `?php=next`.
+
+<!--
+To refresh the local copy manually, run:
+-->
+
+Pour actualiser manuellement la copie locale, exécutez :
+
+<!--
+```sh
+npm run sync:php-next
+```
+-->
+
+```sh
+npm run sync:php-next
+```
+
+<!--
+To rebuild the web artifacts locally from the php-src development branch, run:
+-->
+
+Pour recompiler localement les artefacts web depuis la branche de développement de php-src, exécutez :
+
+<!--
+```sh
+npm run recompile:php:web:next
+```
+-->
+
+```sh
+npm run recompile:php:web:next
+```
+
+<!--
+`php=next` currently ships web main modules only. Matching extension side modules and Playground CLI support are separate follow-up work.
+-->
+
+Actuellement, `php=next` ne distribue que des modules principaux pour le web. Les modules secondaires des extensions correspondantes et la prise en charge de la CLI de Playground feront l’objet de travaux ultérieurs distincts.
+
+<!--
+### PHP extensions
+-->
+
+### Extensions PHP
+
+<!--
+PHP is built with several extensions listed in the [`Dockerfile`](https://github.com/WordPress/wordpress-playground/blob/trunk/packages/php-wasm/compile/php/Dockerfile).
+-->
+
+PHP est compilé avec plusieurs extensions répertoriées dans le [`Dockerfile`](https://github.com/WordPress/wordpress-playground/blob/trunk/packages/php-wasm/compile/php/Dockerfile).
+
+<!--
+Some extensions, like `zip`, can be turned on or off during the build. Others, like `sqlite3`, are hardcoded.
+-->
+
+Certaines extensions, comme `zip`, peuvent être activées ou désactivées lors de la compilation. D’autres, comme `sqlite3`, sont définies directement dans le code.
+
+<!--
+If you need to turn off one of the hardcoded extensions, feel free to open an issue in this repo. Better yet, this project needs contributors. You are more than welcome to open a PR and author the change you need.
+-->
+
+Si vous devez désactiver une extension définie directement dans le code, vous pouvez ouvrir un ticket dans ce dépôt. Mieux encore : ce projet a besoin de contributions. Vous pouvez ouvrir une PR et implémenter la modification dont vous avez besoin.
+
+<!--
+PHP.wasm can also load dynamic `.so` extensions before PHP starts. Built-in
+dynamic extensions such as `intl`, `xdebug`, `redis`, and `memcached` are
+distributed with the Node package, and external extensions can be supplied with
+a manifest that selects the artifact matching the active PHP version and async
+mode. See [Loading PHP extensions](/developers/apis/javascript-api/php-extensions)
+for the runtime API.
+-->
+
+PHP.wasm peut aussi charger des extensions dynamiques `.so` avant le démarrage de PHP. Les extensions dynamiques intégrées, comme `intl`, `xdebug`, `redis` et `memcached`, sont distribuées avec le paquet Node. Les extensions externes peuvent être fournies avec un manifeste qui sélectionne l’artefact correspondant à la version de PHP et au mode asynchrone actifs. Consultez [Charger des extensions PHP](/developers/apis/javascript-api/php-extensions) pour découvrir l’API d’exécution.
+
+<!--
+### C API exposed to JavaScript
+-->
+
+### API C exposée à JavaScript
+
+<!--
+The C API exposed to JavaScript lives in the [`php_wasm.c`](https://github.com/WordPress/wordpress-playground/blob/trunk/src/packages/php-wasm/compile/build-assets/php_wasm.c) file. The most important functions are:
+-->
+
+L’API C exposée à JavaScript se trouve dans le fichier [`php_wasm.c`](https://github.com/WordPress/wordpress-playground/blob/trunk/src/packages/php-wasm/compile/build-assets/php_wasm.c). Les fonctions les plus importantes sont :
+
+<!--
+- `void phpwasm_init()` – It creates a new PHP context and must be called before running any PHP code.
+- `int phpwasm_run(char *code)` – Runs a PHP script and writes the output to /tmp/stdout and /tmp/stderr. Returns the exit code.
+- `void phpwasm_refresh()` – Destroy the current PHP context and starts a new one. Call it after running one PHP script and before running another.
+-->
+
+- `void phpwasm_init()` – Crée un nouveau contexte PHP et doit être appelée avant d’exécuter du code PHP.
+- `int phpwasm_run(char *code)` – Exécute un script PHP et écrit la sortie dans /tmp/stdout et /tmp/stderr. Renvoie le code de sortie.
+- `void phpwasm_refresh()` – Détruit le contexte PHP actuel et en démarre un nouveau. Appelez-la après l’exécution d’un script PHP et avant d’en exécuter un autre.
+
+<!--
+Refer to the inline documentation in [`php_wasm.c`](https://github.com/WordPress/wordpress-playground/blob/trunk/src/packages/php-wasm/compile/build-assets/php_wasm.c) to learn more.
+-->
+
+Consultez la documentation dans le code de [`php_wasm.c`](https://github.com/WordPress/wordpress-playground/blob/trunk/src/packages/php-wasm/compile/build-assets/php_wasm.c) pour en savoir plus.
+
+<!--
+### Build configuration
+-->
+
+### Configuration de la compilation
+
+<!--
+The build is configurable via the [Docker `--build-arg` feature](https://docs.docker.com/engine/reference/commandline/build/#set-build-time-variables---build-arg). You can set them up through the `build.js` script, just run this command to get the usage message:
+-->
+
+La compilation est configurable avec la [fonctionnalité `--build-arg` de Docker](https://docs.docker.com/engine/reference/commandline/build/#set-build-time-variables---build-arg). Vous pouvez définir les options avec le script `build.js` ; exécutez cette commande pour afficher les instructions d’utilisation :
+
+<!--
+```sh
+npx nx recompile-php:jspi php-wasm-web -- --help
+```
+-->
+
+```sh
+npx nx recompile-php:jspi php-wasm-web -- --help
+```
+
+<!--
+**Supported build options:**
+-->
+
+**Options de compilation prises en charge :**
+
+<!--
+- `WITH_DEBUG` – `yes` or `no`. Build with DWARF debug information and disable final optimization. See [Debug builds](#debug-builds).
+- `WITH_SOURCEMAPS` – `yes` or `no`. Generate WebAssembly source maps and disable final optimization. See [Debug builds](#debug-builds).
+- `PHP_VERSION` – The PHP version to build, default: `8.0.24`. This value must point to an existing branch of the https://github.com/php/php-src.git repository when prefixed with `PHP-`. For example, `7.4.0` is valid because the branch `PHP-7.4.0` exists, but just `7` is invalid because there's no branch `PHP-7`. The PHP versions that are known to work are `7.4.*` and `8.0.*`. Others likely work as well but they haven't been tried.
+- `EMSCRIPTEN_ENVIRONMENT` – `web` or `node`, default: `web`. The platform to build for. When building for `web`, two JavaScript loaders will be created: `php-web.js` and `php-webworker.js`. When building for Node.js, only one loader called `php-node.js` will be created.
+- `WITH_LIBXML` – `yes` or `no`, default: `no`. Whether to build with `libxml2` and the `dom`, `xml`, and `simplexml` PHP extensions (`DOMDocument`, `SimpleXML`, ..).
+- `WITH_LIBZIP` – `yes` or `no`, default: `yes`. Whether to build with `zlib`, `libzip`, and the `zip` PHP extension (`ZipArchive`).
+- `WITH_NODEFS` – `yes` or `no`, default: `no`. Whether to include [the Emscripten's NODEFS JavaScript library](https://emscripten.org/docs/api_reference/Filesystem-API.html#filesystem-api-nodefs). It's useful for loading files and mounting directories from the local filesystem when running php.wasm from Node.js.
+-->
+
+- `WITH_DEBUG` – `yes` ou `no`. Compile avec les informations de débogage DWARF et désactive l’optimisation finale. Consultez [Compilations de débogage](#debug-builds).
+- `WITH_SOURCEMAPS` – `yes` ou `no`. Génère des cartes de sources WebAssembly et désactive l’optimisation finale. Consultez [Compilations de débogage](#debug-builds).
+- `PHP_VERSION` – La version de PHP à compiler, par défaut : `8.0.24`. Cette valeur doit correspondre à une branche existante du dépôt https://github.com/php/php-src.git lorsqu’elle est précédée de `PHP-`. Par exemple, `7.4.0` est valide, car la branche `PHP-7.4.0` existe, mais `7` seul n’est pas valide, car il n’existe pas de branche `PHP-7`. Les versions de PHP dont le fonctionnement est confirmé sont `7.4.*` et `8.0.*`. Les autres fonctionnent probablement aussi, mais n’ont pas été testées.
+- `EMSCRIPTEN_ENVIRONMENT` – `web` ou `node`, par défaut : `web`. La plateforme cible de la compilation. Pour `web`, deux chargeurs JavaScript sont créés : `php-web.js` et `php-webworker.js`. Pour Node.js, un seul chargeur, nommé `php-node.js`, est créé.
+- `WITH_LIBXML` – `yes` ou `no`, par défaut : `no`. Indique s’il faut compiler avec `libxml2` et les extensions PHP `dom`, `xml` et `simplexml` (`DOMDocument`, `SimpleXML`, ...).
+- `WITH_LIBZIP` – `yes` ou `no`, par défaut : `yes`. Indique s’il faut compiler avec `zlib`, `libzip` et l’extension PHP `zip` (`ZipArchive`).
+- `WITH_NODEFS` – `yes` ou `no`, par défaut : `no`. Indique s’il faut inclure [la bibliothèque JavaScript NODEFS d’Emscripten](https://emscripten.org/docs/api_reference/Filesystem-API.html#filesystem-api-nodefs). Elle permet de charger des fichiers et de monter des répertoires du système de fichiers local lors de l’exécution de php.wasm depuis Node.js.

--- a/packages/docs/site/i18n/it/docusaurus-plugin-content-docs/current/developers/23-architecture/03-wasm-php-compiling.md
+++ b/packages/docs/site/i18n/it/docusaurus-plugin-content-docs/current/developers/23-architecture/03-wasm-php-compiling.md
@@ -1,5 +1,5 @@
 ---
-title: Compilando PHP
+title: Compilare PHP
 slug: /developers/architecture/wasm-php-compiling
 ---
 
@@ -7,19 +7,19 @@ slug: /developers/architecture/wasm-php-compiling
 # Compiling PHP
 -->
 
-# Compilando PHP
+# Compilare PHP
 
 <!--
 The build pipeline lives in a [`Dockerfile`](https://github.com/WordPress/wordpress-playground/blob/trunk/packages/php-wasm/compile/php/Dockerfile). It was originally forked from [seanmorris/php-wasm](https://github.com/seanmorris/php-wasm)
 -->
 
-O processo de compilação está em um [`Dockerfile`](https://github.com/WordPress/wordpress-playground/blob/trunk/packages/php-wasm/compile/php/Dockerfile). Ele foi originalmente derivado de [seanmorris/php-wasm](https://github.com/seanmorris/php-wasm).
+Il processo di compilazione si trova in un [`Dockerfile`](https://github.com/WordPress/wordpress-playground/blob/trunk/packages/php-wasm/compile/php/Dockerfile). In origine è stato derivato da [seanmorris/php-wasm](https://github.com/seanmorris/php-wasm).
 
 <!--
 In broad strokes, that `Dockerfile`:
 -->
 
-Em linhas gerais, esse `Dockerfile`:
+A grandi linee, questo `Dockerfile`:
 
 <!--
 - Installs all the necessary linux packages (like `build-essential`)
@@ -31,31 +31,31 @@ Em linhas gerais, esse `Dockerfile`:
 - Transforms the Emscripten's default `php.js` output into an ESM module with additional features.
 -->
 
-- Instala todos os pacotes Linux necessários (como `build-essential`).
-- Baixa o PHP e as bibliotecas necessárias, como `sqlite3`.
-- Aplica algumas correções.
-- Compila tudo usando [Emscripten](https://emscripten.org/), um substituto direto para o compilador C.
-- Compila `php_wasm.c` – uma API conveniente para JavaScript.
-- Gera um arquivo `php.wasm` e um ou mais carregadores JavaScript, dependendo da configuração.
-- Transforma a saída padrão `php.js` do Emscripten em um módulo ESM com recursos adicionais.
+- Installa tutti i pacchetti Linux necessari (come `build-essential`).
+- Scarica PHP e le librerie necessarie, come `sqlite3`.
+- Applica alcune patch.
+- Compila tutto con [Emscripten](https://emscripten.org/), un sostituto diretto del compilatore C.
+- Compila `php_wasm.c`, una comoda API per JavaScript.
+- Genera un file `php.wasm` e uno o più loader JavaScript, a seconda della configurazione.
+- Trasforma l'output predefinito `php.js` di Emscripten in un modulo ESM con funzionalità aggiuntive.
 
 <!--
 To find out more about each step, refer directly to the [Dockerfile](https://github.com/WordPress/wordpress-playground/blob/trunk/packages/php-wasm/compile/php/Dockerfile).
 -->
 
-Para saber mais sobre cada etapa, consulte diretamente o [Dockerfile](https://github.com/WordPress/wordpress-playground/blob/trunk/packages/php-wasm/compile/php/Dockerfile).
+Per saperne di più su ogni passaggio, consulta direttamente il [Dockerfile](https://github.com/WordPress/wordpress-playground/blob/trunk/packages/php-wasm/compile/php/Dockerfile).
 
 <!--
 ### Building
 -->
 
-### Compilação
+### Compilazione
 
 <!--
 With Docker running and the repository dependencies installed, run these commands from the repository root:
 -->
 
-Com o Docker em execução e as dependências do repositório instaladas, execute estes comandos na raiz do repositório:
+Con Docker in esecuzione e le dipendenze del repository installate, esegui questi comandi dalla directory principale del repository:
 
 <!--
 ```sh
@@ -68,10 +68,10 @@ npx nx recompile-php:jspi php-wasm-web -- --PHP_VERSION=8.4
 -->
 
 ```sh
-# Compila todas as versões suportadas do PHP para a web, nos modos JSPI e Asyncify.
+# Compila tutte le versioni PHP supportate per il web, nelle modalità JSPI e Asyncify.
 npx nx recompile-php:all php-wasm-web
 
-# Compila apenas o PHP 8.4 para a web, no modo JSPI.
+# Compila solo PHP 8.4 per il web, in modalità JSPI.
 npx nx recompile-php:jspi php-wasm-web -- --PHP_VERSION=8.4
 ```
 
@@ -79,19 +79,19 @@ npx nx recompile-php:jspi php-wasm-web -- --PHP_VERSION=8.4
 Replace `php-wasm-web` with `php-wasm-node` to build for Node.js, or `recompile-php:jspi` with `recompile-php:asyncify` to build the Asyncify variant. The output goes to `packages/php-wasm/web-builds/<major>-<minor>/<mode>/` or `packages/php-wasm/node-builds/<major>-<minor>/<mode>/`.
 -->
 
-Substitua `php-wasm-web` por `php-wasm-node` para compilar para Node.js, ou `recompile-php:jspi` por `recompile-php:asyncify` para compilar a variante Asyncify. A saída é gravada em `packages/php-wasm/web-builds/<major>-<minor>/<mode>/` ou `packages/php-wasm/node-builds/<major>-<minor>/<mode>/`.
+Sostituisci `php-wasm-web` con `php-wasm-node` per compilare per Node.js, oppure `recompile-php:jspi` con `recompile-php:asyncify` per compilare la variante Asyncify. L'output viene salvato in `packages/php-wasm/web-builds/<major>-<minor>/<mode>/` oppure `packages/php-wasm/node-builds/<major>-<minor>/<mode>/`.
 
 <!--
 ### Debug builds
 -->
 
-### Compilações para depuração {#debug-builds}
+### Build di debug {#debug-builds}
 
 <!--
 Use `--WITH_DEBUG=yes` to build PHP.wasm with readable JavaScript output and DWARF debug information for stepping through C code in a WebAssembly debugger:
 -->
 
-Use `--WITH_DEBUG=yes` para compilar PHP.wasm com saída JavaScript legível e informações de depuração DWARF para executar o código C passo a passo em um depurador WebAssembly:
+Usa `--WITH_DEBUG=yes` per compilare PHP.wasm con un output JavaScript leggibile e informazioni di debug DWARF che consentono di eseguire il codice C passo per passo in un debugger WebAssembly:
 
 <!--
 ```sh
@@ -104,10 +104,10 @@ npx nx recompile-php:jspi php-wasm-node -- --PHP_VERSION=8.4 --WITH_DEBUG=yes
 -->
 
 ```sh
-# Compila o PHP 8.4 para depuração no navegador.
+# Compila PHP 8.4 per il debug nel browser.
 npx nx recompile-php:jspi php-wasm-web -- --PHP_VERSION=8.4 --WITH_DEBUG=yes
 
-# Compila o PHP 8.4 para depuração no Node.js.
+# Compila PHP 8.4 per il debug in Node.js.
 npx nx recompile-php:jspi php-wasm-node -- --PHP_VERSION=8.4 --WITH_DEBUG=yes
 ```
 
@@ -115,13 +115,13 @@ npx nx recompile-php:jspi php-wasm-node -- --PHP_VERSION=8.4 --WITH_DEBUG=yes
 The same option works with `recompile-php:asyncify`. Debug builds produce larger files and run more slowly than optimized builds. They replace the selected version's artifacts in the output directory described above. Rebuild with `--WITH_DEBUG=no --WITH_SOURCEMAPS=no` to restore an optimized build.
 -->
 
-A mesma opção funciona com `recompile-php:asyncify`. As compilações para depuração geram arquivos maiores e são mais lentas que as compilações otimizadas. Elas substituem os artefatos da versão selecionada no diretório de saída descrito acima. Compile novamente com `--WITH_DEBUG=no --WITH_SOURCEMAPS=no` para restaurar uma compilação otimizada.
+La stessa opzione funziona con `recompile-php:asyncify`. Le build di debug generano file più grandi e vengono eseguite più lentamente delle build ottimizzate. Sostituiscono gli artefatti della versione selezionata nella directory di output descritta sopra. Ricompila con `--WITH_DEBUG=no --WITH_SOURCEMAPS=no` per ripristinare una build ottimizzata.
 
 <!--
 For WebAssembly source maps, use `--WITH_SOURCEMAPS=yes`:
 -->
 
-Para gerar mapas de código-fonte WebAssembly, use `--WITH_SOURCEMAPS=yes`:
+Per generare le mappe dei sorgenti WebAssembly, usa `--WITH_SOURCEMAPS=yes`:
 
 <!--
 ```sh
@@ -137,19 +137,19 @@ npx nx recompile-php:jspi php-wasm-web -- --PHP_VERSION=8.4 --WITH_SOURCEMAPS=ye
 This generates a `php.wasm.map` file and copies the source files needed for debugging into the build output. For web builds, the source map URL points to the local development server at `http://127.0.0.1:5400`; run `npm run dev` to serve it.
 -->
 
-Isso gera um arquivo `php.wasm.map` e copia os arquivos de código-fonte necessários para depuração para o diretório de saída da compilação. Nas compilações para a web, o URL do mapa de código-fonte aponta para o servidor de desenvolvimento local em `http://127.0.0.1:5400`; execute `npm run dev` para disponibilizá-lo.
+Questo genera un file `php.wasm.map` e copia i file sorgente necessari per il debug nella directory di output della build. Per le build web, l'URL della mappa dei sorgenti punta al server di sviluppo locale all'indirizzo `http://127.0.0.1:5400`; esegui `npm run dev` per renderla disponibile.
 
 <!--
 #### Emscripten options
 -->
 
-#### Opções do Emscripten
+#### Opzioni di Emscripten
 
 <!--
 The build script translates these options into compiler flags in the [PHP Dockerfile](https://github.com/WordPress/wordpress-playground/blob/trunk/packages/php-wasm/compile/php/Dockerfile):
 -->
 
-O script de compilação converte essas opções em sinalizadores do compilador no [Dockerfile do PHP](https://github.com/WordPress/wordpress-playground/blob/trunk/packages/php-wasm/compile/php/Dockerfile):
+Lo script di compilazione converte queste opzioni in flag del compilatore nel [Dockerfile di PHP](https://github.com/WordPress/wordpress-playground/blob/trunk/packages/php-wasm/compile/php/Dockerfile):
 
 <!--
 | Flag           | Purpose                                                                                                | When Playground uses it                                                 |
@@ -160,66 +160,66 @@ O script de compilação converte essas opções em sinalizadores do compilador 
 | `-gsource-map` | Generates a WebAssembly source map from compiler debug information.                                    | `WITH_SOURCEMAPS=yes`.                                                  |
 -->
 
-| Sinalizador    | Finalidade                                                                                       | Quando o Playground o usa                                                     |
-| -------------- | ------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------- |
-| `-O0`          | Desativa a otimização da saída final de WebAssembly e JavaScript.                                | `WITH_DEBUG=yes` ou `WITH_SOURCEMAPS=yes`, substituindo o padrão `-O3`.       |
-| `-g2`          | Mantém os nomes das funções e o JavaScript legível, sem reter informações DWARF no módulo final. | Compilações para Node.js quando nenhuma das opções de depuração está ativada. |
-| `-g3`          | Mantém informações DWARF para depuração no nível do código-fonte.                                | `WITH_DEBUG=yes` ou `WITH_SOURCEMAPS=yes`.                                    |
-| `-gsource-map` | Gera um mapa de código-fonte WebAssembly a partir das informações de depuração do compilador.    | `WITH_SOURCEMAPS=yes`.                                                        |
+| Flag           | Scopo                                                                                                               | Quando viene usato da Playground                                                      |
+| -------------- | ------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| `-O0`          | Disabilita l'ottimizzazione dell'output finale WebAssembly e JavaScript.                                            | `WITH_DEBUG=yes` oppure `WITH_SOURCEMAPS=yes`, al posto del valore predefinito `-O3`. |
+| `-g2`          | Mantiene i nomi delle funzioni e il JavaScript leggibile, senza conservare le informazioni DWARF nel modulo finale. | Build per Node.js quando nessuna delle opzioni di debug è attiva.                     |
+| `-g3`          | Conserva le informazioni DWARF per il debug a livello di codice sorgente.                                           | `WITH_DEBUG=yes` oppure `WITH_SOURCEMAPS=yes`.                                        |
+| `-gsource-map` | Genera una mappa dei sorgenti WebAssembly a partire dalle informazioni di debug del compilatore.                    | `WITH_SOURCEMAPS=yes`.                                                                |
 
 <!--
 See the [Emscripten compiler reference](https://emscripten.org/docs/tools_reference/emcc.html) for details on these flags.
 -->
 
-Consulte a [referência do compilador Emscripten](https://emscripten.org/docs/tools_reference/emcc.html) para saber mais sobre esses sinalizadores.
+Consulta la [documentazione di riferimento del compilatore Emscripten](https://emscripten.org/docs/tools_reference/emcc.html) per maggiori dettagli su questi flag.
 
 <!--
 #### Runtime assertions
 -->
 
-#### Asserções em tempo de execução
+#### Asserzioni a runtime
 
 <!--
 Debug information and runtime assertions are separate settings. Playground explicitly passes `-s ASSERTIONS=0`, including in debug builds, so `--WITH_DEBUG=yes` does not enable extra runtime checks.
 -->
 
-As informações de depuração e as asserções em tempo de execução são configurações separadas. O Playground passa explicitamente `-s ASSERTIONS=0`, inclusive nas compilações para depuração, portanto `--WITH_DEBUG=yes` não ativa verificações adicionais em tempo de execução.
+Le informazioni di debug e le asserzioni a runtime sono impostazioni separate. Playground passa esplicitamente `-s ASSERTIONS=0`, anche nelle build di debug, quindi `--WITH_DEBUG=yes` non abilita controlli aggiuntivi a runtime.
 
 <!--
 To investigate a runtime failure with assertions, change that setting in the PHP Dockerfile's final `emcc` command and rebuild. Emscripten documents `-s ASSERTIONS=1` for runtime checks and `-s ASSERTIONS=2` for additional, slower checks. There is no `WITH_ASSERTIONS` build option. See the [Emscripten assertions reference](https://emscripten.org/docs/tools_reference/settings_reference.html#assertions).
 -->
 
-Para investigar uma falha em tempo de execução com asserções, altere essa configuração no comando `emcc` final do Dockerfile do PHP e compile novamente. O Emscripten documenta `-s ASSERTIONS=1` para verificações em tempo de execução e `-s ASSERTIONS=2` para verificações adicionais, mais lentas. Não existe uma opção de compilação `WITH_ASSERTIONS`. Consulte a [referência de asserções do Emscripten](https://emscripten.org/docs/tools_reference/settings_reference.html#assertions).
+Per analizzare un errore a runtime con le asserzioni, modifica questa impostazione nel comando `emcc` finale del Dockerfile di PHP e ricompila. Emscripten documenta `-s ASSERTIONS=1` per i controlli a runtime e `-s ASSERTIONS=2` per controlli aggiuntivi, più lenti. Non esiste un’opzione di compilazione `WITH_ASSERTIONS`. Consulta la [documentazione di riferimento sulle asserzioni di Emscripten](https://emscripten.org/docs/tools_reference/settings_reference.html#assertions).
 
 <!--
 Assertions can also report an environment mismatch between `web` and `worker`. Check the build's `ENVIRONMENT` setting and the JavaScript loader's execution context when investigating those errors; see the [discussion in issue #176](https://github.com/WordPress/wordpress-playground/issues/176#issuecomment-1483754022).
 -->
 
-As asserções também podem indicar uma incompatibilidade de ambiente entre `web` e `worker`. Verifique a configuração `ENVIRONMENT` da compilação e o contexto de execução do carregador JavaScript ao investigar esses erros; consulte a [discussão na issue #176](https://github.com/WordPress/wordpress-playground/issues/176#issuecomment-1483754022).
+Le asserzioni possono anche segnalare una mancata corrispondenza dell'ambiente tra `web` e `worker`. Controlla l'impostazione `ENVIRONMENT` della build e il contesto di esecuzione del loader JavaScript quando analizzi questi errori; consulta la [discussione nell'issue #176](https://github.com/WordPress/wordpress-playground/issues/176#issuecomment-1483754022).
 
 <!--
 ### PHP next builds
 -->
 
-### Compilações do PHP next
+### Build di PHP next
 
 <!--
 Playground can also run the next PHP version from the php-src development branch in the web runtime. These builds are published separately from the main repository because the generated WebAssembly files are large and change often.
 -->
 
-O Playground também pode executar a próxima versão do PHP a partir do branch de desenvolvimento do php-src no ambiente web. Essas compilações são publicadas separadamente do repositório principal porque os arquivos WebAssembly gerados são grandes e mudam com frequência.
+Playground può anche eseguire nel runtime web la prossima versione di PHP dal branch di sviluppo di php-src. Queste build vengono pubblicate separatamente dal repository principale perché i file WebAssembly generati sono grandi e cambiano spesso.
 
 <!--
 The nightly refresh workflow builds the php-src development branch, writes the web artifacts to the gitignored `packages/playground/website/public/php-next/` directory, and publishes the result to the `php-next-builds` branch. Website deploys and the local dev server sync that branch before serving `?php=next`.
 -->
 
-O fluxo de atualização noturno compila o branch de desenvolvimento do php-src, grava os artefatos para a web no diretório `packages/playground/website/public/php-next/`, ignorado pelo Git, e publica o resultado no branch `php-next-builds`. As implantações do site e o servidor de desenvolvimento local sincronizam esse branch antes de servir `?php=next`.
+Il workflow di aggiornamento notturno compila il branch di sviluppo di php-src, scrive gli artefatti web nella directory `packages/playground/website/public/php-next/`, ignorata da Git, e pubblica il risultato nel branch `php-next-builds`. Le distribuzioni del sito web e il server di sviluppo locale sincronizzano questo branch prima di servire `?php=next`.
 
 <!--
 To refresh the local copy manually, run:
 -->
 
-Para atualizar a cópia local manualmente, execute:
+Per aggiornare manualmente la copia locale, esegui:
 
 <!--
 ```sh
@@ -235,7 +235,7 @@ npm run sync:php-next
 To rebuild the web artifacts locally from the php-src development branch, run:
 -->
 
-Para recompilar localmente os artefatos para a web a partir do branch de desenvolvimento do php-src, execute:
+Per ricompilare localmente gli artefatti web dal branch di sviluppo di php-src, esegui:
 
 <!--
 ```sh
@@ -251,31 +251,31 @@ npm run recompile:php:web:next
 `php=next` currently ships web main modules only. Matching extension side modules and Playground CLI support are separate follow-up work.
 -->
 
-Atualmente, `php=next` distribui apenas módulos principais para a web. Os módulos auxiliares de extensões correspondentes e o suporte à CLI do Playground serão tratados em trabalhos separados.
+Attualmente `php=next` distribuisce solo i moduli principali per il web. I moduli secondari delle estensioni corrispondenti e il supporto per la CLI di Playground saranno affrontati in attività successive separate.
 
 <!--
 ### PHP extensions
 -->
 
-### Extensões PHP
+### Estensioni PHP
 
 <!--
 PHP is built with several extensions listed in the [`Dockerfile`](https://github.com/WordPress/wordpress-playground/blob/trunk/packages/php-wasm/compile/php/Dockerfile).
 -->
 
-O PHP é compilado com várias extensões listadas no [`Dockerfile`](https://github.com/WordPress/wordpress-playground/blob/trunk/packages/php-wasm/compile/php/Dockerfile).
+PHP viene compilato con diverse estensioni elencate nel [`Dockerfile`](https://github.com/WordPress/wordpress-playground/blob/trunk/packages/php-wasm/compile/php/Dockerfile).
 
 <!--
 Some extensions, like `zip`, can be turned on or off during the build. Others, like `sqlite3`, are hardcoded.
 -->
 
-Algumas extensões, como `zip`, podem ser ativadas ou desativadas durante a compilação. Outras, como `sqlite3`, são definidas diretamente no código.
+Alcune estensioni, come `zip`, possono essere abilitate o disabilitate durante la compilazione. Altre, come `sqlite3`, sono definite direttamente nel codice.
 
 <!--
 If you need to turn off one of the hardcoded extensions, feel free to open an issue in this repo. Better yet, this project needs contributors. You are more than welcome to open a PR and author the change you need.
 -->
 
-Se você precisa desativar uma das extensões definidas diretamente no código, fique à vontade para abrir uma issue neste repositório. Melhor ainda: este projeto precisa de colaboradores. Você pode abrir um PR e implementar a alteração de que precisa.
+Se hai bisogno di disabilitare una delle estensioni definite direttamente nel codice, puoi aprire un'issue in questo repository. Ancora meglio: questo progetto ha bisogno di collaboratori. Puoi aprire una PR e implementare la modifica di cui hai bisogno.
 
 <!--
 PHP.wasm can also load dynamic `.so` extensions before PHP starts. Built-in
@@ -286,19 +286,19 @@ mode. See [Loading PHP extensions](/developers/apis/javascript-api/php-extension
 for the runtime API.
 -->
 
-PHP.wasm também pode carregar extensões dinâmicas `.so` antes de iniciar o PHP. Extensões dinâmicas integradas, como `intl`, `xdebug`, `redis` e `memcached`, são distribuídas com o pacote Node, e extensões externas podem ser fornecidas com um manifesto que seleciona o artefato correspondente à versão do PHP e ao modo assíncrono ativos. Consulte [Carregando extensões PHP](/developers/apis/javascript-api/php-extensions) para conhecer a API de execução.
+PHP.wasm può anche caricare estensioni dinamiche `.so` prima dell'avvio di PHP. Le estensioni dinamiche integrate, come `intl`, `xdebug`, `redis` e `memcached`, vengono distribuite con il pacchetto Node, mentre le estensioni esterne possono essere fornite con un manifest che seleziona l'artefatto corrispondente alla versione di PHP e alla modalità asincrona attive. Consulta [Caricare estensioni PHP](/developers/apis/javascript-api/php-extensions) per l'API di runtime.
 
 <!--
 ### C API exposed to JavaScript
 -->
 
-### API C exposta ao JavaScript
+### API C esposta a JavaScript
 
 <!--
 The C API exposed to JavaScript lives in the [`php_wasm.c`](https://github.com/WordPress/wordpress-playground/blob/trunk/src/packages/php-wasm/compile/build-assets/php_wasm.c) file. The most important functions are:
 -->
 
-A API C exposta ao JavaScript está no arquivo [`php_wasm.c`](https://github.com/WordPress/wordpress-playground/blob/trunk/src/packages/php-wasm/compile/build-assets/php_wasm.c). As funções mais importantes são:
+L'API C esposta a JavaScript si trova nel file [`php_wasm.c`](https://github.com/WordPress/wordpress-playground/blob/trunk/src/packages/php-wasm/compile/build-assets/php_wasm.c). Le funzioni più importanti sono:
 
 <!--
 - `void phpwasm_init()` – It creates a new PHP context and must be called before running any PHP code.
@@ -306,27 +306,27 @@ A API C exposta ao JavaScript está no arquivo [`php_wasm.c`](https://github.com
 - `void phpwasm_refresh()` – Destroy the current PHP context and starts a new one. Call it after running one PHP script and before running another.
 -->
 
-- `void phpwasm_init()` – Cria um novo contexto PHP e deve ser chamada antes de executar qualquer código PHP.
-- `int phpwasm_run(char *code)` – Executa um script PHP e grava a saída em /tmp/stdout e /tmp/stderr. Retorna o código de saída.
-- `void phpwasm_refresh()` – Destrói o contexto PHP atual e inicia um novo. Chame-a após executar um script PHP e antes de executar outro.
+- `void phpwasm_init()` – Crea un nuovo contesto PHP e deve essere chiamata prima di eseguire qualsiasi codice PHP.
+- `int phpwasm_run(char *code)` – Esegue uno script PHP e scrive l'output in /tmp/stdout e /tmp/stderr. Restituisce il codice di uscita.
+- `void phpwasm_refresh()` – Elimina il contesto PHP corrente e ne avvia uno nuovo. Chiamala dopo aver eseguito uno script PHP e prima di eseguirne un altro.
 
 <!--
 Refer to the inline documentation in [`php_wasm.c`](https://github.com/WordPress/wordpress-playground/blob/trunk/src/packages/php-wasm/compile/build-assets/php_wasm.c) to learn more.
 -->
 
-Consulte a documentação no código de [`php_wasm.c`](https://github.com/WordPress/wordpress-playground/blob/trunk/src/packages/php-wasm/compile/build-assets/php_wasm.c) para saber mais.
+Consulta la documentazione nel codice di [`php_wasm.c`](https://github.com/WordPress/wordpress-playground/blob/trunk/src/packages/php-wasm/compile/build-assets/php_wasm.c) per saperne di più.
 
 <!--
 ### Build configuration
 -->
 
-### Configuração da compilação
+### Configurazione della build
 
 <!--
 The build is configurable via the [Docker `--build-arg` feature](https://docs.docker.com/engine/reference/commandline/build/#set-build-time-variables---build-arg). You can set them up through the `build.js` script, just run this command to get the usage message:
 -->
 
-A compilação é configurável pelo [recurso `--build-arg` do Docker](https://docs.docker.com/engine/reference/commandline/build/#set-build-time-variables---build-arg). Você pode definir as opções pelo script `build.js`; execute este comando para ver as instruções de uso:
+La build è configurabile tramite la [funzionalità `--build-arg` di Docker](https://docs.docker.com/engine/reference/commandline/build/#set-build-time-variables---build-arg). Puoi impostare le opzioni tramite lo script `build.js`; esegui questo comando per visualizzare le istruzioni di utilizzo:
 
 <!--
 ```sh
@@ -342,7 +342,7 @@ npx nx recompile-php:jspi php-wasm-web -- --help
 **Supported build options:**
 -->
 
-**Opções de compilação suportadas:**
+**Opzioni di compilazione supportate:**
 
 <!--
 - `WITH_DEBUG` – `yes` or `no`. Build with DWARF debug information and disable final optimization. See [Debug builds](#debug-builds).
@@ -354,10 +354,10 @@ npx nx recompile-php:jspi php-wasm-web -- --help
 - `WITH_NODEFS` – `yes` or `no`, default: `no`. Whether to include [the Emscripten's NODEFS JavaScript library](https://emscripten.org/docs/api_reference/Filesystem-API.html#filesystem-api-nodefs). It's useful for loading files and mounting directories from the local filesystem when running php.wasm from Node.js.
 -->
 
-- `WITH_DEBUG` – `yes` ou `no`. Compila com informações de depuração DWARF e desativa a otimização final. Consulte [Compilações para depuração](#debug-builds).
-- `WITH_SOURCEMAPS` – `yes` ou `no`. Gera mapas de código-fonte WebAssembly e desativa a otimização final. Consulte [Compilações para depuração](#debug-builds).
-- `PHP_VERSION` – A versão do PHP a compilar, padrão: `8.0.24`. Esse valor deve corresponder a um branch existente do repositório https://github.com/php/php-src.git quando precedido por `PHP-`. Por exemplo, `7.4.0` é válido porque o branch `PHP-7.4.0` existe, mas apenas `7` é inválido porque não existe um branch `PHP-7`. As versões do PHP que sabemos que funcionam são `7.4.*` e `8.0.*`. Outras provavelmente também funcionam, mas não foram testadas.
-- `EMSCRIPTEN_ENVIRONMENT` – `web` ou `node`, padrão: `web`. A plataforma para a qual compilar. Ao compilar para `web`, dois carregadores JavaScript são criados: `php-web.js` e `php-webworker.js`. Ao compilar para Node.js, apenas um carregador chamado `php-node.js` é criado.
-- `WITH_LIBXML` – `yes` ou `no`, padrão: `no`. Define se a compilação inclui `libxml2` e as extensões PHP `dom`, `xml` e `simplexml` (`DOMDocument`, `SimpleXML`, ...).
-- `WITH_LIBZIP` – `yes` ou `no`, padrão: `yes`. Define se a compilação inclui `zlib`, `libzip` e a extensão PHP `zip` (`ZipArchive`).
-- `WITH_NODEFS` – `yes` ou `no`, padrão: `no`. Define se a compilação inclui [a biblioteca JavaScript NODEFS do Emscripten](https://emscripten.org/docs/api_reference/Filesystem-API.html#filesystem-api-nodefs). Ela permite carregar arquivos e montar diretórios do sistema de arquivos local ao executar php.wasm no Node.js.
+- `WITH_DEBUG` – `yes` oppure `no`. Compila con informazioni di debug DWARF e disabilita l'ottimizzazione finale. Consulta [Build di debug](#debug-builds).
+- `WITH_SOURCEMAPS` – `yes` oppure `no`. Genera mappe dei sorgenti WebAssembly e disabilita l'ottimizzazione finale. Consulta [Build di debug](#debug-builds).
+- `PHP_VERSION` – La versione di PHP da compilare, predefinita: `8.0.24`. Questo valore deve corrispondere a un branch esistente del repository https://github.com/php/php-src.git quando preceduto da `PHP-`. Ad esempio, `7.4.0` è valido perché il branch `PHP-7.4.0` esiste, mentre solo `7` non è valido perché non esiste un branch `PHP-7`. Le versioni di PHP note per funzionare sono `7.4.*` e `8.0.*`. È probabile che anche le altre funzionino, ma non sono state provate.
+- `EMSCRIPTEN_ENVIRONMENT` – `web` oppure `node`, predefinito: `web`. La piattaforma di destinazione della compilazione. Per `web` vengono creati due loader JavaScript: `php-web.js` e `php-webworker.js`. Per Node.js viene creato un solo loader, chiamato `php-node.js`.
+- `WITH_LIBXML` – `yes` oppure `no`, predefinito: `no`. Indica se compilare con `libxml2` e le estensioni PHP `dom`, `xml` e `simplexml` (`DOMDocument`, `SimpleXML`, ...).
+- `WITH_LIBZIP` – `yes` oppure `no`, predefinito: `yes`. Indica se compilare con `zlib`, `libzip` e l'estensione PHP `zip` (`ZipArchive`).
+- `WITH_NODEFS` – `yes` oppure `no`, predefinito: `no`. Indica se includere [la libreria JavaScript NODEFS di Emscripten](https://emscripten.org/docs/api_reference/Filesystem-API.html#filesystem-api-nodefs). È utile per caricare file e montare directory del filesystem locale quando si esegue php.wasm da Node.js.

--- a/packages/docs/site/i18n/it/docusaurus-plugin-content-docs/current/developers/23-architecture/03-wasm-php-compiling.md
+++ b/packages/docs/site/i18n/it/docusaurus-plugin-content-docs/current/developers/23-architecture/03-wasm-php-compiling.md
@@ -46,10 +46,10 @@ To find out more about each step, refer directly to the [Dockerfile](https://git
 Per saperne di più su ogni passaggio, consulta direttamente il [Dockerfile](https://github.com/WordPress/wordpress-playground/blob/trunk/packages/php-wasm/compile/php/Dockerfile).
 
 <!--
-### Building
+## Building
 -->
 
-### Compilazione
+## Compilazione
 
 <!--
 With Docker running and the repository dependencies installed, run these commands from the repository root:
@@ -82,10 +82,10 @@ Replace `php-wasm-web` with `php-wasm-node` to build for Node.js, or `recompile-
 Sostituisci `php-wasm-web` con `php-wasm-node` per compilare per Node.js, oppure `recompile-php:jspi` con `recompile-php:asyncify` per compilare la variante Asyncify. L'output viene salvato in `packages/php-wasm/web-builds/<major>-<minor>/<mode>/` oppure `packages/php-wasm/node-builds/<major>-<minor>/<mode>/`.
 
 <!--
-### Debug builds
+## Debug builds
 -->
 
-### Build di debug {#debug-builds}
+## Build di debug {#debug-builds}
 
 <!--
 Use `--WITH_DEBUG=yes` to build PHP.wasm with readable JavaScript output and DWARF debug information for stepping through C code in a WebAssembly debugger:
@@ -140,10 +140,10 @@ This generates a `php.wasm.map` file and copies the source files needed for debu
 Questo genera un file `php.wasm.map` e copia i file sorgente necessari per il debug nella directory di output della build. Per le build web, l'URL della mappa dei sorgenti punta al server di sviluppo locale all'indirizzo `http://127.0.0.1:5400`; esegui `npm run dev` per renderla disponibile.
 
 <!--
-#### Emscripten options
+### Emscripten options
 -->
 
-#### Opzioni di Emscripten
+### Opzioni di Emscripten
 
 <!--
 The build script translates these options into compiler flags in the [PHP Dockerfile](https://github.com/WordPress/wordpress-playground/blob/trunk/packages/php-wasm/compile/php/Dockerfile):
@@ -174,10 +174,10 @@ See the [Emscripten compiler reference](https://emscripten.org/docs/tools_refere
 Consulta la [documentazione di riferimento del compilatore Emscripten](https://emscripten.org/docs/tools_reference/emcc.html) per maggiori dettagli su questi flag.
 
 <!--
-#### Runtime assertions
+### Runtime assertions
 -->
 
-#### Asserzioni a runtime
+### Asserzioni a runtime
 
 <!--
 Debug information and runtime assertions are separate settings. Playground explicitly passes `-s ASSERTIONS=0`, including in debug builds, so `--WITH_DEBUG=yes` does not enable extra runtime checks.
@@ -192,16 +192,10 @@ To investigate a runtime failure with assertions, change that setting in the PHP
 Per analizzare un errore a runtime con le asserzioni, modifica questa impostazione nel comando `emcc` finale del Dockerfile di PHP e ricompila. Emscripten documenta `-s ASSERTIONS=1` per i controlli a runtime e `-s ASSERTIONS=2` per controlli aggiuntivi, più lenti. Non esiste un’opzione di compilazione `WITH_ASSERTIONS`. Consulta la [documentazione di riferimento sulle asserzioni di Emscripten](https://emscripten.org/docs/tools_reference/settings_reference.html#assertions).
 
 <!--
-Assertions can also report an environment mismatch between `web` and `worker`. Check the build's `ENVIRONMENT` setting and the JavaScript loader's execution context when investigating those errors; see the [discussion in issue #176](https://github.com/WordPress/wordpress-playground/issues/176#issuecomment-1483754022).
+## PHP next builds
 -->
 
-Le asserzioni possono anche segnalare una mancata corrispondenza dell'ambiente tra `web` e `worker`. Controlla l'impostazione `ENVIRONMENT` della build e il contesto di esecuzione del loader JavaScript quando analizzi questi errori; consulta la [discussione nell'issue #176](https://github.com/WordPress/wordpress-playground/issues/176#issuecomment-1483754022).
-
-<!--
-### PHP next builds
--->
-
-### Build di PHP next
+## Build di PHP next
 
 <!--
 Playground can also run the next PHP version from the php-src development branch in the web runtime. These builds are published separately from the main repository because the generated WebAssembly files are large and change often.
@@ -254,10 +248,10 @@ npm run recompile:php:web:next
 Attualmente `php=next` distribuisce solo i moduli principali per il web. I moduli secondari delle estensioni corrispondenti e il supporto per la CLI di Playground saranno affrontati in attività successive separate.
 
 <!--
-### PHP extensions
+## PHP extensions
 -->
 
-### Estensioni PHP
+## Estensioni PHP
 
 <!--
 PHP is built with several extensions listed in the [`Dockerfile`](https://github.com/WordPress/wordpress-playground/blob/trunk/packages/php-wasm/compile/php/Dockerfile).
@@ -289,10 +283,10 @@ for the runtime API.
 PHP.wasm può anche caricare estensioni dinamiche `.so` prima dell'avvio di PHP. Le estensioni dinamiche integrate, come `intl`, `xdebug`, `redis` e `memcached`, vengono distribuite con il pacchetto Node, mentre le estensioni esterne possono essere fornite con un manifest che seleziona l'artefatto corrispondente alla versione di PHP e alla modalità asincrona attive. Consulta [Caricare estensioni PHP](/developers/apis/javascript-api/php-extensions) per l'API di runtime.
 
 <!--
-### C API exposed to JavaScript
+## C API exposed to JavaScript
 -->
 
-### API C esposta a JavaScript
+## API C esposta a JavaScript
 
 <!--
 The C API exposed to JavaScript lives in the [`php_wasm.c`](https://github.com/WordPress/wordpress-playground/blob/trunk/src/packages/php-wasm/compile/build-assets/php_wasm.c) file. The most important functions are:
@@ -317,10 +311,10 @@ Refer to the inline documentation in [`php_wasm.c`](https://github.com/WordPress
 Consulta la documentazione nel codice di [`php_wasm.c`](https://github.com/WordPress/wordpress-playground/blob/trunk/src/packages/php-wasm/compile/build-assets/php_wasm.c) per saperne di più.
 
 <!--
-### Build configuration
+## Build configuration
 -->
 
-### Configurazione della build
+## Configurazione della build
 
 <!--
 The build is configurable via the [Docker `--build-arg` feature](https://docs.docker.com/engine/reference/commandline/build/#set-build-time-variables---build-arg). You can set them up through the `build.js` script, just run this command to get the usage message:
@@ -339,15 +333,19 @@ npx nx recompile-php:jspi php-wasm-web -- --help
 ```
 
 <!--
-**Supported build options:**
+**Selected build options:**
+
+This list highlights debug and basic build settings. For the full set of options, run the help command above; see [the build script](https://github.com/WordPress/wordpress-playground/blob/trunk/packages/php-wasm/compile/build.js) for platform-specific defaults.
 -->
 
-**Opzioni di compilazione supportate:**
+**Opzioni di compilazione selezionate:**
+
+Questo elenco presenta le impostazioni di debug e di compilazione di base. Per tutte le opzioni, esegui il comando di aiuto precedente; consulta [lo script di compilazione](https://github.com/WordPress/wordpress-playground/blob/trunk/packages/php-wasm/compile/build.js) per i valori predefiniti specifici di ogni piattaforma.
 
 <!--
 - `WITH_DEBUG` – `yes` or `no`. Build with DWARF debug information and disable final optimization. See [Debug builds](#debug-builds).
 - `WITH_SOURCEMAPS` – `yes` or `no`. Generate WebAssembly source maps and disable final optimization. See [Debug builds](#debug-builds).
-- `PHP_VERSION` – The PHP version to build, default: `8.0.24`. This value must point to an existing branch of the https://github.com/php/php-src.git repository when prefixed with `PHP-`. For example, `7.4.0` is valid because the branch `PHP-7.4.0` exists, but just `7` is invalid because there's no branch `PHP-7`. The PHP versions that are known to work are `7.4.*` and `8.0.*`. Others likely work as well but they haven't been tried.
+- `PHP_VERSION` – The PHP version to build. Use a major/minor version such as `8.4` to select its latest release from [the supported PHP versions](https://github.com/WordPress/wordpress-playground/blob/trunk/packages/php-wasm/supported-php-versions.mjs), or an exact release such as `8.4.25`. The build clones the corresponding `php-<version>` tag from php-src.
 - `EMSCRIPTEN_ENVIRONMENT` – `web` or `node`, default: `web`. The platform to build for. When building for `web`, two JavaScript loaders will be created: `php-web.js` and `php-webworker.js`. When building for Node.js, only one loader called `php-node.js` will be created.
 - `WITH_LIBXML` – `yes` or `no`, default: `no`. Whether to build with `libxml2` and the `dom`, `xml`, and `simplexml` PHP extensions (`DOMDocument`, `SimpleXML`, ..).
 - `WITH_LIBZIP` – `yes` or `no`, default: `yes`. Whether to build with `zlib`, `libzip`, and the `zip` PHP extension (`ZipArchive`).
@@ -356,7 +354,7 @@ npx nx recompile-php:jspi php-wasm-web -- --help
 
 - `WITH_DEBUG` – `yes` oppure `no`. Compila con informazioni di debug DWARF e disabilita l'ottimizzazione finale. Consulta [Build di debug](#debug-builds).
 - `WITH_SOURCEMAPS` – `yes` oppure `no`. Genera mappe dei sorgenti WebAssembly e disabilita l'ottimizzazione finale. Consulta [Build di debug](#debug-builds).
-- `PHP_VERSION` – La versione di PHP da compilare, predefinita: `8.0.24`. Questo valore deve corrispondere a un branch esistente del repository https://github.com/php/php-src.git quando preceduto da `PHP-`. Ad esempio, `7.4.0` è valido perché il branch `PHP-7.4.0` esiste, mentre solo `7` non è valido perché non esiste un branch `PHP-7`. Le versioni di PHP note per funzionare sono `7.4.*` e `8.0.*`. È probabile che anche le altre funzionino, ma non sono state provate.
+- `PHP_VERSION` – La versione di PHP da compilare. Usa una versione maggiore/minore come `8.4` per selezionare la sua ultima release dalle [versioni di PHP supportate](https://github.com/WordPress/wordpress-playground/blob/trunk/packages/php-wasm/supported-php-versions.mjs), oppure una release esatta come `8.4.25`. La compilazione clona il tag `php-<version>` corrispondente da php-src.
 - `EMSCRIPTEN_ENVIRONMENT` – `web` oppure `node`, predefinito: `web`. La piattaforma di destinazione della compilazione. Per `web` vengono creati due loader JavaScript: `php-web.js` e `php-webworker.js`. Per Node.js viene creato un solo loader, chiamato `php-node.js`.
 - `WITH_LIBXML` – `yes` oppure `no`, predefinito: `no`. Indica se compilare con `libxml2` e le estensioni PHP `dom`, `xml` e `simplexml` (`DOMDocument`, `SimpleXML`, ...).
 - `WITH_LIBZIP` – `yes` oppure `no`, predefinito: `yes`. Indica se compilare con `zlib`, `libzip` e l'estensione PHP `zip` (`ZipArchive`).

--- a/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/developers/23-architecture/03-wasm-php-compiling.md
+++ b/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/developers/23-architecture/03-wasm-php-compiling.md
@@ -46,10 +46,10 @@ To find out more about each step, refer directly to the [Dockerfile](https://git
 Para saber mais sobre cada etapa, consulte diretamente o [Dockerfile](https://github.com/WordPress/wordpress-playground/blob/trunk/packages/php-wasm/compile/php/Dockerfile).
 
 <!--
-### Building
+## Building
 -->
 
-### Compilação
+## Compilação
 
 <!--
 With Docker running and the repository dependencies installed, run these commands from the repository root:
@@ -82,10 +82,10 @@ Replace `php-wasm-web` with `php-wasm-node` to build for Node.js, or `recompile-
 Substitua `php-wasm-web` por `php-wasm-node` para compilar para Node.js, ou `recompile-php:jspi` por `recompile-php:asyncify` para compilar a variante Asyncify. A saída é gravada em `packages/php-wasm/web-builds/<major>-<minor>/<mode>/` ou `packages/php-wasm/node-builds/<major>-<minor>/<mode>/`.
 
 <!--
-### Debug builds
+## Debug builds
 -->
 
-### Compilações para depuração {#debug-builds}
+## Compilações para depuração {#debug-builds}
 
 <!--
 Use `--WITH_DEBUG=yes` to build PHP.wasm with readable JavaScript output and DWARF debug information for stepping through C code in a WebAssembly debugger:
@@ -140,10 +140,10 @@ This generates a `php.wasm.map` file and copies the source files needed for debu
 Isso gera um arquivo `php.wasm.map` e copia os arquivos de código-fonte necessários para depuração para o diretório de saída da compilação. Nas compilações para a web, o URL do mapa de código-fonte aponta para o servidor de desenvolvimento local em `http://127.0.0.1:5400`; execute `npm run dev` para disponibilizá-lo.
 
 <!--
-#### Emscripten options
+### Emscripten options
 -->
 
-#### Opções do Emscripten
+### Opções do Emscripten
 
 <!--
 The build script translates these options into compiler flags in the [PHP Dockerfile](https://github.com/WordPress/wordpress-playground/blob/trunk/packages/php-wasm/compile/php/Dockerfile):
@@ -174,10 +174,10 @@ See the [Emscripten compiler reference](https://emscripten.org/docs/tools_refere
 Consulte a [referência do compilador Emscripten](https://emscripten.org/docs/tools_reference/emcc.html) para saber mais sobre esses sinalizadores.
 
 <!--
-#### Runtime assertions
+### Runtime assertions
 -->
 
-#### Asserções em tempo de execução
+### Asserções em tempo de execução
 
 <!--
 Debug information and runtime assertions are separate settings. Playground explicitly passes `-s ASSERTIONS=0`, including in debug builds, so `--WITH_DEBUG=yes` does not enable extra runtime checks.
@@ -192,16 +192,10 @@ To investigate a runtime failure with assertions, change that setting in the PHP
 Para investigar uma falha em tempo de execução com asserções, altere essa configuração no comando `emcc` final do Dockerfile do PHP e compile novamente. O Emscripten documenta `-s ASSERTIONS=1` para verificações em tempo de execução e `-s ASSERTIONS=2` para verificações adicionais, mais lentas. Não existe uma opção de compilação `WITH_ASSERTIONS`. Consulte a [referência de asserções do Emscripten](https://emscripten.org/docs/tools_reference/settings_reference.html#assertions).
 
 <!--
-Assertions can also report an environment mismatch between `web` and `worker`. Check the build's `ENVIRONMENT` setting and the JavaScript loader's execution context when investigating those errors; see the [discussion in issue #176](https://github.com/WordPress/wordpress-playground/issues/176#issuecomment-1483754022).
+## PHP next builds
 -->
 
-As asserções também podem indicar uma incompatibilidade de ambiente entre `web` e `worker`. Verifique a configuração `ENVIRONMENT` da compilação e o contexto de execução do carregador JavaScript ao investigar esses erros; consulte a [discussão na issue #176](https://github.com/WordPress/wordpress-playground/issues/176#issuecomment-1483754022).
-
-<!--
-### PHP next builds
--->
-
-### Compilações do PHP next
+## Compilações do PHP next
 
 <!--
 Playground can also run the next PHP version from the php-src development branch in the web runtime. These builds are published separately from the main repository because the generated WebAssembly files are large and change often.
@@ -254,10 +248,10 @@ npm run recompile:php:web:next
 Atualmente, `php=next` distribui apenas módulos principais para a web. Os módulos auxiliares de extensões correspondentes e o suporte à CLI do Playground serão tratados em trabalhos separados.
 
 <!--
-### PHP extensions
+## PHP extensions
 -->
 
-### Extensões PHP
+## Extensões PHP
 
 <!--
 PHP is built with several extensions listed in the [`Dockerfile`](https://github.com/WordPress/wordpress-playground/blob/trunk/packages/php-wasm/compile/php/Dockerfile).
@@ -289,10 +283,10 @@ for the runtime API.
 PHP.wasm também pode carregar extensões dinâmicas `.so` antes de iniciar o PHP. Extensões dinâmicas integradas, como `intl`, `xdebug`, `redis` e `memcached`, são distribuídas com o pacote Node, e extensões externas podem ser fornecidas com um manifesto que seleciona o artefato correspondente à versão do PHP e ao modo assíncrono ativos. Consulte [Carregando extensões PHP](/developers/apis/javascript-api/php-extensions) para conhecer a API de execução.
 
 <!--
-### C API exposed to JavaScript
+## C API exposed to JavaScript
 -->
 
-### API C exposta ao JavaScript
+## API C exposta ao JavaScript
 
 <!--
 The C API exposed to JavaScript lives in the [`php_wasm.c`](https://github.com/WordPress/wordpress-playground/blob/trunk/src/packages/php-wasm/compile/build-assets/php_wasm.c) file. The most important functions are:
@@ -317,10 +311,10 @@ Refer to the inline documentation in [`php_wasm.c`](https://github.com/WordPress
 Consulte a documentação no código de [`php_wasm.c`](https://github.com/WordPress/wordpress-playground/blob/trunk/src/packages/php-wasm/compile/build-assets/php_wasm.c) para saber mais.
 
 <!--
-### Build configuration
+## Build configuration
 -->
 
-### Configuração da compilação
+## Configuração da compilação
 
 <!--
 The build is configurable via the [Docker `--build-arg` feature](https://docs.docker.com/engine/reference/commandline/build/#set-build-time-variables---build-arg). You can set them up through the `build.js` script, just run this command to get the usage message:
@@ -339,15 +333,19 @@ npx nx recompile-php:jspi php-wasm-web -- --help
 ```
 
 <!--
-**Supported build options:**
+**Selected build options:**
+
+This list highlights debug and basic build settings. For the full set of options, run the help command above; see [the build script](https://github.com/WordPress/wordpress-playground/blob/trunk/packages/php-wasm/compile/build.js) for platform-specific defaults.
 -->
 
-**Opções de compilação suportadas:**
+**Opções de compilação selecionadas:**
+
+Esta lista destaca as configurações de depuração e compilação básicas. Para consultar todas as opções, execute o comando de ajuda acima; consulte [o script de compilação](https://github.com/WordPress/wordpress-playground/blob/trunk/packages/php-wasm/compile/build.js) para ver os valores padrão de cada plataforma.
 
 <!--
 - `WITH_DEBUG` – `yes` or `no`. Build with DWARF debug information and disable final optimization. See [Debug builds](#debug-builds).
 - `WITH_SOURCEMAPS` – `yes` or `no`. Generate WebAssembly source maps and disable final optimization. See [Debug builds](#debug-builds).
-- `PHP_VERSION` – The PHP version to build, default: `8.0.24`. This value must point to an existing branch of the https://github.com/php/php-src.git repository when prefixed with `PHP-`. For example, `7.4.0` is valid because the branch `PHP-7.4.0` exists, but just `7` is invalid because there's no branch `PHP-7`. The PHP versions that are known to work are `7.4.*` and `8.0.*`. Others likely work as well but they haven't been tried.
+- `PHP_VERSION` – The PHP version to build. Use a major/minor version such as `8.4` to select its latest release from [the supported PHP versions](https://github.com/WordPress/wordpress-playground/blob/trunk/packages/php-wasm/supported-php-versions.mjs), or an exact release such as `8.4.25`. The build clones the corresponding `php-<version>` tag from php-src.
 - `EMSCRIPTEN_ENVIRONMENT` – `web` or `node`, default: `web`. The platform to build for. When building for `web`, two JavaScript loaders will be created: `php-web.js` and `php-webworker.js`. When building for Node.js, only one loader called `php-node.js` will be created.
 - `WITH_LIBXML` – `yes` or `no`, default: `no`. Whether to build with `libxml2` and the `dom`, `xml`, and `simplexml` PHP extensions (`DOMDocument`, `SimpleXML`, ..).
 - `WITH_LIBZIP` – `yes` or `no`, default: `yes`. Whether to build with `zlib`, `libzip`, and the `zip` PHP extension (`ZipArchive`).
@@ -356,7 +354,7 @@ npx nx recompile-php:jspi php-wasm-web -- --help
 
 - `WITH_DEBUG` – `yes` ou `no`. Compila com informações de depuração DWARF e desativa a otimização final. Consulte [Compilações para depuração](#debug-builds).
 - `WITH_SOURCEMAPS` – `yes` ou `no`. Gera mapas de código-fonte WebAssembly e desativa a otimização final. Consulte [Compilações para depuração](#debug-builds).
-- `PHP_VERSION` – A versão do PHP a compilar, padrão: `8.0.24`. Esse valor deve corresponder a um branch existente do repositório https://github.com/php/php-src.git quando precedido por `PHP-`. Por exemplo, `7.4.0` é válido porque o branch `PHP-7.4.0` existe, mas apenas `7` é inválido porque não existe um branch `PHP-7`. As versões do PHP que sabemos que funcionam são `7.4.*` e `8.0.*`. Outras provavelmente também funcionam, mas não foram testadas.
+- `PHP_VERSION` – A versão do PHP a compilar. Use uma versão principal/secundária como `8.4` para selecionar sua versão mais recente na [lista de versões do PHP compatíveis](https://github.com/WordPress/wordpress-playground/blob/trunk/packages/php-wasm/supported-php-versions.mjs), ou uma versão exata como `8.4.25`. A compilação clona a tag `php-<version>` correspondente do php-src.
 - `EMSCRIPTEN_ENVIRONMENT` – `web` ou `node`, padrão: `web`. A plataforma para a qual compilar. Ao compilar para `web`, dois carregadores JavaScript são criados: `php-web.js` e `php-webworker.js`. Ao compilar para Node.js, apenas um carregador chamado `php-node.js` é criado.
 - `WITH_LIBXML` – `yes` ou `no`, padrão: `no`. Define se a compilação inclui `libxml2` e as extensões PHP `dom`, `xml` e `simplexml` (`DOMDocument`, `SimpleXML`, ...).
 - `WITH_LIBZIP` – `yes` ou `no`, padrão: `yes`. Define se a compilação inclui `zlib`, `libzip` e a extensão PHP `zip` (`ZipArchive`).


### PR DESCRIPTION
## Summary

Documents the PHP.WASM debug-build workflow from issue #176.

- Updates PHP compilation commands and Dockerfile links.
- Adds debug-build examples for web and Node.js.
- Documents source maps, Emscripten flags, and runtime assertions.
- Adds commented English-source translations in Brazilian Portuguese, Spanish, Italian, and French.
- Links the README to the new debug-build documentation.

## Testing

- `npx nx format:check --files=...`
- `npx nx build docs-site`
- Built localized docs for English, Brazilian Portuguese, Spanish, Italian, and French.
- Built and smoke-tested PHP 8.4 debug builds for web and Node.js:
  - `npx nx recompile-php:jspi php-wasm-web -- --PHP_VERSION=8.4 --WITH_DEBUG=yes`
  - `npx nx recompile-php:jspi php-wasm-node -- --PHP_VERSION=8.4 --WITH_DEBUG=yes`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated PHP-to-WebAssembly compilation guidance with current Docker and Nx build commands.
  * Added instructions for PHP versions, web and Node.js targets, JSPI and Asyncify modes, debug builds, source maps, Emscripten flags, and runtime assertions.
  * Expanded guidance on extensions, PHP-next artifacts, JavaScript APIs, and build configuration options.
  * Added Spanish, French, and Italian translations and refreshed the Portuguese translation.
  * Added a README link to build examples and Emscripten flag explanations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->