### PR TITLE
Track exact My WP streak lengths

### DIFF
--- a/packages/playground/personal-wp/src/lib/personalwp/usage-stats.spec.ts
+++ b/packages/playground/personal-wp/src/lib/personalwp/usage-stats.spec.ts
@@ -396,7 +396,7 @@ describe('Personal WP usage stats', () => {
 		const day2 = getStreakUsageStatsUpdate(metadata, day1 + DAY);
 		expect(day2.events).toContainEqual({
 			event: 'daily_streak',
-			properties: { bucket: '2' },
+			properties: { length: '2' },
 		});
 		metadata = { ...metadata, ...day2.metadata };
 
@@ -416,7 +416,7 @@ describe('Personal WP usage stats', () => {
 		const first = getStreakUsageStatsUpdate(metadata, day1);
 		expect(first.events).toContainEqual({
 			event: 'daily_streak',
-			properties: { bucket: '1' },
+			properties: { length: '1' },
 		});
 		metadata = { ...metadata, ...first.metadata };
 
@@ -429,21 +429,21 @@ describe('Personal WP usage stats', () => {
 		const day2 = getStreakUsageStatsUpdate(metadata, day1 + DAY);
 		expect(day2.events).toContainEqual({
 			event: 'daily_streak',
-			properties: { bucket: '2' },
+			properties: { length: '2' },
 		});
 		metadata = { ...metadata, ...day2.metadata };
 
 		const afterGap = getStreakUsageStatsUpdate(metadata, day1 + 4 * DAY);
 		expect(afterGap.events).toContainEqual({
 			event: 'daily_streak',
-			properties: { bucket: '1' },
+			properties: { length: '1' },
 		});
 	});
 
-	it('walks the daily streak bucket boundaries across consecutive days', () => {
+	it('walks the daily streak length boundaries across consecutive days', () => {
 		const start = Date.UTC(2026, 5, 1);
 		let metadata = {} as SiteMetadata;
-		const buckets: string[] = [];
+		const lengths: string[] = [];
 
 		for (let day = 0; day < 31; day++) {
 			const update = getStreakUsageStatsUpdate(
@@ -454,16 +454,12 @@ describe('Personal WP usage stats', () => {
 			const dailyEvent = update.events.find(
 				(event) => event.event === 'daily_streak'
 			);
-			buckets.push(dailyEvent!.properties.bucket as string);
+			lengths.push(dailyEvent!.properties.length as string);
 		}
 
-		expect(buckets[0]).toBe('1');
-		expect(buckets[1]).toBe('2');
-		expect(buckets[2]).toBe('3-6');
-		expect(buckets[5]).toBe('3-6');
-		expect(buckets[6]).toBe('7-13');
-		expect(buckets[13]).toBe('14-29');
-		expect(buckets[29]).toBe('30+');
+		expect(lengths[0]).toBe('1');
+		expect(lengths[29]).toBe('30');
+		expect(lengths[30]).toBe('31+');
 	});
 
 	it('advances the weekly streak across calendar weeks and resets on a skipped week', () => {
@@ -473,7 +469,7 @@ describe('Personal WP usage stats', () => {
 		const first = getStreakUsageStatsUpdate(metadata, monday1);
 		expect(first.events).toContainEqual({
 			event: 'weekly_streak',
-			properties: { bucket: '1' },
+			properties: { length: '1' },
 		});
 		metadata = { ...metadata, ...first.metadata };
 
@@ -490,7 +486,7 @@ describe('Personal WP usage stats', () => {
 		const monday2 = getStreakUsageStatsUpdate(metadata, monday1 + 7 * DAY);
 		expect(monday2.events).toContainEqual({
 			event: 'weekly_streak',
-			properties: { bucket: '2' },
+			properties: { length: '2' },
 		});
 		metadata = { ...metadata, ...monday2.metadata };
 
@@ -500,7 +496,7 @@ describe('Personal WP usage stats', () => {
 		);
 		expect(mondaySkippedWeek.events).toContainEqual({
 			event: 'weekly_streak',
-			properties: { bucket: '1' },
+			properties: { length: '1' },
 		});
 	});
 
@@ -511,7 +507,7 @@ describe('Personal WP usage stats', () => {
 		const first = getStreakUsageStatsUpdate(metadata, december);
 		expect(first.events).toContainEqual({
 			event: 'monthly_streak',
-			properties: { bucket: '1' },
+			properties: { length: '1' },
 		});
 		metadata = { ...metadata, ...first.metadata };
 
@@ -521,7 +517,7 @@ describe('Personal WP usage stats', () => {
 		);
 		expect(january.events).toContainEqual({
 			event: 'monthly_streak',
-			properties: { bucket: '2' },
+			properties: { length: '2' },
 		});
 		metadata = { ...metadata, ...january.metadata };
 
@@ -531,7 +527,7 @@ describe('Personal WP usage stats', () => {
 		);
 		expect(marchSkippedFebruary.events).toContainEqual({
 			event: 'monthly_streak',
-			properties: { bucket: '1' },
+			properties: { length: '1' },
 		});
 	});
 });

--- a/packages/playground/personal-wp/src/lib/personalwp/usage-stats.ts
+++ b/packages/playground/personal-wp/src/lib/personalwp/usage-stats.ts
@@ -209,7 +209,7 @@ export function getStreakUsageStatsUpdate(
 		metadataUpdate.dailyStreak = daily.streak;
 		events.push({
 			event: 'daily_streak',
-			properties: { bucket: getDailyStreakBucket(daily.streak) },
+			properties: { length: getStreakLength(daily.streak) },
 		});
 	}
 
@@ -226,7 +226,7 @@ export function getStreakUsageStatsUpdate(
 		metadataUpdate.weeklyStreak = weekly.streak;
 		events.push({
 			event: 'weekly_streak',
-			properties: { bucket: getWeeklyStreakBucket(weekly.streak) },
+			properties: { length: getStreakLength(weekly.streak) },
 		});
 	}
 
@@ -240,7 +240,7 @@ export function getStreakUsageStatsUpdate(
 		metadataUpdate.monthlyStreak = monthly.streak;
 		events.push({
 			event: 'monthly_streak',
-			properties: { bucket: getMonthlyStreakBucket(monthly.streak) },
+			properties: { length: getStreakLength(monthly.streak) },
 		});
 	}
 
@@ -307,58 +307,11 @@ function addUtcDays(date: string, days: number): string {
 	return next.toISOString().slice(0, 10);
 }
 
-function getDailyStreakBucket(streak: number): string {
-	if (streak <= 1) {
-		return '1';
+function getStreakLength(streak: number): string {
+	if (streak > 30) {
+		return '31+';
 	}
-	if (streak === 2) {
-		return '2';
-	}
-	if (streak <= 6) {
-		return '3-6';
-	}
-	if (streak <= 13) {
-		return '7-13';
-	}
-	if (streak <= 29) {
-		return '14-29';
-	}
-	return '30+';
-}
-
-function getWeeklyStreakBucket(streak: number): string {
-	if (streak <= 1) {
-		return '1';
-	}
-	if (streak === 2) {
-		return '2';
-	}
-	if (streak <= 4) {
-		return '3-4';
-	}
-	if (streak <= 8) {
-		return '5-8';
-	}
-	return '9+';
-}
-
-function getMonthlyStreakBucket(streak: number): string {
-	if (streak <= 1) {
-		return '1';
-	}
-	if (streak === 2) {
-		return '2';
-	}
-	if (streak === 3) {
-		return '3';
-	}
-	if (streak <= 6) {
-		return '4-6';
-	}
-	if (streak <= 12) {
-		return '7-12';
-	}
-	return '13+';
+	return String(Math.max(streak, 1));
 }
 
 export function getBlueprintUsageStatsProperties(

--- a/packages/playground/website-deployment/my-wordpress-net/mywp-event-dashboard.php
+++ b/packages/playground/website-deployment/my-wordpress-net/mywp-event-dashboard.php
@@ -631,17 +631,25 @@ function mywp_event_dashboard_load_stats( $dbh, $range, $granularity ) {
 			$time_column,
 			$since,
 			'day' === $granularity ? '%Y-%m-%d' : '%Y-%m-%d %H:00'
-		),
-		'blueprint_plugin_slug_timeline' => mywp_event_dashboard_query_metric_timeline(
-			$dbh,
-			$table,
-			$time_column,
-			$since,
-			'day' === $granularity ? '%Y-%m-%d' : '%Y-%m-%d %H:00',
-			'blueprint_installed:plugin_slug'
-		),
-	);
-}
+			),
+			'blueprint_plugin_slug_timeline' => mywp_event_dashboard_query_metric_timeline(
+				$dbh,
+				$table,
+				$time_column,
+				$since,
+				'day' === $granularity ? '%Y-%m-%d' : '%Y-%m-%d %H:00',
+				'blueprint_installed:plugin_slug'
+			),
+			'daily_streak_length_timeline' => mywp_event_dashboard_query_metric_timeline(
+				$dbh,
+				$table,
+				$time_column,
+				$since,
+				'day' === $granularity ? '%Y-%m-%d' : '%Y-%m-%d %H:00',
+				'daily_streak:length'
+			),
+		);
+	}
 
 function mywp_event_dashboard_query_rollup(
 	$dbh,
@@ -908,15 +916,18 @@ function mywp_event_dashboard_render_json( $stats ) {
 			'since' => $stats['since'],
 			'total_events' => mywp_event_dashboard_sum_views( $events ),
 			'events' => mywp_event_dashboard_json_views_by_value( $events ),
-			'metrics' => (object) $metrics,
-			'timeline' => mywp_event_dashboard_json_timeline( $stats['timeline'] ),
-			'blueprint_plugin_slug_timeline' => mywp_event_dashboard_json_timeline(
-				$stats['blueprint_plugin_slug_timeline']
+				'metrics' => (object) $metrics,
+				'timeline' => mywp_event_dashboard_json_timeline( $stats['timeline'] ),
+				'blueprint_plugin_slug_timeline' => mywp_event_dashboard_json_timeline(
+					$stats['blueprint_plugin_slug_timeline']
+				),
+				'daily_streak_length_timeline' => mywp_event_dashboard_json_timeline(
+					$stats['daily_streak_length_timeline']
+				),
 			),
-		),
-		JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES
-	);
-}
+			JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES
+		);
+	}
 
 function mywp_event_dashboard_json_views_by_value( $rows ) {
 	$views = array();
@@ -1581,9 +1592,36 @@ function mywp_event_dashboard_render_engagement_area(
 	$groups,
 	$metric_definitions
 ) {
-	$daily_active = mywp_event_dashboard_event_count( $groups, 'daily_streak' );
-	$weekly_active = mywp_event_dashboard_event_count( $groups, 'weekly_streak' );
-	$monthly_active = mywp_event_dashboard_event_count( $groups, 'monthly_streak' );
+	$today = gmdate( 'Y-m-d' );
+	$seven_days_ago = gmdate( 'Y-m-d', time() - 6 * 24 * 60 * 60 );
+	$daily_streak_today = mywp_event_dashboard_timeline_value_count_on_date(
+		$stats['timeline'],
+		'daily_streak',
+		$today
+	);
+	$daily_streak_3_day_today = mywp_event_dashboard_timeline_numeric_value_count_at_least_on_date(
+		$stats['daily_streak_length_timeline'],
+		3,
+		$today
+	);
+	$daily_streak_last_7_days = mywp_event_dashboard_timeline_value_count_between_dates(
+		$stats['timeline'],
+		'daily_streak',
+		$seven_days_ago,
+		$today
+	);
+	$daily_streak_selected_range = mywp_event_dashboard_event_count(
+		$groups,
+		'daily_streak'
+	);
+	$weekly_streak_selected_range = mywp_event_dashboard_event_count(
+		$groups,
+		'weekly_streak'
+	);
+	$monthly_streak_selected_range = mywp_event_dashboard_event_count(
+		$groups,
+		'monthly_streak'
+	);
 	$timeline = mywp_event_dashboard_filter_timeline_values(
 		$stats['timeline'],
 		array( 'daily_streak', 'weekly_streak', 'monthly_streak' )
@@ -1593,10 +1631,11 @@ function mywp_event_dashboard_render_engagement_area(
 		<div class="section-heading">
 			<h2>Engagement</h2>
 			<p class="muted">
-				Each site reports at most one ping per day/week/month, so these
-				counts are a privacy-preserving proxy for active sites in the
-				selected range &mdash; not a lifetime unique-user count, and not
-				directly comparable to each other across different-length ranges.
+				The daily streak event is the clearest signal for current
+				engagement: each local site reports at most one daily streak ping
+				per UTC day. Weekly and monthly streak events are period-level
+				pings, so they are shown as context rather than as comparable
+				active-site totals.
 			</p>
 			<p class="muted">
 				Streak tracking started on
@@ -1611,19 +1650,48 @@ function mywp_event_dashboard_render_engagement_area(
 		</div>
 		<div class="grid">
 			<div class="panel">
-				<div class="muted">Daily active sites</div>
-				<div class="stat-number"><?php echo mywp_event_dashboard_number( $daily_active ); ?></div>
-				<div class="kpi-detail">Sum of one-ping-per-day site activity in range</div>
+				<div class="muted">Daily streak visitors today</div>
+				<div class="stat-number"><?php echo mywp_event_dashboard_number( $daily_streak_today ); ?></div>
+				<div class="kpi-detail">Daily streak pings on <?php echo mywp_event_dashboard_h( $today ); ?> UTC</div>
 			</div>
 			<div class="panel">
-				<div class="muted">Weekly active sites</div>
-				<div class="stat-number"><?php echo mywp_event_dashboard_number( $weekly_active ); ?></div>
-				<div class="kpi-detail">Sum of one-ping-per-week site activity in range</div>
+				<div class="muted">3+ day streak visitors today</div>
+				<div class="stat-number"><?php echo mywp_event_dashboard_number( $daily_streak_3_day_today ); ?></div>
+				<div class="kpi-detail">Daily streak pings with length 3 or more today</div>
 			</div>
 			<div class="panel">
-				<div class="muted">Monthly active sites</div>
-				<div class="stat-number"><?php echo mywp_event_dashboard_number( $monthly_active ); ?></div>
-				<div class="kpi-detail">Sum of one-ping-per-month site activity in range</div>
+				<div class="muted">Daily streak visitor-days, last 7 days</div>
+				<div class="stat-number"><?php echo mywp_event_dashboard_number( $daily_streak_last_7_days ); ?></div>
+				<div class="kpi-detail">Sum of daily streak pings since <?php echo mywp_event_dashboard_h( $seven_days_ago ); ?> UTC</div>
+			</div>
+			<div class="panel">
+				<div class="muted">Daily streak visitor-days, selected range</div>
+				<div class="stat-number"><?php echo mywp_event_dashboard_number( $daily_streak_selected_range ); ?></div>
+				<div class="kpi-detail">Sum of daily streak pings in the selected range</div>
+			</div>
+		</div>
+	</section>
+
+	<section class="dashboard-section">
+		<div class="section-heading">
+			<h2>Period pings</h2>
+			<p class="muted">One-ping-per-period streak volume in the selected range.</p>
+		</div>
+		<div class="grid">
+			<div class="panel">
+				<div class="muted">Daily streak pings</div>
+				<div class="stat-number"><?php echo mywp_event_dashboard_number( $daily_streak_selected_range ); ?></div>
+				<div class="kpi-detail">One ping per active local site per UTC day</div>
+			</div>
+			<div class="panel">
+				<div class="muted">Weekly streak pings</div>
+				<div class="stat-number"><?php echo mywp_event_dashboard_number( $weekly_streak_selected_range ); ?></div>
+				<div class="kpi-detail">One ping per active local site per UTC week</div>
+			</div>
+			<div class="panel">
+				<div class="muted">Monthly streak pings</div>
+				<div class="stat-number"><?php echo mywp_event_dashboard_number( $monthly_streak_selected_range ); ?></div>
+				<div class="kpi-detail">One ping per active local site per UTC month</div>
 			</div>
 		</div>
 	</section>
@@ -1641,9 +1709,9 @@ function mywp_event_dashboard_render_engagement_area(
 		'Streak distribution',
 		'Consecutive periods in a row each reporting site has been active for.',
 		array(
-			'daily_streak:bucket',
-			'weekly_streak:bucket',
-			'monthly_streak:bucket',
+			'daily_streak:length',
+			'weekly_streak:length',
+			'monthly_streak:length',
 		),
 		$groups,
 		$metric_definitions
@@ -1748,6 +1816,69 @@ function mywp_event_dashboard_filter_timeline_values( $rows, $values ) {
 			}
 		)
 	);
+}
+
+function mywp_event_dashboard_timeline_value_count_on_date( $rows, $value, $date ) {
+	return mywp_event_dashboard_timeline_value_count_between_dates(
+		$rows,
+		$value,
+		$date,
+		$date
+	);
+}
+
+function mywp_event_dashboard_timeline_value_count_between_dates(
+	$rows,
+	$value,
+	$start_date,
+	$end_date
+) {
+	$total = 0;
+	foreach ( $rows as $row ) {
+		if ( $value !== $row['value'] ) {
+			continue;
+		}
+
+		$row_date = substr( $row['period'], 0, 10 );
+		if ( $row_date >= $start_date && $row_date <= $end_date ) {
+			$total += $row['views'];
+		}
+	}
+
+	return $total;
+}
+
+function mywp_event_dashboard_timeline_numeric_value_count_at_least_on_date(
+	$rows,
+	$minimum,
+	$date
+) {
+	$total = 0;
+	foreach ( $rows as $row ) {
+		$row_date = substr( $row['period'], 0, 10 );
+		if ( $row_date !== $date ) {
+			continue;
+		}
+
+		$value = mywp_event_dashboard_numeric_metric_value( $row['value'] );
+		if ( null !== $value && $value >= $minimum ) {
+			$total += $row['views'];
+		}
+	}
+
+	return $total;
+}
+
+function mywp_event_dashboard_numeric_metric_value( $value ) {
+	if ( is_string( $value ) && str_ends_with( $value, '+' ) ) {
+		$value = substr( $value, 0, -1 );
+	}
+
+	if ( is_string( $value ) && preg_match( '/^\d+$/', $value ) ) {
+		return (int) $value;
+	}
+
+	return null;
 }
 
 function mywp_event_dashboard_metric_value_count( $groups, $metric_name, $value ) {
@@ -2181,9 +2312,9 @@ function mywp_event_dashboard_metric_definitions() {
 		'blueprint_installed:plugin_slug' => 'Blueprint Installs: Plugin Slug',
 		'blueprint_installed:previous_visit_age_bucket' => 'Blueprint Installs: Previous Visit Age',
 		'blueprint_installed:site_age_bucket' => 'Blueprint Installs: Site Age',
-		'daily_streak:bucket' => 'Daily Streak (consecutive days)',
-		'weekly_streak:bucket' => 'Weekly Streak (consecutive weeks)',
-		'monthly_streak:bucket' => 'Monthly Streak (consecutive months)',
+		'daily_streak:length' => 'Daily Streak Length (consecutive days)',
+		'weekly_streak:length' => 'Weekly Streak Length (consecutive weeks)',
+		'monthly_streak:length' => 'Monthly Streak Length (consecutive months)',
 	);
 }
 

--- a/packages/playground/website-deployment/my-wordpress-net/mywp-event.php
+++ b/packages/playground/website-deployment/my-wordpress-net/mywp-event.php
@@ -462,7 +462,7 @@ function mywp_event_add_bump( &$bumps, $name, $value, $views = 1 ) {
 		! is_string( $name ) ||
 		! is_string( $value ) ||
 		! preg_match( '/^[a-z0-9_:.-]{1,80}$/', $name ) ||
-		! preg_match( '/^[A-Za-z0-9_.:\/-]{1,128}$/', $value )
+		! preg_match( '/^[A-Za-z0-9_.:\/+-]{1,128}$/', $value )
 	) {
 		return;
 	}

--- a/packages/playground/website-deployment/my-wordpress-net/mywp-event.php
+++ b/packages/playground/website-deployment/my-wordpress-net/mywp-event.php
@@ -276,9 +276,9 @@ function mywp_event_collect_stat_bumps( $payload ) {
 		mywp_event_add_allowed_property(
 			$bumps,
 			$event,
-			'bucket',
+			'length',
 			$properties,
-			mywp_event_streak_buckets( $event )
+			mywp_event_streak_lengths()
 		);
 		return $bumps;
 	}
@@ -485,21 +485,13 @@ function mywp_event_age_buckets() {
 	);
 }
 
-/**
- * Must match the bucket boundaries in usage-stats.ts (getDailyStreakBucket,
- * getWeeklyStreakBucket, getMonthlyStreakBucket) — these are the values the
- * client is allowed to send for each streak event's `bucket` property.
- */
-function mywp_event_streak_buckets( $event ) {
-	if ( 'daily_streak' === $event ) {
-		return array( '1', '2', '3-6', '7-13', '14-29', '30+' );
+function mywp_event_streak_lengths() {
+	$lengths = array();
+	for ( $length = 1; $length <= 30; $length++ ) {
+		$lengths[] = (string) $length;
 	}
-
-	if ( 'weekly_streak' === $event ) {
-		return array( '1', '2', '3-4', '5-8', '9+' );
-	}
-
-	return array( '1', '2', '3', '4-6', '7-12', '13+' );
+	$lengths[] = '31+';
+	return $lengths;
 }
 
 function mywp_event_sync_bump_extra( $dbh, $name, $value, $num, $today, $hour ) {

--- a/packages/playground/website-deployment/tests.php
+++ b/packages/playground/website-deployment/tests.php
@@ -942,6 +942,29 @@ assert_equal(
     'Allowed daily streak length was not counted'
 );
 
+$capped_daily_streak_bumps = mywp_event_collect_stat_bumps( array(
+    'schema' => 'personal-wp-event/v1',
+    'app' => 'personal-wp',
+    'event' => 'daily_streak',
+    'properties' => array(
+        'length' => '31+',
+    ),
+) );
+
+assert_equal(
+    true,
+    in_array(
+        array(
+            'name' => 'daily_streak:length',
+            'value' => '31+',
+            'views' => 1,
+        ),
+        $capped_daily_streak_bumps,
+        true
+    ),
+    'Capped daily streak length was not counted'
+);
+
 assert_equal(
     false,
     in_array(

--- a/packages/playground/website-deployment/tests.php
+++ b/packages/playground/website-deployment/tests.php
@@ -703,6 +703,85 @@ assert_equal(
     'Dashboard should keep the selected timeline value'
 );
 
+$dashboard_streak_timeline = array(
+    array(
+        'period' => '2026-09-01',
+        'value' => 'daily_streak',
+        'views' => 8,
+    ),
+    array(
+        'period' => '2026-09-02',
+        'value' => 'weekly_streak',
+        'views' => 7,
+    ),
+    array(
+        'period' => '2026-09-03',
+        'value' => 'daily_streak',
+        'views' => 9,
+    ),
+    array(
+        'period' => '2026-09-03 08:00',
+        'value' => 'daily_streak',
+        'views' => 3,
+    ),
+    array(
+        'period' => '2026-09-04',
+        'value' => 'daily_streak',
+        'views' => 4,
+    ),
+);
+assert_equal(
+    12,
+    mywp_event_dashboard_timeline_value_count_on_date(
+        $dashboard_streak_timeline,
+        'daily_streak',
+        '2026-09-03'
+    ),
+    'Dashboard should count daily streak pings for one UTC date'
+);
+assert_equal(
+    16,
+    mywp_event_dashboard_timeline_value_count_between_dates(
+        $dashboard_streak_timeline,
+        'daily_streak',
+        '2026-09-03',
+        '2026-09-04'
+    ),
+    'Dashboard should sum daily streak pings across a UTC date range'
+);
+
+$dashboard_streak_length_timeline = array(
+    array(
+        'period' => '2026-09-03',
+        'value' => '1',
+        'views' => 5,
+    ),
+    array(
+        'period' => '2026-09-03',
+        'value' => '3',
+        'views' => 2,
+    ),
+    array(
+        'period' => '2026-09-03 08:00',
+        'value' => '31+',
+        'views' => 1,
+    ),
+    array(
+        'period' => '2026-09-04',
+        'value' => '4',
+        'views' => 9,
+    ),
+);
+assert_equal(
+    3,
+    mywp_event_dashboard_timeline_numeric_value_count_at_least_on_date(
+        $dashboard_streak_length_timeline,
+        3,
+        '2026-09-03'
+    ),
+    'Dashboard should count streak lengths above a threshold for one UTC date'
+);
+
 $event_bumps = mywp_event_collect_stat_bumps( array(
     'schema' => 'personal-wp-event/v1',
     'app' => 'personal-wp',
@@ -838,6 +917,50 @@ assert_equal(
         true
     ),
     'Allowed request source was not counted'
+);
+
+$daily_streak_bumps = mywp_event_collect_stat_bumps( array(
+    'schema' => 'personal-wp-event/v1',
+    'app' => 'personal-wp',
+    'event' => 'daily_streak',
+    'properties' => array(
+        'length' => '3',
+    ),
+) );
+
+assert_equal(
+    true,
+    in_array(
+        array(
+            'name' => 'daily_streak:length',
+            'value' => '3',
+            'views' => 1,
+        ),
+        $daily_streak_bumps,
+        true
+    ),
+    'Allowed daily streak length was not counted'
+);
+
+assert_equal(
+    false,
+    in_array(
+        array(
+            'name' => 'daily_streak:length',
+            'value' => '365',
+            'views' => 1,
+        ),
+        mywp_event_collect_stat_bumps( array(
+            'schema' => 'personal-wp-event/v1',
+            'app' => 'personal-wp',
+            'event' => 'daily_streak',
+            'properties' => array(
+                'length' => '365',
+            ),
+        ) ),
+        true
+    ),
+    'Unrecognized daily streak length should not be counted'
 );
 
 $remote_access_bumps = mywp_event_collect_stat_bumps( array(


### PR DESCRIPTION
This changes My WP streak reporting from coarse bucket values to bounded exact streak lengths. Daily, weekly, and monthly streak events now report a `length` value from `1` through `30`, capped at `31+`, so the dashboard can answer aggregate continuity questions such as how many of today's daily streak visitors have a 3+ day streak. This intentionally breaks compatibility with the previous `:bucket` streak dimensions.

The engagement dashboard now emphasizes daily streak activity, adds a 3+ day streak KPI for today, keeps period-ping totals as context, and exposes `daily_streak_length_timeline` in the JSON output for per-day length analysis.

Testing:
- `php -l packages/playground/website-deployment/my-wordpress-net/mywp-event.php`
- `php -l packages/playground/website-deployment/my-wordpress-net/mywp-event-dashboard.php`
- `php packages/playground/website-deployment/tests.php`
- `npm exec nx test playground-personal-wp -- --run packages/playground/personal-wp/src/lib/personalwp/usage-stats.spec.ts`
- `git diff --check`
