### PR TITLE
[Website] Remove abandoned metadata-only autosaves on site loading

### DIFF
--- a/packages/playground/website/src/lib/state/opfs/opfs-site-storage.spec.ts
+++ b/packages/playground/website/src/lib/state/opfs/opfs-site-storage.spec.ts
@@ -1,9 +1,6 @@
 import { BlobReader, TextWriter, ZipReader } from '@zip.js/zip.js';
 import type { SiteMetadata } from '../redux/slice-sites';
-import type {
-	StoredSiteMetadata,
-	opfsSiteStorage as exportedOpfsSiteStorage,
-} from './opfs-site-storage';
+import type { opfsSiteStorage as exportedOpfsSiteStorage } from './opfs-site-storage';
 
 describe('opfsSiteStorage', () => {
 	let opfsRoot: MemoryDirectoryHandle;
@@ -86,7 +83,7 @@ describe('opfsSiteStorage', () => {
 	});
 
 	describe('abandoned autosaves', () => {
-		const oldPendingAutosave: Partial<StoredSiteMetadata> = {
+		const oldPendingAutosave: Partial<SiteMetadata> = {
 			persistence: 'autosave',
 			initialOpfsSyncPending: true,
 			whenCreated: 1,
@@ -116,40 +113,23 @@ describe('opfsSiteStorage', () => {
 			});
 		});
 
-		it.each(['current', 'legacy'])(
-			'removes an abandoned %s metadata-only autosave',
-			async (format) => {
-				const sitesRoot = await getSitesRoot(opfsRoot);
-				await writeSiteMetadata(
-					sitesRoot,
-					'site-abandoned',
-					'abandoned',
-					{
-						...oldPendingAutosave,
-						...(format === 'legacy'
-							? {
-									initialOpfsSyncPending: undefined,
-									initialOpfsAutosyncPending: true,
-								}
-							: {}),
-					}
-				);
+		it('removes an abandoned metadata-only autosave', async () => {
+			const sitesRoot = await getSitesRoot(opfsRoot);
+			await writeSiteMetadata(
+				sitesRoot,
+				'site-abandoned',
+				'abandoned',
+				oldPendingAutosave
+			);
 
-				expect(await storage.list()).toEqual([]);
-				expect(await storage.read('abandoned')).toBeUndefined();
-			}
-		);
+			expect(await storage.list()).toEqual([]);
+			expect(await storage.read('abandoned')).toBeUndefined();
+		});
 
 		it.each([
 			['explicit save', { persistence: 'explicit' }],
 			['legacy explicit save', { persistence: undefined }],
-			[
-				'completed sync',
-				{
-					initialOpfsSyncPending: false,
-					initialOpfsAutosyncPending: true,
-				},
-			],
+			['completed sync', { initialOpfsSyncPending: false }],
 			['unknown sync state', { initialOpfsSyncPending: undefined }],
 			['recent use', { whenLastUsed: Date.now() }],
 			['missing date', { whenCreated: undefined }],
@@ -162,7 +142,7 @@ describe('opfsSiteStorage', () => {
 			await writeSiteMetadata(sitesRoot, 'site-kept', 'kept', {
 				...oldPendingAutosave,
 				...metadata,
-			} as Partial<StoredSiteMetadata>);
+			} as Partial<SiteMetadata>);
 			expect((await storage.list()).map((site) => site.slug)).toEqual([
 				'kept',
 			]);
@@ -605,7 +585,7 @@ async function writeSiteMetadata(
 	sitesRoot: MemoryDirectoryHandle,
 	directoryName: string,
 	slug: string,
-	metadata: Partial<StoredSiteMetadata> = {}
+	metadata: Partial<SiteMetadata> = {}
 ) {
 	const siteDirectory = await sitesRoot.getDirectoryHandle(directoryName, {
 		create: true,
@@ -640,7 +620,7 @@ async function writeOpfsPath(
 }
 
 function createSiteMetadata(
-	metadata: Partial<StoredSiteMetadata> = {}
+	metadata: Partial<SiteMetadata> = {}
 ): SiteMetadata {
 	return {
 		storage: 'opfs',

--- a/packages/playground/website/src/lib/state/opfs/opfs-site-storage.spec.ts
+++ b/packages/playground/website/src/lib/state/opfs/opfs-site-storage.spec.ts
@@ -1,6 +1,9 @@
 import { BlobReader, TextWriter, ZipReader } from '@zip.js/zip.js';
 import type { SiteMetadata } from '../redux/slice-sites';
-import type { opfsSiteStorage as exportedOpfsSiteStorage } from './opfs-site-storage';
+import type {
+	StoredSiteMetadata,
+	opfsSiteStorage as exportedOpfsSiteStorage,
+} from './opfs-site-storage';
 
 describe('opfsSiteStorage', () => {
 	let opfsRoot: MemoryDirectoryHandle;
@@ -80,6 +83,177 @@ describe('opfsSiteStorage', () => {
 
 	afterEach(() => {
 		vi.unstubAllGlobals();
+	});
+
+	describe('abandoned autosaves', () => {
+		const oldPendingAutosave: Partial<StoredSiteMetadata> = {
+			persistence: 'autosave',
+			initialOpfsSyncPending: true,
+			whenCreated: 1,
+		};
+
+		beforeEach(() => {
+			const held = new Set<string>();
+			Object.defineProperty(navigator, 'locks', {
+				configurable: true,
+				value: {
+					request: vi.fn(async (name, options, callback) => {
+						if (typeof options === 'function') {
+							callback = options;
+							options = {};
+						}
+						if (options.ifAvailable && held.has(name)) {
+							return callback(null);
+						}
+						held.add(name);
+						try {
+							return await callback({ name });
+						} finally {
+							held.delete(name);
+						}
+					}),
+				},
+			});
+		});
+
+		it.each(['current', 'legacy'])(
+			'removes an abandoned %s metadata-only autosave',
+			async (format) => {
+				const sitesRoot = await getSitesRoot(opfsRoot);
+				await writeSiteMetadata(
+					sitesRoot,
+					'site-abandoned',
+					'abandoned',
+					{
+						...oldPendingAutosave,
+						...(format === 'legacy'
+							? {
+									initialOpfsSyncPending: undefined,
+									initialOpfsAutosyncPending: true,
+								}
+							: {}),
+					}
+				);
+
+				expect(await storage.list()).toEqual([]);
+				expect(await storage.read('abandoned')).toBeUndefined();
+			}
+		);
+
+		it.each([
+			['explicit save', { persistence: 'explicit' }],
+			['legacy explicit save', { persistence: undefined }],
+			[
+				'completed sync',
+				{
+					initialOpfsSyncPending: false,
+					initialOpfsAutosyncPending: true,
+				},
+			],
+			['unknown sync state', { initialOpfsSyncPending: undefined }],
+			['recent use', { whenLastUsed: Date.now() }],
+			['missing date', { whenCreated: undefined }],
+			['invalid date', { whenCreated: 'yesterday' }],
+			['future date', { whenCreated: Date.now() + 86400000 }],
+			['interrupted reset', { opfsSiteRemovalPending: true }],
+			['local site', { storage: 'local-fs' }],
+		])('preserves a %s', async (_label, metadata) => {
+			const sitesRoot = await getSitesRoot(opfsRoot);
+			await writeSiteMetadata(sitesRoot, 'site-kept', 'kept', {
+				...oldPendingAutosave,
+				...metadata,
+			} as Partial<StoredSiteMetadata>);
+			expect((await storage.list()).map((site) => site.slug)).toEqual([
+				'kept',
+			]);
+			expect(await storage.read('kept')).toBeDefined();
+		});
+
+		it.each(['file', 'directory'])(
+			'preserves any extra %s',
+			async (kind) => {
+				const sitesRoot = await getSitesRoot(opfsRoot);
+				const directory = await writeSiteMetadata(
+					sitesRoot,
+					'site-kept',
+					'kept',
+					oldPendingAutosave
+				);
+				if (kind === 'file') {
+					directory.setFile('notes.txt', 'keep me');
+				} else {
+					await directory.getDirectoryHandle('blueprint-bundle', {
+						create: true,
+					});
+				}
+				expect((await storage.list()).map((site) => site.slug)).toEqual(
+					['kept']
+				);
+			}
+		);
+
+		it('preserves a site created by a still-open document even after the grace period', async () => {
+			await storage.create(
+				'active',
+				createSiteMetadata(oldPendingAutosave)
+			);
+			expect((await storage.list()).map((site) => site.slug)).toEqual([
+				'active',
+			]);
+		});
+
+		it('rechecks metadata after acquiring the cleanup lock', async () => {
+			const sitesRoot = await getSitesRoot(opfsRoot);
+			await writeSiteMetadata(
+				sitesRoot,
+				'site-kept',
+				'kept',
+				oldPendingAutosave
+			);
+			const request = navigator.locks.request.bind(navigator.locks);
+			vi.mocked(navigator.locks.request).mockImplementationOnce(
+				async (name: any, options: any, callback: any) => {
+					await writeSiteMetadata(sitesRoot, 'site-kept', 'kept', {
+						...oldPendingAutosave,
+						persistence: 'explicit',
+					});
+					return request(name, options, callback);
+				}
+			);
+			expect((await storage.list()).map((site) => site.slug)).toEqual([
+				'kept',
+			]);
+		});
+
+		it('leaves cleanup disabled without Web Locks', async () => {
+			Object.defineProperty(navigator, 'locks', { value: undefined });
+			const sitesRoot = await getSitesRoot(opfsRoot);
+			await writeSiteMetadata(
+				sitesRoot,
+				'site-kept',
+				'kept',
+				oldPendingAutosave
+			);
+			expect((await storage.list()).map((site) => site.slug)).toEqual([
+				'kept',
+			]);
+		});
+
+		it('still lists a site when deletion fails', async () => {
+			const sitesRoot = await getSitesRoot(opfsRoot);
+			await writeSiteMetadata(
+				sitesRoot,
+				'site-kept',
+				'kept',
+				oldPendingAutosave
+			);
+			vi.spyOn(sitesRoot, 'removeEntry').mockRejectedValueOnce(
+				new Error('busy')
+			);
+			expect((await storage.list()).map((site) => site.slug)).toEqual([
+				'kept',
+			]);
+		});
 	});
 
 	it('reads legacy site metadata when the encoded directory is incomplete', async () => {
@@ -431,7 +605,7 @@ async function writeSiteMetadata(
 	sitesRoot: MemoryDirectoryHandle,
 	directoryName: string,
 	slug: string,
-	metadata: Partial<SiteMetadata> = {}
+	metadata: Partial<StoredSiteMetadata> = {}
 ) {
 	const siteDirectory = await sitesRoot.getDirectoryHandle(directoryName, {
 		create: true,
@@ -466,7 +640,7 @@ async function writeOpfsPath(
 }
 
 function createSiteMetadata(
-	metadata: Partial<SiteMetadata> = {}
+	metadata: Partial<StoredSiteMetadata> = {}
 ): SiteMetadata {
 	return {
 		storage: 'opfs',

--- a/packages/playground/website/src/lib/state/opfs/opfs-site-storage.ts
+++ b/packages/playground/website/src/lib/state/opfs/opfs-site-storage.ts
@@ -41,6 +41,8 @@ export {
 
 // TODO: Decide on metadata filename
 const SITE_METADATA_FILENAME = 'wp-runtime.json';
+const ABANDONED_AUTOSAVE_AGE_MS = 24 * 60 * 60 * 1000;
+const INITIAL_SYNC_LOCK_PREFIX = 'wordpress-playground:initial-opfs-sync:';
 // 0o40755 = 0o40000 | 0o755; ZIP stores it in externalFileAttributes' upper 16 bits.
 const ZIP_DIRECTORY_EXTERNAL_FILE_ATTRIBUTES = 0o40755 << 16;
 
@@ -62,6 +64,8 @@ export const legacyOpfsPathSymbol = Symbol('legacyOpfsPath');
  * design matures.
  */
 export interface StoredSiteMetadata extends SiteMetadata {
+	/** Legacy name of initialOpfsSyncPending. Read old records without writing it back. */
+	initialOpfsAutosyncPending?: boolean;
 	slug: string;
 	originalUrlParams?: OriginalUrlParams;
 }
@@ -109,6 +113,24 @@ class OpfsSiteStorage {
 		const existingSiteDirName = await this.findExistingSiteDirName(slug);
 		if (existingSiteDirName) {
 			throw new Error(`Site with slug '${slug}' already exists.`);
+		}
+		// A new site's files may remain in MEMFS long after metadata is written.
+		// Keep cleanup away for this document's lifetime, including background
+		// sync and retries. Other documents cannot boot a pending stored site.
+		// The browser releases this lock when the document goes away.
+		if (navigator.locks) {
+			await new Promise<void>((resolve, reject) => {
+				void navigator.locks
+					.request(
+						`${INITIAL_SYNC_LOCK_PREFIX}${slug}`,
+						{ mode: 'shared' },
+						() => {
+							resolve();
+							return new Promise<void>(() => {});
+						}
+					)
+					.catch(reject);
+			});
 		}
 		await this.root.getDirectoryHandle(newSiteDirName, {
 			create: true,
@@ -169,11 +191,30 @@ class OpfsSiteStorage {
 		});
 	}
 
+	/** Loads sites after removing old, inactive, metadata-only autosaves. */
 	async list(): Promise<SiteInfo[]> {
 		const sites: SiteInfo[] = [];
+		// Finish iteration before cleanup mutates the directory.
+		const entries = [];
 		for await (const entry of this.root.values()) {
+			entries.push(entry);
+		}
+		for (const entry of entries) {
 			if (entry.kind === 'directory') {
 				try {
+					if (
+						await this.removeAbandonedAutosave(entry).catch(
+							(error) => {
+								logger.warn(
+									`Unable to clean up autosave ${entry.name}:`,
+									error
+								);
+								return false;
+							}
+						)
+					) {
+						continue;
+					}
 					const site = await this.readSite(entry.name);
 					if (site) {
 						sites.push(site);
@@ -399,6 +440,54 @@ class OpfsSiteStorage {
 
 		return undefined;
 	}
+	/**
+	 * Never infer abandonment from the pending flag alone: a live tab may still
+	 * be installing WordPress in memory. Recheck under both the initial-sync
+	 * lock and the metadata lock so a concurrent save cannot become explicit
+	 * between the check and deletion. Without Web Locks, leave the site alone.
+	 */
+	private async removeAbandonedAutosave(
+		directory: FileSystemDirectoryHandle
+	) {
+		if (!navigator.locks) {
+			return false;
+		}
+		const site = await this.readStoredSiteMetadata(directory);
+		if (!isAbandonedAutosave(site)) {
+			return false;
+		}
+		return await navigator.locks.request(
+			`${INITIAL_SYNC_LOCK_PREFIX}${site.slug}`,
+			{ ifAvailable: true },
+			async (lock) => {
+				if (!lock) {
+					return false;
+				}
+				return await withSiteMetadataLock(site.slug, async () => {
+					if (
+						!isAbandonedAutosave(
+							await this.readStoredSiteMetadata(directory)
+						)
+					) {
+						return false;
+					}
+					for await (const entry of directory.values()) {
+						// Preserve partial copies and Blueprint bundles, even empty ones.
+						if (
+							entry.kind !== 'file' ||
+							entry.name !== SITE_METADATA_FILENAME
+						) {
+							return false;
+						}
+					}
+					await this.root.removeEntry(directory.name, {
+						recursive: true,
+					});
+					return true;
+				});
+			}
+		);
+	}
 }
 
 export const opfsSiteStorage: OpfsSiteStorage | undefined = opfsSitesRoot
@@ -406,6 +495,20 @@ export const opfsSiteStorage: OpfsSiteStorage | undefined = opfsSitesRoot
 	: undefined;
 
 export const isOpfsAvailable = !!opfsSiteStorage;
+
+function isAbandonedAutosave(site: SiteInfo) {
+	const lastUsed = site.metadata.whenLastUsed ?? site.metadata.whenCreated;
+	return (
+		site.metadata.storage === 'opfs' &&
+		site.metadata.persistence === 'autosave' &&
+		site.metadata.initialOpfsSyncPending === true &&
+		site.metadata.opfsSiteRemovalPending !== true &&
+		typeof lastUsed === 'number' &&
+		Number.isFinite(lastUsed) &&
+		lastUsed > 0 &&
+		lastUsed <= Date.now() - ABANDONED_AUTOSAVE_AGE_MS
+	);
+}
 
 /**
  * Runs a site metadata transaction under an origin-wide exclusive lock.
@@ -466,9 +569,15 @@ async function metadataToStoredFormat(
 }
 
 function storedFormatToMetadata(data: string) {
-	const { slug, originalUrlParams, ...metadata } = JSON.parse(
-		data
-	) as StoredSiteMetadata;
+	const { slug, originalUrlParams, initialOpfsAutosyncPending, ...metadata } =
+		JSON.parse(data) as StoredSiteMetadata;
+
+	if (
+		metadata.initialOpfsSyncPending === undefined &&
+		initialOpfsAutosyncPending === true
+	) {
+		metadata.initialOpfsSyncPending = true;
+	}
 
 	/**
 	 * Migrate the legacy runtimeConfiguration data format to the new, flat one.

--- a/packages/playground/website/src/lib/state/opfs/opfs-site-storage.ts
+++ b/packages/playground/website/src/lib/state/opfs/opfs-site-storage.ts
@@ -64,8 +64,6 @@ export const legacyOpfsPathSymbol = Symbol('legacyOpfsPath');
  * design matures.
  */
 export interface StoredSiteMetadata extends SiteMetadata {
-	/** Legacy name of initialOpfsSyncPending. Read old records without writing it back. */
-	initialOpfsAutosyncPending?: boolean;
 	slug: string;
 	originalUrlParams?: OriginalUrlParams;
 }
@@ -569,15 +567,9 @@ async function metadataToStoredFormat(
 }
 
 function storedFormatToMetadata(data: string) {
-	const { slug, originalUrlParams, initialOpfsAutosyncPending, ...metadata } =
-		JSON.parse(data) as StoredSiteMetadata;
-
-	if (
-		metadata.initialOpfsSyncPending === undefined &&
-		initialOpfsAutosyncPending === true
-	) {
-		metadata.initialOpfsSyncPending = true;
-	}
+	const { slug, originalUrlParams, ...metadata } = JSON.parse(
+		data
+	) as StoredSiteMetadata;
 
 	/**
 	 * Migrate the legacy runtimeConfiguration data format to the new, flat one.


### PR DESCRIPTION
Remove abandoned autosaves when loading the site list. A candidate must have a pending first OPFS sync, be unused for at least 24 hours, and contain only `wp-runtime.json`.

New sites hold a Web Lock until their creating tab closes. Cleanup skips locked sites and rechecks metadata before deleting. Explicit saves, records without a persistence type, partial copies, Blueprint bundles, and interrupted resets are left alone. Cleanup is disabled without Web Locks.

This does not add a bulk-delete UI or change normal autosave retention.

## Testing

All 417 website tests, website type checking, and lint pass. The storage tests cover active creation, concurrent metadata changes, extra files and directories, and failed deletion.

For a browser check, close older Playground tabs first. Reopen with an old metadata-only autosave and confirm it disappears. An explicit save or a directory with any additional entry must remain.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Automatically cleans up abandoned autosave metadata when it is safe to do so.
  - Preserves explicit saves, recently used sites, incomplete synchronizations, local sites, and associated files or directories.
  - Prevents cleanup from interfering with active synchronization or newly resumed autosaves.
  - Handles interrupted resets, invalid metadata, deletion failures, and unsupported environments safely.
  - Rechecks autosave status before cleanup to avoid removing data that has become active.
  - Improves coordination during initial synchronization to reduce conflicts with autosave cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->