### PR TITLE
Fix programmatic CLI PHP environment

### DIFF
--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -3,6 +3,7 @@ import { ProcessIdAllocator } from '@php-wasm/universal';
 import {
 	createObjectPoolProxy,
 	type Pooled,
+	type PHPRequest,
 	type PHPRunOptions,
 	type PathAlias,
 	type RemoteAPI,

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -857,6 +857,11 @@ export interface RunCLIArgs {
 	memcached?: boolean;
 	xdebug?: boolean | XdebugOptions;
 	phpExtension?: string[];
+	/**
+	 * Environment bindings applied to each PHP request started by this CLI
+	 * instance. These stay in the request context and are cleared at shutdown.
+	 */
+	phpEnv?: Record<string, string>;
 	experimentalUnsafeIdeIntegration?: string[];
 	experimentalDevtools?: boolean;
 	workers?: number | 'auto';
@@ -1716,7 +1721,10 @@ export async function runCLI(
 				}
 
 				return {
-					playground: playgroundPool,
+					playground: withPhpEnvForProgrammaticRuns(
+						playgroundPool,
+						args.phpEnv
+					),
 					server,
 					serverUrl,
 					[Symbol.asyncDispose]: disposeCLI,
@@ -1798,6 +1806,7 @@ export async function runCLI(
 					},
 				};
 			}
+			request = withPhpEnv(request, args.phpEnv);
 
 			// TODO: Explore switching to a worker thread method to adopt an entire HTTP connection
 			// It might be more efficient to let the worker respond directly
@@ -1825,6 +1834,45 @@ export async function runCLI(
 		openInBrowser(server.serverUrl);
 	}
 	return server;
+}
+
+function withPhpEnv<T extends PHPRequest>(request: T, phpEnv?: Record<string, string>): T {
+	if (!phpEnv || Object.keys(phpEnv).length === 0) {
+		return request;
+	}
+
+	return {
+		...request,
+		env: {
+			...phpEnv,
+			...request.env,
+		},
+	};
+}
+
+function withPhpEnvForProgrammaticRuns(
+	playground: Pooled<PlaygroundCliWorker>,
+	phpEnv?: Record<string, string>
+): Pooled<PlaygroundCliWorker> {
+	if (!phpEnv || Object.keys(phpEnv).length === 0) {
+		return playground;
+	}
+
+	return new Proxy(playground, {
+		get(target, property, receiver) {
+			const value = Reflect.get(target, property, receiver);
+			if (
+				(property !== 'run' &&
+					property !== 'request' &&
+					property !== 'requestStreamed') ||
+				typeof value !== 'function'
+			) {
+				return value;
+			}
+
+			return (request: PHPRequest) => value(withPhpEnv(request, phpEnv));
+		},
+	});
 }
 
 /**

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -3,7 +3,7 @@ import { ProcessIdAllocator } from '@php-wasm/universal';
 import {
 	createObjectPoolProxy,
 	type Pooled,
-	type PHPRequest,
+	type PHPRunOptions,
 	type PathAlias,
 	type RemoteAPI,
 	type AllPHPVersion,
@@ -1835,9 +1835,9 @@ export async function runCLI(
 }
 
 function withPhpEnv(
-	request: PHPRequest,
+	request: PHPRunOptions,
 	phpEnv?: Record<string, string>
-): PHPRequest {
+): PHPRunOptions {
 	if (!phpEnv || Object.keys(phpEnv).length === 0) {
 		return request;
 	}
@@ -1863,15 +1863,13 @@ function withPhpEnvForProgrammaticRuns(
 		get(target, property, receiver) {
 			const value = Reflect.get(target, property, receiver);
 			if (
-				(property !== 'run' &&
-					property !== 'request' &&
-					property !== 'requestStreamed') ||
+				property !== 'run' ||
 				typeof value !== 'function'
 			) {
 				return value;
 			}
 
-			return (request: PHPRequest) => value(withPhpEnv(request, phpEnv));
+			return (request: PHPRunOptions) => value(withPhpEnv(request, phpEnv));
 		},
 	});
 }

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -858,8 +858,8 @@ export interface RunCLIArgs {
 	xdebug?: boolean | XdebugOptions;
 	phpExtension?: string[];
 	/**
-	 * Environment bindings applied to each PHP request started by this CLI
-	 * instance. These stay in the request context and are cleared at shutdown.
+	 * Environment bindings applied to programmatic PHP requests. These stay in
+	 * the request context and are cleared at shutdown.
 	 */
 	phpEnv?: Record<string, string>;
 	experimentalUnsafeIdeIntegration?: string[];
@@ -1806,8 +1806,6 @@ export async function runCLI(
 					},
 				};
 			}
-			request = withPhpEnv(request, args.phpEnv);
-
 			// TODO: Explore switching to a worker thread method to adopt an entire HTTP connection
 			// It might be more efficient to let the worker respond directly
 			const response = await playgroundPool.requestStreamed(request);

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -1834,7 +1834,10 @@ export async function runCLI(
 	return server;
 }
 
-function withPhpEnv<T extends PHPRequest>(request: T, phpEnv?: Record<string, string>): T {
+function withPhpEnv(
+	request: PHPRequest,
+	phpEnv?: Record<string, string>
+): PHPRequest {
 	if (!phpEnv || Object.keys(phpEnv).length === 0) {
 		return request;
 	}

--- a/packages/playground/cli/tests/run-cli.spec.ts
+++ b/packages/playground/cli/tests/run-cli.spec.ts
@@ -86,7 +86,7 @@ describe.each(blueprintVersions)(
 			expect(text).toContain('8.0');
 		});
 
-		test('applies PHP environment bindings to HTTP and programmatic requests', async () => {
+		test('applies PHP environment bindings to programmatic requests', async () => {
 			await using cliServer = await runCLI({
 				...suiteCliArgs,
 				command: 'server',
@@ -96,18 +96,21 @@ describe.each(blueprintVersions)(
 				blueprint: undefined,
 				phpEnv: { PLAYGROUND_CLI_TEST_ENV: 'request-bound' },
 			});
-			await cliServer.playground.writeFile(
-				'/wordpress/env.php',
-				"<?php echo getenv('PLAYGROUND_CLI_TEST_ENV');"
-			);
-
 			expect(
 				(await cliServer.playground.run({
 					code: "<?php echo getenv('PLAYGROUND_CLI_TEST_ENV');",
 				})).text
 			).toBe('request-bound');
 			expect(
-				await (await fetch(new URL('/env.php', cliServer.serverUrl))).text()
+				(await cliServer.playground.run({
+					code: "<?php echo getenv('PLAYGROUND_CLI_TEST_ENV');",
+					env: { PLAYGROUND_CLI_TEST_ENV: 'per-request' },
+				})).text
+			).toBe('per-request');
+			expect(
+				(await cliServer.playground.run({
+					code: "<?php echo getenv('PLAYGROUND_CLI_TEST_ENV');",
+				})).text
 			).toBe('request-bound');
 		});
 

--- a/packages/playground/cli/tests/run-cli.spec.ts
+++ b/packages/playground/cli/tests/run-cli.spec.ts
@@ -86,6 +86,31 @@ describe.each(blueprintVersions)(
 			expect(text).toContain('8.0');
 		});
 
+		test('applies PHP environment bindings to HTTP and programmatic requests', async () => {
+			await using cliServer = await runCLI({
+				...suiteCliArgs,
+				command: 'server',
+				php: '8.0',
+				wordpressInstallMode: 'do-not-attempt-installing',
+				skipSqliteSetup: true,
+				blueprint: undefined,
+				phpEnv: { PLAYGROUND_CLI_TEST_ENV: 'request-bound' },
+			});
+			await cliServer.playground.writeFile(
+				'/wordpress/env.php',
+				"<?php echo getenv('PLAYGROUND_CLI_TEST_ENV');"
+			);
+
+			expect(
+				(await cliServer.playground.run({
+					code: "<?php echo getenv('PLAYGROUND_CLI_TEST_ENV');",
+				})).text
+			).toBe('request-bound');
+			expect(
+				await (await fetch(new URL('/env.php', cliServer.serverUrl))).text()
+			).toBe('request-bound');
+		});
+
 		test('should have Intl extension enabled by default', async () => {
 			await using cliServer = await runCLI({
 				...suiteCliArgs,


### PR DESCRIPTION
## Summary

Add a `phpEnv` option to the programmatic Playground CLI API.

The option is merged into each explicit `playground.run()` environment without serializing values into files, blueprints, or bootstrap source. Per-request bindings retain precedence and request shutdown clears the PHP environment before a pooled worker is reused.

## Verification

- `npm exec nx run playground-cli:test-playground-cli -- --testFile=run-cli.spec.ts --testNamePattern="applies PHP environment bindings"`

This test verifies static programmatic bindings, an explicit per-request override, and restoration of the static binding on the following request.

## Context

This adds explicit programmatic environment forwarding, investigated alongside Automattic/wp-codebox#2491. Codebox already carries a downstream CLI environment patch; its reported failure was caused by skipping postinstall, and normal installation passes its database integration gate. This upstream API addition is not a Codebox landing blocker. It does not change the CLI command-line interface.

AI assistance disclosure: OpenCode with OpenAI GPT-5.6 Terra (`openai/gpt-5.6-terra`) traced the request lifecycle, implemented the scoped in-memory forwarding, and ran the focused regression test.

GPT-6 Astra (`openai/gpt-6-astra`) via OpenCode verified the downstream installation cause and corrected this context; the upstream change remains a draft for maintainer review.
